### PR TITLE
Fix shared field reference bug in `TypedBaseModel` inheritance

### DIFF
--- a/src/aiq/data_models/common.py
+++ b/src/aiq/data_models/common.py
@@ -130,7 +130,6 @@ class TypedBaseModel(BaseModel):
 
     @classmethod
     def static_type(cls):
-        # Use our class attribute instead of the shared field's default
         return getattr(cls, '_typed_model_name', None)
 
     @classmethod

--- a/src/aiq/data_models/common.py
+++ b/src/aiq/data_models/common.py
@@ -125,8 +125,9 @@ class TypedBaseModel(BaseModel):
 
     def model_post_init(self, __context):
         """Set the type field to the correct value after instance creation."""
-        if hasattr(self.__class__, '_typed_model_name'):
+        if hasattr(self.__class__, '_typed_model_name') and self.__class__._typed_model_name is not None:
             object.__setattr__(self, 'type', self.__class__._typed_model_name)
+        # If no type name is set, the field retains its default "unknown" value
 
     @classmethod
     def static_type(cls):

--- a/src/aiq/data_models/common.py
+++ b/src/aiq/data_models/common.py
@@ -21,6 +21,8 @@ from hashlib import sha512
 from pydantic import AliasChoices
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic.json_schema import GenerateJsonSchema
+from pydantic.json_schema import JsonSchemaMode
 
 _LT = typing.TypeVar("_LT")
 
