### PR TITLE
Fixing wrong override usage to make it compatible with py 3.11

### DIFF
--- a/src/aiq/data_models/component_ref.py
+++ b/src/aiq/data_models/component_ref.py
@@ -130,7 +130,7 @@ class ObjectStoreRef(ComponentRef):
     """
 
     @property
-    @typing.override
+    @override
     def component_group(self):
         return ComponentGroup.OBJECT_STORES
 


### PR DESCRIPTION
## Description
Replaced `typing.override` with `override` to make it compatible with py 3.11
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
