### PR TITLE
Fix UI docs to launch the simple calculator

### DIFF
--- a/docs/source/quick-start/launching-ui.md
+++ b/docs/source/quick-start/launching-ui.md
@@ -32,7 +32,7 @@ This walk-through guides you through the steps to set up and configure the NeMo 
 ### Prerequisites
 Before starting, ensure you have:
 - NeMo Agent toolkit installed and configured
-- Set up the simple calculator workflow by following the instructions in `examples/getting_started/simple_web_query/README.md`
+- Set up the simple calculator workflow by following the instructions in `examples/getting_started/simple_calculator/README.md`
 - Node.js v18+ installed (required for the web interface)
 
 
@@ -46,28 +46,10 @@ git submodule update --init --recursive
 You can start the NeMo Agent toolkit server using the `aiq serve` command with the appropriate configuration file.
 
 ```bash
-aiq serve --config_file=examples/getting_started/simple_web_query/configs/config.yml
+aiq serve --config_file=examples/getting_started/simple_calculator/configs/config.yml
 ```
-Running this command will produce the expected output as shown below:
+Running this command will produce the expected output as shown below (truncated for brevity):
 ```bash
-2025-03-07 12:54:20,394 - aiq.cli.commands.start - INFO - Starting AIQ toolkit from config file: 'examples/getting_started/simple_web_query/configs/config.yml'
-WARNING:  Current configuration will not reload as not all conditions are met, please refer to documentation.
-INFO:     Started server process [47250]
-INFO:     Waiting for application startup.
-2025-03-07 12:54:20,730 - aiq.profiler.decorators - INFO - Langchain callback handler registered
-2025-03-07 12:54:21,313 - aiq.agent.react_agent.agent - INFO - Filling the prompt variables "tools" and "tool_names", using the tools provided in the config.
-2025-03-07 12:54:21,313 - aiq.agent.react_agent.agent - INFO - Initialized ReAct Agent Graph
-2025-03-07 12:54:21,316 - aiq.agent.react_agent.agent - INFO - ReAct Graph built and compiled successfully
-INFO:     Application startup complete.
-INFO:     Uvicorn running on http://localhost:8000 (Press CTRL+C to quit)
-  Current configuration will not reload as not all conditions are met, please refer to documentation.
-INFO:     Started server process [47250]
-INFO:     Waiting for application startup.
-2025-03-07 12:54:20,730 - aiq.profiler.decorators - INFO - Langchain callback handler registered
-2025-03-07 12:54:21,313 - aiq.agent.react_agent.agent - INFO - Filling the prompt variables "tools" and "tool_names", using the tools provided in the config.
-2025-03-07 12:54:21,313 - aiq.agent.react_agent.agent - INFO - Initialized ReAct Agent Graph
-2025-03-07 12:54:21,316 - aiq.agent.react_agent.agent - INFO - ReAct Graph built and compiled successfully
-INFO:     Application startup complete.
 INFO:     Uvicorn running on http://localhost:8000 (Press CTRL+C to quit)
 ```
 


### PR DESCRIPTION
## Description
* The UI documentation was out of sync, it instructed the user to launch the simple calculator workflow, but provided the yaml for the `simple_web_query` example

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
