### PR TITLE
Increase package/distro resolution in `DiscoveryMetadata` to improve utility of `aiq info components`

### DIFF
--- a/packages/aiqtoolkit_weave/pyproject.toml
+++ b/packages/aiqtoolkit_weave/pyproject.toml
@@ -40,4 +40,4 @@ aiqtoolkit = { workspace = true }
 
 
 [project.entry-points.'aiq.components']
-aiqtoolkit_weave = "aiq.plugins.weave.register"
+aiq_weave = "aiq.plugins.weave.register"

--- a/src/aiq/data_models/discovery_metadata.py
+++ b/src/aiq/data_models/discovery_metadata.py
@@ -21,6 +21,7 @@ import typing
 from enum import Enum
 from functools import lru_cache
 from pathlib import Path
+from types import ModuleType
 from typing import TYPE_CHECKING
 
 from pydantic import BaseModel
@@ -113,7 +114,56 @@ class DiscoveryMetadata(BaseModel):
                 with distinfo_path.open("r") as f:
                     data = json.load(f)
                     return data.get(root_package, None)
-        return None
+        return
+
+    @staticmethod
+    @lru_cache
+    def get_distribution_name_from_module(module: ModuleType | None) -> str:
+        """Get the distribution name from the config type using the mapping of module names to distro names.
+
+        Args:
+            module (ModuleType): A registered component's module.
+
+        Returns:
+            str: The distribution name of the AIQ Toolkit component.
+        """
+        from aiq.runtime.loader import get_all_aiq_entrypoints_mapping
+
+        if module is None:
+            return "aiqtoolkit"
+
+        # Get the mapping of module names to distro names
+        mapping = get_all_aiq_entrypoints_mapping()
+        module_package = module.__package__
+
+        if module_package is None:
+            return "aiqtoolkit"
+
+        # Traverse the module package parts in reverse order to find the distro name
+        # This is because the module package is the root package for the AIQ Toolkit component
+        # and the distro name is the name of the package that contains the component
+        module_package_parts = module_package.split(".")
+        for part_idx in range(len(module_package_parts), 0, -1):
+            candidate_module_name = ".".join(module_package_parts[0:part_idx])
+            candidate_distro_name = mapping.get(candidate_module_name, None)
+            if candidate_distro_name is not None:
+                return candidate_distro_name
+
+        return "aiqtoolkit"
+
+    @staticmethod
+    @lru_cache
+    def get_distribution_name_from_config_type(config_type: type["TypedBaseModelT"]) -> str:
+        """Get the distribution name from the config type using the mapping of module names to distro names.
+
+        Args:
+            config_type (type[TypedBaseModelT]): A registered component's configuration object.
+
+        Returns:
+            str: The distribution name of the AIQ Toolkit component.
+        """
+        module = inspect.getmodule(config_type)
+        return DiscoveryMetadata.get_distribution_name_from_module(module)
 
     @staticmethod
     @lru_cache
@@ -123,6 +173,7 @@ class DiscoveryMetadata(BaseModel):
         root package name 'aiq'. They provide mapping in a metadata file
         for optimized installation.
         """
+
         distro_name = DiscoveryMetadata.get_distribution_name_from_private_data(root_package)
         return distro_name if distro_name else root_package
 
@@ -142,8 +193,7 @@ class DiscoveryMetadata(BaseModel):
 
         try:
             module = inspect.getmodule(config_type)
-            root_package: str = module.__package__.split(".")[0]
-            distro_name = DiscoveryMetadata.get_distribution_name(root_package)
+            distro_name = DiscoveryMetadata.get_distribution_name_from_config_type(config_type)
 
             if not distro_name:
                 # raise an exception
@@ -187,12 +237,13 @@ class DiscoveryMetadata(BaseModel):
 
         try:
             module = inspect.getmodule(fn)
-            root_package: str = module.__package__.split(".")[0]
-            root_package = DiscoveryMetadata.get_distribution_name(root_package)
+            distro_name = DiscoveryMetadata.get_distribution_name_from_module(module)
+
             try:
-                version = importlib.metadata.version(root_package) if root_package != "" else ""
+                # version = importlib.metadata.version(root_package) if root_package != "" else ""
+                version = importlib.metadata.version(distro_name) if distro_name != "" else ""
             except importlib.metadata.PackageNotFoundError:
-                logger.warning("Package metadata not found for %s", root_package)
+                logger.warning("Package metadata not found for %s", distro_name)
                 version = ""
         except Exception as e:
             logger.exception("Encountered issue extracting module metadata for %s: %s", fn, e, exc_info=True)
@@ -201,7 +252,7 @@ class DiscoveryMetadata(BaseModel):
         if isinstance(wrapper_type, LLMFrameworkEnum):
             wrapper_type = wrapper_type.value
 
-        return DiscoveryMetadata(package=root_package,
+        return DiscoveryMetadata(package=distro_name,
                                  version=version,
                                  component_type=component_type,
                                  component_name=wrapper_type,
@@ -220,7 +271,6 @@ class DiscoveryMetadata(BaseModel):
         """
 
         try:
