### PR TITLE
Ragas custom evaluation field in evaluator

### DIFF
--- a/src/aiq/eval/rag_evaluator/register.py
+++ b/src/aiq/eval/rag_evaluator/register.py
@@ -136,6 +136,7 @@ async def register_ragas_evaluator(config: RagasEvaluatorConfig, builder: EvalBu
 
     # Create the RAG evaluator
     _evaluator = RAGEvaluator(evaluator_llm=llm, metrics=metrics,
-                              max_concurrency=builder.get_max_concurrency()) if metrics else None
+                              max_concurrency=builder.get_max_concurrency(),
+                              input_obj_field=config.input_obj_field) if metrics else None
 
     yield EvaluatorInfo(config=config, evaluate_fn=evaluate_fn, description="Evaluator for RAGAS metrics")

--- a/src/aiq/eval/rag_evaluator/register.py
+++ b/src/aiq/eval/rag_evaluator/register.py
@@ -47,6 +47,8 @@ class RagasEvaluatorConfig(EvaluatorBaseConfig, name="ragas"):
     # Ragas metric
     metric: str | dict[str, RagasMetricConfig] = Field(default="AnswerAccuracy",
                                                        description="RAGAS metric callable with optional 'kwargs:'")
+    input_obj_field: str | None = Field(
+        default=None, description="The field in the input object that contains the content to evaluate.")
 
     @model_validator(mode="before")
     @classmethod

--- a/src/aiq/eval/rag_evaluator/register.py
+++ b/src/aiq/eval/rag_evaluator/register.py
@@ -135,7 +135,8 @@ async def register_ragas_evaluator(config: RagasEvaluatorConfig, builder: EvalBu
             metrics.append(metric_callable(**kwargs))
 
     # Create the RAG evaluator
-    _evaluator = RAGEvaluator(evaluator_llm=llm, metrics=metrics,
+    _evaluator = RAGEvaluator(evaluator_llm=llm,
+                              metrics=metrics,
                               max_concurrency=builder.get_max_concurrency(),
                               input_obj_field=config.input_obj_field) if metrics else None
 

--- a/tests/aiq/eval/rag_evaluator/test_rag_evaluate.py
+++ b/tests/aiq/eval/rag_evaluator/test_rag_evaluate.py
@@ -27,8 +27,6 @@ from ragas.evaluation import SingleTurnSample
 from ragas.llms import LangchainLLMWrapper
 from ragas.metrics import Metric
 
-from aiq.eval.evaluator.evaluator_model import EvalInput
-from aiq.eval.evaluator.evaluator_model import EvalInputItem
 from aiq.eval.evaluator.evaluator_model import EvalOutput
 from aiq.eval.rag_evaluator.evaluate import RAGEvaluator
 

--- a/tests/aiq/eval/rag_evaluator/test_rag_evaluate.py
+++ b/tests/aiq/eval/rag_evaluator/test_rag_evaluate.py
@@ -14,21 +14,30 @@
 # limitations under the License.
 
 from collections.abc import Sequence
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pandas as pd
 import pytest
+from pydantic import BaseModel
 from ragas.evaluation import EvaluationDataset
 from ragas.evaluation import SingleTurnSample
 from ragas.llms import LangchainLLMWrapper
 from ragas.metrics import Metric
 
+from aiq.eval.evaluator.evaluator_model import EvalInput
+from aiq.eval.evaluator.evaluator_model import EvalInputItem
 from aiq.eval.evaluator.evaluator_model import EvalOutput
 from aiq.eval.rag_evaluator.evaluate import RAGEvaluator
 
 # pylint: disable=redefined-outer-name
+
+
+class ExampleModel(BaseModel):
+    content: str
+    other: str
 
 
 @pytest.fixture
@@ -57,6 +66,12 @@ def rag_evaluator(ragas_judge_llm, ragas_metrics) -> RAGEvaluator:
 @pytest.fixture
 def metric_name() -> str:
     return "AnswerAccuracy"
+
+
+@pytest.fixture
+def rag_evaluator_content(ragas_judge_llm, ragas_metrics) -> RAGEvaluator:
+    """RAGEvaluator configured to extract a specific field (`content`) from BaseModel or dict input objects."""
+    return RAGEvaluator(evaluator_llm=ragas_judge_llm, metrics=ragas_metrics, input_obj_field="content")
 
 
 def test_eval_input_to_ragas(rag_evaluator, rag_eval_input, intermediate_step_adapter):
@@ -223,3 +238,38 @@ async def test_rag_evaluate_failure(rag_evaluator, rag_eval_input, ragas_judge_l
         assert isinstance(output, EvalOutput)
         assert output.average_score == 0.0
         assert output.eval_output_items == []  # No results due to failure
+
+
+def test_extract_input_obj_base_model_with_field(rag_evaluator_content):
+    """Ensure extract_input_obj returns the specified field from a Pydantic BaseModel."""
+    model_obj = ExampleModel(content="hello world", other="ignore me")
+    dummy_item = SimpleNamespace(input_obj=model_obj)
+
+    extracted = rag_evaluator_content.extract_input_obj(dummy_item)
+    assert extracted == "hello world"
+
+
+def test_extract_input_obj_dict_with_field(rag_evaluator_content):
+    """Ensure extract_input_obj returns the specified key when input_obj is a dict."""
+    dict_obj = {"content": "dict hello", "other": 123}
+    dummy_item = SimpleNamespace(input_obj=dict_obj)
+
+    extracted = rag_evaluator_content.extract_input_obj(dummy_item)
+    assert extracted == "dict hello"
+
+
+def test_extract_input_obj_base_model_without_field(rag_evaluator, rag_evaluator_content):
+    """
+    When no input_obj_field is supplied, extract_input_obj should default to the model's JSON.
+    Compare behaviour between default evaluator and one with a field configured.
+    """
+    model_obj = ExampleModel(content="json hello", other="data")
+    dummy_item = SimpleNamespace(input_obj=model_obj)
+
+    extracted_default = rag_evaluator.extract_input_obj(dummy_item)
+    extracted_with_field = rag_evaluator_content.extract_input_obj(dummy_item)
+
+    # Default evaluator returns the full JSON string, evaluator with field returns the field value.
+    assert extracted_with_field == "json hello"
+    assert extracted_default != extracted_with_field
+    assert '"content":"json hello"' in extracted_default  # basic sanity check on JSON output


### PR DESCRIPTION
## Description
Add's a configuration in the RAGAS evaluator that allows users to chose a field in a workflow's output to use for evaluation if a the workflow produces structured output. 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
