### PR TITLE
Set SCM versioning for `text_file_ingest` allowing it to be built in CI

### DIFF
--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -27,9 +27,7 @@ rapids-logger "Git Version: ${GIT_TAG} - Is Tagged: ${IS_TAGGED}"
 if [[ "${CI_CRON_NIGHTLY}" == "1" || ( ${IS_TAGGED} == "1" && "${CI_COMMIT_BRANCH}" != "main" ) ]]; then
     export SETUPTOOLS_SCM_PRETEND_VERSION="${GIT_TAG}"
     export USE_FULL_VERSION="1"
-fi
 
-if [[ "${CI_CRON_NIGHTLY}" == "1" ]]; then
     create_env group:dev
     export SKIP_MD_UPDATE=1
     ${PROJECT_ROOT}/ci/release/update-version.sh "${GIT_TAG}"

--- a/docs/source/tutorials/create-a-new-workflow.md
+++ b/docs/source/tutorials/create-a-new-workflow.md
@@ -223,6 +223,26 @@ The `pyproject.toml` file defines your package metadata and dependencies. In thi
 
   In this example, you have been using NeMo Agent toolkit with LangChain. This is why the dependency is declared on `aiqtoolkit[langchain]`, that is to say NeMo Agent toolkit with the LangChain integration plugin. If you want to use LlamaIndex, declare the dependency on `aiqtoolkit[llama-index]`. This is described in more detail in [Framework Integrations](../quick-start/installing.md#framework-integrations).
 
+- **Version**: In this example, and in NeMo Agent toolkit in general, we use [setuptools-scm](https://setuptools-scm.readthedocs.io/en/latest/) to automatically determine the version of the package based on the Git tags. We did this by setting `dynamic = ["version"]` and declaring a build dependency on both `setuptools` and `setuptools_scm` in the `build-system` section of `pyproject.toml`:
+  ```toml
+  [build-system]
+  requires = ["setuptools", "setuptools_scm"]
+  build-backend = "setuptools.build_meta"
+  ```
+
+  Alternately if we did not want to do this we would instead:
+  ```toml
+  [build-system]
+  build-backend = "setuptools.build_meta"
+  requires = ["setuptools >= 64"]
+
+  [project]
+  name = "text_file_ingest"
+  version = "0.1.0"
+  ...
+  ```
+
+
 - **Entry Points**: This tells NeMo Agent toolkit where to find your workflow registration.
 
   ```toml

--- a/docs/source/tutorials/create-a-new-workflow.md
+++ b/docs/source/tutorials/create-a-new-workflow.md
@@ -212,7 +212,7 @@ The `pyproject.toml` file defines your package metadata and dependencies. In thi
   aiq --version
   ```
 
- Use the first two digits of the version number. For example, if the version is `1.1.0`, then the dependency would be `aiqtoolkit[langchain]~=1.1`.
+  Use the first two digits of the version number. For example, if the version is `1.1.0`, then the dependency would be `aiqtoolkit[langchain]~=1.1`.
 
   ```toml
   dependencies = [

--- a/examples/documentation_guides/workflows/text_file_ingest/pyproject.toml
+++ b/examples/documentation_guides/workflows/text_file_ingest/pyproject.toml
@@ -1,15 +1,11 @@
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools >= 64"]
+requires = ["setuptools >= 64", "setuptools-scm>=8"]
 
 [project]
 name = "text_file_ingest"
-version = "0.1.0"
-dependencies = [
-  "aiqtoolkit[langchain]~=1.2",
-  "bs4==0.0.2",
-  "faiss-cpu==1.9.0",
-]
+dynamic = ["version"]
+dependencies = ["aiqtoolkit[langchain]~=1.2", "bs4==0.0.2", "faiss-cpu==1.9.0"]
 requires-python = ">=3.11,<3.13"
 description = "Ingest data from text files"
 keywords = ["ai", "rag", "agents"]


### PR DESCRIPTION
## Description
* This should fix the nightly builds
* Run the `update-version.sh` script when performing CI builds


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
