### PR TITLE
Allow non-json string outputs for workflows that use unstructured datasets

### DIFF
--- a/src/aiq/eval/dataset_handler/dataset_handler.py
+++ b/src/aiq/eval/dataset_handler/dataset_handler.py
@@ -152,6 +152,14 @@ class DatasetHandler:
         allow re-running evaluation using the orignal config file and '--skip_workflow' option.
         """
 
+        def parse_if_json_string(value):
+            if isinstance(value, str):
+                try:
+                    return json.loads(value)
+                except json.JSONDecodeError:
+                    return value
+            return value
+
         indent = 2
         if self.is_structured_input():
             # Extract structured data from EvalInputItems
@@ -165,6 +173,6 @@ class DatasetHandler:
             } for item in eval_input.eval_input_items]
         else:
             # Unstructured case: return only raw output objects as a JSON array
-            data = [json.loads(item.output_obj) for item in eval_input.eval_input_items]
+            data = [parse_if_json_string(item.output_obj) for item in eval_input.eval_input_items]
 
         return json.dumps(data, indent=indent, ensure_ascii=False, default=str)

--- a/src/aiq/eval/dataset_handler/dataset_handler.py
+++ b/src/aiq/eval/dataset_handler/dataset_handler.py
@@ -158,6 +158,8 @@ class DatasetHandler:
                     return json.loads(value)
                 except json.JSONDecodeError:
                     return value
+            if hasattr(value, "model_dump"):
+                return value.model_dump()
             return value
 
         indent = 2


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Unstructured datasets were expecting json outputs (overfitted to swe-bench datasets). This change removes the restrictions and allows workflows that use unstructured datasets to return any output object.
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
