### PR TITLE
Ak mcp required fields 2

### DIFF
--- a/src/aiq/tool/mcp/mcp_client.py
+++ b/src/aiq/tool/mcp/mcp_client.py
@@ -45,6 +45,7 @@ def model_from_mcp_schema(name: str, mcp_input_schema: dict) -> type[BaseModel]:
     }
 
     properties = mcp_input_schema.get("properties", {})
+    required_fields = set(mcp_input_schema.get("required", []))
     schema_dict = {}
 
     def _generate_valid_classname(class_name: str):
@@ -70,7 +71,17 @@ def model_from_mcp_schema(name: str, mcp_input_schema: dict) -> type[BaseModel]:
         else:
             field_type = _type_map.get(json_type, Any)
 
-        default_value = field_properties.get("default", ...)
+        # Determine the default value based on whether the field is required
+        if field_name in required_fields:
+            # Field is required - use explicit default if provided, otherwise make it required
+            default_value = field_properties.get("default", ...)
+        else:
+            # Field is optional - use explicit default if provided, otherwise None
+            default_value = field_properties.get("default", None)
+            # Make the type optional if no default was provided
+            if "default" not in field_properties:
+                field_type = field_type | None
+
         nullable = field_properties.get("nullable", False)
         description = field_properties.get("description", "")
 

--- a/tests/aiq/tools/test_mcp.py
+++ b/tests/aiq/tools/test_mcp.py
@@ -142,7 +142,7 @@ def test_schema_generation(sample_schema):
     m = _model.model_validate(test_input)
     assert isinstance(m, _model)
 
-    # Check that the optional field with no default is -
+    # Check that the optional field with no default is
     # 1. present
     # 2. has a default value of None
     # 3. has a type of str | None

--- a/tests/aiq/tools/test_mcp.py
+++ b/tests/aiq/tools/test_mcp.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import get_args
+
 import pytest
 from pydantic import ValidationError
 from pytest_httpserver import HTTPServer
@@ -38,6 +40,12 @@ def _get_sample_schema():
             },
             'optional_string_field': {
                 'default': 'default_string',
+                'description': 'Optional field that needs to be a string',
+                'minLength': 1,
+                'title': 'OptionalString',
+                'type': 'string'
+            },
+            'optional_string_field_no_default': {
                 'description': 'Optional field that needs to be a string',
                 'minLength': 1,
                 'title': 'OptionalString',
@@ -133,6 +141,16 @@ def test_schema_generation(sample_schema):
 
     m = _model.model_validate(test_input)
     assert isinstance(m, _model)
+
+    # Check that the optional field with no default is -
+    # 1. present
+    # 2. has a default value of None
+    # 3. has a type of str | None
+    assert hasattr(m, "optional_string_field_no_default")
+    assert m.optional_string_field_no_default is None
+    field_type = m.model_fields["optional_string_field_no_default"].annotation
+    args = get_args(field_type)
+    assert str in args and type(None) in args, f"Expected str | None, got {field_type}"
 
 
 def test_schema_missing_required_fields_raises(sample_schema):


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes #354 
If no default is defined in the schema, and the field isn’t in the "required" list, it should default to None (i.e., optional).

Earlier logic marked the field as required (using ...) unless "default" is explicitly set i.e. it would mark optional fields with no default as required.

This failed for tools like kubectl_get -

Starting Kubernetes MCP server v0.1.0, handling commands...
Tool: kubectl_get
Description: Get or list Kubernetes resources by resource type, name, and optionally namespace
Input Schema:
{
  "type": "object",
  "properties": {
    "resourceType": {
      "type": "string",
      "description": "Type of resource to get (e.g., pods, deployments, services, configmaps, events, etc.)"
    },
    "name": {
      "type": "string",
      "description": "Name of the resource (optional - if not provided, lists all resources of the specified type)"
    },
    "namespace": {
      "type": "string",
      "description": "Namespace of the resource (optional - defaults to 'default' for namespaced resources)",
      "default": "default"
    },
    "output": {
      "type": "string",
      "enum": [
        "json",
        "yaml",
        "wide",
        "name",
        "custom"
      ],
      "description": "Output format",
      "default": "json"
    },
    "allNamespaces": {
      "type": "boolean",
      "description": "If true, list resources across all namespaces",
      "default": false
    },
    "labelSelector": {
      "type": "string",
      "description": "Filter resources by label selector (e.g. 'app=nginx')",
      "optional": true
    },
    "fieldSelector": {
      "type": "string",
      "description": "Filter resources by field selector (e.g. 'metadata.name=my-pod')",
      "optional": true
    },
    "sortBy": {
      "type": "string",
      "description": "Sort events by a field (default: lastTimestamp). Only applicable for events.",
      "optional": true
    }
  },
  "required": [
    "resourceType"
  ]
}

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.





























































































































































































