### PR TITLE
Collapse the `docs` dependency group into the `dev` dependencies group

### DIFF
--- a/ci/scripts/github/checks.sh
+++ b/ci/scripts/github/checks.sh
@@ -20,7 +20,7 @@ GITHUB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 
 source ${GITHUB_SCRIPT_DIR}/common.sh
 
-create_env group:dev group:docs extra:examples
+create_env group:dev extra:examples
 
 rapids-logger "Running checks"
 ${SCRIPT_DIR}/checks.sh

--- a/ci/scripts/github/docs.sh
+++ b/ci/scripts/github/docs.sh
@@ -23,7 +23,7 @@ source ${GITHUB_SCRIPT_DIR}/common.sh
 rapids-logger "Installing non-pip deps"
 get_lfs_files
 
-create_env group:dev group:docs
+create_env group:dev
 
 rapids-logger "Building documentation"
 pushd ${PROJECT_ROOT}/docs

--- a/ci/scripts/gitlab/checks.sh
+++ b/ci/scripts/gitlab/checks.sh
@@ -20,7 +20,7 @@ GITLAB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 
 source ${GITLAB_SCRIPT_DIR}/common.sh
 
-create_env group:dev group:docs extra:examples
+create_env group:dev extra:examples
 
 # Before running the checks, make sure we have no changes in the repo
 git reset --hard

--- a/ci/scripts/gitlab/docs.sh
+++ b/ci/scripts/gitlab/docs.sh
@@ -24,7 +24,7 @@ rapids-logger "Installing non-pip deps"
 apt update
 apt install --no-install-recommends -y make
 
-create_env group:dev group:docs
+create_env group:dev
 
 rapids-logger "Building documentation"
 pushd ${CI_PROJECT_DIR}/docs

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,14 +27,13 @@ uv sync --all-groups --all-extras
 
 ## Build Documentation
 ```bash
-cd docs
-make
+make -C docs
 
 # verify
-firefox build/html/index.html
+firefox docs/build/html/index.html
 ```
 <!-- path-check-skip-next-line -->
-Outputs to `build/docs/html`
+Outputs to `docs/build/docs/html`
 
 ## Contributing
 Refer to the [Contributing to NeMo Agent toolkit](./source/resources/contributing.md) guide.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ examples = [
 profiling = [
   "matplotlib~=3.9",
   "prefixspan~=0.5.2",
-  "scikit-learn~=1.6",
+  "scikit-learn~=1.6"
 ]
 
 # Optional dependency needed when use_gunicorn is set to true
@@ -176,7 +176,11 @@ dev = [
   "flake8-pyproject~=1.2",
   "flake8~=7.1",
   "httpx-sse~=0.4",
+  "ipython~=8.31",
   "isort==5.12.0",
+  "myst-parser~=4.0",
+  "nbsphinx~=0.9",
+  "nvidia-sphinx-theme>=0.0.7",
   "pip>=24.3.1",
   "pre-commit>=4.0,<5.0",
   "pylint==3.3.*",
@@ -188,23 +192,15 @@ dev = [
   "python-docx~=1.1.0",
   "setuptools >= 64",
   "setuptools_scm>=8",
-  "tomlkit~=0.13.2",
-  "twine~=6.0",
-  "yapf==0.43.*",
-]
-
-docs = [
-  "ipython~=8.31",
-  "myst-parser~=4.0",
-  "nbsphinx~=0.9",
-  "nvidia-sphinx-theme>=0.0.7",
   "sphinx~=8.2",
   "sphinx-copybutton>=0.5",
   "sphinx-autoapi>=3.6",
   "sphinx-mermaid",
+  "tomlkit~=0.13.2",
+  "twine~=6.0",
   "vale==3.9.5",
+  "yapf==0.43.*",
 ]
-
 
 [project.entry-points.'aiq.components']
 aiq_agents = "aiq.agent.register"

--- a/uv.lock
+++ b/uv.lock
@@ -680,7 +680,11 @@ dev = [
     { name = "flake8" },
     { name = "flake8-pyproject" },
     { name = "httpx-sse" },
+    { name = "ipython" },
     { name = "isort" },
+    { name = "myst-parser" },
+    { name = "nbsphinx" },
+    { name = "nvidia-sphinx-theme" },
     { name = "pip" },
     { name = "pre-commit" },
     { name = "pylint" },
@@ -692,20 +696,14 @@ dev = [
     { name = "python-docx" },
     { name = "setuptools" },
     { name = "setuptools-scm" },
-    { name = "tomlkit" },
-    { name = "twine" },
-    { name = "yapf" },
-]
-docs = [
-    { name = "ipython" },
-    { name = "myst-parser" },
-    { name = "nbsphinx" },
-    { name = "nvidia-sphinx-theme" },
     { name = "sphinx" },
     { name = "sphinx-autoapi" },
     { name = "sphinx-copybutton" },
     { name = "sphinx-mermaid" },
+    { name = "tomlkit" },
+    { name = "twine" },
     { name = "vale" },
+    { name = "yapf" },
 ]
 
 [package.metadata]
@@ -791,7 +789,11 @@ dev = [
     { name = "flake8", specifier = "~=7.1" },
     { name = "flake8-pyproject", specifier = "~=1.2" },
     { name = "httpx-sse", specifier = "~=0.4" },
+    { name = "ipython", specifier = "~=8.31" },
     { name = "isort", specifier = "==5.12.0" },
+    { name = "myst-parser", specifier = "~=4.0" },
+    { name = "nbsphinx", specifier = "~=0.9" },
+    { name = "nvidia-sphinx-theme", specifier = ">=0.0.7" },
     { name = "pip", specifier = ">=24.3.1" },
     { name = "pre-commit", specifier = ">=4.0,<5.0" },
     { name = "pylint", specifier = "==3.3.*" },
@@ -803,20 +805,14 @@ dev = [
     { name = "python-docx", specifier = "~=1.1.0" },
     { name = "setuptools", specifier = ">=64" },
     { name = "setuptools-scm", specifier = ">=8" },
-    { name = "tomlkit", specifier = "~=0.13.2" },
-    { name = "twine", specifier = "~=6.0" },
-    { name = "yapf", specifier = "==0.43.*" },
-]
-docs = [
-    { name = "ipython", specifier = "~=8.31" },
-    { name = "myst-parser", specifier = "~=4.0" },
-    { name = "nbsphinx", specifier = "~=0.9" },
-    { name = "nvidia-sphinx-theme", specifier = ">=0.0.7" },
     { name = "sphinx", specifier = "~=8.2" },
     { name = "sphinx-autoapi", specifier = ">=3.6" },
     { name = "sphinx-copybutton", specifier = ">=0.5" },
     { name = "sphinx-mermaid" },
+    { name = "tomlkit", specifier = "~=0.13.2" },
+    { name = "twine", specifier = "~=6.0" },
     { name = "vale", specifier = "==3.9.5" },
+    { name = "yapf", specifier = "==0.43.*" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
* Ensures that anyone installing with `uv sync --all-extras --no-dev` won't receive documentation specific packages
* Most developers will likely need to build documentation

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
