### PR TITLE
Fix issue where aiq fails for certain log levels

### DIFF
--- a/src/aiq/front_ends/console/console_front_end_plugin.py
+++ b/src/aiq/front_ends/console/console_front_end_plugin.py
@@ -65,9 +65,6 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
 
         # Must yield the workflow function otherwise it cleans up
         async with WorkflowBuilder.from_config(config=self.full_config) as builder:
-
-            session_manager: AIQSessionManager = None
-
             if logger.isEnabledFor(logging.INFO):
                 stream = StringIO()
                 self.full_config.print_summary(stream=stream)
@@ -79,7 +76,7 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
 
             await self.run_workflow(session_manager)
 
-    async def run_workflow(self, session_manager: AIQSessionManager = None):
+    async def run_workflow(self, session_manager: AIQSessionManager):
 
         assert session_manager is not None, "Session manager must be provided"
         runner_outputs = None

--- a/src/aiq/front_ends/console/console_front_end_plugin.py
+++ b/src/aiq/front_ends/console/console_front_end_plugin.py
@@ -61,21 +61,6 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         if (not self.front_end_config.input_query and not self.front_end_config.input_file):
             raise click.UsageError("Must specify either --input_query or --input_file")
 
-    async def run(self):
-
-        # Must yield the workflow function otherwise it cleans up
-        async with WorkflowBuilder.from_config(config=self.full_config) as builder:
-            if logger.isEnabledFor(logging.INFO):
-                stream = StringIO()
-                self.full_config.print_summary(stream=stream)
-
-                click.echo(stream.getvalue())
-
-            workflow = builder.build()
-            session_manager = AIQSessionManager(workflow)
-
-            await self.run_workflow(session_manager)
-
     async def run_workflow(self, session_manager: AIQSessionManager):
 
         assert session_manager is not None, "Session manager must be provided"

--- a/src/aiq/front_ends/console/console_front_end_plugin.py
+++ b/src/aiq/front_ends/console/console_front_end_plugin.py
@@ -81,6 +81,7 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
 
     async def run_workflow(self, session_manager: AIQSessionManager = None):
 
+        assert session_manager is not None, "Session manager must be provided"
         runner_outputs = None
 
         if (self.front_end_config.input_query):

--- a/src/aiq/front_ends/console/console_front_end_plugin.py
+++ b/src/aiq/front_ends/console/console_front_end_plugin.py
@@ -67,16 +67,15 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         async with WorkflowBuilder.from_config(config=self.full_config) as builder:
 
             session_manager: AIQSessionManager = None
+            stream = StringIO()
 
             if logger.isEnabledFor(logging.INFO):
-                stream = StringIO()
-
                 self.full_config.print_summary(stream=stream)
 
-                click.echo(stream.getvalue())
+            click.echo(stream.getvalue())
 
-                workflow = builder.build()
-                session_manager = AIQSessionManager(workflow)
+            workflow = builder.build()
+            session_manager = AIQSessionManager(workflow)
 
             await self.run_workflow(session_manager)
 

--- a/src/aiq/front_ends/console/console_front_end_plugin.py
+++ b/src/aiq/front_ends/console/console_front_end_plugin.py
@@ -15,12 +15,10 @@
 
 import asyncio
 import logging
-from io import StringIO
 
 import click
 from colorama import Fore
 
-from aiq.builder.workflow_builder import WorkflowBuilder
 from aiq.data_models.interactive import HumanPromptModelType
 from aiq.data_models.interactive import HumanResponse
 from aiq.data_models.interactive import HumanResponseText

--- a/src/aiq/front_ends/console/console_front_end_plugin.py
+++ b/src/aiq/front_ends/console/console_front_end_plugin.py
@@ -67,12 +67,12 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         async with WorkflowBuilder.from_config(config=self.full_config) as builder:
 
             session_manager: AIQSessionManager = None
-            stream = StringIO()
 
             if logger.isEnabledFor(logging.INFO):
+                stream = StringIO()
                 self.full_config.print_summary(stream=stream)
 
-            click.echo(stream.getvalue())
+                click.echo(stream.getvalue())
 
             workflow = builder.build()
             session_manager = AIQSessionManager(workflow)

--- a/src/aiq/front_ends/simple_base/simple_front_end_plugin_base.py
+++ b/src/aiq/front_ends/simple_base/simple_front_end_plugin_base.py
@@ -45,8 +45,8 @@ class SimpleFrontEndPluginBase(FrontEndBase[FrontEndConfigT], ABC):
 
                 click.echo(stream.getvalue())
 
-            await self.run_workflow(builder.build())
+            await self.run_workflow(AIQSessionManager(builder.build()))
 
     @abstractmethod
-    async def run_workflow(self, session_manager: AIQSessionManager = None):
+    async def run_workflow(self, session_manager: AIQSessionManager):
         pass

--- a/src/aiq/front_ends/simple_base/simple_front_end_plugin_base.py
+++ b/src/aiq/front_ends/simple_base/simple_front_end_plugin_base.py
@@ -45,7 +45,9 @@ class SimpleFrontEndPluginBase(FrontEndBase[FrontEndConfigT], ABC):
 
                 click.echo(stream.getvalue())
 
-            await self.run_workflow(AIQSessionManager(builder.build()))
+            workflow = builder.build()
+            session_manager = AIQSessionManager(workflow)
+            await self.run_workflow(session_manager)
 
     @abstractmethod
     async def run_workflow(self, session_manager: AIQSessionManager):


### PR DESCRIPTION
## Description
* `SimpleFrontEndPluginBase.run_workflow` should never receive a `None` value for `session_manager`
* Fix `SimpleFrontEndPluginBase.run`
* Remove unnecessary overload of `ConsoleFrontEndPlugin.run`

Closes #521

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
