### PR TITLE
Fixes for `adding-an-authentication-provider.md`

### DIFF
--- a/docs/source/extend/adding-an-authentication-provider.md
+++ b/docs/source/extend/adding-an-authentication-provider.md
@@ -17,8 +17,7 @@ limitations under the License.
 
 # Adding an API Authentication Provider to NeMo Agent Toolkit
 :::{note}
-We recommend reading the [Streamlining API Authentication](../reference/api-authentication.md) guide before proceeding with
-this detailed documentation.
+We recommend reading the [Streamlining API Authentication](../reference/api-authentication.md) guide before proceeding with this detailed documentation.
 :::
 
 The NeMo Agent toolkit offers a set of built-in authentication providers for accessing API resources. Additionally, it includes
@@ -27,7 +26,7 @@ a plugin system that allows developers to define and integrate custom authentica
 ## Existing API Authentication Providers
 You can view the list of existing API Authentication Providers by running the following command:
 ```bash
-aiq info components -t authentication_provider
+aiq info components -t auth_provider
 ```
 
 ## Provider Types

--- a/docs/source/extend/adding-an-authentication-provider.md
+++ b/docs/source/extend/adding-an-authentication-provider.md
@@ -36,12 +36,12 @@ from the clients that facilitate the authentication process. Authentication prov
 `AuthCodeGrantClient` use those credentials to perform authentication.
 
 ## Extending an API Authentication Provider
-The first step in adding an authentication provider is to create a configuration model that inherits from
-{class}`aiq.data_models.authentication.AuthenticationBaseConfig` class and define the credentials required to
+The first step in adding an authentication provider is to create a configuration model that inherits from the
+{py:class}`~aiq.data_models.authentication.AuthenticationBaseConfig` class and define the credentials required to
 authenticate with the target API resource.
 
 The following example shows how to define and register a custom evaluator and can be found here:
-{class}`aiq.authentication.oauth2.OAuth2AuthorizationCodeFlowConfig` class:
+{py:class}`~aiq.authentication.oauth2.OAuth2AuthorizationCodeFlowConfig` class:
 ```python
 class OAuth2AuthorizationCodeFlowConfig(AuthenticationBaseConfig, name="oauth2_auth_code_flow"):
 
@@ -63,9 +63,9 @@ class OAuth2AuthorizationCodeFlowConfig(AuthenticationBaseConfig, name="oauth2_a
 ```
 
 ### Registering the Provider
-An asynchronous function decorated with {py:deco}`aiq.cli.register_workflow.register_authentication_provider` is used to
+An asynchronous function decorated with {py:deco}`~aiq.cli.register_workflow.register_authentication_provider` is used to
 register the provider with NeMo Agent toolkit by yielding an instance of
-{class}`aiq.builder.authentication.AuthenticationProviderInfo`.
+{py:class}`~aiq.builder.authentication.AuthenticationProviderInfo`.
 
 The `OAuth2AuthorizationCodeFlowConfig` from the previous section is registered as follows:
 ```python
@@ -85,11 +85,11 @@ to simplify the development of custom authentication clients for various authent
 
 To implement a custom client, extend the appropriate base class and override the required methods. For detailed
 documentation on the methods and expected behavior, refer to the docstrings provided in the
-{py:deco}`aiq.authentication.interfaces` module.
+{py:deco}`~aiq.authentication.interfaces` module.
 
 ## Registering the API Authentication Client
 To register an authentication client, define an asynchronous function decorated
-with {py:deco}`aiq.cli.register_workflow.register_authentication_client`. The `register_authentication_client`
+with {py:deco}`~aiq.cli.register_workflow.register_authentication_client`. The `register_authentication_client`
 decorator requires a single argument: `config_type`, which specifies the authentication configuration class associated
 with the provider.
 
@@ -110,15 +110,13 @@ at `tests/aiq/authentication`.
 
 ## Packaging the Provider and Client
 
-The provider and client will need to be bundled into a Python package, which in turn will be registered with AIQ
-toolkit as a [plugin](../extend/plugins.md). In the `pyproject.toml` file of the package the
+The provider and client will need to be bundled into a Python package, which in turn will be registered with the toolkit as a [plugin](../extend/plugins.md). In the `pyproject.toml` file of the package the
 `project.entry-points.'aiq.components'` section, defines a Python module as the entry point of the plugin. Details on
 how this is defined are found in the [Entry Point](../extend/plugins.md#entry-point) section of the plugins document.
 By convention, the entry point module is named `register.py`, but this is not a requirement.
 
 In the entry point module, it is important that the provider is defined first followed by the client. This ensures that
-the provider is added to the NeMo Agent toolkit registry before the client is registered. A hypothetical `register.py` file
-could be defined as follows:
+the provider is added to the NeMo Agent toolkit registry before the client is registered. A hypothetical `register.py` file could be defined as follows:
 
 ```python
 # We need to ensure that the provider is registered prior to the client

