### PR TITLE
Fix fastapi endpoint for plot_charts

### DIFF
--- a/examples/custom_functions/plot_charts/src/aiq_plot_charts/register.py
+++ b/examples/custom_functions/plot_charts/src/aiq_plot_charts/register.py
@@ -58,9 +58,9 @@ async def plot_charts_function(config: PlotChartsWorkflowConfig, builder: Builde
     output_dir = Path(config.output_directory)
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    async def _create_chart(user_request: str) -> str:
+    async def _create_chart(input_message: str) -> str:
         """Internal function to create charts based on user requests."""
-        logger.info("Processing chart request: %s", user_request)
+        logger.info("Processing chart request: %s", input_message)
 
         try:
             # Load data from configured file
@@ -77,7 +77,7 @@ async def plot_charts_function(config: PlotChartsWorkflowConfig, builder: Builde
                         f"{config.max_data_points}.")
 
             # Determine chart type from user request
-            chart_type = determine_chart_type(user_request, config.chart_types)
+            chart_type = determine_chart_type(input_message, config.chart_types)
             logger.info("Selected chart type: %s", chart_type)
 
             # Generate unique filename


### PR DESCRIPTION
## Description

#449 (later merged into develop) innocently changed the parameter name from `input_message` to `user_request`. This PR corrects the accidental change.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
