### PR TITLE
Enhancement: prefer JSON data for semantic kernel example 

### DIFF
--- a/examples/frameworks/semantic_kernel_demo/data/local_events.json
+++ b/examples/frameworks/semantic_kernel_demo/data/local_events.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:e9fe6cd6942cfb26412ca3e176e85cd9760a0339763f0480f69597cb0bcbc44d
+size 422

--- a/examples/frameworks/semantic_kernel_demo/src/aiq_semantic_kernel_demo/local_events_tool.py
+++ b/examples/frameworks/semantic_kernel_demo/src/aiq_semantic_kernel_demo/local_events_tool.py
@@ -32,28 +32,19 @@ class LocalEventsResponse(BaseModel):
 
 
 class LocalEventsToolConfig(FunctionBaseConfig, name="local_events"):
-    pass
+    data_path: str = "examples/frameworks/semantic_kernel_demo/data/local_events.json"
 
 
 @register_function(config_type=LocalEventsToolConfig)
 async def local_events(tool_config: LocalEventsToolConfig, builder: Builder):
 
+    import json
+
+    with open(tool_config.data_path, "r") as f:
+        events = LocalEventsResponse.model_validate({"events": json.load(f)}).events
+
     async def _local_events(city: str) -> LocalEventsResponse:
-        events_data = [{
-            "event": "Cherry Blossom Tour", "cost": 40
-        }, {
-            "event": "Modern Art Expo", "cost": 30
-        }, {
-            "event": "Sushi Making Workshop", "cost": 50
-        }, {
-            "event": "Vegan Food Festival", "cost": 20
-        }, {
-            "event": "Vegan Michelin Star Restaurant", "cost": 100
-        }]
-        events = []
-        for event in events_data:
-            events.append(LocalEvent(name=event["event"], cost=event["cost"], city=city))
-        return LocalEventsResponse(events=events)
+        return LocalEventsResponse(events=[e for e in events if e.city == city])
 
     yield FunctionInfo.from_fn(
         _local_events,


### PR DESCRIPTION
## Description
* Separate data load to JSON file rather than hardcoded for semantic kernel example
* Validate JSON data on load

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
