### PR TITLE
Add missing uv.source for `simple_calculator_hitl`

### DIFF
--- a/examples/HITL/simple_calculator_hitl/pyproject.toml
+++ b/examples/HITL/simple_calculator_hitl/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = ["Programming Language :: Python"]
 [tool.uv.sources]
 nvidia-nat = { path = "../../..", editable = true }
 nat_simple_calculator = { path = "../../getting_started/simple_calculator", editable = true }
+nat_por_to_jiratickets = { path = "../por_to_jiratickets", editable = true }
 
 [project.entry-points.'nat.components']
 nat_simple_calculator_hitl = "nat_simple_calculator_hitl.register"


### PR DESCRIPTION
## Description

When installing the example in a standalone manner, we get an error:
```
warning: Missing version constraint (e.g., a lower bound) for `nat-por-to-jiratickets`
warning: Missing version constraint (e.g., a lower bound) for `sphinx-mermaid`
  × No solution found when resolving dependencies:
  ╰─▶ Because only the following versions of nvidia-nat[langchain] are available:
          nvidia-nat[langchain]<1.2
          nvidia-nat[langchain]>=2.dev0
      and nat-por-to-jiratickets==1.2.0rc6.dev9+gc0055ac2.d20250812 depends on nvidia-nat[langchain]>=1.2,<2.dev0, we can conclude that
      nat-por-to-jiratickets==1.2.0rc6.dev9+gc0055ac2.d20250812 cannot be used.
      And because nat-por-to-jiratickets was not found in the package registry and nat-simple-calculator-hitl==1.2.0rc6.dev20+gd94ec677.d20250813 depends
      on nat-por-to-jiratickets, we can conclude that nat-simple-calculator-hitl==1.2.0rc6.dev20+gd94ec677.d20250813 cannot be used.
      And because only nat-simple-calculator-hitl==1.2.0rc6.dev20+gd94ec677.d20250813 is available and you require nat-simple-calculator-hitl, we can
      conclude that your requirements are unsatisfiable.
```

This PR adds the missing source dependency for `nat_por_to_jiratickets`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
