### PR TITLE
Add percentile computation (p90, p95, p99) to profiling

### DIFF
--- a/src/aiq/profiler/inference_metrics_model.py
+++ b/src/aiq/profiler/inference_metrics_model.py
@@ -23,3 +23,6 @@ class InferenceMetricsModel(BaseModel):
     ninetieth_interval: tuple[float, float] = Field(default=(0, 0), description="90% confidence interval")
     ninety_fifth_interval: tuple[float, float] = Field(default=(0, 0), description="95% confidence interval")
     ninety_ninth_interval: tuple[float, float] = Field(default=(0, 0), description="99% confidence interval")
+    p90: float = Field(default=0, description="90th percentile of the samples")
+    p95: float = Field(default=0, description="95th percentile of the samples")
+    p99: float = Field(default=0, description="99th percentile of the samples")

--- a/src/aiq/profiler/profile_runner.py
+++ b/src/aiq/profiler/profile_runner.py
@@ -391,7 +391,8 @@ class ProfilerRunner:
 
     def _compute_confidence_intervals(self, data: list[float], metric_name: str) -> InferenceMetricsModel:
         """
-        Helper to compute 90, 95, 99% confidence intervals for the mean of a dataset.
+        Helper to compute 90, 95, 99 % confidence intervals **and** the empirical
+        90th/95th/99th percentiles (p90/p95/p99) for the mean of a dataset.
         Uses a z-score from the normal approximation for large samples.
 
         Returns a dict like::
@@ -409,11 +410,16 @@ class ProfilerRunner:
         n = len(data)
         mean_val = statistics.mean(data)
         if n <= 1:
-            return InferenceMetricsModel(n=n,
-                                         mean=mean_val,
-                                         ninetieth_interval=(mean_val, mean_val),
-                                         ninety_fifth_interval=(mean_val, mean_val),
-                                         ninety_ninth_interval=(mean_val, mean_val))
+            return InferenceMetricsModel(
+                n=n,
+                mean=mean_val,
+                ninetieth_interval=(mean_val, mean_val),
+                ninety_fifth_interval=(mean_val, mean_val),
+                ninety_ninth_interval=(mean_val, mean_val),
+                p90=mean_val,
+                p95=mean_val,
+                p99=mean_val,
+            )
 
         stdev_val = statistics.pstdev(data)  # population stdev or use stdev for sample
         # standard error
@@ -430,4 +436,32 @@ class ProfilerRunner:
         # Optionally, store more info
         intervals["n"] = n
         intervals["mean"] = mean_val
+
+        # ------------------------------------------------------------------
+        # Percentiles
+        # ------------------------------------------------------------------
+        sorted_data = sorted(data)
+
+        def _percentile(arr: list[float], pct: float) -> float:
+            """
+            Linear interpolation between closest ranks.
+            pct is given from 0‑100 (e.g. 90 for p90).
+            """
+            if not arr:
+                return 0.0
+            k = (len(arr) - 1) * (pct / 100.0)
+            f = math.floor(k)
+            c = math.ceil(k)
+            if f == c:
+                return arr[int(k)]
+            return arr[f] + (arr[c] - arr[f]) * (k - f)
+
+        p90_val = _percentile(sorted_data, 90)
+        p95_val = _percentile(sorted_data, 95)
+        p99_val = _percentile(sorted_data, 99)
+
+        intervals["p90"] = p90_val
+        intervals["p95"] = p95_val
+        intervals["p99"] = p99_val
+
         return InferenceMetricsModel(**intervals)

--- a/tests/aiq/profiler/test_percentile_interval_computation.py
+++ b/tests/aiq/profiler/test_percentile_interval_computation.py
@@ -1,0 +1,108 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import statistics
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from aiq.profiler.inference_metrics_model import InferenceMetricsModel
+from aiq.profiler.profile_runner import ProfilerRunner
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+
+def _percentile_reference(arr: list[float], pct: float) -> float:
+    """
+    Reference percentile implementation mirroring the one in
+    _compute_confidence_intervals for cross-checking.
+    * pct is in the range [0, 1] – e.g. 0.90 for p90.
+    """
+    if not arr:
+        return 0.0
+    k = (len(arr) - 1) * pct
+    f = math.floor(k)
+    c = math.ceil(k)
+    if f == c:
+        return arr[int(k)]
+    return arr[f] + (arr[c] - arr[f]) * (k - f)
+
+
+@pytest.fixture
+def runner(tmp_path) -> ProfilerRunner:
+    """A ProfilerRunner pointing at a temp directory."""
+    return ProfilerRunner(MagicMock(), Path(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# tests
+# ---------------------------------------------------------------------------
+
+
+def test_empty_input_returns_defaults(runner: ProfilerRunner):
+    """Empty data → model with default values."""
+    result = runner._compute_confidence_intervals([], "dummy")
+    assert isinstance(result, InferenceMetricsModel)
+    assert result.n == 0
+    assert result.mean == 0
+    assert result.ninetieth_interval == (0, 0)
+    assert result.ninety_fifth_interval == (0, 0)
+    assert result.ninety_ninth_interval == (0, 0)
+    assert result.p90 == 0
+    assert result.p95 == 0
+    assert result.p99 == 0
+
+
+def test_single_value_collapses_intervals_and_percentiles(runner: ProfilerRunner):
+    """Single sample: all intervals collapse to the mean."""
+    value = 5.0
+    res = runner._compute_confidence_intervals([value], "single-point")
+    assert res.n == 1
+    assert res.mean == pytest.approx(value)
+    assert res.ninetieth_interval == (value, value)
+    assert res.ninety_fifth_interval == (value, value)
+    assert res.ninety_ninth_interval == (value, value)
+    assert res.p90 == value
+    assert res.p95 == value
+    assert res.p99 == value
+
+
+def test_multiple_values_compute_correct_stats(runner: ProfilerRunner):
+    """Validate mean, CI bounds, and percentiles for a small dataset."""
+    data = [1, 2, 3, 4, 5]
+    res = runner._compute_confidence_intervals(data, "multi-point")
+
+    # mean
+    expected_mean = statistics.mean(data)
+    assert res.mean == pytest.approx(expected_mean)
+
+    # percentiles
+    sorted_data = sorted(data)
+    assert res.p90 == pytest.approx(_percentile_reference(sorted_data, 0.90))
+    assert res.p95 == pytest.approx(_percentile_reference(sorted_data, 0.95))
+    assert res.p99 == pytest.approx(_percentile_reference(sorted_data, 0.99))
+
+    # 90 % confidence interval bounds
+    stdev_val = statistics.pstdev(data)
+    se = stdev_val / math.sqrt(len(data))
+    z_90 = 1.645
+    lower_90 = expected_mean - z_90 * se
+    upper_90 = expected_mean + z_90 * se
+    assert res.ninetieth_interval[0] == pytest.approx(lower_90)
+    assert res.ninetieth_interval[1] == pytest.approx(upper_90)


### PR DESCRIPTION
Extend the confidence interval calculation to include empirical percentiles (p90, p95, p99) for datasets. Updated the `InferenceMetricsModel` to store these values and added unit tests to validate correctness for various cases.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
