### PR TITLE
Fix module discovery errors when publishing with registry handlers

### DIFF
--- a/packages/aiqtoolkit_opentelemetry/pyproject.toml
+++ b/packages/aiqtoolkit_opentelemetry/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
   "opentelemetry-sdk~=1.3",
 ]
 requires-python = ">=3.11,<3.13"
-description = "Subpackage for Weave integration in AIQtoolkit"
+description = "Subpackage for OpenTelemetry integration in AIQtoolkit"
 readme = "src/aiq/meta/pypi.md"
 keywords = ["ai", "observability", "opentelemetry"]
 classifiers = ["Programming Language :: Python"]

--- a/packages/aiqtoolkit_opentelemetry/src/aiq/meta/pypi.md
+++ b/packages/aiqtoolkit_opentelemetry/src/aiq/meta/pypi.md
@@ -18,6 +18,6 @@ limitations under the License.
 ![NVIDIA Agent Intelligence Toolkit](https://media.githubusercontent.com/media/NVIDIA/NeMo-Agent-Toolkit/refs/heads/main/docs/source/_static/aiqtoolkit_banner.png "AIQ toolkit banner image"
 
 # NVIDIA Agent Intelligence Toolkit Subpackage
-This is a subpackage for Weights and Biases Weave integration for observability.
+This is a subpackage for OpenTelemetry integration for observability.
 
 For more information about AIQ toolkit, please visit the [AIQ toolkit package](https://pypi.org/project/aiqtoolkit/).

--- a/src/aiq/registry_handlers/package_utils.py
+++ b/src/aiq/registry_handlers/package_utils.py
@@ -469,7 +469,7 @@ def build_wheel(package_root: str) -> WheelData:
 
     toml_dependencies_transitive = get_all_transitive_dependencies(list(toml_dependencies))
     union_dependencies = toml_dependencies.union(toml_packages)
-    union_dependencies.add(toml_dependencies_transitive)
+    union_dependencies.update(toml_dependencies_transitive)
 
     working_dir = os.getcwd()
     os.chdir(package_root)

--- a/src/aiq/registry_handlers/package_utils.py
+++ b/src/aiq/registry_handlers/package_utils.py
@@ -449,15 +449,6 @@ def build_wheel(package_root: str) -> WheelData:
 
     toml_project: dict = data.get("project", {})
     toml_project_name = toml_project.get("name", None)
-
-    # assert toml_project_name is not None, f"Package name '{toml_project_name}' not found in pyproject.toml"
-    # # replace "aiqtoolkit" substring with "aiq" to get the import name
-    # module_name = get_module_name_from_distribution(toml_project_name)
-    # assert module_name is not None, f"No modules found for package name '{toml_project_name}'"
-
-    # assert importlib.util.find_spec(module_name) is not None, (f"Package {module_name} not "
-    #                                                            "installed, cannot discover components.")
-
     toml_packages = set(i for i in data.get("project", {}).get("entry-points", {}).get("aiq.plugins", {}))
 
     # Extract dependencies using the robust requirement parser with extras resolution
@@ -477,13 +468,8 @@ def build_wheel(package_root: str) -> WheelData:
                 logger.warning("Failed to parse dependency '%s': %s", dep_spec, e)
 
     toml_dependencies_transitive = get_all_transitive_dependencies(list(toml_dependencies))
-    print("My transitive toml_dependencies", toml_dependencies_transitive)
-    print()
-    print("My toml_dependencies", toml_dependencies)
-    print()
-
     union_dependencies = toml_dependencies.union(toml_packages)
-    union_dependencies.add(toml_project_name)
+    union_dependencies.add(toml_dependencies_transitive)
 
     working_dir = os.getcwd()
     os.chdir(package_root)

--- a/src/aiq/registry_handlers/package_utils.py
+++ b/src/aiq/registry_handlers/package_utils.py
@@ -20,6 +20,8 @@ import os
 import subprocess
 from functools import lru_cache
 
+from packaging.requirements import Requirement
+
 from aiq.data_models.component import AIQComponentEnum
 from aiq.data_models.discovery_metadata import DiscoveryMetadata
 from aiq.registry_handlers.schemas.package import WheelData
@@ -57,6 +59,372 @@ def get_module_name_from_distribution(distro_name: str) -> str | None:
     return None
 
 
+def parse_requirement(requirement: str) -> str:
+    """Extract the base package name from a requirement string.
+
+    This function extracts only the package name, ignoring extras, version specifiers,
+    and environment markers.
+
+    Args:
+        requirement (str): A requirement string like 'numpy>=1.20.0' or 'requests[security]~=2.28.0'
+
+    Returns:
+        str: The base package name (e.g., 'numpy' from 'numpy>=1.20.0',
+        'requests' from 'requests[security]~=2.28.0')
+    """
+    # Handle inline comments by splitting on '#' and taking the first part
+    clean_requirement = requirement.split('#')[0].strip()
+    if not clean_requirement:
+        return ""
+
+    try:
+        parsed = Requirement(clean_requirement)
+        return parsed.name.lower()
+    except Exception as e:
+        logger.warning("Failed to parse requirement '%s': %s. Skipping this dependency.", requirement, e)
+        return ""
+
+
+def resolve_extras_to_packages(package_name: str, extras: list[str]) -> set[str]:
+    """Resolve package extras to their actual package dependencies.
+
+    Args:
+        package_name (str): The base package name (e.g., 'aiqtoolkit')
+        extras (list[str]): List of extra names (e.g., ['langchain', 'telemetry'])
+
+    Returns:
+        set[str]: Set of additional package names that the extras resolve to
+        (e.g., {'aiqtoolkit-langchain', 'aiqtoolkit-opentelemetry', 'aiqtoolkit-phoenix',
+        'aiqtoolkit-weave', 'aiqtoolkit-ragaai'})
+    """
+    resolved_packages = set()
+
+    try:
+        # Get the distribution metadata for the package
+        dist = importlib.metadata.distribution(package_name)
+
+        # Parse all requirements to find optional dependencies
+        requires = dist.requires or []
+
+        for requirement_str in requires:
+            try:
+                req = Requirement(requirement_str)
+
+                # Check if this requirement has a marker that matches our extras
+                if req.marker:
+                    for extra in extras:
+                        # Try marker evaluation first
+                        try:
+                            if req.marker.evaluate({'extra': extra}):
+                                resolved_packages.add(req.name.lower())
+                                break
+                        except Exception:
+                            # Fallback to simple string check
+                            marker_str = str(req.marker)
+                            if f'extra == "{extra}"' in marker_str or f"extra == '{extra}'" in marker_str:
+                                resolved_packages.add(req.name.lower())
+                                break
+
+            except Exception as e:
+                logger.warning("Failed to parse requirement '%s' for extras resolution: %s", requirement_str, e)
+
+    except importlib.metadata.PackageNotFoundError:
+        logger.warning("Package '%s' not found for extras resolution", package_name)
+    except Exception as e:
+        logger.warning("Failed to resolve extras for package '%s': %s", package_name, e)
+
+    return resolved_packages
+
+
+def extract_dependencies_with_extras_resolved(pyproject_path: str) -> set[str]:
+    """Extract dependency names from pyproject.toml with extras properly resolved.
+
+    This function not only extracts the base package names but also resolves
+    any extras (e.g., package[extra1,extra2]) to their actual package dependencies.
+
+    Args:
+        pyproject_path (str): Path to the pyproject.toml file
+
+    Returns:
+        set[str]: Set of all dependency names including those resolved from extras
+
+    Example:
+        For a dependency like "aiqtoolkit[langchain,telemetry]~=1.2", this will return:
+        {'aiqtoolkit', 'aiqtoolkit-langchain', 'aiqtoolkit-opentelemetry', 'aiqtoolkit-phoenix', ...}
+
+    Raises:
+        FileNotFoundError: If the pyproject.toml file doesn't exist
+        ValueError: If the file cannot be parsed
+    """
+    import tomllib
+
+    if not os.path.exists(pyproject_path):
+        raise FileNotFoundError(f"pyproject.toml not found at {pyproject_path}")
+
+    try:
+        with open(pyproject_path, "rb") as f:
+            data = tomllib.load(f)
+    except Exception as e:
+        raise ValueError(f"Failed to parse pyproject.toml: {e}") from e
+
+    project_data = data.get("project", {})
+    all_dependencies = set()
+
+    def _process_dependency(dep_spec: str):
+        """Process a single dependency specification and resolve extras."""
+        # Handle inline comments
+        clean_req = dep_spec.split('#')[0].strip()
+        if not clean_req:
+            return
+
+        try:
+            parsed = Requirement(clean_req)
+            base_name = parsed.name.lower()
+            all_dependencies.add(base_name)
+
+            # If there are extras, try to resolve them
+            if parsed.extras:
+                resolved_extras = resolve_extras_to_packages(base_name, list(parsed.extras))
+                all_dependencies.update(resolved_extras)
+
+        except Exception as e:
+            logger.warning("Failed to process dependency '%s': %s", dep_spec, e)
+
+    # Process main dependencies
+    for dep_spec in project_data.get("dependencies", []):
+        _process_dependency(dep_spec)
+
+    # Process optional dependencies
+    optional_deps = project_data.get("optional-dependencies", {})
+    for _group_name, group_deps in optional_deps.items():
+        for dep_spec in group_deps:
+            _process_dependency(dep_spec)
+
+    return all_dependencies
+
+
+@lru_cache
+def get_distributions() -> list[importlib.metadata.Distribution]:
+    """Get all installed distributions. This is an expensive operation and should be cached."""
+    return list(importlib.metadata.distributions())
+
+
+def find_distribution_name(name: str) -> str | None:
+    """Try to find the correct distribution name for a given package name.
+
+    Uses dynamic discovery through importlib.metadata to find distributions
+    that provide the requested module/package name.
+
+    Args:
+        name (str): Package name to search for.
+
+    Returns:
+        str | None: The correct distribution name if found, None otherwise.
+    """
+    # First try the name as-is
+    try:
+        importlib.metadata.distribution(name)
+        return name
+    except importlib.metadata.PackageNotFoundError:
+        pass
+
+    # Try common case variations
+    variations = [
+        name.lower(),
+        name.upper(),
+        name.replace('-', '_'),
+        name.replace('_', '-'),
+    ]
+
+    # Try each variation
+    for variation in variations:
+        if variation != name:  # Skip the original name we already tried
+            try:
+                importlib.metadata.distribution(variation)
+                return variation
+            except importlib.metadata.PackageNotFoundError:
+                continue
+
+    # Search through all installed distributions to find one that provides this module
+    try:
+        for dist in get_distributions():
+            dist_name = dist.metadata['Name']
+
+            # Check top-level packages provided by this distribution
+            try:
+                # Try to get top-level packages from metadata
+                top_level_txt = dist.read_text('top_level.txt')
+                if top_level_txt:
+                    top_level_packages = set(top_level_txt.strip().split('\n'))
+                    if name in top_level_packages:
+                        return dist_name
+            except (FileNotFoundError, AttributeError):
+                # top_level.txt doesn't exist, try alternative method
+                pass
+
+            # Fallback: check file paths for top-level modules
+            try:
+                if hasattr(dist, 'files') and dist.files:
+                    top_level_from_files = {
+                        f.parts[0]
+                        for f in dist.files if len(f.parts) > 0 and not f.parts[0].endswith('.dist-info')
+                    }
+                    if name in top_level_from_files:
+                        return dist_name
+            except Exception:
+                # Some distributions might not have files info or it might be inaccessible
+                continue
+
+    except Exception as e:
+        logger.debug("Error searching distributions for %s: %s", name, e)
+
+    return None
+
+
+def get_transitive_dependencies(distribution_names: list[str]) -> dict[str, set[str]]:
+    """Get transitive dependencies from a list of Python distribution names.
+
+    This function recursively resolves all dependencies for the given distribution names,
+    returning a mapping of each package to its complete set of transitive dependencies.
+    This is useful when publishing plugins to remote registries that contain with nested dependencies,
+    ensuring that all dependencies are included in the AIQArtifact's metadata.
+
+    Args:
+        distribution_names (list[str]): List of Python distribution names (package names) to analyze.
+
+    Returns:
+        dict[str, set[str]]: Dictionary mapping each distribution name to its set of transitive dependencies.
+        The dependencies include both direct and indirect dependencies.
+    """
+    result: dict[str, set[str]] = {}
+    processing: set[str] = set()  # Track packages currently being processed (cycle detection)
+    completed: set[str] = set()  # Track packages that have been fully processed
+
+    def _get_dependencies_recursive(dist_name: str, path: set[str]) -> set[str]:
+        """Recursively get all dependencies for a distribution.
+
+        Args:
+            dist_name: The distribution name to process
+            path: Set of packages in the current dependency path (for cycle detection)
+        """
+        # If we've already computed this package's dependencies, return them
+        if dist_name in completed:
+            return result.get(dist_name, set())
+
+        # If we encounter this package in the current path, we have a cycle
+        if dist_name in path:
+            logger.debug("Cycle detected in dependency chain: %s", " -> ".join(list(path) + [dist_name]))
+            return set()
+
+        # If we're currently processing this package in another branch, return empty
+        # to avoid duplicate work (we'll get the full result when that branch completes)
+        if dist_name in processing:
+            return set()
+
+        processing.add(dist_name)
+        new_path = path | {dist_name}
+        dependencies = set()
+
+        try:
+            dist = importlib.metadata.distribution(dist_name)
+            requires = dist.requires or []
+
+            for requirement in requires:
+                # Skip requirements with extra markers (optional dependencies)
+                # These should only be included if the extra is explicitly requested
+                if 'extra ==' in requirement:
+                    continue
+
+                # Parse the requirement to get the package name
+                dep_name = parse_requirement(requirement)
+
+                # Skip self-references and empty names
+                if not dep_name or dep_name == dist_name.lower():
+                    continue
+
+                dependencies.add(dep_name)
+
+                # Recursively get dependencies of this dependency
+                try:
+                    transitive_deps = _get_dependencies_recursive(dep_name, new_path)
+                    dependencies.update(transitive_deps)
+                except importlib.metadata.PackageNotFoundError:
+                    # Check if this is likely a conditional dependency (has markers)
+                    is_conditional = any(marker in requirement for marker in [
+                        'python_version', 'sys_platform', 'platform_system', 'platform_machine', 'implementation_name',
+                        'implementation_version'
+                    ])
+
+                    if is_conditional:
+                        # This is expected - conditional dependencies aren't always installed
+                        logger.debug("Conditional dependency %s of %s is not installed: %s",
+                                     dep_name,
+                                     dist_name,
+                                     requirement)
+                    else:
+                        # This might be a real issue - a non-conditional dependency is missing
+                        logger.warning("Dependency %s of %s is not installed", dep_name, dist_name)
+                    continue
+
+        except importlib.metadata.PackageNotFoundError:
+            # Transitive dependencies that aren't found are usually conditional (platform/version specific)
+            # and this is expected behavior
+            logger.debug("Distribution %s not found (likely conditional dependency)", dist_name)
+            # Don't raise - just return empty dependencies for missing distributions
+        finally:
+            processing.remove(dist_name)
+
+        result[dist_name] = dependencies
+        completed.add(dist_name)
+        return dependencies
+
+    # Process each distribution name
+    for dist_name in distribution_names:
+        if dist_name not in completed:
+            try:
+                _get_dependencies_recursive(dist_name.lower(), set())
+            except importlib.metadata.PackageNotFoundError:
+                # Try to find the correct distribution name
+                correct_name = find_distribution_name(dist_name)
+                if correct_name:
+                    logger.debug("Found distribution '%s' for requested name '%s'", correct_name, dist_name)
+                    try:
+                        _get_dependencies_recursive(correct_name.lower(), set())
+                        # Map the original name to the results of the correct name
+                        if correct_name.lower() in result:
+                            result[dist_name] = result[correct_name.lower()]
+                        continue
+                    except importlib.metadata.PackageNotFoundError:
+                        pass
+
+                logger.error("Distribution %s not found (tried common variations)", dist_name)
+                result[dist_name] = set()
+
+    return result
+
+
+def get_all_transitive_dependencies(distribution_names: list[str]) -> set[str]:
+    """Get all unique transitive dependencies from a list of Python distribution names.
+
+    Returns a flattened set of all unique dependencies across all the provided distribution names.
+    This is useful when publishing plugins to remote registries that contain with nested dependencies,
+    ensuring that all dependencies are included in the AIQArtifact's metadata.
+
+    Args:
+        distribution_names: List of Python distribution names (package names) to analyze
+
+    Returns:
+        set[str]: Set of all unique transitive dependency names
+    """
+    deps_map = get_transitive_dependencies(distribution_names)
+    all_deps = set()
+
+    for deps in deps_map.values():
+        all_deps.update(deps)
+
+    return all_deps
+
+
 def build_wheel(package_root: str) -> WheelData:
     """Builds a Python .whl for the specified package and saves to disk, sets self._whl_path, and returned as bytes.
 
@@ -67,8 +435,6 @@ def build_wheel(package_root: str) -> WheelData:
         WheelData: Data model containing a built python wheel and its corresponding metadata.
     """
 
-    import importlib.util
-    import re
     import tomllib
 
     from pkginfo import Wheel
@@ -84,18 +450,37 @@ def build_wheel(package_root: str) -> WheelData:
     toml_project: dict = data.get("project", {})
     toml_project_name = toml_project.get("name", None)
 
-    assert toml_project_name is not None, f"Package name '{toml_project_name}' not found in pyproject.toml"
-    # replace "aiqtoolkit" substring with "aiq" to get the import name
-    module_name = get_module_name_from_distribution(toml_project_name)
-    assert module_name is not None, f"No modules found for package name '{toml_project_name}'"
+    # assert toml_project_name is not None, f"Package name '{toml_project_name}' not found in pyproject.toml"
+    # # replace "aiqtoolkit" substring with "aiq" to get the import name
+    # module_name = get_module_name_from_distribution(toml_project_name)
+    # assert module_name is not None, f"No modules found for package name '{toml_project_name}'"
 
-    assert importlib.util.find_spec(module_name) is not None, (f"Package {module_name} not "
-                                                               "installed, cannot discover components.")
+    # assert importlib.util.find_spec(module_name) is not None, (f"Package {module_name} not "
+    #                                                            "installed, cannot discover components.")
 
     toml_packages = set(i for i in data.get("project", {}).get("entry-points", {}).get("aiq.plugins", {}))
-    toml_dependencies = set(
-        re.search(r"[a-zA-Z][a-zA-Z\d_-]*", package_name).group(0)
-        for package_name in toml_project.get("dependencies", []))
+
+    # Extract dependencies using the robust requirement parser with extras resolution
+    try:
+        toml_dependencies = extract_dependencies_with_extras_resolved(pyproject_toml_path)
+        logger.debug("Extracted dependencies with extras resolved: %s", toml_dependencies)
+    except Exception as e:
+        logger.warning("Failed to extract dependencies with extras resolution, falling back to basic extraction: %s", e)
+        # Fallback to basic extraction
+        toml_dependencies = set()
+        for dep_spec in toml_project.get("dependencies", []):
+            try:
+                dep_name = parse_requirement(dep_spec)
+                if dep_name:
+                    toml_dependencies.add(dep_name)
+            except Exception as e:
+                logger.warning("Failed to parse dependency '%s': %s", dep_spec, e)
+
+    toml_dependencies_transitive = get_all_transitive_dependencies(list(toml_dependencies))
+    print("My transitive toml_dependencies", toml_dependencies_transitive)
+    print()
+    print("My toml_dependencies", toml_dependencies)
+    print()
 
     union_dependencies = toml_dependencies.union(toml_packages)
     union_dependencies.add(toml_project_name)

--- a/tests/aiq/registry_handlers/test_package_utils.py
+++ b/tests/aiq/registry_handlers/test_package_utils.py
@@ -13,6 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+import tempfile
+import textwrap
+from unittest.mock import Mock
+from unittest.mock import patch
+
 import pytest
 
 from aiq.data_models.component import AIQComponentEnum
@@ -20,6 +26,11 @@ from aiq.data_models.discovery_metadata import DiscoveryMetadata
 from aiq.registry_handlers.package_utils import build_aiq_artifact
 from aiq.registry_handlers.package_utils import build_package_metadata
 from aiq.registry_handlers.package_utils import build_wheel
+from aiq.registry_handlers.package_utils import extract_dependencies_with_extras_resolved
+from aiq.registry_handlers.package_utils import get_all_transitive_dependencies
+from aiq.registry_handlers.package_utils import get_transitive_dependencies
+from aiq.registry_handlers.package_utils import parse_requirement
+from aiq.registry_handlers.package_utils import resolve_extras_to_packages
 from aiq.registry_handlers.schemas.package import WheelData
 from aiq.registry_handlers.schemas.publish import AIQArtifact
 
@@ -70,3 +81,210 @@ def test_build_aiq_artifact():
     aiq_artifact = build_aiq_artifact(package_root=package_root)
 
     assert isinstance(aiq_artifact, AIQArtifact)
+
+
+class TestParseRequirement:
+    """Test the parse_requirement function."""
+
+    def test_simple_package_name(self):
+        """Test parsing simple package names."""
+        assert parse_requirement("numpy") == "numpy"
+        assert parse_requirement("requests") == "requests"
+        assert parse_requirement("Django") == "django"  # Should be lowercase
+
+    def test_package_with_version_specifier(self):
+        """Test parsing packages with version specifiers."""
+        assert parse_requirement("numpy>=1.20.0") == "numpy"
+        assert parse_requirement("requests~=2.28.0") == "requests"
+        assert parse_requirement("pydantic==2.10.*") == "pydantic"
+
+    def test_package_with_extras(self):
+        """Test parsing packages with extras."""
+        assert parse_requirement("requests[security]") == "requests"
+        assert parse_requirement("uvicorn[standard]~=0.32.0") == "uvicorn"
+        assert parse_requirement("aiqtoolkit[langchain,telemetry]~=1.2") == "aiqtoolkit"
+
+    def test_package_with_comments(self):
+        """Test parsing packages with inline comments."""
+        assert parse_requirement("numpy>=1.20.0 # required for calculations") == "numpy"
+        assert parse_requirement("requests # HTTP library") == "requests"
+
+    def test_package_with_environment_markers(self):
+        """Test parsing packages with environment markers."""
+        assert parse_requirement("pytest ; python_version >= '3.8'") == "pytest"
+        assert parse_requirement("sphinx ; extra == 'docs'") == "sphinx"
+
+    def test_empty_or_invalid_requirements(self):
+        """Test parsing empty or invalid requirements."""
+        assert parse_requirement("") == ""
+        assert parse_requirement("   ") == ""
+        assert parse_requirement("# just a comment") == ""
+
+    def test_whitespace_handling(self):
+        """Test proper whitespace handling."""
+        assert parse_requirement("  numpy  ") == "numpy"
+        assert parse_requirement("\tnumpy\n") == "numpy"
+
+
+class TestResolveExtrasToPackages:
+    """Test the resolve_extras_to_packages function."""
+
+    @patch('aiq.registry_handlers.package_utils.importlib.metadata.distribution')
+    def test_resolve_simple_extras(self, mock_distribution):
+        """Test resolving simple extras."""
+        # Mock the distribution metadata
+        mock_dist = Mock()
+        mock_dist.requires = [
+            'package-a ; extra == "extra1"',
+            'package-b ; extra == "extra2"',
+            'package-c',  # No extra marker
+        ]
+        mock_distribution.return_value = mock_dist
+
+        result = resolve_extras_to_packages("test-package", ["extra1"])
+        assert result == {"package-a"}
+
+        result = resolve_extras_to_packages("test-package", ["extra2"])
+        assert result == {"package-b"}
+
+        result = resolve_extras_to_packages("test-package", ["extra1", "extra2"])
+        assert result == {"package-a", "package-b"}
+
+    @patch('aiq.registry_handlers.package_utils.importlib.metadata.distribution')
+    def test_resolve_nonexistent_extras(self, mock_distribution):
+        """Test resolving non-existent extras."""
+        mock_dist = Mock()
+        mock_dist.requires = [
+            'package-a ; extra == "extra1"',
+        ]
+        mock_distribution.return_value = mock_dist
+
+        result = resolve_extras_to_packages("test-package", ["nonexistent"])
+        assert result == set()
+
+    @patch('aiq.registry_handlers.package_utils.importlib.metadata.distribution')
+    def test_package_not_found(self, mock_distribution):
+        """Test behavior when package is not found."""
+        from importlib.metadata import PackageNotFoundError
+        mock_distribution.side_effect = PackageNotFoundError("Package not found")
+
+        result = resolve_extras_to_packages("nonexistent-package", ["extra1"])
+        assert result == set()
+
+
+class TestExtractDependenciesWithExtrasResolved:
+    """Test the extract_dependencies_with_extras_resolved function."""
+
+    @patch('aiq.registry_handlers.package_utils.resolve_extras_to_packages')
+    def test_extract_with_extras_resolution(self, mock_resolve_extras):
+        """Test extracting dependencies with extras resolution."""
+        mock_resolve_extras.return_value = {"resolved-package-1", "resolved-package-2"}
+
+        content = textwrap.dedent("""
+            [project]
+            name = "test-package"
+            dependencies = [
+                "base-package[extra1,extra2]~=1.0",
+                "simple-package"
+            ]
+            """)
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.toml', delete=False) as f:
+            f.write(content)
+            f.flush()
+
+            try:
+                deps = extract_dependencies_with_extras_resolved(f.name)
+
+                # Should include base package, simple package, and resolved extras
+                expected = {"base-package", "simple-package", "resolved-package-1", "resolved-package-2"}
+                assert deps == expected
+
+                # Verify resolve_extras_to_packages was called correctly
+                mock_resolve_extras.assert_called_once()
+                call_args = mock_resolve_extras.call_args
+                assert call_args[0][0] == "base-package"  # First argument: package name
+                assert set(call_args[0][1]) == {"extra1", "extra2"}  # Second argument: extras (order doesn't matter)
+
+            finally:
+                os.unlink(f.name)
+
+
+class TestGetTransitiveDependencies:
+    """Test the get_transitive_dependencies function."""
+
+    @patch('aiq.registry_handlers.package_utils.importlib.metadata.distribution')
+    def test_simple_transitive_dependencies(self, mock_distribution):
+        """Test getting simple transitive dependencies."""
+
+        def mock_dist_side_effect(name):
+            mock_dist = Mock()
+            if name == "package-a":
+                mock_dist.requires = ["package-b>=1.0", "package-c"]
+            elif name == "package-b":
+                mock_dist.requires = ["package-d"]
+            elif name == "package-c":
+                mock_dist.requires = []
+            elif name == "package-d":
+                mock_dist.requires = []
+            else:
+                from importlib.metadata import PackageNotFoundError
+                raise PackageNotFoundError(f"Package {name} not found")
+            return mock_dist
+
+        mock_distribution.side_effect = mock_dist_side_effect
+
+        result = get_transitive_dependencies(["package-a"])
+
+        assert "package-a" in result
+        expected_deps = {"package-b", "package-c", "package-d"}
+        assert result["package-a"] == expected_deps
+
+    @patch('aiq.registry_handlers.package_utils.importlib.metadata.distribution')
+    def test_cycle_detection(self, mock_distribution):
+        """Test that cycles are properly detected and handled."""
+
+        def mock_dist_side_effect(name):
+            mock_dist = Mock()
+            if name == "package-a":
+                mock_dist.requires = ["package-b"]
+            elif name == "package-b":
+                mock_dist.requires = ["package-a"]  # Creates a cycle
+            else:
+                from importlib.metadata import PackageNotFoundError
+                raise PackageNotFoundError(f"Package {name} not found")
+            return mock_dist
+
+        mock_distribution.side_effect = mock_dist_side_effect
+
+        # Should not hang due to cycle detection
+        result = get_transitive_dependencies(["package-a"])
+
+        assert "package-a" in result
+        # Should include package-b despite the cycle
+        assert "package-b" in result["package-a"]
+
+    @patch('aiq.registry_handlers.package_utils.importlib.metadata.distribution')
+    def test_missing_package(self, mock_distribution):
+        """Test behavior with missing packages."""
+        from importlib.metadata import PackageNotFoundError
+        mock_distribution.side_effect = PackageNotFoundError("Package not found")
+
+        result = get_transitive_dependencies(["nonexistent-package"])
+
+        assert result == {"nonexistent-package": set()}
+
+
+class TestGetAllTransitiveDependencies:
+    """Test the get_all_transitive_dependencies function."""
+
+    @patch('aiq.registry_handlers.package_utils.get_transitive_dependencies')
+    def test_flatten_dependencies(self, mock_get_transitive):
+        """Test flattening of transitive dependencies."""
+        mock_get_transitive.return_value = {
+            "package-a": {"dep1", "dep2", "dep3"}, "package-b": {"dep2", "dep4", "dep5"}
+        }
+
+        result = get_all_transitive_dependencies(["package-a", "package-b"])
+
+        expected = {"dep1", "dep2", "dep3", "dep4", "dep5"}
+        assert result == expected


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR fixes module discovery errors when publishing with registry handlers. It also ensures comprehensive plugin metadata is included in the `AIQArtifact`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
