### PR TITLE
Documentation: Specify minimum uv version

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Before you begin using NeMo Agent toolkit, ensure that you meet the following so
 
 - Install [Git](https://git-scm.com/)
 - Install [Git Large File Storage](https://git-lfs.github.com/) (LFS)
-- Install [uv](https://docs.astral.sh/uv/getting-started/installation/)
+- Install [uv](https://docs.astral.sh/uv/getting-started/installation/) (version 0.5.4 or later, latest version is recommended)
 - Install [Python (3.11 or 3.12)](https://www.python.org/downloads/)
 
 ### Install From Source

--- a/docs/source/quick-start/installing.md
+++ b/docs/source/quick-start/installing.md
@@ -53,7 +53,7 @@ Before you begin using NeMo Agent toolkit, ensure that you meet the following so
 
 - Install [Git](https://git-scm.com/)
 - Install [Git Large File Storage](https://git-lfs.github.com/) (LFS)
-- Install [uv](https://docs.astral.sh/uv/getting-started/installation/)
+- Install [uv](https://docs.astral.sh/uv/getting-started/installation/) (version 0.5.4 or later, latest version is recommended)
 
 ## Install From Source
 


### PR DESCRIPTION
## Description

This is a documentation PR that adds a minimum required version for `uv` with the recommendation to install the latest version.

Closes #516

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
