### PR TITLE
Removes redundant config variable from Retry Agent Function.

### DIFF
--- a/examples/intermediate/HITL/simple_calculator_hitl/src/aiq_simple_calculator_hitl/retry_react_agent.py
+++ b/examples/intermediate/HITL/simple_calculator_hitl/src/aiq_simple_calculator_hitl/retry_react_agent.py
@@ -54,12 +54,12 @@ async def retry_react_agent(config: RetryReactAgentConfig, builder: Builder):
 
     from langgraph.errors import GraphRecursionError
 
-    from aiq.agent.react_agent.register import ReActAgentWorkflowConfig
     from aiq.builder.function import Function
 
     # Get references to the underlying React agent and approval function
     react_agent: Function = builder.get_function(config.react_agent_fn)
-    react_agent_config: ReActAgentWorkflowConfig = builder.get_function_config(config.react_agent_fn)
+    react_agent_config: FunctionBaseConfig = builder.get_function_config(
+        config.react_agent_fn)  # ReActAgentWorkflowConfig
     hitl_approval_fn: Function = builder.get_function(config.hitl_approval_fn)
 
     # Regex pattern to detect GraphRecursionError message
@@ -108,10 +108,9 @@ async def retry_react_agent(config: RetryReactAgentConfig, builder: Builder):
                 await temp_builder.add_function(tool_name, tool_config)
 
             # Create the retry agent with the original configuration
-            retry_agent = await temp_builder.add_function("retry_agent", retry_config)
-            retry_agent_config = temp_builder.get_function_config("retry_agent")
+            temp_retry_agent = await temp_builder.add_function("retry_agent", retry_config)
 
-            return retry_agent, retry_agent_config
+            return temp_retry_agent, retry_config
 
     async def handle_recursion_error(input_message: AIQChatRequest) -> AIQChatResponse:
         """


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This pull request removes the redundant `retry_agent_config` variable to eliminate confusion caused by returning the unnecessary value.
Closes [AIQ-1553](https://jirasw.nvidia.com/browse/AIQ-1553)

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