--- a/docs/source/extend/adding-an-authentication-provider.md
+++ b/docs/source/extend/adding-an-authentication-provider.md
@@ -65,9 +65,8 @@ class OAuth2AuthCodeFlowProviderConfig(AuthenticationBaseConfig, name="oauth2_au
 ```
 
 ### Registering the Provider
-An asynchronous function decorated with {py:func}`~aiq.cli.register_workflow.register_auth_provider` is used to
-register the provider with NeMo Agent toolkit by yielding an instance of
-{py:class}`~aiq.builder.authentication.AuthenticationProviderInfo`.
+An asynchronous function decorated with {py:func}`~aiq.cli.register_workflow.register_auth_provider` is used to register the provider with NeMo Agent toolkit by yielding an instance of
+{py:class}`~aiq.authentication.interfaces.AuthenticationClientBase`.
 
 The `OAuth2AuthCodeFlowProviderConfig` from the previous section is registered as follows:
 ```python
@@ -77,54 +76,20 @@ async def oauth2_client(authentication_provider: OAuth2AuthCodeFlowProviderConfi
 
     yield OAuth2AuthCodeFlowProvider(authentication_provider)
 ```
-## Extending the API Authentication Client
-As described earlier, each API authentication provider defines the credentials and parameters required to authenticate
-with a specific API service. A corresponding API authentication client uses this configuration to initiate and
-complete the authentication process. NeMo Agent toolkit provides an extensible base class `AuthenticationClientBase`
-to simplify the development of custom authentication clients for various authentication methods.
- These base classes provide a structured interface for implementing key functionality, including:
-- Validating configuration credentials
-- Interfacing with the NeMo Agent toolkit frontend authentication flow handlers
-- Returning appropriate authentication tokens or credentials
 
-To implement a custom client, extend the appropriate base class and override the required methods. For detailed
-documentation on the methods and expected behavior, refer to the docstrings provided in the
-{py:mod}`~aiq.authentication.interfaces` module.
+## Defining the Provider
+Each authentication provider should inherit from the {py:class}`~aiq.authentication.interfaces.AuthenticationClientBase` class.
 
-## Registering the API Authentication Client
-To register an authentication client, define an asynchronous function decorated
-with {py:func}`~aiq.cli.register_workflow.register_authentication_client`. The `register_authentication_client`
-decorator requires a single argument: `config_type`, which specifies the authentication configuration class associated
-with the provider.
+## Testing the new Provider
+After implementing a new authentication provider, it’s important to verify that the required functionality works as expected. This can be done by writing integration tests. It is important to minimize the amount of mocking in the tests to ensure that the provider behaves as expected in a real-world scenario. You can find examples of existing tests in the repository at `tests/aiq/authentication`.
 
-`src/aiq/authentication/oauth2/register.py`:
-```python
-@register_authentication_client(config_type=OAuth2AuthCodeFlowProviderConfig)
-async def oauth2_client(authentication_provider: OAuth2AuthCodeFlowProviderConfig, builder: Builder):
-    yield OAuth2Client(authentication_provider)
-```
-Similar to the registration function for the provider, the client registration function can perform any necessary setup
-actions before yielding the client, along with cleanup actions after the `yield` statement.
+## Packaging the Provider
 
-## Testing an Authentication Client
-After implementing a new authentication client, it’s important to verify that the required functionality works as
-expected. This can be done by writing integration tests. It is important to minimize the amount of mocking in the tests
-to ensure that the client behaves as expected in a real-world scenario. You can find examples of existing tests in the repository
-at `tests/aiq/authentication`.
+The provider will need to be bundled into a Python package, which in turn will be registered with the toolkit as a [plugin](../extend/plugins.md). In the `pyproject.toml` file of the package the
+`project.entry-points.'aiq.components'` section, defines a Python module as the entry point of the plugin. Details on how this is defined are found in the [Entry Point](../extend/plugins.md#entry-point) section of the plugins document. By convention, the entry point module is named `register.py`, but this is not a requirement.
 
-## Packaging the Provider and Client
-
-The provider and client will need to be bundled into a Python package, which in turn will be registered with the toolkit as a [plugin](../extend/plugins.md). In the `pyproject.toml` file of the package the
-`project.entry-points.'aiq.components'` section, defines a Python module as the entry point of the plugin. Details on
-how this is defined are found in the [Entry Point](../extend/plugins.md#entry-point) section of the plugins document.
-By convention, the entry point module is named `register.py`, but this is not a requirement.
-
-In the entry point module, it is important that the provider is defined first followed by the client. This ensures that
-the provider is added to the NeMo Agent toolkit registry before the client is registered. A hypothetical `register.py` file could be defined as follows:
+In the entry point module, the registration of provider, that is the function decorated with `register_auth_provider`, needs to be defined, either directly or imported from another module. A hypothetical `register.py` file could be defined as follows:
 
 ```python
-# We need to ensure that the provider is registered prior to the client
-
 import register_provider
-import register_client
 ```

--- a/docs/source/reference/api-authentication.md
+++ b/docs/source/reference/api-authentication.md
@@ -78,7 +78,7 @@ API configurations are
 
 ### Authentication YAML Configuration Example
 
-The following example shows how to configure the authentication credentials for the OAuth 2.0 Authorization Code Grant Flow and API Key authentication. More information about each field can be queried using the `aiq info components -t authentication_provider` command.
+The following example shows how to configure the authentication credentials for the OAuth 2.0 Authorization Code Grant Flow and API Key authentication. More information about each field can be queried using the `aiq info components -t auth_provider` command.
 
 ```yaml
 authentication:


### PR DESCRIPTION
## Description
* Remove parts about authentication clients as this appears to have been removed from the toolkit
* Fix class/function names which appear to have changed since the initial writing
* Fix `aiq info` command
* Avoid using the `py:deco` role as as work-around for sphinx-doc/sphinx#13528 (the bug fixed but doesn't appear to be included in a release yet)
* Remove usage of the name AIQ

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
