### PR TITLE
Fix: Docker setup and configuration for deploying external MCP

### DIFF
--- a/examples/getting_started/simple_calculator/deploy_external_mcp/Dockerfile
+++ b/examples/getting_started/simple_calculator/deploy_external_mcp/Dockerfile
@@ -19,7 +19,7 @@ FROM ubuntu:22.04
 RUN apt-get update && apt-get upgrade -y && apt install -y python3 python3-pip
 
 # Install MCP proxy and tools
-RUN pip3 install uv uvx
+RUN pip3 install uv uvenv
 
 RUN pip3 install "mcp==1.5.0"
 RUN pip3 install "mcp-proxy==0.5.1"

--- a/examples/getting_started/simple_calculator/deploy_external_mcp/README.md
+++ b/examples/getting_started/simple_calculator/deploy_external_mcp/README.md
@@ -30,13 +30,16 @@ This example uses the `mcp-server-time` service. For a list of available public 
 
 ## Setup
 
-1. Change the service name and brief name to the service you want to use.
+1. Change the service name and brief name to the service you want to use. Additionally specify any optional service arguments.
 
 ```bash
 # This should be the name of the MCP service you want to use.
 export SERVICE_NAME=mcp-server-time
 # This can be any name you want to give to your service.
 export SERVICE_BRIEF_NAME=time
+# Any arguments to pass to the service. Example: `mcp-server-time` requires --local-timezone if the container's timezone hasn't been configured.
+export SERVICE_ARGS=--local-timezone "America/New_York"
+
 ```
 
 2. Set the service directory, server port, and container name.
@@ -51,7 +54,7 @@ export SERVER_PORT=8080
 
 ```bash
 mkdir -p ${SERVICE_DIR}
-cp examples/getting_started/simple_web_query/deploy_external_mcp/Dockerfile ${SERVICE_DIR}/
+cp examples/getting_started/simple_calculator/deploy_external_mcp/Dockerfile ${SERVICE_DIR}/
 ```
 
 4. Create the run script:
@@ -59,7 +62,7 @@ cp examples/getting_started/simple_web_query/deploy_external_mcp/Dockerfile ${SE
 ```bash
 cat > ${SERVICE_DIR}/run_service.sh <<EOF
 #!/bin/bash
-uvx run ${SERVICE_NAME}
+uvx ${SERVICE_NAME} ${SERVICE_ARGS}
 EOF
 
 chmod +x ${SERVICE_DIR}/run_service.sh


### PR DESCRIPTION
## Description
* Remove deprecated package of `uvx` within container
* Update MCP setup directions to include optional `$SERVICE_ARGS`
* Ensure that timezone is specified for provided example

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
