### PR TITLE
Resolve batch flushing failure during `SpanExporter` cleanup

### DIFF
--- a/packages/aiqtoolkit_opentelemetry/src/aiq/plugins/opentelemetry/otel_span_exporter.py
+++ b/packages/aiqtoolkit_opentelemetry/src/aiq/plugins/opentelemetry/otel_span_exporter.py
@@ -114,15 +114,13 @@ class OtelSpanExporter(SpanExporter[Span, OtelSpan]):  # pylint: disable=R0901
             resource_attributes = {}
         self._resource = Resource(attributes=resource_attributes)
 
-        self._batching_processor = OtelSpanBatchProcessor(batch_size=batch_size,
-                                                          flush_interval=flush_interval,
-                                                          max_queue_size=max_queue_size,
-                                                          drop_on_overflow=drop_on_overflow,
-                                                          shutdown_timeout=shutdown_timeout,
-                                                          done_callback=self.export_processed)
-
         self.add_processor(SpanToOtelProcessor())
-        self.add_processor(self._batching_processor)
+        self.add_processor(
+            OtelSpanBatchProcessor(batch_size=batch_size,
+                                   flush_interval=flush_interval,
+                                   max_queue_size=max_queue_size,
+                                   drop_on_overflow=drop_on_overflow,
+                                   shutdown_timeout=shutdown_timeout))
 
     async def export_processed(self, item: OtelSpan | list[OtelSpan]) -> None:
         """Export the processed span(s).

--- a/src/aiq/observability/exporter/processing_exporter.py
+++ b/src/aiq/observability/exporter/processing_exporter.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 from abc import abstractmethod
 from collections.abc import Coroutine
+from typing import Any
 from typing import Generic
 from typing import TypeVar
 
@@ -24,6 +25,7 @@ from aiq.builder.context import AIQContextState
 from aiq.data_models.intermediate_step import IntermediateStep
 from aiq.observability.exporter.base_exporter import BaseExporter
 from aiq.observability.mixin.type_introspection_mixin import TypeIntrospectionMixin
+from aiq.observability.processor.callback_processor import CallbackProcessor
 from aiq.observability.processor.processor import Processor
 from aiq.utils.type_utils import DecomposedType
 from aiq.utils.type_utils import override
@@ -89,6 +91,14 @@ class ProcessingExporter(Generic[PipelineInputT, PipelineOutputT], BaseExporter,
                     self._processors[-1].output_type)
         self._processors.append(processor)
 
+        # Set up pipeline continuation callback for processors that support it
+        if isinstance(processor, CallbackProcessor):
+            # Create a callback that continues processing through the rest of the pipeline
+            async def pipeline_callback(item):
+                await self._continue_pipeline_after(processor, item)
+
+            processor.set_done_callback(pipeline_callback)
+
     def remove_processor(self, processor: Processor) -> None:
         """Remove a processor from the processing pipeline.
 
