### PR TITLE
Revert `simple_web_query` examples' file paths in preparation for move to categorized folders

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,13 +25,13 @@ Each NVIDIA Agent Intelligence (AIQ) toolkit example demonstrates a particular f
 - **[`scaffolding`](getting_started/scaffolding/)**: Workflow scaffolding and project generation using automated commands and intelligent code generation
 - **[`simple_web_query`](getting_started/simple_web_query/)**: Basic LangSmith documentation agent that searches the internet to answer questions about LangSmith.
 - **[`simple_calculator`](getting_started/simple_calculator/)**: Mathematical agent with tools for arithmetic operations, time comparison, and complex calculations
-- **[`simple_rag`](getting_started/simple_rag/)**: Simple demonstration of using Retrieval Augmented Generation (RAG) with a vector database and document ingestion.
+- **[`simple_rag`](rag/simple_rag/)**: Simple demonstration of using Retrieval Augmented Generation (RAG) with a vector database and document ingestion.
 
 ### Custom Functions ([`custom_functions`](custom_functions/))
 - **[`automated_description_generation`](custom_functions/automated_description_generation/)**: Intelligent system that automatically generates descriptions for vector database collections by sampling and summarizing documents
 - **[`plot_charts`](custom_functions/plot_charts/)**: Multi-agent chart plotting system that routes requests to create different chart types (line, bar, etc.) from data
-- **[`simple_calculator`](custom_functions/simple_calculator/)**: Mathematical agent with tools for arithmetic operations, time comparison, and complex calculations
-- **[`por_to_jiratickets`](custom_functions/por_to_jiratickets/)**: Project requirements to Jira ticket conversion with human oversight
+- **[`simple_calculator`](getting_started/simple_calculator/)**: Mathematical agent with tools for arithmetic operations, time comparison, and complex calculations
+- **[`por_to_jiratickets`](HITL/por_to_jiratickets/)**: Project requirements to Jira ticket conversion with human oversight
 
 ### Frameworks ([`frameworks`](frameworks/))
 - **[`agno_personal_finance`](frameworks/agno_personal_finance/)**: Personal finance planning agent built with Agno framework that researches and creates tailored financial plans
@@ -48,7 +48,7 @@ Each NVIDIA Agent Intelligence (AIQ) toolkit example demonstrates a particular f
 - **[`simple_calculator_custom_routes`](front_ends/simple_calculator_custom_routes/)**: Simple calculator example with custom API routing and endpoint configuration
 
 ### Human In The Loop (HITL) ([`HITL`](HITL/))
-- **[`por_to_jiratickets`](custom_functions/por_to_jiratickets/)**: Project requirements to Jira ticket conversion with human oversight
+- **[`por_to_jiratickets`](HITL/por_to_jiratickets/)**: Project requirements to Jira ticket conversion with human oversight
 - **[`simple_calculator_hitl`](HITL/simple_calculator_hitl/)**: Human-in-the-loop version of the basic simple calculator that requests approval from the user before allowing the agent to make additional tool calls.
 
 ### MCP ([`MCP`](MCP/))
@@ -57,14 +57,14 @@ Each NVIDIA Agent Intelligence (AIQ) toolkit example demonstrates a particular f
 ### Observability ([`observability`](observability/))
 - **[`redact_pii`](observability/redact_pii/)**: Demonstrates how to use Weights & Biases (W&B) Weave with PII redaction
 - **[`simple_calculator_observability`](observability/simple_calculator_observability/)**: Basic simple calculator with integrated monitoring, telemetry, and observability features
