### PR TITLE
Fixing `nat workflow create` templates with deprecated references to `aiqtoolkit`

### DIFF
--- a/src/nat/cli/commands/workflow/templates/pyproject.toml.j2
+++ b/src/nat/cli/commands/workflow/templates/pyproject.toml.j2
@@ -9,14 +9,14 @@ root = "{{ rel_path_to_repo_root}}"{% else %}requires = ["setuptools >= 64"]{% e
 name = "{{ package_name }}"
 {% if editable %}dynamic = ["version"]{% else %}version = "0.1.0"{% endif %}
 dependencies = [
-  "aiqtoolkit[langchain]",
+  "nvidia-nat[langchain]",
 ]
 requires-python = ">=3.11,<3.13"
 description = "Custom AIQ Toolkit Workflow"
 classifiers = ["Programming Language :: Python"]
 
 {% if editable %}[tool.uv.sources]
-aiqtoolkit = { path = "{{ rel_path_to_repo_root}}", editable = true }{% endif %}
+nvidia-nat = { path = "{{ rel_path_to_repo_root}}", editable = true }{% endif %}
 
-[project.entry-points.'aiq.components']
+[project.entry-points.'nat.components']
 {{ package_name }} = "{{ package_name }}.register"


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR resolves an issue with the `nat workflow create` command that used a template with old references to aiqtoolkit. These references have been updated to `nvidia-nat`.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
