### PR TITLE
Fix: getting_started docker containers build with added compiler dependency

### DIFF
--- a/examples/getting_started/simple_calculator/Dockerfile
+++ b/examples/getting_started/simple_calculator/Dockerfile
@@ -27,6 +27,10 @@ ARG PYTHON_VERSION
 
 ENV PYTHONDONTWRITEBYTECODE=1
 
+# Install compiler (currently only needed for thinc indirect dependency)
+RUN apt-get update && \
+    apt-get install -y g++ gcc
+
 # Set working directory
 WORKDIR /workspace
 
@@ -45,7 +49,7 @@ RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \
     uv pip install -e '.[telemetry]' --link-mode=copy --compile-bytecode --python ${PYTHON_VERSION} && \
     uv pip install --link-mode=copy ./examples/getting_started/simple_calculator
 
-# Enivronment variables for the venv
+# Environment variables for the venv
 ENV PATH="/workspace/.venv/bin:$PATH"
 
 # Set the config file environment variable

--- a/examples/getting_started/simple_web_query/Dockerfile
+++ b/examples/getting_started/simple_web_query/Dockerfile
@@ -32,6 +32,9 @@ RUN apt-get update && \
     apt-get install -y ca-certificates curl && \
     update-ca-certificates
 
+# Install compiler (currently only needed for thinc indirect dependency)
+RUN apt-get install -y g++ gcc
+
 # Set SSL environment variables
 ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
@@ -56,7 +59,7 @@ RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \
 # Set the config file environment variable
 ENV AIQ_CONFIG_FILE=/workspace/examples/getting_started/simple_web_query/configs/config.yml
 
-# Enivronment variables for the venv
+# Environment variables for the venv
 ENV PATH="/workspace/.venv/bin:$PATH"
 
 # Define the entry point to start the server


### PR DESCRIPTION
## Description
The docker containers for the getting_started examples fail to build in the case where:
1. user is on some host platform
2. `.[telemetry]` has an indirect dependency to `thinc`
3. `thinc` does not ship wheels for the corresponding docker platform

Example: on macOS (arm64 processor), when attempting to build the containers for linux aarch64, it fails due to `thinc` not shipping linux arm wheels.

Thus, we need to add a compiler to the base image to ensure that `thinc` can be built from source if necessary.

This PR also fixes a small typo.

Closes nvbugs-5425577

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