-            package_name = DiscoveryMetadata.get_distribution_name(package_name)
             try:
                 metadata = importlib.metadata.metadata(package_name)
                 description = metadata.get("Summary", "")
@@ -263,12 +313,11 @@ class DiscoveryMetadata(BaseModel):
 
         try:
             module = inspect.getmodule(config_type)
-            root_package: str = module.__package__.split(".")[0]
-            root_package = DiscoveryMetadata.get_distribution_name(root_package)
+            distro_name = DiscoveryMetadata.get_distribution_name_from_module(module)
             try:
-                version = importlib.metadata.version(root_package) if root_package != "" else ""
+                version = importlib.metadata.version(distro_name) if distro_name != "" else ""
             except importlib.metadata.PackageNotFoundError:
-                logger.warning("Package metadata not found for %s", root_package)
+                logger.warning("Package metadata not found for %s", distro_name)
                 version = ""
         except Exception as e:
             logger.exception("Encountered issue extracting module metadata for %s: %s", config_type, e, exc_info=True)
@@ -279,7 +328,7 @@ class DiscoveryMetadata(BaseModel):
 
         description = generate_config_type_docs(config_type=config_type)
 
-        return DiscoveryMetadata(package=root_package,
+        return DiscoveryMetadata(package=distro_name,
                                  version=version,
                                  component_type=component_type,
                                  component_name=component_name,

--- a/src/aiq/data_models/discovery_metadata.py
+++ b/src/aiq/data_models/discovery_metadata.py
@@ -127,13 +127,13 @@ class DiscoveryMetadata(BaseModel):
         Returns:
             str: The distribution name of the AIQ Toolkit component.
         """
-        from aiq.runtime.loader import get_all_aiq_entrypoints_mapping
+        from aiq.runtime.loader import get_all_aiq_entrypoints_distro_mapping
 
         if module is None:
             return "aiqtoolkit"
 
         # Get the mapping of module names to distro names
-        mapping = get_all_aiq_entrypoints_mapping()
+        mapping = get_all_aiq_entrypoints_distro_mapping()
         module_package = module.__package__
 
         if module_package is None:

--- a/src/aiq/data_models/discovery_metadata.py
+++ b/src/aiq/data_models/discovery_metadata.py
@@ -114,7 +114,7 @@ class DiscoveryMetadata(BaseModel):
                 with distinfo_path.open("r") as f:
                     data = json.load(f)
                     return data.get(root_package, None)
-        return
+        return None
 
     @staticmethod
     @lru_cache

--- a/src/aiq/registry_handlers/package_utils.py
+++ b/src/aiq/registry_handlers/package_utils.py
@@ -119,16 +119,15 @@ def build_wheel(package_root: str) -> WheelData:
 
     whl_version = Wheel(whl_path).version
 
-    return WheelData(
-        package_root=package_root,
-        package_name=module_name,  # should it be module name or distro name here
-        toml_project=toml_project,
-        toml_dependencies=toml_dependencies,
-        toml_aiq_packages=toml_packages,
-        union_dependencies=union_dependencies,
-        whl_path=whl_path,
-        whl_base64=whl_base64,
-        whl_version=whl_version)
+    return WheelData(package_root=package_root,
+                     package_name=toml_project_name,
+                     toml_project=toml_project,
+                     toml_dependencies=toml_dependencies,
+                     toml_aiq_packages=toml_packages,
+                     union_dependencies=union_dependencies,
+                     whl_path=whl_path,
+                     whl_base64=whl_base64,
+                     whl_version=whl_version)
 
 
 def build_package_metadata(wheel_data: WheelData | None) -> dict[AIQComponentEnum, list[dict | DiscoveryMetadata]]:
@@ -155,7 +154,7 @@ def build_package_metadata(wheel_data: WheelData | None) -> dict[AIQComponentEnu
     if (wheel_data is not None):
         registry.register_package(package_name=wheel_data.package_name, package_version=wheel_data.whl_version)
         for entry_point in aiq_plugins:
-            package_name = entry_point.module.split('.')[0]
+            package_name = entry_point.dist.name
             if (package_name == wheel_data.package_name):
                 continue
             if (package_name in wheel_data.union_dependencies):
@@ -163,8 +162,7 @@ def build_package_metadata(wheel_data: WheelData | None) -> dict[AIQComponentEnu
 
     else:
         for entry_point in aiq_plugins:
-            package_name = entry_point.module.split('.')[0]
-            registry.register_package(package_name=package_name)
+            registry.register_package(package_name=entry_point.dist.name)
 
     discovery_metadata = {}
     for component_type in AIQComponentEnum:

--- a/src/aiq/runtime/loader.py
+++ b/src/aiq/runtime/loader.py
@@ -146,8 +146,10 @@ def discover_entrypoints(plugin_type: PluginTypes):
 
 
 @lru_cache
-def get_all_aiq_entrypoints_mapping() -> dict[str, str]:
-    # Get ALL AIQ entry points
+def get_all_aiq_entrypoints_distro_mapping() -> dict[str, str]:
+    """
+    Get the mapping of all AIQ entry points to their distribution names.
+    """
 
     mapping = {}
     aiq_entrypoints = discover_entrypoints(PluginTypes.ALL)

--- a/src/aiq/runtime/loader.py
+++ b/src/aiq/runtime/loader.py
@@ -21,6 +21,7 @@ import time
 from contextlib import asynccontextmanager
 from enum import IntFlag
 from enum import auto
+from functools import lru_cache
 from functools import reduce
 
 from aiq.builder.workflow_builder import WorkflowBuilder
@@ -116,6 +117,7 @@ async def load_workflow(config_file: StrPath, max_concurrency: int = -1):
         yield AIQSessionManager(workflow.build(), max_concurrency=max_concurrency)
 
 
+@lru_cache
 def discover_entrypoints(plugin_type: PluginTypes):
     """
     Discover all the requested plugin types which were registered via an entry point group and return them.
@@ -141,6 +143,23 @@ def discover_entrypoints(plugin_type: PluginTypes):
     aiq_plugins = reduce(lambda x, y: list(x) + list(y), [entry_points.select(group=y) for y in plugin_groups])
 
     return aiq_plugins
+
+
+@lru_cache
+def get_all_aiq_entrypoints_mapping() -> dict[str, str]:
+    # Get ALL AIQ entry points
+
+    mapping = {}
+    aiq_entrypoints = discover_entrypoints(PluginTypes.ALL)
+    for ep in aiq_entrypoints:
+        ep_module_parts = ep.module.split(".")
+        current_parts = []
+        for part in ep_module_parts:
+            current_parts.append(part)
+            module_prefix = ".".join(current_parts)
+            mapping[module_prefix] = ep.dist.name
+
+    return mapping
 
 
 def discover_and_register_plugins(plugin_type: PluginTypes):

--- a/src/aiq/utils/dump_distro_mapping.py
+++ b/src/aiq/utils/dump_distro_mapping.py
@@ -1,11 +1,11 @@
 import argparse
 import json
 
-from aiq.runtime.loader import get_all_aiq_entrypoints_mapping
+from aiq.runtime.loader import get_all_aiq_entrypoints_distro_mapping
 
 
 def dump_distro_mapping(path: str):
-    mapping = get_all_aiq_entrypoints_mapping()
+    mapping = get_all_aiq_entrypoints_distro_mapping()
     with open(path, "w", encoding="utf-8") as f:
         json.dump(mapping, f, indent=4)
 

--- a/src/aiq/utils/dump_distro_mapping.py
+++ b/src/aiq/utils/dump_distro_mapping.py
@@ -1,0 +1,17 @@
+import argparse
+import json
+
+from aiq.runtime.loader import get_all_aiq_entrypoints_mapping
+
+
+def dump_distro_mapping(path: str):
+    mapping = get_all_aiq_entrypoints_mapping()
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(mapping, f, indent=4)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--path", type=str, required=True)
+    args = parser.parse_args()
+    dump_distro_mapping(args.path)


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR increases the resolution on package/version gathered in `DiscoveryMetadata` without the performance penalty of `importlib.metadata.packages_distributions()`. With this fix, `aiq info components` will now properly list the package/distro name and version for each registered plugin.

Previously subpackages were resolved to `aiqtoolkit` instead of their proper subpackage. For example, a plugin contained in `aiqtoolkit-phoenix` would resolve to `aiqtoolkit` in the `package` column. This made it harder for developers to identify the necessary subpackages to include as dependencies in their toolkit-based applications.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