@@ -143,20 +153,82 @@ class ProcessingExporter(Generic[PipelineInputT, PipelineOutputT], BaseExporter,
         """Process item through all registered processors.
 
         Args:
-            item: The item to process (starts as PipelineInputT, can transform to PipelineOutputT)
+            item (PipelineInputT): The item to process (starts as PipelineInputT, can transform to PipelineOutputT)
+
+        Returns:
+            PipelineOutputT: The processed item after running through all processors
+        """
+        return await self._process_through_processors(self._processors, item)  # type: ignore
+
+    async def _process_through_processors(self, processors: list[Processor], item: Any) -> Any:
+        """Process an item through a list of processors.
+
+        Args:
+            processors (list[Processor]): List of processors to run the item through
+            item (Any): The item to process
 
         Returns:
             The processed item after running through all processors
         """
         processed_item = item
-        for processor in self._processors:
+        for processor in processors:
             try:
                 processed_item = await processor.process(processed_item)
             except Exception as e:
                 logger.error("Error in processor %s: %s", processor.__class__.__name__, e, exc_info=True)
-                # Continue with unprocessed item rather than failing the export
+                # Continue with unprocessed item rather than failing
+        return processed_item
 
-        return processed_item  # type: ignore
+    async def _export_final_item(self, processed_item: Any, raise_on_invalid: bool = False) -> None:
+        """Export a processed item with proper type handling.
+
+        Args:
+            processed_item (Any): The item to export
+            raise_on_invalid (bool): If True, raise ValueError for invalid types instead of logging warning
+        """
+        if isinstance(processed_item, list):
+            if len(processed_item) > 0:
+                await self.export_processed(processed_item)
+            else:
+                logger.debug("Skipping export of empty batch")
+        elif isinstance(processed_item, self.output_class):
+            await self.export_processed(processed_item)
+        else:
+            if raise_on_invalid:
+                raise ValueError(f"Processed item {processed_item} is not a valid output type. "
+                                 f"Expected {self.output_class} or list[{self.output_class}]")
+            logger.warning("Processed item %s is not a valid output type for export", processed_item)
+
+    async def _continue_pipeline_after(self, source_processor: Processor, item: Any) -> None:
+        """Continue processing an item through the pipeline after a specific processor.
+
+        This is used when processors (like BatchingProcessor) need to inject items
+        back into the pipeline flow to continue through downstream processors.
+
+        Args:
+            source_processor (Processor): The processor that generated the item
+            item (Any): The item to continue processing through the remaining pipeline
+        """
+        try:
+            # Find the source processor's position
+            try:
+                source_index = self._processors.index(source_processor)
+            except ValueError:
+                logger.error("Source processor %s not found in pipeline", source_processor.__class__.__name__)
+                return
+
+            # Process through remaining processors (skip the source processor)
+            remaining_processors = self._processors[source_index + 1:]
+            processed_item = await self._process_through_processors(remaining_processors, item)
+
+            # Export the final result
+            await self._export_final_item(processed_item)
+
+        except Exception as e:
+            logger.error("Failed to continue pipeline processing after %s: %s",
+                         source_processor.__class__.__name__,
+                         e,
+                         exc_info=True)
 
     async def _export_with_processing(self, item: PipelineInputT) -> None:
         """Export an item after processing it through the pipeline.
@@ -169,20 +241,11 @@ class ProcessingExporter(Generic[PipelineInputT, PipelineOutputT], BaseExporter,
             final_item: PipelineOutputT = await self._process_pipeline(item)
 
             # Handle different output types from batch processors
-            if isinstance(final_item, list):
-                # Empty lists from batch processors should be skipped, not exported
-                if len(final_item) == 0:
-                    logger.debug("Skipping export of empty batch from processor pipeline")
-                    return
+            if isinstance(final_item, list) and len(final_item) == 0:
+                logger.debug("Skipping export of empty batch from processor pipeline")
+                return
 
-                # Non-empty lists should be exported (batch processors)
-                await self.export_processed(final_item)
-            elif isinstance(final_item, self.output_class):
-                # Single items should be exported normally
-                await self.export_processed(final_item)
-            else:
-                raise ValueError(f"Processed item {final_item} is not a valid output type. "
-                                 f"Expected {self.output_class} or list[{self.output_class}]")
+            await self._export_final_item(final_item, raise_on_invalid=True)
 
         except Exception as e:
             logger.error("Failed to export item '%s': %s", item, e, exc_info=True)
@@ -235,35 +298,25 @@ class ProcessingExporter(Generic[PipelineInputT, PipelineOutputT], BaseExporter,
 
     @override
     async def _cleanup(self):
-        """Enhanced cleanup that shuts down all shutdown-aware processors."""
+        """Enhanced cleanup that shuts down all shutdown-aware processors.
+
+        Each processor is responsible for its own cleanup, including routing
+        any final batches through the remaining pipeline via their done callbacks.
+        """
         # Shutdown all processors that support it
-        if hasattr(self, '_processors'):
-            shutdown_tasks = []
-            for processor in getattr(self, '_processors', []):
-                if hasattr(processor, 'shutdown'):
-                    logger.debug("Shutting down processor: %s", processor.__class__.__name__)
-                    shutdown_tasks.append(processor.shutdown())
+        shutdown_tasks = []
+        for processor in getattr(self, '_processors', []):
+            shutdown_method = getattr(processor, 'shutdown', None)
+            if shutdown_method:
+                logger.debug("Shutting down processor: %s", processor.__class__.__name__)
+                shutdown_tasks.append(shutdown_method())
 
-            if shutdown_tasks:
-                try:
-                    await asyncio.gather(*shutdown_tasks, return_exceptions=True)
-                    logger.info("Successfully shut down %d processors", len(shutdown_tasks))
-                except Exception as e:
-                    logger.error("Error shutting down processors: %s", e, exc_info=True)
-
-            # Process final batches from batch processors
-            for processor in getattr(self, '_processors', []):
-                if hasattr(processor, 'has_final_batch') and hasattr(processor, 'get_final_batch'):
-                    if processor.has_final_batch():
-                        final_batch = processor.get_final_batch()
-                        if final_batch:
-                            logger.info("Processing final batch of %d items from %s during cleanup",
-                                        len(final_batch),
-                                        processor.__class__.__name__)
-                            try:
-                                await self.export_processed(final_batch)
-                            except Exception as e:
-                                logger.error("Error processing final batch during cleanup: %s", e, exc_info=True)
+        if shutdown_tasks:
+            try:
+                await asyncio.gather(*shutdown_tasks, return_exceptions=True)
+                logger.info("Successfully shut down %d processors", len(shutdown_tasks))
+            except Exception as e:
+                logger.error("Error shutting down processors: %s", e, exc_info=True)
 
         # Call parent cleanup
         await super()._cleanup()

--- a/src/aiq/observability/exporter/span_exporter.py
+++ b/src/aiq/observability/exporter/span_exporter.py
@@ -262,3 +262,4 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
         self._outstanding_spans.clear()  # type: ignore
         self._span_stack.clear()  # type: ignore
         self._metadata_stack.clear()  # type: ignore
+        await super()._cleanup()

--- a/src/aiq/observability/processor/batching_processor.py
+++ b/src/aiq/observability/processor/batching_processor.py
@@ -23,17 +23,17 @@ from typing import Any
 from typing import Generic
 from typing import TypeVar
 
-from aiq.observability.processor.processor import Processor
+from aiq.observability.processor.callback_processor import CallbackProcessor
 
 logger = logging.getLogger(__name__)
 
 T = TypeVar('T')
 
 
-class BatchingProcessor(Processor[T, list[T]], Generic[T]):
+class BatchingProcessor(CallbackProcessor[T, list[T]], Generic[T]):
     """Pass-through batching processor that accumulates items and outputs batched lists.
 
-    This processor fits properly into the generics design by implementing Processor[T, List[T]].
+    This processor extends CallbackProcessor[T, List[T]] to provide batching functionality.
     It accumulates individual items and outputs them as batches when size or time thresholds
     are met. The batched output continues through the processing pipeline.
 
@@ -43,25 +43,31 @@ class BatchingProcessor(Processor[T, list[T]], Generic[T]):
     Key Features:
     - Pass-through design: Processor[T, List[T]]
     - Size-based and time-based batching
-    - Fits into generics processing pipeline design
+    - Pipeline flow: batches continue through downstream processors
     - GUARANTEED: No items lost during cleanup
     - Comprehensive statistics and monitoring
     - Proper cleanup and shutdown handling
     - High-performance async implementation
     - Back-pressure handling with queue limits
 
+    Pipeline Flow:
+        Normal processing: Individual items → BatchingProcessor → List[items] → downstream processors → export
+        Time-based flush: Scheduled batches automatically continue through remaining pipeline
+        Shutdown: Final batch immediately routed through remaining pipeline
+
     Cleanup Guarantee:
-        When ProcessingExporter._cleanup() calls shutdown(), this processor:
+        When shutdown() is called, this processor:
         1. Stops accepting new items
-        2. Processes all queued items as final batch
-        3. Returns final batch to continue through pipeline
-        4. Ensures zero data loss during shutdown
+        2. Creates final batch from all queued items
+        3. Immediately routes final batch through remaining pipeline via callback
+        4. Ensures zero data loss with no external coordination needed
 
     Usage in Pipeline:
         ```python
-        # Individual spans → Batched spans → Continue processing
-        exporter.add_processor(BatchingProcessor[Span](batch_size=100))
-        exporter.add_processor(BatchedSpanProcessor())  # Processes List[Span]
+        # Individual spans → Batched spans → Continue through downstream processors
+        exporter.add_processor(BatchingProcessor[Span](batch_size=100))  # Auto-wired with pipeline callback
+        exporter.add_processor(FilterProcessor())  # Processes List[Span] from batching
+        exporter.add_processor(TransformProcessor())  # Further processing
         ```
 
     Args:
@@ -70,6 +76,10 @@ class BatchingProcessor(Processor[T, list[T]], Generic[T]):
         max_queue_size: Maximum items to queue before blocking (default: 1000)
         drop_on_overflow: If True, drop items when queue is full (default: False)
         shutdown_timeout: Max seconds to wait for final batch processing (default: 10.0)
+
+    Note:
+        The done_callback for pipeline integration is automatically set by ProcessingExporter
+        when the processor is added to a pipeline. For standalone usage, call set_done_callback().
     """
 
     def __init__(self,
@@ -77,14 +87,13 @@ class BatchingProcessor(Processor[T, list[T]], Generic[T]):
                  flush_interval: float = 5.0,
                  max_queue_size: int = 1000,
                  drop_on_overflow: bool = False,
-                 shutdown_timeout: float = 10.0,
-                 done_callback: Callable[[list[T]], Awaitable[None]] | None = None):
+                 shutdown_timeout: float = 10.0):
         self._batch_size = batch_size
         self._flush_interval = flush_interval
         self._max_queue_size = max_queue_size
         self._drop_on_overflow = drop_on_overflow
         self._shutdown_timeout = shutdown_timeout
-        self._done_callback = done_callback
+        self._done_callback: Callable[[list[T]], Awaitable[None]] | None = None
 
         # Batching state
         self._batch_queue: deque[T] = deque()
@@ -93,11 +102,7 @@ class BatchingProcessor(Processor[T, list[T]], Generic[T]):
         self._batch_lock = asyncio.Lock()
         self._shutdown_requested = False
         self._shutdown_complete = False
-        self._shutdown_complete_event: asyncio.Event | None = None
-
-        # Final batch handling for cleanup
-        self._final_batch: list[T] | None = None
-        self._final_batch_processed = False
+        self._shutdown_complete_event = asyncio.Event()
 
         # Callback for immediate export of scheduled batches
         self._done = None
@@ -167,7 +172,11 @@ class BatchingProcessor(Processor[T, list[T]], Generic[T]):
             return []
 
     def set_done_callback(self, callback: Callable[[list[T]], Awaitable[None]]):
-        """Set callback function for immediate export of scheduled batches."""
+        """Set callback function for routing batches through the remaining pipeline.
+
+        This is automatically set by ProcessingExporter.add_processor() to continue
+        batches through downstream processors before final export.
+        """
         self._done_callback = callback
 
     async def _schedule_flush(self):
@@ -178,15 +187,15 @@ class BatchingProcessor(Processor[T, list[T]], Generic[T]):
                 if not self._shutdown_requested and self._batch_queue:
                     batch = await self._create_batch()
                     if batch:
-                        # Immediately export scheduled batches via callback
+                        # Route scheduled batches through pipeline via callback
                         if self._done_callback is not None:
                             try:
                                 await self._done_callback(batch)
-                                logger.debug("Scheduled flush exported batch of %d items", len(batch))
+                                logger.debug("Scheduled flush routed batch of %d items through pipeline", len(batch))
                             except Exception as e:
-                                logger.error("Error exporting scheduled batch: %s", e, exc_info=True)
+                                logger.error("Error routing scheduled batch through pipeline: %s", e, exc_info=True)
                         else:
-                            logger.warning("Scheduled flush created batch of %d items but no export callback set",
+                            logger.warning("Scheduled flush created batch of %d items but no pipeline callback set",
                                            len(batch))
         except asyncio.CancelledError:
             pass
@@ -223,11 +232,8 @@ class BatchingProcessor(Processor[T, list[T]], Generic[T]):
         """Shutdown the processor and ensure all items are processed.
 
         CRITICAL: This method is called by ProcessingExporter._cleanup() to ensure
-        no items are lost during shutdown. It creates a final batch from any
-        remaining items and stores it for processing.
-
-        The final batch will be processed by the next process() call or can be
-        retrieved via get_final_batch().
+        no items are lost during shutdown. It immediately routes any remaining
+        items as a final batch through the rest of the processing pipeline.
         """
         if self._shutdown_requested:
             logger.debug("Shutdown already requested, waiting for completion")
@@ -251,13 +257,26 @@ class BatchingProcessor(Processor[T, list[T]], Generic[T]):
                 except asyncio.CancelledError:
                     pass
 
-            # Create final batch from remaining items
+            # Create and route final batch through pipeline
             async with self._batch_lock:
                 if self._batch_queue:
-                    self._final_batch = await self._create_batch()
-                    logger.info("Created final batch of %d items during shutdown", len(self._final_batch))
+                    final_batch = await self._create_batch()
+                    logger.info("Created final batch of %d items during shutdown", len(final_batch))
+
+                    # Route final batch through pipeline via callback
+                    if self._done_callback is not None:
+                        try:
+                            await self._done_callback(final_batch)
+                            logger.info("Successfully routed final batch of %d items through pipeline during shutdown",
+                                        len(final_batch))
+                        except Exception as e:
+                            logger.error("Error routing final batch through pipeline during shutdown: %s",
+                                         e,
+                                         exc_info=True)
+                    else:
+                        logger.warning("Final batch of %d items created during shutdown but no pipeline callback set",
+                                       len(final_batch))
                 else:
-                    self._final_batch = []
                     logger.info("No items remaining during shutdown")
 
             self._shutdown_complete = True
@@ -268,30 +287,6 @@ class BatchingProcessor(Processor[T, list[T]], Generic[T]):
             logger.error("Error during BatchingProcessor shutdown: %s", e, exc_info=True)
             self._shutdown_complete = True
             self._shutdown_complete_event.set()
-
-    def get_final_batch(self) -> list[T]:
-        """Get the final batch created during shutdown.
-
-        This method allows the exporter to retrieve and process any items
-        that were queued when shutdown was called.
-
-        Returns:
-            List[T]: Final batch of items, empty list if none
-        """
-        if self._final_batch is not None:
-            final_batch = self._final_batch
-            self._final_batch = None  # Clear to avoid double processing
-            self._final_batch_processed = True
-            return final_batch
-        return []
-
-    def has_final_batch(self) -> bool:
-        """Check if there's a final batch waiting to be processed.
-
-        Returns:
-            bool: True if final batch exists and hasn't been processed
-        """
-        return self._final_batch is not None and not self._final_batch_processed
 
     def get_stats(self) -> dict[str, Any]:
         """Get comprehensive batching statistics."""
@@ -309,8 +304,6 @@ class BatchingProcessor(Processor[T, list[T]], Generic[T]):
             "shutdown_batches": self._shutdown_batches,
             "shutdown_requested": self._shutdown_requested,
             "shutdown_complete": self._shutdown_complete,
-            "final_batch_size": len(self._final_batch) if self._final_batch else 0,
-            "final_batch_processed": self._final_batch_processed,
             "avg_items_per_batch": self._items_processed / max(1, self._batches_created),
             "drop_rate": self._items_dropped / max(1, self._items_processed) * 100 if self._items_processed > 0 else 0
         }

--- a/src/aiq/observability/processor/callback_processor.py
+++ b/src/aiq/observability/processor/callback_processor.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from abc import abstractmethod
+from collections.abc import Awaitable
+from collections.abc import Callable
+from typing import Any
+from typing import Generic
+from typing import TypeVar
+
+from aiq.observability.processor.processor import Processor
+
+InputT = TypeVar('InputT')
+OutputT = TypeVar('OutputT')
+
+
+class CallbackProcessor(Processor[InputT, OutputT], Generic[InputT, OutputT]):
+    """Abstract base class for processors that support done callbacks.
+
+    Processors inheriting from this class can register callbacks that are
+    invoked when items are ready for further processing or export.
+    """
+
+    @abstractmethod
+    def set_done_callback(self, callback: Callable[[Any], Awaitable[None]]) -> None:
+        """Set a callback function to be invoked when items are processed.
+
+        Args:
+            callback (Callable[[Any], Awaitable[None]]): Function to call with processed items
+        """
+        pass

--- a/src/aiq/observability/processor/processor.py
+++ b/src/aiq/observability/processor/processor.py
@@ -63,6 +63,9 @@ class Processor(Generic[InputT, OutputT], TypeIntrospectionMixin, ABC):
         """Process an item and return a potentially different type.
 
         Args:
-            item: The item to process
+            item (InputT): The item to process
+
+        Returns:
+            OutputT: The processed item
         """
         pass

--- a/tests/aiq/observability/exporter/test_processing_exporter.py
+++ b/tests/aiq/observability/exporter/test_processing_exporter.py
@@ -82,7 +82,6 @@ class MockProcessorWithShutdown(Processor[str, str]):
 
     def shutdown(self):
         """Mock shutdown method that returns an awaitable to avoid coroutine creation during type introspection."""
-        import asyncio
         self.shutdown_called = True
 
         # Create a completed future instead of a coroutine to avoid the warning
@@ -836,7 +835,7 @@ class TestCallbackProcessorIntegration:
         assert processing_exporter.export_processed_called
         assert 5 in processing_exporter.exported_items  # len("hello") = 5
 
-    async def test_continue_pipeline_after_with_remaining_processors(self, processing_exporter):
+    async def test_continue_pipeline_after_with_remaining_processors(self):
         """Test _continue_pipeline_after processes through remaining pipeline."""
 
         # Create a string-processing exporter to avoid type issues

--- a/tests/aiq/observability/exporter/test_processing_exporter.py
+++ b/tests/aiq/observability/exporter/test_processing_exporter.py
@@ -24,6 +24,7 @@ import pytest
 
 from aiq.builder.context import AIQContextState
 from aiq.observability.exporter.processing_exporter import ProcessingExporter
+from aiq.observability.processor.callback_processor import CallbackProcessor
 from aiq.observability.processor.processor import Processor
 from aiq.utils.reactive.subject import Subject
 
@@ -74,27 +75,20 @@ class MockProcessorWithShutdown(Processor[str, str]):
     def __init__(self, name: str = "MockProcessorWithShutdown"):
         self.name = name
         self.shutdown_called = False
-        self.has_final_batch_called = False
-        self.get_final_batch_called = False
-        self._final_batch = ["final1", "final2"]
 
     async def process(self, item: str) -> str:
         """Identity processor."""
         return item.upper()
 
-    async def shutdown(self):
-        """Mock shutdown method."""
+    def shutdown(self):
+        """Mock shutdown method that returns an awaitable to avoid coroutine creation during type introspection."""
+        import asyncio
         self.shutdown_called = True
 
-    def has_final_batch(self) -> bool:
-        """Mock has_final_batch method."""
-        self.has_final_batch_called = True
-        return True
-
-    def get_final_batch(self) -> list[str]:
-        """Mock get_final_batch method."""
-        self.get_final_batch_called = True
-        return self._final_batch.copy()
+        # Create a completed future instead of a coroutine to avoid the warning
+        future = asyncio.Future()
+        future.set_result(None)
+        return future
 
 
 class IncompatibleProcessor(Processor[float, bool]):
@@ -102,6 +96,35 @@ class IncompatibleProcessor(Processor[float, bool]):
 
     async def process(self, item: float) -> bool:
         return item > 0.0
+
+
+class MockCallbackProcessor(CallbackProcessor[str, str]):
+    """Mock callback processor for testing pipeline continuation."""
+
+    def __init__(self, name: str = "MockCallbackProcessor", trigger_callback: bool = False):
+        self.name = name
+        self.trigger_callback = trigger_callback
+        self.process_called = False
+        self.processed_items = []
+        self.callback_set = False
+        self.done_callback = None
+
+    async def process(self, item: str) -> str:
+        """Process item normally - callback triggering is separate."""
+        self.process_called = True
+        self.processed_items.append(item)
+        processed_item = item.upper()
+        return processed_item
+
+    def set_done_callback(self, callback):
+        """Set callback for pipeline continuation."""
+        self.callback_set = True
+        self.done_callback = callback
+
+    async def trigger_callback_manually(self, item: str):
+        """Manually trigger the callback for testing purposes."""
+        if self.done_callback:
+            await self.done_callback(item)
 
 
 # Concrete implementation for testing
@@ -518,6 +541,8 @@ class TestExportMethod:
         # Verify the coroutine is created correctly
         args, _ = mock_create_task.call_args
         assert asyncio.iscoroutine(args[0])
+        # Clean up the coroutine to avoid RuntimeWarning
+        args[0].close()
 
     @pytest.mark.filterwarnings("ignore:.*coroutine.*was never awaited:RuntimeWarning")
     def test_export_incompatible_event_warning(self, processing_exporter, caplog):
@@ -681,8 +706,8 @@ class TestCleanup:
             # so let's just check the method was called
             assert processor.shutdown != processor.__class__.shutdown  # Verify it was replaced
 
-    async def test_cleanup_final_batch_processing(self, processing_exporter, caplog):
-        """Test processing of final batches during cleanup."""
+    async def test_cleanup_calls_processor_shutdown(self, processing_exporter, caplog):
+        """Test that cleanup calls shutdown on processors that have it."""
         processor = MockProcessorWithShutdown("proc1")
         processing_exporter.add_processor(processor)
 
@@ -693,30 +718,44 @@ class TestCleanup:
             with caplog.at_level(logging.INFO):
                 await processing_exporter._cleanup()
 
-            assert processor.has_final_batch_called
-            assert processor.get_final_batch_called
-            assert processing_exporter.export_processed_called
-            assert "Processing final batch of 2 items" in caplog.text
+            assert processor.shutdown_called
+            assert "Successfully shut down 1 processors" in caplog.text
 
-    async def test_cleanup_final_batch_processing_error(self, processing_exporter, caplog):
-        """Test error handling during final batch processing."""
+    async def test_cleanup_processor_shutdown_error_handling(self, processing_exporter):
+        """Test error handling during processor shutdown."""
         processor = MockProcessorWithShutdown("proc1")
         processing_exporter.add_processor(processor)
 
-        # Mock export_processed to raise an error
-        async def failing_export(item):
-            raise RuntimeError("Export failed")
+        # Mock processor shutdown to raise an error
+        async def failing_shutdown():
+            raise RuntimeError("Shutdown failed")
 
-        processing_exporter.export_processed = failing_export
+        processor.shutdown = failing_shutdown
 
-        with patch('aiq.observability.exporter.base_exporter.BaseExporter._cleanup') as mock_parent_cleanup:
+        # Mock asyncio.gather to handle exceptions properly
+        async def mock_gather(*tasks, return_exceptions=True):
+            results = []
+            for task in tasks:
+                try:
+                    result = await task
+                    results.append(result)
+                except Exception as e:
+                    if return_exceptions:
+                        results.append(e)
+                    else:
+                        raise
+            return results
+
+        with patch('aiq.observability.exporter.base_exporter.BaseExporter._cleanup') as mock_parent_cleanup, \
+             patch('asyncio.gather', side_effect=mock_gather):
             mock_parent_cleanup.return_value = asyncio.Future()
             mock_parent_cleanup.return_value.set_result(None)
 
-            with caplog.at_level(logging.ERROR):
-                await processing_exporter._cleanup()
+            # Should not raise an error due to return_exceptions=True
+            await processing_exporter._cleanup()
 
-            assert "Error processing final batch during cleanup" in caplog.text
+            # Verify the shutdown was called (even though it failed)
+            assert processor.shutdown != processor.__class__.shutdown  # Verify it was replaced
 
     async def test_cleanup_without_processors_attribute(self, processing_exporter):
         """Test cleanup when _processors attribute doesn't exist."""
@@ -758,6 +797,206 @@ class TestAbstractMethod:
 
             # This should raise TypeError due to missing abstract method implementation
             IncompleteExporter()  # pylint: disable=abstract-class-instantiated
+
+
+class TestCallbackProcessorIntegration:
+    """Test CallbackProcessor integration and pipeline continuation."""
+
+    def test_callback_processor_callback_setup(self, processing_exporter):
+        """Test that CallbackProcessor gets its callback set during add_processor."""
+        callback_processor = MockCallbackProcessor("callback_proc")
+
+        processing_exporter.add_processor(callback_processor)
+
+        # Verify the callback was set (covers lines 97-100)
+        assert callback_processor.callback_set
+        assert callback_processor.done_callback is not None
+
+    async def test_callback_processor_pipeline_continuation(self, processing_exporter):
+        """Test CallbackProcessor triggers pipeline continuation."""
+        # Setup: Callback processor -> Regular processor
+        callback_processor = MockCallbackProcessor("callback_proc")
+        regular_processor = MockProcessor("regular_proc")  # str -> int
+
+        processing_exporter.add_processor(callback_processor)  # str -> str
+        processing_exporter.add_processor(regular_processor)  # str -> int
+
+        # Manually trigger the callback to test pipeline continuation
+        # This simulates what would happen when a real callback processor (like BatchingProcessor)
+        # triggers its callback with items to continue processing
+        test_item = "hello"  # String item to process
+        await callback_processor.trigger_callback_manually(test_item)
+
+        # Verify the regular processor was called through pipeline continuation
+        assert regular_processor.process_called
+        assert test_item in regular_processor.processed_items
+
+        # The final result should be exported (int from len("hello") = 5)
+        # This covers the pipeline continuation logic (lines 212-228)
+        assert processing_exporter.export_processed_called
+        assert 5 in processing_exporter.exported_items  # len("hello") = 5
+
+    async def test_continue_pipeline_after_with_remaining_processors(self, processing_exporter):
+        """Test _continue_pipeline_after processes through remaining pipeline."""
+
+        # Create a string-processing exporter to avoid type issues
+        class StringProcessingExporter(ProcessingExporter[str, str]):
+
+            def __init__(self, context_state=None):
+                super().__init__(context_state)
+                self.exported_items = []
+                self.export_processed_called = False
+
+            async def export_processed(self, item):
+                self.export_processed_called = True
+                self.exported_items.append(item)
+
+        # Create processors that all work with strings
+        class StringProcessor(Processor[str, str]):
+
+            def __init__(self, name):
+                self.name = name
+                self.process_called = False
+                self.processed_items = []
+
+            async def process(self, item: str) -> str:
+                self.process_called = True
+                self.processed_items.append(item)
+                return f"{item}_{self.name}"
+
+        string_exporter = StringProcessingExporter()
+        source_processor = StringProcessor("source")
+        middle_processor = StringProcessor("middle")
+        final_processor = StringProcessor("final")
+
+        string_exporter.add_processor(source_processor)
+        string_exporter.add_processor(middle_processor)
+        string_exporter.add_processor(final_processor)
+
+        # Manually call _continue_pipeline_after to test the method
+        test_item = "test"
+        await string_exporter._continue_pipeline_after(source_processor, test_item)
+
+        # Verify only the processors after source were called
+        assert not source_processor.process_called  # Should be skipped
+        assert middle_processor.process_called  # Should process
+        assert final_processor.process_called  # Should process
+        assert string_exporter.export_processed_called
+        # Should be "test_middle_final" after processing through middle and final
+        assert "test_middle_final" in string_exporter.exported_items
+
+    async def test_continue_pipeline_processor_not_found(self, processing_exporter, caplog):
+        """Test _continue_pipeline_after when source processor not in pipeline."""
+        # Add one processor to pipeline
+        pipeline_processor = MockProcessor("in_pipeline")
+        processing_exporter.add_processor(pipeline_processor)
+
+        # Try to continue from a processor not in pipeline
+        unknown_processor = MockProcessor("not_in_pipeline")
+
+        with caplog.at_level(logging.ERROR):
+            await processing_exporter._continue_pipeline_after(unknown_processor, "test")
+
+        # Verify error was logged (covers lines 216-218)
+        assert "Source processor MockProcessor not found in pipeline" in caplog.text
+        assert not processing_exporter.export_processed_called
+
+    async def test_continue_pipeline_exception_handling(self, processing_exporter, caplog):
+        """Test _continue_pipeline_after exception handling."""
+        # Setup a processor that will cause an exception
+        failing_processor = MockProcessor("source", should_fail=True)
+        processing_exporter.add_processor(failing_processor)
+
+        # Mock _process_through_processors to raise an exception
+        async def failing_process(*args, **kwargs):
+            raise RuntimeError("Pipeline processing failed")
+
+        processing_exporter._process_through_processors = failing_process
+
+        with caplog.at_level(logging.ERROR):
+            await processing_exporter._continue_pipeline_after(failing_processor, "test")
+
+        # Verify exception was logged (covers lines 227-231)
+        assert "Failed to continue pipeline processing after MockProcessor" in caplog.text
+
+    async def test_callback_processor_no_remaining_processors(self, processing_exporter):
+        """Test _continue_pipeline_after when no processors follow source."""
+        # Add only one processor
+        solo_processor = MockProcessor("solo")
+        processing_exporter.add_processor(solo_processor)
+
+        # Continue pipeline after the only processor with the processed output (integer)
+        # MockProcessor converts strings to their length, so "test" -> 4
+        await processing_exporter._continue_pipeline_after(solo_processor, 4)
+
+        # Should still call export_processed with the item
+        assert processing_exporter.export_processed_called
+        assert len(processing_exporter.exported_items) == 1
+        assert processing_exporter.exported_items[0] == 4
+
+
+class TestErrorPathCoverage:
+    """Test error paths and logging coverage."""
+
+    async def test_empty_batch_debug_logging(self, processing_exporter, caplog):
+        """Test debug logging when exporting empty batch."""
+        # Create an empty list to trigger the debug log
+        empty_batch = []
+
+        with caplog.at_level(logging.DEBUG):
+            await processing_exporter._export_final_item(empty_batch)
+
+        # Verify debug log was emitted (covers line 193)
+        assert "Skipping export of empty batch" in caplog.text
+        assert not processing_exporter.export_processed_called
+
+    async def test_invalid_output_type_warning_path(self, processing_exporter, caplog):
+        """Test warning path for invalid output types."""
+        # Create an invalid output type (not int or list[int] for our exporter)
+        invalid_item = {"invalid": "dict"}
+
+        with caplog.at_level(logging.WARNING):
+            # Call with raise_on_invalid=False to trigger warning path
+            await processing_exporter._export_final_item(invalid_item, raise_on_invalid=False)
+
+        # Verify warning was logged (covers line 200)
+        assert "is not a valid output type for export" in caplog.text
+        assert not processing_exporter.export_processed_called
+
+    async def test_cleanup_shutdown_exception_handling(self, processing_exporter, caplog):
+        """Test exception handling during processor shutdown in cleanup."""
+        processor = MockProcessorWithShutdown("test_proc")
+        processing_exporter.add_processor(processor)
+
+        # Mock asyncio.gather to raise an exception
+        async def failing_gather(*tasks, return_exceptions=True):
+            raise RuntimeError("Shutdown failed")
+
+        with patch('aiq.observability.exporter.base_exporter.BaseExporter._cleanup') as mock_parent_cleanup:
+            mock_parent_cleanup.return_value = asyncio.Future()
+            mock_parent_cleanup.return_value.set_result(None)
+
+            with patch('asyncio.gather', side_effect=failing_gather):
+                with caplog.at_level(logging.ERROR):
+                    await processing_exporter._cleanup()
+
+        # Verify exception was logged (covers lines 318-319)
+        assert "Error shutting down processors" in caplog.text
+
+    async def test_export_final_item_empty_list_vs_none(self, processing_exporter):
+        """Test distinction between empty list and None for batch handling."""
+        # Test empty list (should not export)
+        await processing_exporter._export_final_item([])
+        assert not processing_exporter.export_processed_called
+
+        # Reset and test with valid single item
+        processing_exporter.export_processed_called = False
+        processing_exporter.exported_items = []
+
+        valid_item = 5  # int matches our exporter's output type
+        await processing_exporter._export_final_item(valid_item)
+        assert processing_exporter.export_processed_called
+        assert processing_exporter.exported_items == [5]
 
 
 class TestEdgeCases:

--- a/tests/aiq/observability/processor/test_batching_processor.py
+++ b/tests/aiq/observability/processor/test_batching_processor.py
@@ -1,0 +1,709 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# pylint: disable=redefined-outer-name  # pytest fixtures
+
+import asyncio
+import logging
+import time
+
+import pytest
+
+from aiq.observability.processor.batching_processor import BatchingProcessor
+
+
+class TestBatchingProcessorInitialization:
+    """Test BatchingProcessor initialization and configuration."""
+
+    def test_default_initialization(self):
+        """Test processor with default parameters."""
+        processor = BatchingProcessor[str]()
+
+        assert processor._batch_size == 100
+        assert processor._flush_interval == 5.0
+        assert processor._max_queue_size == 1000
+        assert processor._drop_on_overflow is False
+        assert processor._shutdown_timeout == 10.0
+        assert len(processor._batch_queue) == 0
+        assert processor._shutdown_requested is False
+        assert processor._shutdown_complete is False
+
+    def test_custom_initialization(self):
+        """Test processor with custom parameters."""
+        processor = BatchingProcessor[int](batch_size=50,
+                                           flush_interval=2.0,
+                                           max_queue_size=500,
+                                           drop_on_overflow=True,
+                                           shutdown_timeout=30.0)
+
+        assert processor._batch_size == 50
+        assert processor._flush_interval == 2.0
+        assert processor._max_queue_size == 500
+        assert processor._drop_on_overflow is True
+        assert processor._shutdown_timeout == 30.0
+
+    def test_type_introspection(self):
+        """Test that type introspection works correctly."""
+        processor = BatchingProcessor[str]()
+
+        # Type introspection works with TypeVars in generics
+        # The actual types are preserved through the generic system
+        assert str(processor.input_type) in ['str', '~T']  # Could be TypeVar
+        assert str(processor.output_type) in ['list[str]', 'list[~T]']  # Could be TypeVar
+        # Classes might also be TypeVars depending on implementation
+        assert str(processor.input_class) in ['str', '~T', '<class \'str\'>']
+        assert str(processor.output_class) in ['list', '<class \'list\'>', '~T']
+
+    def test_initial_statistics(self):
+        """Test initial statistics are correct."""
+        processor = BatchingProcessor[str]()
+        stats = processor.get_stats()
+
+        assert stats["current_queue_size"] == 0
+        assert stats["batches_created"] == 0
+        assert stats["items_processed"] == 0
+        assert stats["items_dropped"] == 0
+        assert stats["queue_overflows"] == 0
+        assert stats["shutdown_batches"] == 0
+        assert stats["shutdown_requested"] is False
+        assert stats["shutdown_complete"] is False
+        assert stats["avg_items_per_batch"] == 0
+        assert stats["drop_rate"] == 0
+
+
+class TestBatchingProcessorSizeBased:
+    """Test size-based batching functionality."""
+
+    @pytest.mark.asyncio
+    async def test_batch_creation_by_size(self):
+        """Test that batches are created when size threshold is reached."""
+        processor = BatchingProcessor[str](batch_size=3)
+
+        # Add items one by one - should not create batch until size reached
+        result1 = await processor.process("item1")
+        assert result1 == []
+        assert len(processor._batch_queue) == 1
+
+        result2 = await processor.process("item2")
+        assert result2 == []
+        assert len(processor._batch_queue) == 2
+
+        # Third item should trigger batch creation
+        result3 = await processor.process("item3")
+        assert result3 == ["item1", "item2", "item3"]
+        assert len(processor._batch_queue) == 0
+
+    @pytest.mark.asyncio
+    async def test_multiple_batches_by_size(self):
+        """Test multiple batch creations."""
+        processor = BatchingProcessor[int](batch_size=2)
+
+        # First batch
+        await processor.process(1)
+        batch1 = await processor.process(2)
+        assert batch1 == [1, 2]
+
+        # Second batch
+        await processor.process(3)
+        batch2 = await processor.process(4)
+        assert batch2 == [3, 4]
+
+        stats = processor.get_stats()
+        assert stats["batches_created"] == 2
+        assert stats["items_processed"] == 4
+
+    @pytest.mark.asyncio
+    async def test_partial_batch_remains_queued(self):
+        """Test that partial batches remain in queue."""
+        processor = BatchingProcessor[str](batch_size=5)
+
+        await processor.process("item1")
+        await processor.process("item2")
+
+        stats = processor.get_stats()
+        assert stats["current_queue_size"] == 2
+        assert stats["batches_created"] == 0
+
+
+class TestBatchingProcessorTimeBased:
+    """Test time-based batching functionality."""
+
+    @pytest.mark.asyncio
+    async def test_time_based_flush_with_callback(self):
+        """Test that time-based flush routes through callback."""
+        processor = BatchingProcessor[str](batch_size=10, flush_interval=0.1)
+
+        # Set up callback to capture batches
+        callback_results = []
+
+        async def test_callback(batch):
+            callback_results.append(batch)
+
+        processor.set_done_callback(test_callback)
+
+        # Add items that won't trigger size-based batching
+        await processor.process("item1")
+        await processor.process("item2")
+
+        # Wait for time-based flush
+        await asyncio.sleep(0.2)
+
+        # Batch should have been routed through callback
+        assert len(callback_results) == 1
+        assert callback_results[0] == ["item1", "item2"]
+
+    @pytest.mark.asyncio
+    async def test_time_based_flush_without_callback(self, caplog):
+        """Test time-based flush when no callback is set."""
+        processor = BatchingProcessor[str](batch_size=10, flush_interval=0.1)
+
+        await processor.process("item1")
+
+        with caplog.at_level(logging.WARNING):
+            await asyncio.sleep(0.2)
+
+        # Should log warning about missing callback
+        assert "no pipeline callback set" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_scheduled_flush_task_management(self):
+        """Test that scheduled flush tasks are properly managed."""
+        processor = BatchingProcessor[str](batch_size=10, flush_interval=0.1)
+
+        # First item should schedule a flush
+        await processor.process("item1")
+        assert processor._flush_task is not None
+        assert not processor._flush_task.done()
+
+        # Second item should not create new task
+        first_task = processor._flush_task
+        await processor.process("item2")
+        assert processor._flush_task is first_task
+
+    @pytest.mark.asyncio
+    async def test_immediate_flush_cancels_scheduled_flush(self):
+        """Test that immediate batch creation cancels scheduled flush."""
+        processor = BatchingProcessor[str](batch_size=2, flush_interval=1.0)
+
+        # First item schedules flush
+        await processor.process("item1")
+        original_flush_task = processor._flush_task
+
+        # Second item triggers immediate batch and should leave task as-is
+        batch = await processor.process("item2")
+        assert batch == ["item1", "item2"]
+        # Original task reference might be the same but would complete naturally
+        assert original_flush_task is not None
+
+
+class TestBatchingProcessorOverflowHandling:
+    """Test queue overflow handling."""
+
+    @pytest.mark.asyncio
+    async def test_drop_on_overflow_enabled(self):
+        """Test dropping items when queue overflows and drop_on_overflow=True."""
+        processor = BatchingProcessor[str](batch_size=10, max_queue_size=2, drop_on_overflow=True)
+
+        # Fill queue to capacity
+        await processor.process("item1")
+        await processor.process("item2")
+
+        # Next item should be dropped
+        result = await processor.process("item3")
+        assert result == []
+
+        stats = processor.get_stats()
+        assert stats["current_queue_size"] == 2
+        assert stats["items_dropped"] == 1
+        assert stats["queue_overflows"] == 1
+
+    @pytest.mark.asyncio
+    async def test_force_flush_on_overflow(self):
+        """Test force flush when queue overflows and drop_on_overflow=False."""
+        processor = BatchingProcessor[str](
+            batch_size=10,  # Higher than queue size to test overflow
+            max_queue_size=2,
+            drop_on_overflow=False)
+
+        # Fill queue to capacity
+        await processor.process("item1")
+        await processor.process("item2")
+
+        # Next item should force flush and return the forced batch
+        result = await processor.process("item3")
+        assert result == ["item1", "item2"]
+
+        # New item should now be in queue
+        stats = processor.get_stats()
+        assert stats["current_queue_size"] == 1
+        assert stats["items_dropped"] == 0
+        assert stats["queue_overflows"] == 1
+
+    @pytest.mark.asyncio
+    async def test_overflow_statistics_tracking(self):
+        """Test that overflow statistics are properly tracked."""
+        processor = BatchingProcessor[str](max_queue_size=1, drop_on_overflow=True)
+
+        await processor.process("item1")
+        await processor.process("item2")  # Should be dropped
+        await processor.process("item3")  # Should be dropped
+
+        stats = processor.get_stats()
+        assert stats["queue_overflows"] == 2
+        assert stats["items_dropped"] == 2
+        assert stats["drop_rate"] == 200.0  # 2 dropped / 1 processed * 100
+
+
+class TestBatchingProcessorCallbacks:
+    """Test callback functionality."""
+
+    @pytest.mark.asyncio
+    async def test_set_done_callback(self):
+        """Test setting and using done callback."""
+        processor = BatchingProcessor[str](batch_size=2)
+
+        callback_results = []
+
+        async def test_callback(batch):
+            callback_results.append(batch)
+
+        processor.set_done_callback(test_callback)
+
+        # This won't use callback for immediate return
+        await processor.process("item1")
+        batch = await processor.process("item2")
+
+        # Batch returned directly, not through callback for size-based batching
+        assert batch == ["item1", "item2"]
+        assert len(callback_results) == 0
+
+    @pytest.mark.asyncio
+    async def test_callback_error_handling(self, caplog):
+        """Test error handling in callback execution."""
+        processor = BatchingProcessor[str](batch_size=10, flush_interval=0.1)
+
+        async def failing_callback(batch):
+            raise ValueError("Callback failed")
+
+        processor.set_done_callback(failing_callback)
+        await processor.process("item1")
+
+        with caplog.at_level(logging.ERROR):
+            await asyncio.sleep(0.2)
+
+        assert "Error routing scheduled batch through pipeline" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_callback_during_shutdown(self):
+        """Test callback execution during shutdown."""
+        processor = BatchingProcessor[str](batch_size=10)
+
+        callback_results = []
+
+        async def test_callback(batch):
+            callback_results.append(batch)
+
+        processor.set_done_callback(test_callback)
+
+        # Add items
+        await processor.process("item1")
+        await processor.process("item2")
+
+        # Shutdown should route final batch through callback
+        await processor.shutdown()
+
+        assert len(callback_results) == 1
+        assert callback_results[0] == ["item1", "item2"]
+
+
+class TestBatchingProcessorShutdown:
+    """Test shutdown functionality."""
+
+    @pytest.mark.asyncio
+    async def test_basic_shutdown(self):
+        """Test basic shutdown functionality."""
+        processor = BatchingProcessor[str]()
+
+        await processor.process("item1")
+        await processor.process("item2")
+
+        await processor.shutdown()
+
+        assert processor._shutdown_requested is True
+        assert processor._shutdown_complete is True
+        assert len(processor._batch_queue) == 0
+
+    @pytest.mark.asyncio
+    async def test_shutdown_during_processing(self):
+        """Test shutdown behavior when items are processed during shutdown."""
+        processor = BatchingProcessor[str](batch_size=10)
+
+        await processor.process("item1")
+
+        # Start shutdown and give it a moment to set the shutdown flag
+        shutdown_task = asyncio.create_task(processor.shutdown())
+        await asyncio.sleep(0.01)  # Small delay to ensure shutdown starts
+
+        # Try to process during shutdown - should return single-item batch
+        result = await processor.process("item2")
+        assert result == ["item2"]
+
+        await shutdown_task
+
+        stats = processor.get_stats()
+        assert stats["shutdown_batches"] == 1
+
+    @pytest.mark.asyncio
+    async def test_double_shutdown_idempotent(self):
+        """Test that calling shutdown multiple times is safe."""
+        processor = BatchingProcessor[str](shutdown_timeout=1.0)
+
+        await processor.process("item1")
+
+        # First shutdown
+        await processor.shutdown()
+        assert processor._shutdown_complete is True
+
+        # Second shutdown should wait and complete quickly
+        start_time = time.time()
+        await processor.shutdown()
+        end_time = time.time()
+
+        # Should complete quickly since already shut down
+        assert end_time - start_time < 0.5
+
+    @pytest.mark.asyncio
+    async def test_shutdown_with_scheduled_flush(self):
+        """Test shutdown behavior when scheduled flush is active."""
+        processor = BatchingProcessor[str](batch_size=10, flush_interval=1.0)
+
+        # This should schedule a flush
+        await processor.process("item1")
+        assert processor._flush_task is not None
+
+        # Shutdown should cancel the flush task
+        await processor.shutdown()
+
+        assert processor._flush_task.cancelled() or processor._flush_task.done()
+
+    @pytest.mark.asyncio
+    async def test_shutdown_callback_error_handling(self, caplog):
+        """Test error handling when callback fails during shutdown."""
+        processor = BatchingProcessor[str]()
+
+        async def failing_callback(batch):
+            raise ValueError("Shutdown callback failed")
+
+        processor.set_done_callback(failing_callback)
+        await processor.process("item1")
+
+        with caplog.at_level(logging.ERROR):
+            await processor.shutdown()
+
+        assert "Error routing final batch through pipeline during shutdown" in caplog.text
+        assert processor._shutdown_complete is True
+
+    @pytest.mark.asyncio
+    async def test_shutdown_timeout_handling(self, caplog):
+        """Test shutdown timeout handling by simulating concurrent shutdown calls."""
+        processor = BatchingProcessor[str](shutdown_timeout=0.1)
+
+        await processor.process("item1")
+
+        # Test the scenario where shutdown is called multiple times concurrently
+        # The second call should wait and potentially timeout
+
+        # Create a barrier to simulate a hanging shutdown event
+        # We'll patch the shutdown complete event to never be set
+        original_event = processor._shutdown_complete_event
+
+        # Create a new event that will never be set to simulate hanging
+        hanging_event = asyncio.Event()
+        processor._shutdown_complete_event = hanging_event
+
+        # Set shutdown requested to trigger the timeout path
+        processor._shutdown_requested = True
+
+        # This should trigger the timeout path
+        with caplog.at_level(logging.WARNING):
+            await processor.shutdown()
+
+        # Check if timeout warning was logged
+        timeout_logged = "Shutdown completion timeout exceeded" in caplog.text
+
+        # Restore original state
+        processor._shutdown_complete_event = original_event
+        processor._shutdown_requested = False
+        processor._shutdown_complete = False
+
+        # Complete a normal shutdown to clean up
+        await processor.shutdown()
+
+        # We expect the timeout to have been logged
+        assert timeout_logged, f"Expected timeout warning in logs: {caplog.text}"
+
+
+class TestBatchingProcessorForceFlush:
+    """Test force flush functionality."""
+
+    @pytest.mark.asyncio
+    async def test_force_flush_with_items(self):
+        """Test force flush when items are queued."""
+        processor = BatchingProcessor[str](batch_size=10)
+
+        await processor.process("item1")
+        await processor.process("item2")
+
+        batch = await processor.force_flush()
+        assert batch == ["item1", "item2"]
+        assert len(processor._batch_queue) == 0
+
+    @pytest.mark.asyncio
+    async def test_force_flush_empty_queue(self):
+        """Test force flush when queue is empty."""
+        processor = BatchingProcessor[str]()
+
+        batch = await processor.force_flush()
+        assert batch == []
+
+    @pytest.mark.asyncio
+    async def test_force_flush_statistics(self):
+        """Test that force flush updates statistics correctly."""
+        processor = BatchingProcessor[str](batch_size=10)
+
+        await processor.process("item1")
+        await processor.force_flush()
+
+        stats = processor.get_stats()
+        assert stats["batches_created"] == 1
+        assert stats["items_processed"] == 1
+
+
+class TestBatchingProcessorStatistics:
+    """Test comprehensive statistics functionality."""
+
+    @pytest.mark.asyncio
+    async def test_comprehensive_statistics(self):
+        """Test all statistics are properly tracked."""
+        # Use separate scenarios to avoid conflicts between batch_size and max_queue_size
+
+        # First, test normal batch creation
+        processor = BatchingProcessor[str](batch_size=3, max_queue_size=10)
+        await processor.process("item1")
+        await processor.process("item2")
+        batch = await processor.process("item3")  # Creates batch
+        assert batch == ["item1", "item2", "item3"]
+
+        # Now test overflow with a separate processor
+        overflow_processor = BatchingProcessor[str](batch_size=10, max_queue_size=2, drop_on_overflow=True)
+        await overflow_processor.process("item4")
+        await overflow_processor.process("item5")
+        await overflow_processor.process("item6")  # Should be dropped
+
+        # Check combined statistics concepts
+        stats = processor.get_stats()
+        assert stats["batches_created"] == 1
+        assert stats["items_processed"] == 3
+        assert stats["avg_items_per_batch"] == 3.0
+
+        overflow_stats = overflow_processor.get_stats()
+        assert overflow_stats["items_dropped"] == 1
+        assert overflow_stats["queue_overflows"] == 1
+        assert overflow_stats["drop_rate"] == 50.0  # 1 dropped / 2 processed * 100
+
+    @pytest.mark.asyncio
+    async def test_shutdown_statistics(self):
+        """Test statistics tracking during shutdown processing."""
+        processor = BatchingProcessor[str](batch_size=10)
+
+        await processor.process("item1")
+        await processor.shutdown()
+
+        # Process during shutdown
+        await processor.process("item2")
+
+        stats = processor.get_stats()
+        assert stats["shutdown_batches"] == 1
+        assert stats["shutdown_requested"] is True
+        assert stats["shutdown_complete"] is True
+
+    @pytest.mark.asyncio
+    async def test_statistics_edge_cases(self):
+        """Test statistics edge cases like division by zero."""
+        processor = BatchingProcessor[str]()
+
+        stats = processor.get_stats()
+
+        # Should handle division by zero gracefully
+        assert stats["avg_items_per_batch"] == 0
+        assert stats["drop_rate"] == 0
+
+
+class TestBatchingProcessorErrorHandling:
+    """Test error handling scenarios."""
+
+    @pytest.mark.asyncio
+    async def test_lock_acquisition_during_shutdown(self):
+        """Test proper lock handling during shutdown."""
+        processor = BatchingProcessor[str]()
+
+        # Add item to queue
+        await processor.process("item1")
+
+        # Shutdown should properly acquire lock and process remaining items
+        await processor.shutdown()
+
+        assert processor._shutdown_complete is True
+        assert len(processor._batch_queue) == 0
+
+    @pytest.mark.asyncio
+    async def test_flush_task_cancellation(self):
+        """Test proper cancellation of flush tasks."""
+        processor = BatchingProcessor[str](batch_size=10, flush_interval=1.0)
+
+        # Schedule a flush
+        await processor.process("item1")
+        flush_task = processor._flush_task
+
+        # Shutdown should cancel the task
+        await processor.shutdown()
+
+        # Task should be cancelled or completed
+        assert flush_task is not None and (flush_task.cancelled() or flush_task.done())
+
+    @pytest.mark.asyncio
+    async def test_batch_creation_during_concurrent_access(self):
+        """Test batch creation under concurrent access."""
+        processor = BatchingProcessor[str](batch_size=2)
+
+        # Simulate concurrent processing
+        tasks = [processor.process(f"item{i}") for i in range(5)]
+
+        results = await asyncio.gather(*tasks)
+
+        # Should create appropriate batches without data loss
+        total_items = sum(len(batch) for batch in results if batch)
+        stats = processor.get_stats()
+
+        # All items should be accounted for
+        assert stats["items_processed"] == 5
+        assert total_items + stats["current_queue_size"] == 5
+
+
+class TestBatchingProcessorIntegration:
+    """Test integration scenarios and complex workflows."""
+
+    @pytest.mark.asyncio
+    async def test_mixed_batching_scenarios(self):
+        """Test mixed size-based and time-based batching."""
+        processor = BatchingProcessor[str](batch_size=3, flush_interval=0.1)
+
+        callback_batches = []
+
+        async def capture_callback(batch):
+            callback_batches.append(batch)
+
+        processor.set_done_callback(capture_callback)
+
+        # Size-based batch
+        await processor.process("1")
+        await processor.process("2")
+        size_batch = await processor.process("3")  # Immediate return
+
+        # Time-based batch
+        await processor.process("4")
+        await processor.process("5")
+        await asyncio.sleep(0.2)  # Wait for time-based flush
+
+        # Add more items before shutdown to ensure shutdown batch is created
+        await processor.process("6")
+        await processor.process("7")
+        await processor.shutdown()
+
+        # Verify results
+        assert size_batch == ["1", "2", "3"]
+        assert len(callback_batches) == 2  # Time-based + shutdown batches
+        assert callback_batches[0] == ["4", "5"]
+        # The shutdown batch might vary due to timing, but should contain at least the last item
+        assert "7" in callback_batches[1], f"Expected '7' in shutdown batch, got {callback_batches[1]}"
+        assert len(callback_batches[1]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_high_throughput_processing(self):
+        """Test high throughput processing scenario."""
+        processor = BatchingProcessor[int](batch_size=100, max_queue_size=1000)
+
+        # Process many items rapidly
+        batches = []
+        for i in range(250):
+            batch = await processor.process(i)
+            if batch:
+                batches.append(batch)
+
+        # Force flush remaining items
+        final_batch = await processor.force_flush()
+        if final_batch:
+            batches.append(final_batch)
+
+        # Verify all items processed
+        total_items = sum(len(batch) for batch in batches)
+        assert total_items == 250
+
+        stats = processor.get_stats()
+        assert stats["items_processed"] == 250
+        assert stats["batches_created"] >= 2  # At least 2 full batches + remainder
+
+    @pytest.mark.asyncio
+    async def test_stress_shutdown_during_processing(self):
+        """Test shutdown behavior under stress conditions."""
+        processor = BatchingProcessor[str](batch_size=100, flush_interval=0.5)
+
+        callback_batches = []
+
+        async def capture_callback(batch):
+            callback_batches.append(batch)
+            await asyncio.sleep(0.01)  # Simulate processing time
+
+        processor.set_done_callback(capture_callback)
+
+        # Start background processing
+        async def background_processing():
+            for i in range(10):
+                await processor.process(f"bg_item_{i}")
+                await asyncio.sleep(0.01)
+
+        background_task = asyncio.create_task(background_processing())
+
+        # Let some processing happen
+        await asyncio.sleep(0.05)
+
+        # Shutdown while processing
+        await processor.shutdown()
+
+        # Wait for background task to complete
+        try:
+            await asyncio.wait_for(background_task, timeout=1.0)
+        except asyncio.TimeoutError:
+            background_task.cancel()
+
+        # Verify shutdown completed properly
+        assert processor._shutdown_complete is True
+
+        # All processed items should be accounted for
+        total_callback_items = sum(len(batch) for batch in callback_batches)
+        stats = processor.get_stats()
+
+        # Items processed should be >= callback items (some might return directly)
+        assert stats["items_processed"] >= total_callback_items


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR fixes the exporter processing logic to resolve issues where a `BatchingProcessor` was not flushing batches during cleanup. The core elements of this PR:

- Added new `CallbackProcessor` class to facilitate callback functionality in processing pipelines.
- Updated `ProcessingExporter` to integrate `CallbackProcessor`, allowing for pipeline continuation through registered callbacks. 
- Enhanced `BatchingProcessor` to extend `CallbackProcessor`, ensuring batches are routed through the pipeline during processing and shutdown.
- Improved error handling and logging during processor shutdown and final batch processing.
- Added additional tests for improved coverage of functionality.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