-- **[`alert_triage_agent`](observability/alert_triage_agent/)**: Production-ready intelligent alert triage system using LangGraph that automates system monitoring diagnostics with tools for hardware checks, network connectivity, performance analysis, and generates structured triage reports with root cause categorization
-- **[`profiler_agent`](observability/profiler_agent/)**: Performance profiling agent for analyzing AIQ toolkit workflow performance and bottlenecks using Phoenix observability server with comprehensive metrics collection and analysis
-- **[`email_phishing_analyzer`](observability/email_phishing_analyzer/)**: Security-focused email analysis system that detects phishing attempts using multiple LLMs, including its evaluation and profiling configurations
-- **[`text_file_ingest`](observability/text_file_ingest/)**: Text file processing and ingestion pipeline for document workflows
+- **[`alert_triage_agent`](advanced_agents/alert_triage_agent/)**: Production-ready intelligent alert triage system using LangGraph that automates system monitoring diagnostics with tools for hardware checks, network connectivity, performance analysis, and generates structured triage reports with root cause categorization
+- **[`profiler_agent`](advanced_agents/profiler_agent/)**: Performance profiling agent for analyzing AIQ toolkit workflow performance and bottlenecks using Phoenix observability server with comprehensive metrics collection and analysis
+- **[`email_phishing_analyzer`](evaluation_and_profiling/email_phishing_analyzer/)**: Security-focused email analysis system that detects phishing attempts using multiple LLMs, including its evaluation and profiling configurations
+- **[`text_file_ingest`](documentation_guides/workflows/text_file_ingest/)**: Text file processing and ingestion pipeline for document workflows
 
 ### Memory ([`memory`](memory/))
-- **[`simple_rag`](memory/simple_rag/)**: Complete RAG system with Milvus vector database, document ingestion, and long-term memory using Mem0 platform
-- **[`semantic_kernel_demo`](memory/semantic_kernel_demo/)**: Multi-agent travel planning system using Microsoft Semantic Kernel with specialized agents for itinerary creation, budget management, and report formatting, including long-term memory for user preferences
+- **[`simple_rag`](RAG/simple_rag/)**: Complete RAG system with Milvus vector database, document ingestion, and long-term memory using Mem0 platform
+- **[`semantic_kernel_demo`](frameworks/semantic_kernel_demo/)**: Multi-agent travel planning system using Microsoft Semantic Kernel with specialized agents for itinerary creation, budget management, and report formatting, including long-term memory for user preferences
 
 ### RAG ([`RAG`](RAG/))
 - **[`simple_rag`](RAG/simple_rag/)**: Complete RAG system with Milvus vector database, document ingestion, and long-term memory using Mem0 platform
@@ -73,9 +73,9 @@ Each NVIDIA Agent Intelligence (AIQ) toolkit example demonstrates a particular f
 - **[`swe_bench`](evaluation_and_profiling/swe_bench/)**: Software engineering benchmark system for evaluating AI models on real-world coding tasks
 - **[`simple_calculator_eval`](evaluation_and_profiling/simple_calculator_eval/)**: Evaluation and profiling configurations based on the basic simple calculator example
 - **[`simple_web_query_eval`](evaluation_and_profiling/simple_web_query_eval/)**: Evaluation and profiling configurations based on the basic simple web query example
-- **[`alert_triage_agent`](evaluation_and_profiling/alert_triage_agent/)**: Evaluation and profiling configurations for the alert triage agent example
+- **[`alert_triage_agent`](advanced_agents/alert_triage_agent/)**: Evaluation and profiling configurations for the alert triage agent example
 - **[`email_phishing_analyzer`](evaluation_and_profiling/email_phishing_analyzer/)**: Evaluation and profiling configurations for the email phishing analyzer example
-- **[`text_file_ingest`](evaluation_and_profiling/text_file_ingest/)**: Evaluation and profiling configurations for the text file ingestion example
+- **[`text_file_ingest`](documentation_guides/workflows/text_file_ingest/)**: Evaluation and profiling configurations for the text file ingestion example
 
 ## Advanced Agents ([`advanced_agents`](advanced_agents/))
 - **[`alert_triage_agent`](advanced_agents/alert_triage_agent/)**: Production-ready intelligent alert triage system using LangGraph that automates system monitoring diagnostics with tools for hardware checks, network connectivity, performance analysis, and generates structured triage reports with root cause categorization
