### PR TITLE
Update template to use `logger` instead of `print`

### DIFF
--- a/src/aiq/cli/commands/workflow/templates/workflow.py.j2
+++ b/src/aiq/cli/commands/workflow/templates/workflow.py.j2
@@ -31,6 +31,6 @@ async def {{ python_safe_workflow_name }}_function(
     try:
         yield FunctionInfo.create(single_fn=_response_fn)
     except GeneratorExit:
-        print("Function exited early!")
+        logger.warning("Function exited early!")
     finally:
-        print("Cleaning up {{ workflow_name }} workflow.")
+        logger.info("Cleaning up {{ workflow_name }} workflow.")


### PR DESCRIPTION
This PR updates the template used by `aiq workflow create` to use logger instead of print.