### PR TITLE
Fix the artifactory component name to aiqtoolkit for all packages

### DIFF
--- a/ci/scripts/gitlab/artifactory_upload.sh
+++ b/ci/scripts/gitlab/artifactory_upload.sh
@@ -38,6 +38,8 @@ AIQ_ARCH="any"
 AIQ_OS="any"
 
 AIQ_COMPONENTS=("nvidia-nat" "aiqtoolkit")
+# We need to fix the name of the component in artifactory to aiqtoolkit
+ARTIFACTORY_COMPONENT_FIXED_NAME="aiqtoolkit"
 
 WHEELS_BASE_DIR="${CI_PROJECT_DIR}/.tmp/wheels"
 
@@ -110,8 +112,7 @@ if [[ "${UPLOAD_TO_ARTIFACTORY}" == "true" ]]; then
                 RELATIVE_PATH="${WHEEL_FILE#${WHEELS_BASE_DIR}/}"
                 RELATIVE_PATH=$(echo "${RELATIVE_PATH}" | sed -e 's|^nvidia-nat/|aiqtoolkit/|')
                 ARTIFACTORY_PATH="${AIQ_ARTIFACTORY_NAME}/${RELATIVE_PATH}"
-                # Like the RELATIVE_PATH above, we need to fix the name of the component in artifactory to aiqtoolkit
-                ARTIFACTORY_COMPONENT_FIXED_NAME="aiqtoolkit"
+"
                 echo "Uploading ${WHEEL_FILE} to ${ARTIFACTORY_PATH}..."
 
                 CI=true jf rt u --fail-no-op --url="${AIQ_ARTIFACTORY_URL}" \


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
