### PR TITLE
Enable testing tools in isolation

### DIFF
--- a/examples/simple_calculator/tests/test_tool_isolation.py
+++ b/examples/simple_calculator/tests/test_tool_isolation.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Demonstration of isolated tool testing using the new ToolTestRunner.
+
+This shows how tools can be tested in isolation without requiring:
+- Full workflow setup
+- LLM connections
+- Complex configuration files
+- All dependencies loaded
+
+This addresses AIQ-940: "No clear way to test tools in isolation"
+"""
+
+import pytest
+from aiq_simple_calculator.register import DivisionToolConfig
+from aiq_simple_calculator.register import InequalityToolConfig
+from aiq_simple_calculator.register import MultiplyToolConfig
+from aiq_simple_calculator.register import SubtractToolConfig
+
+from aiq.test.tool_test_runner import test_tool
+
+
+class TestCalculatorToolsIsolation:
+    """
+    Test calculator tools in complete isolation from workflows, agents, and LLMs.
+
+    These tests are:
+    - Fast: No workflow loading, no LLM initialization
+    - Simple: No config files needed
+    - Focused: Test only the tool logic
+    - Reliable: No external dependencies
+    """
+
+    @pytest.mark.asyncio
+    async def test_inequality_tool_direct(self):
+        """Test inequality tool logic directly."""
+
+        result = await test_tool(config_type=InequalityToolConfig,
+                                 input_data="Is 8 greater than 15?",
+                                 expected_output="First number 8 is less than the second number 15")
+
+        assert "8" in result
+        assert "15" in result
+        assert "less" in result
+
+    @pytest.mark.asyncio
+    async def test_inequality_tool_equal_case(self):
+        """Test inequality tool with equal numbers."""
+
+        result = await test_tool(config_type=InequalityToolConfig,
+                                 input_data="Compare 5 and 5",
+                                 expected_output="First number 5 is equal to the second number 5")
+
+        assert "equal" in result
+
+    @pytest.mark.asyncio
+    async def test_inequality_tool_greater_case(self):
+        """Test inequality tool with first number greater."""
+
+        result = await test_tool(config_type=InequalityToolConfig,
+                                 input_data="Is 15 greater than 8?",
+                                 expected_output="First number 15 is greater than the second number 8")
+
+        assert "greater" in result
+
+    @pytest.mark.asyncio
+    async def test_multiply_tool_direct(self):
+        """Test multiply tool logic directly."""
+
+        result = await test_tool(config_type=MultiplyToolConfig,
+                                 input_data="What is 2 times 4?",
+                                 expected_output="The product of 2 * 4 is 8")
+
+        assert "8" in result
+        assert "product" in result
+
+    @pytest.mark.asyncio
+    async def test_multiply_tool_edge_cases(self):
+        """Test multiply tool with various inputs."""
+
+        # Test with zero
+        result = await test_tool(config_type=MultiplyToolConfig,
+                                 input_data="Multiply 0 and 5",
+                                 expected_output="The product of 0 * 5 is 0")
+        assert "0" in result
+
+        # Test with larger numbers
+        result = await test_tool(config_type=MultiplyToolConfig,
+                                 input_data="Calculate 12 times 13",
+                                 expected_output="The product of 12 * 13 is 156")
+        assert "156" in result
+
+    @pytest.mark.asyncio
+    async def test_division_tool_direct(self):
+        """Test division tool logic directly."""
+
+        result = await test_tool(config_type=DivisionToolConfig,
+                                 input_data="What is 8 divided by 2?",
+                                 expected_output="The result of 8 / 2 is 4.0")
+
+        assert "4.0" in result
+        assert "result" in result
+
+    @pytest.mark.asyncio
+    async def test_division_tool_with_remainder(self):
+        """Test division with decimal result."""
+
+        result = await test_tool(config_type=DivisionToolConfig,
+                                 input_data="Divide 7 by 2",
+                                 expected_output="The result of 7 / 2 is 3.5")
+
+        assert "3.5" in result
+
+    @pytest.mark.asyncio
+    async def test_subtract_tool_direct(self):
+        """Test subtract tool logic directly."""
+
+        result = await test_tool(config_type=SubtractToolConfig,
+                                 input_data="What is 10 minus 3?",
+                                 expected_output="The result of 10 - 3 is 7")
+
+        assert "7" in result
+        assert "result" in result
+
+    @pytest.mark.asyncio
+    async def test_subtract_tool_negative_result(self):
+        """Test subtract tool with negative result."""
+
+        result = await test_tool(config_type=SubtractToolConfig,
+                                 input_data="Subtract 15 from 10",
+                                 expected_output="The result of 15 - 10 is 5")
+
+        assert "5" in result
+
+    @pytest.mark.asyncio
+    async def test_tool_error_handling(self):
+        """Test error handling for insufficient numbers."""
+
+        result = await test_tool(config_type=MultiplyToolConfig, input_data="Multiply just one number: 5")
+
+        # Should return an error message
+        assert "Provide at least 2 numbers" in result
+
+    @pytest.mark.asyncio
+    async def test_tool_validation_too_many_numbers(self):
+        """Test validation for too many numbers."""
+
+        result = await test_tool(config_type=MultiplyToolConfig, input_data="Multiply 2, 3, and 4 together")
+
+        # Should return an error message about only supporting 2 numbers
+        assert "only supports" in result and "2 numbers" in result
+
+
+# Performance comparison test
+@pytest.mark.performance
+class TestPerformanceComparison:
+    """
+    Demonstrate the performance benefits of isolated testing vs full workflow testing.
+    """
+
+    @pytest.mark.asyncio
+    async def test_isolated_performance(self):
+        """Test multiple tools quickly in isolation."""
+        import time
+
+        start_time = time.time()
+
+        # Test multiple tools rapidly
+        await test_tool(InequalityToolConfig, input_data="5 vs 3")
+        await test_tool(MultiplyToolConfig, input_data="5 times 3")
+        await test_tool(DivisionToolConfig, input_data="15 divided by 3")
+        await test_tool(SubtractToolConfig, input_data="10 minus 7")
+
+        end_time = time.time()
+
+        # Isolated testing should be very fast (under 1 second for 4 tools)
+        elapsed = end_time - start_time
+        print(f"Isolated testing took {elapsed:.3f} seconds for 4 tools")
+        assert elapsed < 1.0, f"Isolated testing should be fast, took {elapsed:.3f}s"
+
+
+# Demo of advanced usage with mocked dependencies
+class TestAdvancedToolIsolation:
+    """
+    Demonstrate testing tools that have dependencies on other components.
+
+    This would be useful for tools that call LLMs, access memory, etc.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tool_with_mocked_dependencies(self):
+        """
+        Example of how to test a tool that depends on other components.
+
+        While the calculator tools don't have dependencies, this shows the pattern
+        for tools that do (like tools that call LLMs or access memory).
+        """
+        from aiq.test.tool_test_runner import with_mocked_dependencies
+
+        # This pattern would be used for tools with dependencies:
+        async with with_mocked_dependencies() as (runner, mock_builder):
+            # Mock any dependencies the tool needs
+            mock_builder.mock_llm("gpt-4", "Mocked LLM response")
+            mock_builder.mock_memory_client("user_memory", {"key": "value"})
+
+            # Test the tool with mocked dependencies
+            result = await runner.test_tool_with_builder(
+                config_type=MultiplyToolConfig,  # Using simple tool for demo
+                builder=mock_builder,
+                input_data="2 times 3")
+
+            assert "6" in result
+
+
+if __name__ == "__main__":
+    """
+    Run this file directly to see the tool isolation testing in action:
+
+    python -m pytest examples/simple_calculator/tests/test_tool_isolation.py -v
+    """
+    pytest.main([__file__, "-v"])