@@ -85,7 +85,7 @@ Each NVIDIA Agent Intelligence (AIQ) toolkit example demonstrates a particular f
 ### Documentation Guides ([`documentation_guides`](documentation_guides/))
 - **[`locally_hosted_llms`](documentation_guides/locally_hosted_llms/)**: Configuration examples for the basic simple LangSmith agent using locally hosted LLM models (NIM and vLLM configurations)
 - **[`workflows`](documentation_guides/workflows/)**: Workflow examples for documentation and tutorials:
-  - [`custom_workflow`](documentation_guides/workflows/custom_workflow/): Extended version of the basic simple example with multiple documentation sources (LangSmith and LangGraph)
-  - [`text_file_ingest`](documentation_guides/workflows/text_file_ingest/): Text file processing and ingestion pipeline for document workflows
+  - **[`custom_workflow`](documentation_guides/workflows/custom_workflow/)**: Extended version of the basic simple example with multiple documentation sources (LangSmith and LangGraph)
+  - **[`text_file_ingest`](documentation_guides/workflows/text_file_ingest/)**: Text file processing and ingestion pipeline for document workflows
 
 To run the examples, install the AIQ toolkit from source, if you haven't already done so, by following the instructions in  [Install From Source](../docs/source/quick-start/installing.md#install-from-source) .

--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@ Each NVIDIA Agent Intelligence (AIQ) toolkit example demonstrates a particular f
 - **[`scaffolding`](getting_started/scaffolding/)**: Workflow scaffolding and project generation using automated commands and intelligent code generation
 - **[`simple_web_query`](getting_started/simple_web_query/)**: Basic LangSmith documentation agent that searches the internet to answer questions about LangSmith.
 - **[`simple_calculator`](getting_started/simple_calculator/)**: Mathematical agent with tools for arithmetic operations, time comparison, and complex calculations
-- **[`simple_rag`](rag/simple_rag/)**: Simple demonstration of using Retrieval Augmented Generation (RAG) with a vector database and document ingestion.
+- **[`simple_rag`](RAG/simple_rag/)**: Simple demonstration of using Retrieval Augmented Generation (RAG) with a vector database and document ingestion.
 
 ### Custom Functions ([`custom_functions`](custom_functions/))
 - **[`automated_description_generation`](custom_functions/automated_description_generation/)**: Intelligent system that automatically generates descriptions for vector database collections by sampling and summarizing documents

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -1,0 +1,1 @@
+Placeholder for memory examples.

--- a/examples/memory/README.md
+++ b/examples/memory/README.md
@@ -1,1 +1,18 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
 Placeholder for memory examples.

--- a/examples/src/simple_web_query/Dockerfile
+++ b/examples/src/simple_web_query/Dockerfile
@@ -51,10 +51,10 @@ RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \
     export SETUPTOOLS_SCM_PRETEND_VERSION_FOR_AIQ_SIMPLE=${AIQ_VERSION} && \
     uv venv --python ${PYTHON_VERSION} /workspace/.venv && \
     uv sync --link-mode=copy --compile-bytecode --python ${PYTHON_VERSION} && \
-    uv pip install --link-mode=copy ./examples/src/simple_web_query
+    uv pip install --link-mode=copy ./examples/getting_started/simple_web_query
 
 # Set the config file environment variable
-ENV AIQ_CONFIG_FILE=/workspace/examples/src/simple_web_query/configs/config.yml
+ENV AIQ_CONFIG_FILE=/workspace/examples/getting_started/simple_web_query/configs/config.yml
 
 # Enivronment variables for the venv
 ENV PATH="/workspace/.venv/bin:$PATH"

