### PR TITLE
Update `object_store` example to use NVIDIA key instead of missing OPENAI key

### DIFF
--- a/examples/object_store/user_report/README.md
+++ b/examples/object_store/user_report/README.md
@@ -24,6 +24,7 @@ And example tool in the NeMo Agent toolkit that makes use of an Object Store to 
 - [Key Features](#key-features)
 - [Installation and Setup](#installation-and-setup)
   - [Install this Workflow](#install-this-workflow)
+  - [Set Up API Keys](#set-up-api-keys)
   - [Setting up MinIO (Optional)](#setting-up-minio-optional)
   - [Setting up the MySQL Server (Optional)](#setting-up-the-mysql-server-optional)
 - [NeMo Agent Toolkit File Server](#nemo-agent-toolkit-file-server)
@@ -51,6 +52,13 @@ From the root directory of the NeMo Agent toolkit repository, run the following 
 
 ```bash
 uv pip install -e examples/object_store/user_report
+```
+
+### Set Up API Keys
+If you have not already done so, follow the [Obtaining API Keys](../../../docs/source/quick-start/installing.md#obtaining-api-keys) instructions to obtain an NVIDIA API key. You need to set your NVIDIA API key as an environment variable to access NVIDIA AI services:
+
+```bash
+export NVIDIA_API_KEY=<YOUR_API_KEY>
 ```
 
 ### Setting up MinIO (Optional)

--- a/examples/object_store/user_report/configs/config_mem.yml
+++ b/examples/object_store/user_report/configs/config_mem.yml
@@ -26,9 +26,9 @@ object_stores:
     bucket_name: my-bucket
 
 llms:
-  gpt:
-    _type: openai
-    model_name : gpt-4o
+  nim_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
     temperature: 0.0
 
 functions:
@@ -54,7 +54,7 @@ functions:
 workflow:
   _type: react_agent
   tool_names: [get_user_report, put_user_report]
-  llm_name: gpt
+  llm_name: nim_llm
   verbose: true
   handle_parsing_errors: true
   max_retries: 2

--- a/examples/object_store/user_report/configs/config_mysql.yml
+++ b/examples/object_store/user_report/configs/config_mysql.yml
@@ -29,9 +29,9 @@ object_stores:
     bucket_name: my-bucket
 
 llms:
-  gpt:
-    _type: openai
-    model_name : gpt-4o
+  nim_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
     temperature: 0.0
 
 functions:
@@ -57,7 +57,7 @@ functions:
 workflow:
   _type: react_agent
   tool_names: [get_user_report, put_user_report]
-  llm_name: gpt
+  llm_name: nim_llm
   verbose: true
   handle_parsing_errors: true
   max_retries: 2

--- a/examples/object_store/user_report/configs/config_s3.yml
+++ b/examples/object_store/user_report/configs/config_s3.yml
@@ -29,9 +29,9 @@ object_stores:
     bucket_name: my-bucket
 
 llms:
-  gpt:
-    _type: openai
-    model_name : gpt-4o
+  nim_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
     temperature: 0.0
 
 functions:
@@ -57,7 +57,7 @@ functions:
 workflow:
   _type: react_agent
   tool_names: [get_user_report, put_user_report]
-  llm_name: gpt
+  llm_name: nim_llm
   verbose: true
   handle_parsing_errors: true
   max_retries: 2


### PR DESCRIPTION
## Description

The object store example was missing an export for the key to access the selected LLM.

Additionally, this PR switches the LLM from OpenAI's gpt4o to NVIDIA's NIM of meta/llama3.1-70B-instruct

Closes nvbugs-5431266

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
