### PR TITLE
Ensure type system and functional behavior are consistent for `to_type` specifications

### DIFF
--- a/src/aiq/builder/function.py
+++ b/src/aiq/builder/function.py
@@ -76,11 +76,16 @@ class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
         -------
         _T
             The converted value.
+
+        Raises
+        ------
+        ValueError
+            If the value cannot be converted to the specified type (when `to_type` is specified).
         """
 
         return self._converter.convert(value, to_type=to_type)
 
-    def try_convert(self, value: typing.Any, to_type: type[_T]) -> _T:
+    def try_convert(self, value: typing.Any, to_type: type[_T]) -> _T | typing.Any:
         """
         Converts the given value to the specified type using graceful error handling.
         If conversion fails, returns the original value and continues processing.
@@ -94,7 +99,7 @@ class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
 
         Returns
         -------
-        _T
+        _T | typing.Any
             The converted value, or original value if conversion fails.
         """
         return self._converter.try_convert(value, to_type=to_type)
@@ -129,6 +134,11 @@ class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
         -------
         typing.Any
             The output of the function optionally converted to the specified type.
+
+        Raises
+        ------
+        ValueError
+            If the output of the function cannot be converted to the specified type.
         """
 
         with self._context.push_active_function(self.instance_name,
@@ -139,7 +149,7 @@ class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
                 result = await self._ainvoke(converted_input)
 
                 if to_type is not None and not isinstance(result, to_type):
-                    result = self._converter.try_convert(result, to_type=to_type)
+                    result = self._converter.convert(result, to_type=to_type)
 
                 manager.set_output(result)
 
@@ -215,6 +225,11 @@ class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
         ------
         typing.Any
             The output of the function optionally converted to the specified type.
+
+        Raises
+        ------
+        ValueError
+            If the output of the function cannot be converted to the specified type (when `to_type` is specified).
         """
 
         with self._context.push_active_function(self.instance_name, input_data=value) as manager:
@@ -226,7 +241,7 @@ class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
 
                 async for data in self._astream(converted_input):
                     if to_type is not None and not isinstance(data, to_type):
-                        converted_data = self._converter.try_convert(data, to_type=to_type)
+                        converted_data = self._converter.convert(data, to_type=to_type)
                         final_output.append(converted_data)
                         yield converted_data
                     else:

--- a/src/aiq/builder/function.py
+++ b/src/aiq/builder/function.py
@@ -144,12 +144,12 @@ class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
         with self._context.push_active_function(self.instance_name,
                                                 input_data=value) as manager:  # Set the current invocation context
             try:
-                converted_input: InputT = self._convert_input(value)  # type: ignore
+                converted_input: InputT = self._convert_input(value)
 
                 result = await self._ainvoke(converted_input)
 
                 if to_type is not None and not isinstance(result, to_type):
-                    result = self._converter.convert(result, to_type=to_type)
+                    result = self.convert(result, to_type)
 
                 manager.set_output(result)
 
@@ -234,14 +234,14 @@ class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
 
         with self._context.push_active_function(self.instance_name, input_data=value) as manager:
             try:
-                converted_input: InputT = self._convert_input(value)  # type: ignore
+                converted_input: InputT = self._convert_input(value)
 
                 # Collect streaming outputs to capture the final result
                 final_output: list[typing.Any] = []
 
                 async for data in self._astream(converted_input):
                     if to_type is not None and not isinstance(data, to_type):
-                        converted_data = self._converter.convert(data, to_type=to_type)
+                        converted_data = self.convert(data, to_type=to_type)
                         final_output.append(converted_data)
                         yield converted_data
                     else:

--- a/src/aiq/builder/function_base.py
+++ b/src/aiq/builder/function_base.py
@@ -350,7 +350,7 @@ class FunctionBase(typing.Generic[InputT, StreamingOutputT, SingleOutputT], ABC)
         # output because the ABC has it.
         return True
 
-    def _convert_input(self, value: typing.Any):
+    def _convert_input(self, value: typing.Any) -> InputT:
         if (isinstance(value, self.input_class)):
             return value
 
@@ -373,4 +373,8 @@ class FunctionBase(typing.Generic[InputT, StreamingOutputT, SingleOutputT], ABC)
             return value
 
         # Fallback to the converter
-        return self._converter.try_convert(value, to_type=self.input_class)
+        try:
+            return self._converter.convert(value, to_type=self.input_class)
+        except ValueError as e:
+            # Input parsing should yield a TypeError instead of a ValueError
+            raise TypeError from e

--- a/tests/aiq/runner/test_runner.py
+++ b/tests/aiq/runner/test_runner.py
@@ -1,0 +1,284 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import AsyncGenerator
+
+import pytest
+from pydantic import BaseModel
+
+from aiq.builder.builder import Builder
+from aiq.builder.context import AIQContextState
+from aiq.builder.workflow_builder import WorkflowBuilder
+from aiq.cli.register_workflow import register_function
+from aiq.data_models.function import FunctionBaseConfig
+from aiq.observability.exporter_manager import ExporterManager
+from aiq.runtime.runner import AIQRunner
+
+
+class DummyConfig(FunctionBaseConfig, name="dummy_runner"):
+    pass
+
+
+class SingleOutputConfig(FunctionBaseConfig, name="single_output_runner"):
+    pass
+
+
+class StreamOutputConfig(FunctionBaseConfig, name="stream_output_runner"):
+    pass
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def _register_single_output_fn():
+
+    @register_function(config_type=SingleOutputConfig)
+    async def register(config: SingleOutputConfig, b: Builder):
+
+        async def _inner(message: str) -> str:
+            return message + "!"
+
+        yield _inner
+
+
+@pytest.fixture(scope="module", autouse=True)
+async def _register_stream_output_fn():
+
+    @register_function(config_type=StreamOutputConfig)
+    async def register(config: StreamOutputConfig, b: Builder):
+
+        async def _inner_stream(message: str) -> AsyncGenerator[str]:
+            yield message + "!"
+
+        yield _inner_stream
+
+
+async def test_runner_result_successful_type_conversion():
+    """Test that AIQRunner.result() successfully converts output when compatible to_type is provided."""
+
+    async with WorkflowBuilder() as builder:
+        entry_fn = await builder.add_function(name="test_function", config=SingleOutputConfig())
+
+        context_state = AIQContextState()
+        exporter_manager = ExporterManager()
+
+        async with AIQRunner(input_message="test",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            # Test successful conversion to compatible type
+            result = await runner.result(to_type=str)
+            assert result == "test!"
+
+            # Test successful conversion without to_type
+            async with AIQRunner(input_message="test2",
+                                 entry_fn=entry_fn,
+                                 context_state=context_state,
+                                 exporter_manager=exporter_manager) as runner2:
+                result2 = await runner2.result()
+                assert result2 == "test2!"
+
+
+async def test_runner_result_type_conversion_failure():
+    """Test that AIQRunner.result() raises ValueError when output cannot be converted to specified to_type."""
+
+    class UnconvertibleOutput(BaseModel):
+        value: str
+
+    class IncompatibleType(BaseModel):
+        different_field: int
+
+    @register_function(config_type=DummyConfig)
+    async def _register(config: DummyConfig, b: Builder):
+
+        async def _inner(message: str) -> UnconvertibleOutput:
+            return UnconvertibleOutput(value=message + "!")
+
+        yield _inner
+
+    async with WorkflowBuilder() as builder:
+        entry_fn = await builder.add_function(name="test_function", config=DummyConfig())
+
+        context_state = AIQContextState()
+        exporter_manager = ExporterManager()
+
+        async with AIQRunner(input_message="test",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            # Verify normal operation works
+            result = await runner.result(to_type=UnconvertibleOutput)
+            assert result.value == "test!"
+
+        # Test that conversion to incompatible type raises ValueError
+        async with AIQRunner(input_message="test",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            with pytest.raises(ValueError, match="Cannot convert type .* to .* No match found"):
+                await runner.result(to_type=IncompatibleType)
+
+
+async def test_runner_result_primitive_type_conversion_failure():
+    """Test that AIQRunner.result() raises ValueError when primitive output cannot be converted to incompatible type."""
+
+    async with WorkflowBuilder() as builder:
+        entry_fn = await builder.add_function(name="test_function", config=SingleOutputConfig())
+
+        context_state = AIQContextState()
+        exporter_manager = ExporterManager()
+
+        async with AIQRunner(input_message="test",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            # Verify normal operation works
+            result = await runner.result(to_type=str)
+            assert result == "test!"
+
+        # Test that conversion to incompatible type raises ValueError
+        async with AIQRunner(input_message="test",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            with pytest.raises(ValueError, match="Cannot convert type .* to .* No match found"):
+                await runner.result(to_type=dict)
+
+
+async def test_runner_result_stream_successful_type_conversion():
+    """Test that AIQRunner.result_stream() successfully converts output when compatible to_type is provided."""
+
+    async with WorkflowBuilder() as builder:
+        entry_fn = await builder.add_function(name="test_function", config=StreamOutputConfig())
+
+        context_state = AIQContextState()
+        exporter_manager = ExporterManager()
+
+        async with AIQRunner(input_message="test",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            # Test successful conversion to compatible type
+            result = None
+            async for output in runner.result_stream(to_type=str):
+                result = output
+            assert result == "test!"
+
+        async with AIQRunner(input_message="test2",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            # Test successful conversion without to_type
+            result2 = None
+            async for output in runner.result_stream():
+                result2 = output
+            assert result2 == "test2!"
+
+
+async def test_runner_result_stream_type_conversion_failure():
+    """Test that AIQRunner.result_stream() raises ValueError when output cannot be converted to specified to_type."""
+
+    class UnconvertibleOutput(BaseModel):
+        value: str
+
+    class IncompatibleType(BaseModel):
+        different_field: int
+
+    @register_function(config_type=DummyConfig)
+    async def _register(config: DummyConfig, b: Builder):
+
+        async def _stream_inner(message: str) -> AsyncGenerator[UnconvertibleOutput]:
+            yield UnconvertibleOutput(value=message + "!")
+
+        yield _stream_inner
+
+    async with WorkflowBuilder() as builder:
+        entry_fn = await builder.add_function(name="test_function", config=DummyConfig())
+
+        context_state = AIQContextState()
+        exporter_manager = ExporterManager()
+
+        async with AIQRunner(input_message="test",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            # Verify normal operation works
+            result = None
+            async for output in runner.result_stream(to_type=UnconvertibleOutput):
+                result = output
+            assert result is not None and result.value == "test!"
+
+        # Test that conversion to incompatible type raises ValueError during streaming
+        async with AIQRunner(input_message="test",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            with pytest.raises(ValueError, match="Cannot convert type .* to .* No match found"):
+                async for output in runner.result_stream(to_type=IncompatibleType):
+                    pass  # The exception should be raised during the first iteration
+
+
+async def test_runner_result_stream_primitive_type_conversion_failure():
+    """
+    Test that AIQRunner.result_stream() raises ValueError when primitive output cannot
+    be converted to incompatible type.
+    """
+
+    async with WorkflowBuilder() as builder:
+        entry_fn = await builder.add_function(name="test_function", config=StreamOutputConfig())
+
+        context_state = AIQContextState()
+        exporter_manager = ExporterManager()
+
+        async with AIQRunner(input_message="test",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            # Verify normal operation works
+            result = None
+            async for output in runner.result_stream(to_type=str):
+                result = output
+            assert result == "test!"
+
+        # Test that conversion to incompatible type raises ValueError during streaming
+        async with AIQRunner(input_message="test",
+                             entry_fn=entry_fn,
+                             context_state=context_state,
+                             exporter_manager=exporter_manager) as runner:
+            with pytest.raises(ValueError, match="Cannot convert type .* to .* No match found"):
+                async for output in runner.result_stream(to_type=dict):
+                    pass  # The exception should be raised during the first iteration
+
+
+async def test_runner_state_management():
+    """Test that AIQRunner properly manages state transitions during execution."""
+
+    async with WorkflowBuilder() as builder:
+        entry_fn = await builder.add_function(name="test_function", config=SingleOutputConfig())
+
+        context_state = AIQContextState()
+        exporter_manager = ExporterManager()
+
+        runner = AIQRunner(input_message="test",
+                           entry_fn=entry_fn,
+                           context_state=context_state,
+                           exporter_manager=exporter_manager)
+
+        # Test that runner cannot be used outside of async context
+        with pytest.raises(ValueError, match="Cannot run the workflow without entering the context"):
+            await runner.result()
+
+        # Test successful execution within context
+        async with runner:
+            result = await runner.result()
+            assert result == "test!"


### PR DESCRIPTION
## Description
This PR fixes a behavioral bug related to type conversions silently failing.

Additionally, this PR:
* Adds new tests which exposed the original failures (you can cherry-pick the first commit on ToT to see failures)
* Adds a new suite of tests for `AIQRunner` which previously did not exist (can be cherry-picked on ToT to see failures)
* Fixes the type hinting for `try_convert` functions
* Adds exception handling documentation to `convert` functions

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
