### PR TITLE
fix(phoenix): set project name when using phoenix telemetry exporter (#337)

### DIFF
--- a/src/aiq/observability/register.py
+++ b/src/aiq/observability/register.py
@@ -103,7 +103,7 @@ async def langsmith_telemetry_exporter(config: LangsmithTelemetryExporter, build
     if not api_key:
         raise ValueError("API key is required for langsmith")
 
-    headers = {"x-api-key": api_key, "LANGSMITH_PROJECT": config.project}
+    headers = {"x-api-key": api_key, "Langsmith-Project": config.project}
     yield trace_exporter.OTLPSpanExporter(endpoint=config.endpoint, headers=headers)
 
 


### PR DESCRIPTION
This adds a fix for the Phoenix telemetry exporter. Currently it does not use the project name in the configuration. For Phoenix this needs to be set in the TraceProvider like so: 

```
provider = TracerProvider(resource=Resource(attributes={ResourceAttributes.PROJECT_NAME: trace_exporter_config.project}))
```

where `ResourceAttributes.PROJECT_NAME` is `openinference.project.name`.

This allows for traces to be sent to projects other than the default project: 

![phoenix_projects](https://github.com/user-attachments/assets/a5a374be-ccde-426b-81df-92035af8c5fb)

This also fixes a typo in the Langsmith telemetry exporter that allows for traces to go to the correct project. (header changed from`LANGSMITH_PROJECT` to `Langsmith-Project`)

Langsmith and Langfuse set their `project` differently: Langsmith uses a header value (`Langsmith-Project` and Langfuse uses per-project keys.

This could be problematic if other telemetry exporters also relied on `attributes` in the `TracerProvider` to set the project value. It would also not work if there were multiple `telemetry.tracing` configurations using phoenix defined in a config file.  So this might not be an ideal solution, but it should work for simple configurations where you want to use different projects for different configuration files with phoenix.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes #337 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/AIQToolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
