### PR TITLE
Refactor embedder client structure for LangChain and Llama Index.

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
@@ -17,6 +17,7 @@ from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.cli.register_workflow import register_embedder_client
 from nat.data_models.retry_mixin import RetryMixin
+from nat.embedder.nim_embedder import NIMEmbedderModelConfig
 from nat.embedder.openai_embedder import OpenAIEmbedderModelConfig
 from nat.utils.exception_handlers.automatic_retries import patch_with_retry
 
@@ -27,6 +28,22 @@ async def openai_langchain(embedder_config: OpenAIEmbedderModelConfig, builder: 
     from langchain_openai import OpenAIEmbeddings
 
     client = OpenAIEmbeddings(**embedder_config.model_dump(exclude={"type"}, by_alias=True))
+
+    if isinstance(embedder_config, RetryMixin):
+        client = patch_with_retry(client,
+                                  retries=embedder_config.num_retries,
+                                  retry_codes=embedder_config.retry_on_status_codes,
+                                  retry_on_messages=embedder_config.retry_on_errors)
+
+    yield client
+
+
+@register_embedder_client(config_type=NIMEmbedderModelConfig, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
+async def nim_langchain(embedder_config: NIMEmbedderModelConfig, builder: Builder):
+
+    from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings
+
+    client = NVIDIAEmbeddings(**embedder_config.model_dump(exclude={"type"}, by_alias=True))
 
     if isinstance(embedder_config, RetryMixin):
         client = patch_with_retry(client,

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
@@ -16,15 +16,9 @@
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.cli.register_workflow import register_embedder_client
+from nat.data_models.retry_mixin import RetryMixin
 from nat.embedder.nim_embedder import NIMEmbedderModelConfig
-
-
-@register_embedder_client(config_type=NIMEmbedderModelConfig, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
-async def nim_langchain(embedder_config: NIMEmbedderModelConfig, builder: Builder):
-
-    from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings
-
-    yield NVIDIAEmbeddings(**embedder_config.model_dump(exclude={"type"}, by_alias=True))
+from nat.utils.exception_handlers.automatic_retries import patch_with_retry
 
 
 @register_embedder_client(config_type=NIMEmbedderModelConfig, wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)
@@ -38,4 +32,12 @@ async def nim_llamaindex(embedder_config: NIMEmbedderModelConfig, builder: Build
             embedder_config.model_name,
     }
 
-    yield NVIDIAEmbedding(**config_obj)
+    client = NVIDIAEmbedding(**config_obj)
+
+    if isinstance(embedder_config, RetryMixin):
+        client = patch_with_retry(client,
+                                  retries=embedder_config.num_retries,
+                                  retry_codes=embedder_config.retry_on_status_codes,
+                                  retry_on_messages=embedder_config.retry_on_errors)
+
+    yield client

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/register.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/register.py
@@ -21,3 +21,4 @@
 
 from . import llm
 from . import tool_wrapper
+from . import embedder

--- a/src/nat/embedder/register.py
+++ b/src/nat/embedder/register.py
@@ -20,5 +20,3 @@
 # Import any providers which need to be automatically registered here
 from . import nim_embedder
 from . import openai_embedder
-# Import any clients which need to be automatically registered here
-from . import langchain_client


### PR DESCRIPTION
## Description
Moved embedder clients to plugin-specific directories for better organization. Added retry logic to both LangChain and Llama Index embedders, improving resilience to errors and configurable retry behaviors. Removed deprecated file `langchain_client.py` and adjusted imports accordingly.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
