### PR TITLE
Fixes Function and LambdaFunction classes to push active function instance names

### DIFF
--- a/src/aiq/builder/workflow_builder.py
+++ b/src/aiq/builder/workflow_builder.py
@@ -333,7 +333,7 @@ class WorkflowBuilder(Builder, AbstractAsyncContextManager):
 
         if (isinstance(build_result, FunctionInfo)):
             # Create the function object
-            build_result = LambdaFunction.from_info(config=config, info=build_result)
+            build_result = LambdaFunction.from_info(config=config, info=build_result, instance_name=name)
 
         if (not isinstance(build_result, Function)):
             raise ValueError("Expected a function, FunctionInfo object, or FunctionBase object to be "


### PR DESCRIPTION

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes https://github.com/NVIDIA/NeMo-Agent-Toolkit/issues/364

This PR resolves an issue with how function names are set when invoking the `AIQContext.push_active_function` from the `Function` and `LambdaFunction` classes. Now, `instance_name` is passed into the `LambdaFunction.from_info` factory method and is an argument in class instance construction. This change removes ambiguity when working with `IntermediateStep` objects and exported traces when the same function is configured >1 times in the configuration object.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
