### PR TITLE
Update `async_otel_listener` to skip processing events if `opentelemetry` is not installed

### DIFF
--- a/src/aiq/observability/async_otel_listener.py
+++ b/src/aiq/observability/async_otel_listener.py
@@ -175,8 +175,8 @@ class AsyncOtelSpanListener:
         # Skip processing if OpenTelemetry is not properly installed (using dummy implementations)
         if self._is_using_dummy_implementations:
             if not self._skip_warning_logged:
-                logger.debug("Skipping OpenTelemetry event processing because OpenTelemetry is not installed. "
-                             "Install with: pip install opentelemetry-api opentelemetry-sdk")
+                logger.warning("Skipping OpenTelemetry event processing because OpenTelemetry is not installed. "
+                               "Install with: pip install opentelemetry-api opentelemetry-sdk")
                 self._skip_warning_logged = True
             return
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes AIQ-1550.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
