### PR TITLE
Integrate latest `RetryMixin` fixes with `aiqtoolkit_agno` subpackage

### DIFF
--- a/packages/aiqtoolkit_agno/src/aiq/plugins/agno/llm.py
+++ b/packages/aiqtoolkit_agno/src/aiq/plugins/agno/llm.py
@@ -70,9 +70,7 @@ async def openai_agno(llm_config: OpenAIModelConfig, builder: Builder):
     from agno.models.openai import OpenAIChat
 
     # Use model_dump to get the proper field values with correct types
-    kwargs = llm_config.model_dump(
-        exclude={"type", "do_auto_retry", "max_retries", "retry_on_status_codes", "retry_on_errors", "num_retries"},
-        by_alias=True)
+    kwargs = llm_config.model_dump(exclude={"type"}, by_alias=True)
 
     # AGNO uses 'id' instead of 'model' for the model name
     if "model" in kwargs:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This removes now redundant field exclusions from Agno OpenAI LLM client with the merge of https://github.com/NVIDIA/NeMo-Agent-Toolkit/pull/480

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
