### PR TITLE
Drop redundant average scores in the weave dashboard

### DIFF
--- a/src/aiq/eval/utils/weave_eval.py
+++ b/src/aiq/eval/utils/weave_eval.py
@@ -123,13 +123,5 @@ class WeaveEvaluationIntegration:  # pylint: disable=too-many-public-methods
         """Log summary statistics to Weave."""
         if not self.eval_logger:
             return
-
-        summary = {}
-        for evaluator_name, eval_output in evaluation_results:
-            # Calculate average score for this evaluator
-            scores = [item.score for item in eval_output.eval_output_items if item.score is not None]
-            if scores:
-                summary[f"{evaluator_name}_avg"] = sum(scores) / len(scores)
-
         # Log the summary to finish the evaluation
-        self.eval_logger.log_summary(summary)
+        self.eval_logger.log_summary()


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
eval_logger.log_summary is creating a summary (auto_summarize is true by default) and also appending the provided summary resulting in a redundant score display: 
![image](https://github.com/user-attachments/assets/552b2d3c-f56a-4499-a82a-44f6338251f7)

This PR drops the "provided summary" to remove the redundant plots:
![image](https://github.com/user-attachments/assets/5a064d9a-c32f-4ff9-8cc4-954617e0ad3e)


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
