### PR TITLE
Update the LangSmith environment variable names in `simple_calculator_observability` example

### DIFF
--- a/examples/observability/simple_calculator_observability/README.md
+++ b/examples/observability/simple_calculator_observability/README.md
@@ -100,8 +100,8 @@ LangSmith offers comprehensive monitoring within the LangChain ecosystem.
 1. Set your LangSmith credentials:
 
 ```bash
-export LANGCHAIN_API_KEY=<your_api_key>
-export LANGCHAIN_PROJECT=<your_project>
+export LANGSMITH_API_KEY=<your_api_key>
+export LANGSMITH_PROJECT=<your_project>
 ```
 
 2. Run the workflow:


### PR DESCRIPTION
## Description
* It appears that `LANGCHAIN_API_KEY` and `LANGCHAIN_PROJECT` were used in older versions of LangChain.
* Per [trace_with_langchain](https://docs.smith.langchain.com/observability/how_to_guides/trace_with_langchain#statically)  these are the new preferred environment variables.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