--- a/packages/aiqtoolkit_test/src/aiq/test/__init__.py
+++ b/packages/aiqtoolkit_test/src/aiq/test/__init__.py
@@ -1,0 +1,25 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Tool testing utilities
+from .tool_test_runner import ToolTestRunner
+from .tool_test_runner import test_tool
+from .tool_test_runner import with_mocked_dependencies
+
+__all__ = [
+    "ToolTestRunner",
+    "test_tool",
+    "with_mocked_dependencies",
+]

--- a/packages/aiqtoolkit_test/src/aiq/test/tool_test_runner.py
+++ b/packages/aiqtoolkit_test/src/aiq/test/tool_test_runner.py
@@ -1,0 +1,420 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import logging
+import typing
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+
+from aiq.builder.builder import Builder
+from aiq.builder.function import Function
+from aiq.builder.function_info import FunctionInfo
+from aiq.cli.type_registry import GlobalTypeRegistry
+from aiq.data_models.function import FunctionBaseConfig
+from aiq.runtime.loader import PluginTypes
+from aiq.runtime.loader import discover_and_register_plugins
+
+logger = logging.getLogger(__name__)
+
+
+class MockBuilder(Builder):
+    """
+    A lightweight mock builder for tool testing that provides minimal dependencies.
+    """
+
+    def __init__(self):
+        self._functions = {}
+        self._mocks = {}
+
+    def mock_function(self, name: str, mock_response: typing.Any):
+        """Add a mock function that returns a fixed response."""
+        self._mocks[name] = mock_response
+
+    def mock_llm(self, name: str, mock_response: typing.Any):
+        """Add a mock LLM that returns a fixed response."""
+        self._mocks[f"llm_{name}"] = mock_response
+
+    def mock_embedder(self, name: str, mock_response: typing.Any):
+        """Add a mock embedder that returns a fixed response."""
+        self._mocks[f"embedder_{name}"] = mock_response
+
+    def mock_memory_client(self, name: str, mock_response: typing.Any):
+        """Add a mock memory client that returns a fixed response."""
+        self._mocks[f"memory_{name}"] = mock_response
+
+    def mock_retriever(self, name: str, mock_response: typing.Any):
+        """Add a mock retriever that returns a fixed response."""
+        self._mocks[f"retriever_{name}"] = mock_response
+
+    async def add_function(self, name: str, config: FunctionBaseConfig) -> Function:
+        """Mock implementation - not used in tool testing."""
+        raise NotImplementedError("Mock implementation does not support add_function")
+
+    def get_function(self, name: str) -> Function:
+        """Return a mock function if one is configured."""
+        if name in self._mocks:
+            mock_fn = AsyncMock()
+            mock_fn.ainvoke = AsyncMock(return_value=self._mocks[name])
+            return mock_fn
+        raise ValueError(f"Function '{name}' not mocked. Use mock_function() to add it.")
+
+    def get_function_config(self, name: str) -> FunctionBaseConfig:
+        """Mock implementation."""
+        pass
+
+    async def set_workflow(self, config: FunctionBaseConfig) -> Function:
+        """Mock implementation."""
+        pass
+
+    def get_workflow(self) -> Function:
+        """Mock implementation."""
+        pass
+
+    def get_workflow_config(self) -> FunctionBaseConfig:
+        """Mock implementation."""
+        pass
+
+    def get_tool(self, fn_name: str, wrapper_type):
+        """Mock implementation."""
+        pass
+
+    async def add_llm(self, name: str, config):
+        """Mock implementation."""
+        pass
+
+    async def get_llm(self, llm_name: str, wrapper_type):
+        """Return a mock LLM if one is configured."""
+        key = f"llm_{llm_name}"
+        if key in self._mocks:
+            mock_llm = MagicMock()
+            mock_llm.invoke = MagicMock(return_value=self._mocks[key])
+            mock_llm.ainvoke = AsyncMock(return_value=self._mocks[key])
+            return mock_llm
+        raise ValueError(f"LLM '{llm_name}' not mocked. Use mock_llm() to add it.")
+
+    def get_llm_config(self, llm_name: str):
+        """Mock implementation."""
+        pass
+
+    async def add_embedder(self, name: str, config):
+        """Mock implementation."""
+        pass
+
+    async def get_embedder(self, embedder_name: str, wrapper_type):
+        """Return a mock embedder if one is configured."""
+        key = f"embedder_{embedder_name}"
+        if key in self._mocks:
+            mock_embedder = MagicMock()
+            mock_embedder.embed_query = MagicMock(return_value=self._mocks[key])
+            mock_embedder.embed_documents = MagicMock(return_value=self._mocks[key])
+            return mock_embedder
+        raise ValueError(f"Embedder '{embedder_name}' not mocked. Use mock_embedder() to add it.")
+
+    def get_embedder_config(self, embedder_name: str):
+        """Mock implementation."""
+        pass
+
+    async def add_memory_client(self, name: str, config):
+        """Mock implementation."""
+        pass
+
+    def get_memory_client(self, memory_name: str):
+        """Return a mock memory client if one is configured."""
+        key = f"memory_{memory_name}"
+        if key in self._mocks:
+            mock_memory = MagicMock()
+            mock_memory.add = AsyncMock(return_value=self._mocks[key])
+            mock_memory.search = AsyncMock(return_value=self._mocks[key])
+            return mock_memory
+        raise ValueError(f"Memory client '{memory_name}' not mocked. Use mock_memory_client() to add it.")
+
+    def get_memory_client_config(self, memory_name: str):
+        """Mock implementation."""
+        pass
+
+    async def add_retriever(self, name: str, config):
+        """Mock implementation."""
+        pass
+
+    async def get_retriever(self, retriever_name: str, wrapper_type=None):
+        """Return a mock retriever if one is configured."""
+        key = f"retriever_{retriever_name}"
+        if key in self._mocks:
+            mock_retriever = MagicMock()
+            mock_retriever.retrieve = AsyncMock(return_value=self._mocks[key])
+            return mock_retriever
+        raise ValueError(f"Retriever '{retriever_name}' not mocked. Use mock_retriever() to add it.")
+
+    async def get_retriever_config(self, retriever_name: str):
+        """Mock implementation."""
+        pass
+
+    def get_user_manager(self):
+        """Mock implementation."""
+        mock_user = MagicMock()
+        mock_user.get_id = MagicMock(return_value="test_user")
+        return mock_user
+
+    def get_function_dependencies(self, fn_name: str):
+        """Mock implementation."""
+        pass
+
+
+class ToolTestRunner:
+    """
+    A test runner that enables isolated testing of AIQ tools without requiring
+    full workflow setup, LLMs, or complex dependencies.
+
+    Usage:
+        runner = ToolTestRunner()
+
+        # Test a tool with minimal setup
+        result = await runner.test_tool(
+            config_type=MyToolConfig,
+            config_params={"param1": "value1"},
+            input_data="test input"
+        )
+
+        # Test a tool with mocked dependencies
+        async with runner.with_mocks() as mock_builder:
+            mock_builder.mock_llm("my_llm", "mocked response")
+            result = await runner.test_tool(
+                config_type=MyToolConfig,
+                config_params={"llm_name": "my_llm"},
+                input_data="test input"
+            )
+    """
+
+    def __init__(self):
+        self._ensure_plugins_loaded()
+
+    def _ensure_plugins_loaded(self):
+        """Ensure all plugins are loaded for tool registration."""
+        discover_and_register_plugins(PluginTypes.CONFIG_OBJECT)
+
+    async def test_tool(self,
+                        config_type: type[FunctionBaseConfig],
+                        config_params: dict[str, typing.Any] | None = None,
+                        input_data: typing.Any = None,
+                        expected_output: typing.Any = None,
+                        **kwargs) -> typing.Any:
+        """
+        Test a tool in isolation with minimal setup.
+
+        Args:
+            config_type: The tool configuration class
+            config_params: Parameters to pass to the config constructor
+            input_data: Input data to pass to the tool
+            expected_output: Expected output for assertion (optional)
+            **kwargs: Additional parameters
+
+        Returns:
+            The tool's output
+
+        Raises:
+            AssertionError: If expected_output is provided and doesn't match
+            ValueError: If tool registration or execution fails
+        """
+        config_params = config_params or {}
+
+        # Create tool configuration
+        config = config_type(**config_params)
+
+        # Get the registered tool function
+        registry = GlobalTypeRegistry.get()
+        try:
+            tool_registration = registry.get_function(config_type)
+        except KeyError:
+            raise ValueError(
+                f"Tool {config_type} is not registered. Make sure it's imported and registered with @register_function."
+            )
+
+        # Create a mock builder for dependencies
+        mock_builder = MockBuilder()
+
+        # Build the tool function
+        async with tool_registration.build_fn(config, mock_builder) as tool_result:
+
+            # Handle different tool result types
+            if isinstance(tool_result, Function):
+                tool_function = tool_result
+            elif isinstance(tool_result, FunctionInfo):
+                # Extract the actual function from FunctionInfo
+                if tool_result.single_fn:
+                    tool_function = tool_result.single_fn
+                elif tool_result.stream_fn:
+                    tool_function = tool_result.stream_fn
+                else:
+                    raise ValueError("Tool function not found in FunctionInfo")
+            elif callable(tool_result):
+                tool_function = tool_result
+            else:
+                raise ValueError(f"Unexpected tool result type: {type(tool_result)}")
+
+            # Execute the tool
+            if input_data is not None:
+                if asyncio.iscoroutinefunction(tool_function):
+                    result = await tool_function(input_data)
+                else:
+                    result = tool_function(input_data)
+            else:
+                if asyncio.iscoroutinefunction(tool_function):
+                    result = await tool_function()
+                else:
+                    result = tool_function()
+
+            # Assert expected output if provided
+            if expected_output is not None:
+                assert result == expected_output, f"Expected {expected_output}, got {result}"
+
+            return result
+
+    @asynccontextmanager
+    async def with_mocks(self):
+        """
+        Context manager that provides a mock builder for setting up dependencies.
+
+        Usage:
+            async with runner.with_mocks() as mock_builder:
+                mock_builder.mock_llm("my_llm", "mocked response")
+                result = await runner.test_tool_with_builder(
+                    config_type=MyToolConfig,
+                    builder=mock_builder,
+                    input_data="test input"
+                )
+        """
+        mock_builder = MockBuilder()
+        try:
+            yield mock_builder
+        finally:
+            pass
+
+    async def test_tool_with_builder(
+        self,
+        config_type: type[FunctionBaseConfig],
+        builder: MockBuilder,
+        config_params: dict[str, typing.Any] | None = None,
+        input_data: typing.Any = None,
+        expected_output: typing.Any = None,
+    ) -> typing.Any:
+        """
+        Test a tool with a pre-configured mock builder.
+
+        Args:
+            config_type: The tool configuration class
+            builder: Pre-configured MockBuilder with mocked dependencies
+            config_params: Parameters to pass to the config constructor
+            input_data: Input data to pass to the tool
+            expected_output: Expected output for assertion (optional)
+
+        Returns:
+            The tool's output
+        """
+        config_params = config_params or {}
+
+        # Create tool configuration
+        config = config_type(**config_params)
+
+        # Get the registered tool function
+        registry = GlobalTypeRegistry.get()
+        try:
+            tool_registration = registry.get_function(config_type)
+        except KeyError:
+            raise ValueError(
+                f"Tool {config_type} is not registered. Make sure it's imported and registered with @register_function."
+            )
+
+        # Build the tool function with the provided builder
+        async with tool_registration.build_fn(config, builder) as tool_result:
+
+            # Handle different tool result types (same as above)
+            if isinstance(tool_result, Function):
+                tool_function = tool_result
+            elif isinstance(tool_result, FunctionInfo):
+                if tool_result.single_fn:
+                    tool_function = tool_result.single_fn
+                elif tool_result.streaming_fn:
+                    tool_function = tool_result.streaming_fn
+                else:
+                    raise ValueError("Tool function not found in FunctionInfo")
+            elif callable(tool_result):
+                tool_function = tool_result
+            else:
+                raise ValueError(f"Unexpected tool result type: {type(tool_result)}")
+
+            # Execute the tool
+            if input_data is not None:
+                if asyncio.iscoroutinefunction(tool_function):
+                    result = await tool_function(input_data)
+                else:
+                    result = tool_function(input_data)
+            else:
+                if asyncio.iscoroutinefunction(tool_function):
+                    result = await tool_function()
+                else:
+                    result = tool_function()
+
+            # Assert expected output if provided
+            if expected_output is not None:
+                assert result == expected_output, f"Expected {expected_output}, got {result}"
+
+            return result
+
+
+# Convenience functions for simpler usage
+async def test_tool(
+    config_type: type[FunctionBaseConfig],
+    config_params: dict[str, typing.Any] | None = None,
+    input_data: typing.Any = None,
+    expected_output: typing.Any = None,
+) -> typing.Any:
+    """
+    Convenience function to test a tool without creating a ToolTestRunner instance.
+
+    Args:
+        config_type: The tool configuration class
+        config_params: Parameters to pass to the config constructor
+        input_data: Input data to pass to the tool
+        expected_output: Expected output for assertion (optional)
+
+    Returns:
+        The tool's output
+    """
+    runner = ToolTestRunner()
+    return await runner.test_tool(config_type=config_type,
+                                  config_params=config_params,
+                                  input_data=input_data,
+                                  expected_output=expected_output)
+
+
+@asynccontextmanager
+async def with_mocked_dependencies():
+    """
+    Convenience context manager for testing tools with mocked dependencies.
+
+    Usage:
+        async with with_mocked_dependencies() as (runner, mock_builder):
+            mock_builder.mock_llm("my_llm", "mocked response")
+            result = await runner.test_tool_with_builder(
+                config_type=MyToolConfig,
+                builder=mock_builder,
+                input_data="test input"
+            )
+    """
+    runner = ToolTestRunner()
+    async with runner.with_mocks() as mock_builder:
+        yield runner, mock_builder


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Implements a comprehensive tool isolation testing framework that enables developers to test AIQ tools without requiring full workflow setup, LLM connections, or complex dependencies.

This addresses a major developer productivity bottleneck where testing simple tool logic required spinning up entire workflows and external services.

Closes [AIQ-940](https://jirasw.nvidia.com/browse/AIQ-940)

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