@@ -67,8 +69,8 @@ def subclass_depth(cls: type) -> int:
     Compute a class' subclass depth.
     """
     depth = 0
-    while (cls is not object):
-        cls = cls.__base__
+    while (cls is not object and cls.__base__ is not None):
+        cls = cls.__base__  # type: ignore
         depth += 1
     return depth
 
@@ -128,6 +130,25 @@ class TypedBaseModel(BaseModel):
         if hasattr(self.__class__, '_typed_model_name') and self.__class__._typed_model_name is not None:
             object.__setattr__(self, 'type', self.__class__._typed_model_name)
         # If no type name is set, the field retains its default "unknown" value
+
+    @classmethod
+    def model_json_schema(cls,
+                          by_alias: bool = True,
+                          ref_template: str = '#/$defs/{model}',
+                          schema_generator: "type[GenerateJsonSchema]" = GenerateJsonSchema,
+                          mode: JsonSchemaMode = 'validation') -> dict:
+        """Override to provide correct default for type field in schema."""
+        schema = super().model_json_schema(by_alias=by_alias,
+                                           ref_template=ref_template,
+                                           schema_generator=schema_generator,
+                                           mode=mode)
+
+        # Fix the type field default to show the actual component type instead of "unknown"
+        if ('properties' in schema and 'type' in schema['properties'] and hasattr(cls, '_typed_model_name')
+                and cls._typed_model_name is not None):
+            schema['properties']['type']['default'] = cls._typed_model_name
+
+        return schema
 
     @classmethod
     def static_type(cls):

--- a/tests/aiq/data_models/test_common.py
+++ b/tests/aiq/data_models/test_common.py
@@ -85,3 +85,185 @@ def test_subclass_depth():
                          ids=["dict-with-_type", "dict-with-type", "dict with both", "no_type", "object"])
 def test_type_discriminator(v: typing.Any, expected_value: str | None):
     assert common.TypedBaseModel.discriminator(v) == expected_value
+
+
+class TestTypedBaseModelInheritance:
+    """Test suite for TypedBaseModel inheritance and type handling."""
+
+    def test_simple_inheritance_static_type(self):
+        """Test that simple inheritance classes have correct static_type."""
+
+        class ComponentA(common.TypedBaseModel, name="component_a"):
+            pass
+
+        class ComponentB(common.TypedBaseModel, name="component_b"):
+            pass
+
+        class ComponentC(common.TypedBaseModel, name="component_c"):
+            pass
+
+        # Each class should return its own name, not the last loaded one
+        assert ComponentA.static_type() == "component_a"
+        assert ComponentB.static_type() == "component_b"
+        assert ComponentC.static_type() == "component_c"
+
+    def test_instance_type_field_correct(self):
+        """Test that instances get the correct type field value."""
+
+        class ComponentA(common.TypedBaseModel, name="component_a"):
+            pass
+
+        class ComponentB(common.TypedBaseModel, name="component_b"):
+            pass
+
+        # Create instances
+        instance_a = ComponentA()
+        instance_b = ComponentB()
+
+        # Each instance should have the correct type
+        assert instance_a.type == "component_a"
+        assert instance_b.type == "component_b"
+
+    def test_no_cross_contamination(self):
+        """Test that there's no cross-contamination between classes (regression test)."""
+
+        # Simulate the original bug scenario with multiple classes loaded in sequence
+        class FirstComponent(common.TypedBaseModel, name="first"):
+            pass
+
+        class SecondComponent(common.TypedBaseModel, name="second"):
+            pass
+
+        class ThirdComponent(common.TypedBaseModel, name="third"):
+            pass
+
+        # Verify no class shows the wrong name (original bug was all showing "third")
+        assert FirstComponent.static_type() == "first"
+        assert SecondComponent.static_type() == "second"
+        assert ThirdComponent.static_type() == "third"
+
+        # Also test instances
+        first_instance = FirstComponent()
+        second_instance = SecondComponent()
+        third_instance = ThirdComponent()
+
+        assert first_instance.type == "first"
+        assert second_instance.type == "second"
+        assert third_instance.type == "third"
+
+    def test_mixin_inheritance_patterns(self):
+        """Test that mixin inheritance patterns work correctly."""
+
+        # Simulate the mixin patterns used in telemetry exporters
+        class BatchConfigMixin:
+            batch_size: int = 100
+
+        class CollectorConfigMixin:
+            endpoint = "http://localhost"
+
+        class TelemetryExporterBase(common.TypedBaseModel):
+            pass
+
+        class WeaveExporter(TelemetryExporterBase, name="weave"):
+            pass
+
+        class PhoenixExporter(BatchConfigMixin, CollectorConfigMixin, TelemetryExporterBase, name="phoenix"):
+            pass
+
+        class CatalystExporter(BatchConfigMixin, TelemetryExporterBase, name="catalyst"):
+            pass
+
+        # Test static types (this was the main visible bug)
+        assert WeaveExporter.static_type() == "weave"
+        assert PhoenixExporter.static_type() == "phoenix"
+        assert CatalystExporter.static_type() == "catalyst"
+
+        # Test instances
+        weave = WeaveExporter()
+        phoenix = PhoenixExporter()
+        catalyst = CatalystExporter()
+
+        assert weave.type == "weave"
+        assert phoenix.type == "phoenix"
+        assert catalyst.type == "catalyst"
+
+    def test_deep_inheritance_chains(self):
+        """Test that deep inheritance chains work correctly."""
+
+        class BaseComponent(common.TypedBaseModel, name="base"):
+            pass
+
+        class MiddleComponent(BaseComponent, name="middle"):
+            pass
+
+        class LeafComponent(MiddleComponent, name="leaf"):
+            pass
+
+        # Each level should have correct type
+        assert BaseComponent.static_type() == "base"
+        assert MiddleComponent.static_type() == "middle"
+        assert LeafComponent.static_type() == "leaf"
+
+        # Test instances
+        base_instance = BaseComponent()
+        middle_instance = MiddleComponent()
+        leaf_instance = LeafComponent()
+
+        assert base_instance.type == "base"
+        assert middle_instance.type == "middle"
+        assert leaf_instance.type == "leaf"
+
+    def test_type_field_assignment(self):
+        """Test that type field assignment works (needed for YAML loading)."""
+
+        class TestComponent(common.TypedBaseModel, name="test_component"):
+            pass
+
+        instance = TestComponent()
+
+        # Initial type should be correct
+        assert instance.type == "test_component"
+
+        # Should be able to assign new value (YAML loading scenario)
+        instance.type = "custom_type"
+        assert instance.type == "custom_type"
+
+        # Static type should remain unchanged
+        assert TestComponent.static_type() == "test_component"
+
+    def test_unnamed_class_handling(self):
+        """Test that classes without names are handled gracefully."""
+
+        class UnnamedComponent(common.TypedBaseModel):
+            pass
+
+        # Should return None for static_type
+        assert UnnamedComponent.static_type() is None
+
+        # Instance should get default value
+        instance = UnnamedComponent()
+        assert instance.type == "unknown"
+
+    def test_class_attribute_storage(self):
+        """Test that type names are stored as class attributes."""
+
+        class AttributeTestComponent(common.TypedBaseModel, name="attribute_test"):
+            pass
+
+        # Should have the class attribute
+        assert hasattr(AttributeTestComponent, '_typed_model_name')
+        assert AttributeTestComponent._typed_model_name == "attribute_test"
+
+    def test_model_post_init_behavior(self):
+        """Test that model_post_init correctly sets the type field."""
+
+        class PostInitComponent(common.TypedBaseModel, name="post_init_test"):
+            field1: str = "value1"
+
+        instance = PostInitComponent()
+
+        # Type should be set correctly after post-init
+        assert instance.type == "post_init_test"
+
+        # Other fields should work normally
+        assert instance.field1 == "value1"

--- a/tests/aiq/data_models/test_common.py
+++ b/tests/aiq/data_models/test_common.py
@@ -244,16 +244,6 @@ class TestTypedBaseModelInheritance:
         instance = UnnamedComponent()
         assert instance.type == "unknown"
 
-    def test_class_attribute_storage(self):
-        """Test that type names are stored as class attributes."""
-
-        class AttributeTestComponent(common.TypedBaseModel, name="attribute_test"):
-            pass
-
-        # Should have the class attribute
-        assert hasattr(AttributeTestComponent, '_typed_model_name')
-        assert AttributeTestComponent._typed_model_name == "attribute_test"
-
     def test_model_post_init_behavior(self):
         """Test that model_post_init correctly sets the type field."""
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

All classes inheriting from `TypedBaseModel` shared the same Field object 
for the type field, causing the last-loaded class to overwrite the type 
names of all previous classes. This affected deep 
inheritance chains and mixin inheritance patterns.

- Store type name as class attribute instead of modifying shared field
- Implement model_post_init to set correct type after instance creation  
- Set type field default to "unknown" for validation compatibility

This fixes component discovery (e.g. `aiq info components -t tracing`) across all `TypedBaseModel` subclasses and 
enables proper inheritance patterns throughout the codebase.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
