### PR TITLE
Fix file paths for simple_calculator_eval

### DIFF
--- a/docs/source/workflows/sizing-calc.md
+++ b/docs/source/workflows/sizing-calc.md
@@ -69,7 +69,7 @@ eval:
     output_dir: .tmp/aiq/examples/simple_calculator/eval
     dataset:
       _type: json
-      file_path: examples/getting_started/simple_web_query/data/simple_calculator.json
+      file_path: examples/getting_started/simple_calculator/data/simple_calculator.json
 ```
 In addition to the dataset, you need to specify the `eval.general.output_dir` parameter for storing the evaluation results. Other parameters in the eval section are not used by the calculator. For more information, refer to the [Evaluate](./evaluate.md) documentation.
 

--- a/examples/evaluation_and_profiling/simple_calculator_eval/README.md
+++ b/examples/evaluation_and_profiling/simple_calculator_eval/README.md
@@ -60,9 +60,9 @@ aiq eval --config_file examples/evaluation_and_profiling/simple_calculator_eval/
 The configuration file specified above contains configurations for the NeMo Agent Toolkit `evaluation` and `profiler` capabilities. Additional documentation for evaluation configuration can be found in the [evaluation guide](../../../docs/source/workflows/evaluate.md). Furthermore, similar documentation for profiling configuration can be found in the [profiling guide](../../../docs/source/workflows/profiler.md).
 
 This command:
-- Uses the test dataset from `examples/getting_started/simple_web_query/data/simple_calculator.json`
+- Uses the test dataset from `examples/getting_started/simple_calculator/data/simple_calculator.json`
 - Applies the Tunable RAG Evaluator to measure response accuracy
-- Saves detailed results to `.tmp/aiq/examples/getting_started/simple_web_query/tuneable_eval_output.json`
+- Saves detailed results to `.tmp/aiq/examples/getting_started/simple_calculator/tuneable_eval_output.json`
 
 ### Understanding Results
 

--- a/examples/evaluation_and_profiling/simple_calculator_eval/configs/config-tunable-rag-eval.yml
+++ b/examples/evaluation_and_profiling/simple_calculator_eval/configs/config-tunable-rag-eval.yml
@@ -77,7 +77,7 @@ eval:
     output_dir: .tmp/aiq/examples/getting_started/simple_web_query
     dataset:
       _type: json
-      file_path: examples/getting_started/simple_web_query/data/simple_calculator.json
+      file_path: examples/getting_started/simple_calculator/data/simple_calculator.json
   evaluators:
     tuneable_eval:
       _type: tunable_rag_evaluator


### PR DESCRIPTION
## Description

This is a bugfix for the blanket find/replace done during the example reorg.

`eval` spec was pointing to a non-existent file, causing eval to fail.

Closes nvbugs-5425596

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
