### PR TITLE
Draft: Adding LLM retries logic to (tool_calling, react, rewoo) agents

### DIFF
--- a/src/aiq/agent/llm_retry.py
+++ b/src/aiq/agent/llm_retry.py
@@ -1,0 +1,189 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Retry utilities for LLM calls with exponential backoff and jitter."""
+
+import asyncio
+import logging
+import random
+from collections.abc import Callable
+from typing import Any
+
+from langchain_core.messages.base import BaseMessage
+from langchain_core.runnables import RunnableConfig
+
+logger = logging.getLogger(__name__)
+
+# Default retry configuration
+DEFAULT_MAX_RETRIES = 10
+DEFAULT_BASE_DELAY = 1.0  # seconds
+DEFAULT_MAX_DELAY = 60.0  # seconds
+
+
+class LLMRetryConfig:
+    """Configuration for LLM retry behavior."""
+
+    def __init__(self,
+                 max_retries: int = DEFAULT_MAX_RETRIES,
+                 base_delay: float = DEFAULT_BASE_DELAY,
+                 max_delay: float = DEFAULT_MAX_DELAY,
+                 allow_empty_response: bool = False):
+        self.max_retries = max_retries
+        self.base_delay = base_delay
+        self.max_delay = max_delay
+        self.allow_empty_response = allow_empty_response
+
+
+async def retry_llm_ainvoke(
+    llm_call: Callable,
+    messages: list[BaseMessage],
+    config: RunnableConfig,
+    retry_config: LLMRetryConfig | None = None,
+    agent_prefix: str = "Agent"
+) -> Any:
+    """
+    Retry wrapper for LLM ainvoke calls with exponential backoff and jitter.
+
+    Args:
+        llm_call: The LLM ainvoke method to call
+        messages: The messages to pass to the LLM
+        config: The runnable config
+        retry_config: Optional retry configuration
+        agent_prefix: Prefix for logging (e.g., "Tool Calling Agent")
+
+    Returns:
+        The LLM response
+
+    Raises:
+        The last exception if all retries are exhausted
+    """
+    if retry_config is None:
+        retry_config = LLMRetryConfig()
+
+    last_exception = None
+    for attempt in range(retry_config.max_retries):
+        try:
+            response = await llm_call(messages, config=config)
+
+            # Check for empty response
+            if not retry_config.allow_empty_response:
+                # A response is considered empty only if it has no content AND no tool calls
+                has_content = response and response.content and response.content.strip() != ""
+                has_tool_calls = hasattr(response, 'tool_calls') and response.tool_calls
+
+                if not has_content and not has_tool_calls:
+                    raise ValueError("LLM returned empty response (no content and no tool calls)")
+
+            return response
+
+        except Exception as e:
+            last_exception = e
+            logger.warning(
+                "%s LLM invocation failed (attempt %d/%d): %s: %s",
+                agent_prefix,
+                attempt + 1,
+                retry_config.max_retries,
+                type(e).__name__,
+                str(e)
+            )
+
+            # If this is the last attempt, raise the exception
+            if attempt >= retry_config.max_retries - 1:
+                logger.error("%s All %d retry attempts failed", agent_prefix, retry_config.max_retries)
+                raise
+
+            # Calculate delay with exponential backoff plus jitter
+            delay = min(
+                retry_config.base_delay * (2 ** attempt) + random.uniform(0, 1),
+                retry_config.max_delay
+            )
+            logger.info("%s Retrying in %.1f seconds...", agent_prefix, delay)
+            await asyncio.sleep(delay)
+
+    # Just in case
+    raise last_exception or RuntimeError("Unexpected: Exited retry loop without returning")
+
+
+async def retry_llm_astream(
+    llm_stream_call: Callable,
+    input_data: dict,
+    config: RunnableConfig,
+    retry_config: LLMRetryConfig | None = None,
+    agent_prefix: str = "Agent"
+) -> str:
+    """
+    Retry wrapper for LLM astream calls with exponential backoff and jitter.
+
+    Args:
+        llm_stream_call: The LLM astream method to call
+        input_data: The input dictionary to pass to the LLM
+        config: The runnable config
+        retry_config: Optional retry configuration
+        agent_prefix: Prefix for logging (e.g., "ReAct Agent")
+
+    Returns:
+        The accumulated string response from the stream
+
+    Raises:
+        The last exception if all retries are exhausted
+    """
+    if retry_config is None:
+        retry_config = LLMRetryConfig()
+
+    last_exception = None
+
+    for attempt in range(retry_config.max_retries):
+        try:
+            output_message = ""
+            async for event in llm_stream_call(input_data, config=config):
+                # Handle different event types - could be string or object with content
+                if hasattr(event, 'content'):
+                    output_message += event.content
+                else:
+                    output_message += str(event)
+
+            # Check for empty response
+            # Note: Tool calls are typically not available in streaming mode
+            if not retry_config.allow_empty_response and output_message.strip() == "":
+                raise ValueError("LLM returned empty response")
+
+            return output_message
+
+        except Exception as e:
+            last_exception = e
+            logger.warning(
+                "%s LLM streaming invocation failed (attempt %d/%d): %s: %s",
+                agent_prefix,
+                attempt + 1,
+                retry_config.max_retries,
+                type(e).__name__,
+                str(e)
+            )
+
+            # If this is the last attempt, raise the exception
+            if attempt >= retry_config.max_retries - 1:
+                logger.error("%s All %d retry attempts failed", agent_prefix, retry_config.max_retries)
+                raise
+
+            # Calculate delay with exponential backoff plus jitter
+            delay = min(
+                retry_config.base_delay * (2 ** attempt) + random.uniform(0, 1),
+                retry_config.max_delay
+            )
+            logger.info("%s Retrying in %.1f seconds...", agent_prefix, delay)
+            await asyncio.sleep(delay)
+
+    # Just in case
+    raise last_exception or RuntimeError("Unexpected: Exited retry loop without returning")

--- a/src/aiq/agent/react_agent/register.py
+++ b/src/aiq/agent/react_agent/register.py
@@ -28,6 +28,7 @@ from aiq.data_models.component_ref import FunctionRef
 from aiq.data_models.component_ref import LLMRef
 from aiq.data_models.function import FunctionBaseConfig
 from aiq.utils.type_converter import GlobalTypeConverter
+from aiq.agent.llm_retry import LLMRetryConfig
 
 logger = logging.getLogger(__name__)
 
@@ -57,6 +58,11 @@ class ReActAgentWorkflowConfig(FunctionBaseConfig, name="react_agent"):
                                               "If False, strings will be used."))
     additional_instructions: str | None = Field(
         default=None, description="Additional instructions to provide to the agent in addition to the base prompt.")
+    # LLM retry configuration
+    llm_max_retries: int = Field(default=10, description="Maximum number of retries for LLM calls on failure.")
+    llm_retry_base_delay: float = Field(default=1.0, description="Base delay in seconds for exponential backoff.")
+    llm_retry_max_delay: float = Field(default=60.0, description="Maximum delay in seconds between retries.")
+    allow_empty_response: bool = Field(default=False, description="Allow LLM to return empty responses without retrying.")
 
 
 @register_function(config_type=ReActAgentWorkflowConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
@@ -78,6 +84,15 @@ async def react_agent_workflow(config: ReActAgentWorkflowConfig, builder: Builde
     tools = builder.get_tools(tool_names=config.tool_names, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
     if not tools:
         raise ValueError(f"No tools specified for ReAct Agent '{config.llm_name}'")
+
+    # Create retry configuration from config parameters
+    llm_retry_config = LLMRetryConfig(
+        max_retries=config.llm_max_retries,
+        base_delay=config.llm_retry_base_delay,
+        max_delay=config.llm_retry_max_delay,
+        allow_empty_response=config.allow_empty_response
+    )
+
     # configure callbacks, for sending intermediate steps
     # construct the ReAct Agent Graph from the configured llm, prompt, and tools
     graph: CompiledGraph = await ReActAgentGraph(llm=llm,
@@ -86,7 +101,8 @@ async def react_agent_workflow(config: ReActAgentWorkflowConfig, builder: Builde
                                                  use_tool_schema=config.include_tool_input_schema_in_tool_description,
                                                  detailed_logs=config.verbose,
                                                  retry_parsing_errors=config.retry_parsing_errors,
-                                                 max_retries=config.max_retries).build_graph()
+                                                 max_retries=config.max_retries,
+                                                 llm_retry_config=llm_retry_config).build_graph()
 
     async def _response_fn(input_message: AIQChatRequest) -> AIQChatResponse:
         try:


### PR DESCRIPTION
## Description
Adds helper wrappers for agents that allow for a simple exponential jittered backoff retries for LLM calls, making agents (`tool_calling`, `react`, `rewoo`) more robust. This is an **example, draft PR** which provides a working, but limited solution. Ideal solution should be framework-wide as described in the issue.
Closes #434 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
