### PR TITLE
Fix HITL `por_to_jiratickets` example

### DIFF
--- a/examples/HITL/por_to_jiratickets/README.md
+++ b/examples/HITL/por_to_jiratickets/README.md
@@ -57,7 +57,7 @@ If you have not already done so, follow the instructions in the [Install Guide](
 From the root directory of the NeMo Agent toolkit library, run the following commands:
 
 ```bash
-uv pip install -e examples/por_to_jiratickets
+uv pip install -e examples/HITL/por_to_jiratickets
 ```
 
 ### Set Up API Keys
@@ -142,7 +142,7 @@ This can occur in any tool or function in the workflow, allowing for dynamic int
 Run the following command from the root of the NeMo Agent toolkit repo to execute this workflow with the specified input:
 
 ```bash
-aiq run --config_file examples/por_to_jiratickets/configs/config.yml  --input "Can you extract por file por_requirements.txt, assign story points and create jira tickets for epics first and then followed by tasks?"
+aiq run --config_file examples/HITL/por_to_jiratickets/configs/config.yml  --input "Can you extract por file por_requirements.txt, assign story points and create jira tickets for epics first and then followed by tasks?"
 ```
 
 **Expected Workflow Result When Giving Permission**

--- a/examples/HITL/por_to_jiratickets/src/aiq_por_to_jiratickets/configs/config.yml
+++ b/examples/HITL/por_to_jiratickets/src/aiq_por_to_jiratickets/configs/config.yml
@@ -26,20 +26,21 @@ functions:
   extract_por_tool:
     _type: extract_por_tool
     llm: extract_llm
-    root_path: "./examples/custom_functions/por_to_jiratickets/data/"
+    root_path: "./examples/HITL/por_to_jiratickets/data/"
   show_jira_tickets:
     _type: show_jira_tickets
-    root_path: "./examples/custom_functions/por_to_jiratickets/data/"
+    root_path: "./examples/HITL/por_to_jiratickets/data/"
   create_jira_tickets_tool:
     _type: create_jira_tickets_tool
-    root_path: "./examples/custom_functions/por_to_jiratickets/data/"
+    root_path: "./examples/HITL/por_to_jiratickets/data/"
     timeout: 20.0
     connect: 10.0
     jira_domain: ""
     jira_project_key: ""
+    hitl_approval_fn: "hitl_approval_tool"
   get_jira_tickets_tool:
     _type: get_jira_tickets_tool
-    root_path: "./examples/custom_functions/por_to_jiratickets/data/"
+    root_path: "./examples/HITL/por_to_jiratickets/data/"
     jira_domain: ""
     jira_project_key: ""
   hitl_approval_tool:


### PR DESCRIPTION
## Description
* Fix path to the `por_to_jiratickets` example
* Add missing `hitl_approval_fn` config entry

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
