### PR TITLE
Refactor retry mechanism and update retry mixin field config

### DIFF
--- a/src/aiq/data_models/retry_mixin.py
+++ b/src/aiq/data_models/retry_mixin.py
@@ -21,11 +21,15 @@ class RetryMixin(BaseModel):
     """Mixin class for retry configuration."""
     do_auto_retry: bool = Field(default=True,
                                 description="Whether to automatically retry method calls"
-                                " that fail with a retryable error.")
+                                " that fail with a retryable error.",
+                                exclude=True)
     num_retries: int = Field(default=5,
                              description="Number of times to retry a method call that fails"
-                             " with a retryable error.")
+                             " with a retryable error.",
+                             exclude=True)
     retry_on_status_codes: list[int | str] = Field(default_factory=lambda: [429, 500, 502, 503, 504],
-                                                   description="List of HTTP status codes that should trigger a retry.")
+                                                   description="List of HTTP status codes that should trigger a retry.",
+                                                   exclude=True)
     retry_on_errors: list[str] | None = Field(default_factory=lambda: ["Too Many Requests"],
-                                              description="List of error substrings that should trigger a retry.")
+                                              description="List of error substrings that should trigger a retry.",
+                                              exclude=True)


### PR DESCRIPTION
Refactor exception handler to fix descriptor handling and improve class-level patching consistency. Updated `RetryMixin` fields to include the `exclude=True` metadata, ensuring they are excluded from certain outputs like serialization. These changes enhance retry logic reliability and configuration clarity.

## Description
Refactor exception handler to fix descriptor handling and improve class-level patching consistency. Updated `RetryMixin` fields to include the `exclude=True` metadata, ensuring they are excluded from certain outputs like serialization. These changes enhance retry logic reliability and configuration clarity.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
