### PR TITLE
Relax overly restrictive constraints on AIQChatRequest model

### DIFF
--- a/src/aiq/data_models/api_server.py
+++ b/src/aiq/data_models/api_server.py
@@ -121,28 +121,22 @@ class AIQChatRequest(BaseModel):
     # Optional fields (OpenAI Chat Completions API compatible)
     model: str | None = Field(default=None, description="name of the model to use")
     frequency_penalty: float | None = Field(default=0.0,
-                                            ge=-2.0,
-                                            le=2.0,
                                             description="Penalty for new tokens based on frequency in text")
     logit_bias: dict[str, float] | None = Field(default=None,
                                                 description="Modify likelihood of specified tokens appearing")
     logprobs: bool | None = Field(default=None, description="Whether to return log probabilities")
-    top_logprobs: int | None = Field(default=None, ge=0, le=20, description="Number of most likely tokens to return")
-    max_tokens: int | None = Field(default=None, ge=1, description="Maximum number of tokens to generate")
-    n: int | None = Field(default=1, ge=1, le=128, description="Number of chat completion choices to generate")
-    presence_penalty: float | None = Field(default=0.0,
-                                           ge=-2.0,
-                                           le=2.0,
-                                           description="Penalty for new tokens based on presence in text")
+    top_logprobs: int | None = Field(default=None, description="Number of most likely tokens to return")
+    max_tokens: int | None = Field(default=None, description="Maximum number of tokens to generate")
+    n: int | None = Field(default=1, description="Number of chat completion choices to generate")
+    presence_penalty: float | None = Field(default=0.0, description="Penalty for new tokens based on presence in text")
     response_format: dict[str, typing.Any] | None = Field(default=None, description="Response format specification")
     seed: int | None = Field(default=None, description="Random seed for deterministic sampling")
     service_tier: typing.Literal["auto", "default"] | None = Field(default=None,
                                                                    description="Service tier for the request")
-    stop: str | list[str] | None = Field(default=None, description="Up to 4 sequences where API will stop generating")
     stream: bool | None = Field(default=False, description="Whether to stream partial message deltas")
     stream_options: dict[str, typing.Any] | None = Field(default=None, description="Options for streaming")
-    temperature: float | None = Field(default=1.0, ge=0.0, le=2.0, description="Sampling temperature between 0 and 2")
-    top_p: float | None = Field(default=None, ge=0.0, le=1.0, description="Nucleus sampling parameter")
+    temperature: float | None = Field(default=1.0, description="Sampling temperature between 0 and 2")
+    top_p: float | None = Field(default=None, description="Nucleus sampling parameter")
     tools: list[dict[str, typing.Any]] | None = Field(default=None, description="List of tools the model may call")
     tool_choice: str | dict[str, typing.Any] | None = Field(default=None, description="Controls which tool is called")
     parallel_tool_calls: bool | None = Field(default=True, description="Whether to enable parallel function calling")


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This pull request removes overly restrictive validation constraints from the AIQChatRequest data model to better align with the OpenAI Chat Completions API schema. The intent is to maintain compatibility with the official specification while avoiding premature validation errors that should be handled by the OpenAI API itself. By deferring strict field validation, we minimize the risk of false negatives on valid inputs and reduce maintenance overhead in the event that OpenAI updates their schema. This change ensures clients have the flexibility to use all supported parameters without being blocked by overly rigid local checks.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
