### PR TITLE
Reduce the number of warnings logged while running the `getting_started` examples

### DIFF
--- a/examples/getting_started/simple_web_query/src/aiq_simple_web_query/register.py
+++ b/examples/getting_started/simple_web_query/src/aiq_simple_web_query/register.py
@@ -32,7 +32,7 @@ class WebQueryToolConfig(FunctionBaseConfig, name="webpage_query"):
     embedder_name: EmbedderRef = "nvidia/nv-embedqa-e5-v5"
 
 
-@register_function(config_type=WebQueryToolConfig)
+@register_function(config_type=WebQueryToolConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def webquery_tool(config: WebQueryToolConfig, builder: Builder):
 
     from langchain.tools.retriever import create_retriever_tool

--- a/src/aiq/cli/commands/start.py
+++ b/src/aiq/cli/commands/start.py
@@ -190,11 +190,6 @@ class StartCommandGroup(click.Group):
         # Override default front end config with values from the config file for serverless execution modes.
         # Check that we have the right kind of front end
         if (not isinstance(config.general.front_end, front_end.config_type)):
-            logger.warning(
-                "The front end type in the config file (%s) does not match the command name (%s). "
-                "Overwriting the config file front end.",
-                config.general.front_end.type,
-                cmd_name)
 
             # Set the front end config
             config.general.front_end = front_end.config_type()

--- a/src/aiq/runtime/loader.py
+++ b/src/aiq/runtime/loader.py
@@ -176,7 +176,7 @@ def discover_and_register_plugins(plugin_type: PluginTypes):
                 # The threshold is 300 ms if no plugins have been loaded yet, and 100 ms otherwise. Triple the threshold
                 # if a debugger is attached.
                 if (elapsed_time > (300.0 if count == 0 else 100.0) * (3 if is_debugger_attached() else 1)):
-                    logger.warning(
+                    logger.debug(
                         "Loading module '%s' from entry point '%s' took a long time (%f ms). "
                         "Ensure all imports are inside your registered functions.",
                         entry_point.module,


### PR DESCRIPTION
## Description
* Remove the `The front end type in the config file` warning, using overrides should not be a warning, this occurs for all or nearly all uses of `aiq run`
* Reduce the slow runtime loader log from warning to debug. This is always logged even when the user hasn't added any plugins of their own, as our own examples trigger this.
* Pass `framework_wrappers` when registering  `webquery_tool`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