--- a/examples/src/simple_web_query/README.md
+++ b/examples/src/simple_web_query/README.md
@@ -46,7 +46,7 @@ If you have not already done so, follow the instructions in the [Install Guide](
 From the root directory of the AIQ toolkit library, run the following commands:
 
 ```bash
-uv pip install -e examples/src/simple_web_query
+uv pip install -e examples/getting_started/simple_web_query
 ```
 
 ### Set Up API Keys
@@ -61,15 +61,15 @@ export NVIDIA_API_KEY=<YOUR_API_KEY>
 Run the following command from the root of the AIQ toolkit repo to execute this workflow with the specified input:
 
 ```bash
-aiq run --config_file examples/src/simple_web_query/configs/config.yml --input "What is LangSmith?"
+aiq run --config_file examples/getting_started/simple_web_query/configs/config.yml --input "What is LangSmith?"
 ```
 
 **Expected Output**
 
 ```console
-aiq run --config_file examples/src/simple_web_query/configs/config.yml --input "What is LangSmith?"
+aiq run --config_file examples/getting_started/simple_web_query/configs/config.yml --input "What is LangSmith?"
 2025-07-18 13:54:37,355 - aiq.runtime.loader - WARNING - Loading module 'aiq.agent.register' from entry point 'aiq_agents' took a long time (474.130869 ms). Ensure all imports are inside your registered functions.
-2025-07-18 13:54:37,503 - aiq.cli.commands.start - INFO - Starting AIQ Toolkit from config file: 'examples/src/simple_web_query/configs/config.yml'
+2025-07-18 13:54:37,503 - aiq.cli.commands.start - INFO - Starting AIQ Toolkit from config file: 'examples/getting_started/simple_web_query/configs/config.yml'
 2025-07-18 13:54:37,506 - aiq.cli.commands.start - WARNING - The front end type in the config file (fastapi) does not match the command name (console). Overwriting the config file front end.
 2025-07-18 13:54:37,524 - aiq.profiler.utils - WARNING - Discovered frameworks: {<LLMFrameworkEnum.LANGCHAIN: 'langchain'>} in function webquery_tool by inspecting source. It is recommended and more reliable to instead add the used LLMFrameworkEnum types in the framework_wrappers argument when calling @register_function.
 2025-07-18 13:54:37,566 - langchain_community.utils.user_agent - WARNING - USER_AGENT environment variable not set, consider setting it to identify your requests.
@@ -147,7 +147,7 @@ export NVIDIA_API_KEY="your_nvidia_api_key"
 From the git repository root, run the following command to build AIQ toolkit and the simple agent into a Docker image.
 
 ```bash
-docker build --build-arg AIQ_VERSION=$(python -m setuptools_scm) -f examples/src/simple_web_query/Dockerfile -t simple-web-query-agent .
+docker build --build-arg AIQ_VERSION=$(python -m setuptools_scm) -f examples/getting_started/simple_web_query/Dockerfile -t simple-web-query-agent .
 ```
 
 Then, run the following command to run the simple agent.

--- a/examples/src/simple_web_query_eval/README.md
+++ b/examples/src/simple_web_query_eval/README.md
@@ -44,7 +44,7 @@ This example builds upon the [basic Simple LangSmith-Documentation Agent](../sim
 Install this evaluation example:
 
 ```bash
-uv pip install -e examples/src/simple_web_query_eval
+uv pip install -e examples/evaluation_and_profiling/simple_web_query_eval
 ```
 
 ## Usage
@@ -64,32 +64,32 @@ Evaluate the Simple LangSmith-Documentation agent's accuracy using different con
 
 #### Basic Evaluation
 ```bash
-aiq eval --config_file examples/src/simple_web_query_eval/configs/eval_config.yml
+aiq eval --config_file examples/evaluation_and_profiling/simple_web_query_eval/configs/eval_config.yml
 ```
 
 #### OpenAI Model Evaluation
 ```bash
-aiq eval --config_file examples/src/simple_web_query_eval/configs/eval_config_openai.yml
+aiq eval --config_file examples/evaluation_and_profiling/simple_web_query_eval/configs/eval_config_openai.yml
 ```
 
 #### Llama 3.1 Model Evaluation
 ```bash
-aiq eval --config_file examples/src/simple_web_query_eval/configs/eval_config_llama31.yml
+aiq eval --config_file examples/evaluation_and_profiling/simple_web_query_eval/configs/eval_config_llama31.yml
 ```
 
 #### Llama 3.3 Model Evaluation
 ```bash
-aiq eval --config_file examples/src/simple_web_query_eval/configs/eval_config_llama33.yml
+aiq eval --config_file examples/evaluation_and_profiling/simple_web_query_eval/configs/eval_config_llama33.yml
 ```
 
 #### Evaluation-Only Mode
 ```bash
-aiq eval --skip_workflow --config_file examples/src/simple_web_query_eval/configs/eval_only_config.yml --dataset ./.tmp/aiq/examples/src/simple_web_query_eval/eval/workflow_output.json
+aiq eval --skip_workflow --config_file examples/evaluation_and_profiling/simple_web_query_eval/configs/eval_only_config.yml --dataset ./.tmp/aiq/examples/evaluation_and_profiling/simple_web_query_eval/eval/workflow_output.json
 ```
 
 #### Evaluation with Upload
 ```bash
-aiq eval --config_file examples/src/simple_web_query_eval/configs/eval_upload.yml
+aiq eval --config_file examples/evaluation_and_profiling/simple_web_query_eval/configs/eval_upload.yml
 ```
 
 ### Understanding Results

--- a/examples/src/simple_web_query_eval/pyproject.toml
+++ b/examples/src/simple_web_query_eval/pyproject.toml
@@ -19,4 +19,4 @@ classifiers = ["Programming Language :: Python"]
 
 [tool.uv.sources]
 aiqtoolkit = { path = "../../..", editable = true }
-aiq_simple_web_query = { path = "../../src/simple_web_query", editable = true }
+aiq_simple_web_query = { path = "../../getting_started/simple_web_query", editable = true }

--- a/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_config.yml
+++ b/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_config.yml
@@ -57,11 +57,11 @@ workflow:
 eval:
   general:
     output:
-      dir: ./.tmp/aiq/examples/src/simple_web_query_eval/eval/
+      dir: ./.tmp/aiq/examples/evaluation_and_profiling/simple_web_query_eval/eval/
       cleanup: true
     dataset:
       _type: json
-      file_path: examples/src/simple_web_query_eval/data/langsmith.json
+      file_path: examples/evaluation_and_profiling/simple_web_query_eval/data/langsmith.json
     profiler:
       # Compute inter query token uniqueness
       token_uniqueness_forecast: true

--- a/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_config_llama31.yml
+++ b/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_config_llama31.yml
@@ -63,11 +63,11 @@ eval:
   general:
     workflow_alias: nat-simple-llama-31-8b
     output:
-      dir: ./.tmp/aiq/examples/src/simple_web_query_eval/llama-31-8b
+      dir: ./.tmp/aiq/examples/evaluation_and_profiling/simple_web_query_eval/llama-31-8b
       cleanup: true
     dataset:
       _type: json
-      file_path: examples/src/simple_web_query_eval/data/langsmith.json
+      file_path: examples/evaluation_and_profiling/simple_web_query_eval/data/langsmith.json
     profiler:
       base_metrics: true
 

--- a/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_config_llama33.yml
+++ b/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_config_llama33.yml
@@ -63,11 +63,11 @@ eval:
   general:
     workflow_alias: nat-simple-llama-33-70b
     output:
-      dir: ./.tmp/aiq/examples/src/simple_web_query_eval/llama-33-70b
+      dir: ./.tmp/aiq/examples/evaluation_and_profiling/simple_web_query_eval/llama-33-70b
       cleanup: true
     dataset:
       _type: json
-      file_path: examples/src/simple_web_query_eval/data/langsmith.json
+      file_path: examples/evaluation_and_profiling/simple_web_query_eval/data/langsmith.json
     profiler:
       base_metrics: true
 

--- a/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_config_openai.yml
+++ b/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_config_openai.yml
@@ -63,11 +63,11 @@ eval:
   general:
     workflow_alias: nat-simple-gpt-4o-mini
     output:
-      dir: ./.tmp/aiq/examples/src/simple_web_query_eval/openai/
+      dir: ./.tmp/aiq/examples/evaluation_and_profiling/simple_web_query_eval/openai/
       cleanup: true
     dataset:
       _type: json
-      file_path: examples/src/simple_web_query_eval/data/langsmith.json
+      file_path: examples/evaluation_and_profiling/simple_web_query_eval/data/langsmith.json
     profiler:
       # Compute inter query token uniqueness
       token_uniqueness_forecast: true

--- a/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_only_config.yml
+++ b/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_only_config.yml
@@ -31,11 +31,11 @@ llms:
 eval:
   general:
     output:
-      dir: ./.tmp/aiq/examples/src/simple_web_query_eval/eval_only/
+      dir: ./.tmp/aiq/examples/evaluation_and_profiling/simple_web_query_eval/eval_only/
       cleanup: true
     dataset:
       _type: json
-      file_path: examples/src/simple_web_query_eval/data/langsmith.json
+      file_path: examples/evaluation_and_profiling/simple_web_query_eval/data/langsmith.json
     profiler:
       # Compute inter query token uniqueness
       token_uniqueness_forecast: true

--- a/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_upload.yml
+++ b/examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/configs/eval_upload.yml
@@ -62,13 +62,13 @@ workflow:
 eval:
   general:
     output:
-      dir: ./.tmp/aiq/examples/src/simple_web_query_eval/upload/
+      dir: ./.tmp/aiq/examples/evaluation_and_profiling/simple_web_query_eval/upload/
       remote_dir: output
       # Whether to cleanup the output directory before running the workflow
       cleanup: true
       custom_scripts:
         convert_workflow_to_csv:
-          script: examples/src/simple_web_query_eval/src/aiq_simple_web_query_eval/scripts/workflow_to_csv.py
+          script: examples/evaluation_and_profiling/simple_web_query_eval/src/aiq_simple_web_query_eval/scripts/workflow_to_csv.py
           kwargs:
             # input and output files here are relative to the output dir
             input: workflow_output.json
@@ -81,7 +81,7 @@ eval:
     dataset:
       _type: json
       remote_file_path: input/langsmith.json
-      file_path: ./.tmp/aiq/examples/simple_input/langsmith.json
+      file_path: ./.tmp/aiq/examples/evaluation_and_profiling/simple_web_query_eval/data/langsmith.json
       s3:
         endpoint_url: http://10.185.X.X:9000
         bucket: aiq-simple-bucket

--- a/uv.lock
+++ b/uv.lock
@@ -476,7 +476,7 @@ requires-dist = [{ name = "aiqtoolkit", extras = ["ingestion", "langchain", "mem
 
 [[package]]
 name = "aiq-simple-web-query"
-source = { editable = "examples/src/simple_web_query" }
+source = { editable = "examples/getting_started/simple_web_query" }
 dependencies = [
     { name = "aiqtoolkit", extra = ["langchain", "telemetry"] },
     { name = "faiss-cpu" },
@@ -499,7 +499,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiq-simple-web-query", editable = "examples/src/simple_web_query" },
+    { name = "aiq-simple-web-query", editable = "examples/getting_started/simple_web_query" },
     { name = "aiqtoolkit", extras = ["langchain"], editable = "." },
 ]
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR reverts the file paths of `simple_web_query` and `simple_web_query_eval` to their corresponding planned categorized example folders.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
