### PR TITLE
Fix broken `additional_instructions` options for `ReWOO` agent

### DIFF
--- a/docs/source/workflows/about/rewoo-agent.md
+++ b/docs/source/workflows/about/rewoo-agent.md
@@ -91,7 +91,9 @@ functions:
 
 * `use_openai_api`: Defaults to False. If set to True, the ReWOO agent will output in OpenAI API spec. If set to False, strings will be used.
 
-* `additional_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base prompt.
+* `additional_planner_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base planner prompt.
+
+* `additional_solver_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base solver prompt.
 
 
 ## **Step-by-Step Breakdown of a ReWOO Agent**

--- a/src/nat/agent/rewoo_agent/prompt.py
+++ b/src/nat/agent/rewoo_agent/prompt.py
@@ -13,9 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# flake8: noqa
-from langchain_core.prompts.chat import ChatPromptTemplate
-
 PLANNER_SYSTEM_PROMPT = """
 For the following task, make plans that can solve the problem step by step. For each plan, indicate \
 which external tool together with tool input to retrieve evidence. You can store the evidence into a \
@@ -87,8 +84,6 @@ PLANNER_USER_PROMPT = """
 task: {task}
 """
 
-rewoo_planner_prompt = ChatPromptTemplate([("system", PLANNER_SYSTEM_PROMPT), ("user", PLANNER_USER_PROMPT)])
-
 SOLVER_SYSTEM_PROMPT = """
 Solve the following task or problem. To solve the problem, we have made step-by-step Plan and \
 retrieved corresponding Evidence to each Plan. Use them with caution since long evidence might \
@@ -104,5 +99,3 @@ task: {task}
 
 Response:
 """
-
-rewoo_solver_prompt = ChatPromptTemplate([("system", SOLVER_SYSTEM_PROMPT), ("user", SOLVER_USER_PROMPT)])

--- a/tests/nat/agent/test_rewoo.py
+++ b/tests/nat/agent/test_rewoo.py
@@ -19,6 +19,7 @@ import pytest
 from langchain_core.messages.ai import AIMessage
 from langchain_core.messages.human import HumanMessage
 from langchain_core.messages.tool import ToolMessage
+from langchain_core.prompts import ChatPromptTemplate
 from langgraph.graph.graph import CompiledGraph
 
 from nat.agent.base import AgentDecision
@@ -26,8 +27,6 @@ from nat.agent.rewoo_agent.agent import NO_INPUT_ERROR_MESSAGE
 from nat.agent.rewoo_agent.agent import TOOL_NOT_FOUND_ERROR_MESSAGE
 from nat.agent.rewoo_agent.agent import ReWOOAgentGraph
 from nat.agent.rewoo_agent.agent import ReWOOGraphState
-from nat.agent.rewoo_agent.prompt import rewoo_planner_prompt
-from nat.agent.rewoo_agent.prompt import rewoo_solver_prompt
 from nat.agent.rewoo_agent.register import ReWOOAgentWorkflowConfig
 
 
@@ -47,9 +46,14 @@ def mock_config():
 
 
 def test_rewoo_init(mock_config_rewoo_agent, mock_llm, mock_tool):
+    from nat.agent.rewoo_agent.prompt import PLANNER_SYSTEM_PROMPT
+    from nat.agent.rewoo_agent.prompt import PLANNER_USER_PROMPT
+    from nat.agent.rewoo_agent.prompt import SOLVER_SYSTEM_PROMPT
+    from nat.agent.rewoo_agent.prompt import SOLVER_USER_PROMPT
+
     tools = [mock_tool('mock_tool_A'), mock_tool('mock_tool_B')]
-    planner_prompt = rewoo_planner_prompt
-    solver_prompt = rewoo_solver_prompt
+    planner_prompt = ChatPromptTemplate([("system", PLANNER_SYSTEM_PROMPT), ("user", PLANNER_USER_PROMPT)])
+    solver_prompt = ChatPromptTemplate([("system", SOLVER_SYSTEM_PROMPT), ("user", SOLVER_USER_PROMPT)])
     agent = ReWOOAgentGraph(llm=mock_llm,
                             planner_prompt=planner_prompt,
                             solver_prompt=solver_prompt,
@@ -64,9 +68,14 @@ def test_rewoo_init(mock_config_rewoo_agent, mock_llm, mock_tool):
 
 @pytest.fixture(name='mock_rewoo_agent', scope="module")
 def mock_agent(mock_config_rewoo_agent, mock_llm, mock_tool):
+    from nat.agent.rewoo_agent.prompt import PLANNER_SYSTEM_PROMPT
+    from nat.agent.rewoo_agent.prompt import PLANNER_USER_PROMPT
+    from nat.agent.rewoo_agent.prompt import SOLVER_SYSTEM_PROMPT
+    from nat.agent.rewoo_agent.prompt import SOLVER_USER_PROMPT
+
     tools = [mock_tool('mock_tool_A'), mock_tool('mock_tool_B')]
-    planner_prompt = rewoo_planner_prompt
-    solver_prompt = rewoo_solver_prompt
+    planner_prompt = ChatPromptTemplate([("system", PLANNER_SYSTEM_PROMPT), ("user", PLANNER_USER_PROMPT)])
+    solver_prompt = ChatPromptTemplate([("system", SOLVER_SYSTEM_PROMPT), ("user", SOLVER_USER_PROMPT)])
     agent = ReWOOAgentGraph(llm=mock_llm,
                             planner_prompt=planner_prompt,
                             solver_prompt=solver_prompt,
@@ -288,3 +297,310 @@ def test_validate_solver_prompt_no_input():
 def test_validate_solver_prompt():
     mock_prompt = 'solve the problem'
     assert ReWOOAgentGraph.validate_solver_prompt(mock_prompt)
+
+
+# New tests for additional instructions functionality
+
+
+def test_additional_planner_instructions_are_appended():
+    """Test that additional planner instructions are properly appended to the base planner prompt."""
+    from langchain_core.prompts import ChatPromptTemplate
+
+    from nat.agent.rewoo_agent.prompt import PLANNER_SYSTEM_PROMPT
+
+    base_prompt = PLANNER_SYSTEM_PROMPT
+    additional_instructions = "\n\nAdditional instruction: Always consider performance implications."
+
+    # Test with additional instructions
+    planner_system_prompt_with_additional = base_prompt + additional_instructions
+    assert additional_instructions in planner_system_prompt_with_additional
+    assert base_prompt in planner_system_prompt_with_additional
+
+    # Verify the prompt still validates
+    assert ReWOOAgentGraph.validate_planner_prompt(planner_system_prompt_with_additional)
+
+    # Test that we can create a valid ChatPromptTemplate with additional instructions
+    from nat.agent.rewoo_agent.prompt import PLANNER_USER_PROMPT
+    planner_prompt = ChatPromptTemplate([("system", planner_system_prompt_with_additional),
+                                         ("user", PLANNER_USER_PROMPT)])
+    assert isinstance(planner_prompt, ChatPromptTemplate)
+
+
+def test_additional_solver_instructions_are_appended():
+    """Test that additional solver instructions are properly appended to the base solver prompt."""
+    from langchain_core.prompts import ChatPromptTemplate
+
+    from nat.agent.rewoo_agent.prompt import SOLVER_SYSTEM_PROMPT
+
+    base_prompt = SOLVER_SYSTEM_PROMPT
+    additional_instructions = "\n\nAdditional instruction: Provide concise answers."
+
+    # Test with additional instructions
+    solver_system_prompt_with_additional = base_prompt + additional_instructions
+    assert additional_instructions in solver_system_prompt_with_additional
+    assert base_prompt in solver_system_prompt_with_additional
+
+    # Verify the prompt still validates
+    assert ReWOOAgentGraph.validate_solver_prompt(solver_system_prompt_with_additional)
+
+    # Test that we can create a valid ChatPromptTemplate with additional instructions
+    from nat.agent.rewoo_agent.prompt import SOLVER_USER_PROMPT
+    solver_prompt = ChatPromptTemplate([("system", solver_system_prompt_with_additional), ("user", SOLVER_USER_PROMPT)])
+    assert isinstance(solver_prompt, ChatPromptTemplate)
+
+
+def test_prompt_validation_with_additional_instructions():
+    """Test that prompt validation still works correctly when additional instructions are provided."""
+    from nat.agent.rewoo_agent.prompt import PLANNER_SYSTEM_PROMPT
+    from nat.agent.rewoo_agent.prompt import SOLVER_SYSTEM_PROMPT
+
+    # Test planner prompt validation with additional instructions
+    base_planner_prompt = PLANNER_SYSTEM_PROMPT
+    additional_planner_instructions = "\n\nAdditional instruction: Be thorough in planning."
+    combined_planner_prompt = base_planner_prompt + additional_planner_instructions
+
+    # Should still be valid because it contains required variables
+    assert ReWOOAgentGraph.validate_planner_prompt(combined_planner_prompt)
+
+    # Test with additional instructions that break validation
+    broken_additional_instructions = "\n\nThis breaks {tools} formatting"
+    # Create a prompt that's missing required variables due to override
+    broken_planner_prompt = "This is a custom prompt without required variables" + broken_additional_instructions
+    with pytest.raises(ValueError):
+        ReWOOAgentGraph.validate_planner_prompt(broken_planner_prompt)
+
+    # Test solver prompt validation with additional instructions
+    base_solver_prompt = SOLVER_SYSTEM_PROMPT
+    additional_solver_instructions = "\n\nAdditional instruction: Be concise."
+    combined_solver_prompt = base_solver_prompt + additional_solver_instructions
+
+    # Should still be valid
+    assert ReWOOAgentGraph.validate_solver_prompt(combined_solver_prompt)
+
+
+def test_json_output_parsing_valid_format():
+    """Test that the planner can parse valid JSON output correctly."""
+    import json
+
+    # Test with valid JSON matching the expected format
+    valid_json_output = json.dumps([{
+        "plan": "Calculate the result of 2023 minus 25.",
+        "evidence": {
+            "placeholder": "#E1", "tool": "calculator_subtract", "tool_input": [2023, 25]
+        }
+    },
+                                    {
+                                        "plan": "Search for information about the result.",
+                                        "evidence": {
+                                            "placeholder": "#E2",
+                                            "tool": "internet_search",
+                                            "tool_input": "What happened in year #E1"
+                                        }
+                                    }])
+
+    # Test that the parsing method works correctly
+    parsed_output = ReWOOAgentGraph._parse_planner_output(valid_json_output)
+    assert isinstance(parsed_output, AIMessage)
+    assert isinstance(parsed_output.content, list)
+    assert len(parsed_output.content) == 2
+
+    # Verify the structure of parsed content
+    first_step = parsed_output.content[0]
+    assert "plan" in first_step
+    assert "evidence" in first_step
+    assert "placeholder" in first_step["evidence"]
+    assert "tool" in first_step["evidence"]
+    assert "tool_input" in first_step["evidence"]
+
+
+def test_json_output_parsing_invalid_format():
+    """Test that the planner handles invalid JSON output correctly."""
+
+    # Test with invalid JSON
+    invalid_json_output = "This is not valid JSON"
+    with pytest.raises(ValueError, match="The output of planner is invalid JSON format"):
+        ReWOOAgentGraph._parse_planner_output(invalid_json_output)
+
+    # Test with malformed JSON
+    malformed_json = '{"plan": "incomplete json"'
+    with pytest.raises(ValueError, match="The output of planner is invalid JSON format"):
+        ReWOOAgentGraph._parse_planner_output(malformed_json)
+
+    # Test with empty string
+    with pytest.raises(ValueError, match="The output of planner is invalid JSON format"):
+        ReWOOAgentGraph._parse_planner_output("")
+
+
+def test_json_output_parsing_with_string_tool_input():
+    """Test parsing JSON output with string tool inputs."""
+    import json
+
+    # Test with string tool input
+    json_with_string_input = json.dumps([{
+        "plan": "Search for the capital of France",
+        "evidence": {
+            "placeholder": "#E1", "tool": "search_tool", "tool_input": "What is the capital of France?"
+        }
+    }])
+
+    parsed_output = ReWOOAgentGraph._parse_planner_output(json_with_string_input)
+    assert isinstance(parsed_output.content[0]["evidence"]["tool_input"], str)
+
+
+def test_json_output_parsing_with_dict_tool_input():
+    """Test parsing JSON output with dictionary tool inputs."""
+    import json
+
+    # Test with dict tool input
+    json_with_dict_input = json.dumps([{
+        "plan": "Query database for user information",
+        "evidence": {
+            "placeholder": "#E1",
+            "tool": "database_query",
+            "tool_input": {
+                "table": "users", "filter": {
+                    "active": True
+                }
+            }
+        }
+    }])
+
+    parsed_output = ReWOOAgentGraph._parse_planner_output(json_with_dict_input)
+    assert isinstance(parsed_output.content[0]["evidence"]["tool_input"], dict)
+    assert parsed_output.content[0]["evidence"]["tool_input"]["table"] == "users"
+
+
+def test_edge_cases_empty_additional_instructions():
+    """Test edge cases with empty additional instructions."""
+    from nat.agent.rewoo_agent.prompt import PLANNER_SYSTEM_PROMPT
+    from nat.agent.rewoo_agent.prompt import SOLVER_SYSTEM_PROMPT
+
+    # Test empty string additional instructions
+    base_planner_prompt = PLANNER_SYSTEM_PROMPT
+    empty_additional_instructions = ""
+    combined_planner_prompt = base_planner_prompt + empty_additional_instructions
+
+    # Should still be valid
+    assert ReWOOAgentGraph.validate_planner_prompt(combined_planner_prompt)
+    assert combined_planner_prompt == base_planner_prompt
+
+    # Test None additional instructions (simulating config.additional_instructions being None)
+    # In the actual register.py, None would not be concatenated
+    assert ReWOOAgentGraph.validate_planner_prompt(base_planner_prompt)
+
+    # Test for solver prompt as well
+    base_solver_prompt = SOLVER_SYSTEM_PROMPT
+    combined_solver_prompt = base_solver_prompt + empty_additional_instructions
+    assert ReWOOAgentGraph.validate_solver_prompt(combined_solver_prompt)
+    assert combined_solver_prompt == base_solver_prompt
+
+
+def test_edge_cases_whitespace_additional_instructions():
+    """Test edge cases with whitespace-only additional instructions."""
+    from nat.agent.rewoo_agent.prompt import PLANNER_SYSTEM_PROMPT
+    from nat.agent.rewoo_agent.prompt import SOLVER_SYSTEM_PROMPT
+
+    # Test whitespace-only additional instructions
+    whitespace_instructions = "   \n\t  "
+
+    planner_prompt_with_whitespace = PLANNER_SYSTEM_PROMPT + whitespace_instructions
+    assert ReWOOAgentGraph.validate_planner_prompt(planner_prompt_with_whitespace)
+
+    solver_prompt_with_whitespace = SOLVER_SYSTEM_PROMPT + whitespace_instructions
+    assert ReWOOAgentGraph.validate_solver_prompt(solver_prompt_with_whitespace)
+
+
+def test_placeholder_replacement_functionality():
+    """Test the placeholder replacement functionality with various data types."""
+
+    # Test string replacement
+    tool_input = "Search for information about #E1 in the year #E1"
+    placeholder = "#E1"
+    tool_output = "1998"
+
+    result = ReWOOAgentGraph._replace_placeholder(placeholder, tool_input, tool_output)
+    assert result == "Search for information about 1998 in the year 1998"
+
+    # Test dict replacement - exact match
+    tool_input = {"query": "#E1", "year": "#E1"}
+    result = ReWOOAgentGraph._replace_placeholder(placeholder, tool_input, tool_output)
+    assert result["query"] == "1998"
+    assert result["year"] == "1998"
+
+    # Test dict replacement - partial match in string value
+    tool_input = {"query": "What happened in #E1?", "metadata": {"source": "test"}}
+    result = ReWOOAgentGraph._replace_placeholder(placeholder, tool_input, tool_output)
+    assert result["query"] == "What happened in 1998?"
+    assert result["metadata"]["source"] == "test"
+
+    # Test with complex tool output (dict)
+    complex_output = {"result": "France", "confidence": 0.95}
+    tool_input = "The capital of the country in #E1"
+    result = ReWOOAgentGraph._replace_placeholder("#E1", tool_input, complex_output)
+    expected = f"The capital of the country in {str(complex_output)}"
+    assert result == expected
+
+
+def test_tool_input_parsing_edge_cases():
+    """Test edge cases in tool input parsing."""
+
+    # Test with valid JSON string
+    json_string = '{"key": "value", "number": 42}'
+    result = ReWOOAgentGraph._parse_tool_input(json_string)
+    assert isinstance(result, dict)
+    assert result["key"] == "value"
+    assert result["number"] == 42
+
+    # Test with single quotes that get converted
+    single_quote_json = "{'key': 'value', 'number': 42}"
+    result = ReWOOAgentGraph._parse_tool_input(single_quote_json)
+    assert isinstance(result, dict)
+    assert result["key"] == "value"
+
+    # Test with raw string that can't be parsed
+    raw_string = "just a plain string"
+    result = ReWOOAgentGraph._parse_tool_input(raw_string)
+    assert result == raw_string
+
+    # Test with dict input (should return as-is)
+    dict_input = {"already": "a dict"}
+    result = ReWOOAgentGraph._parse_tool_input(dict_input)
+    assert result is dict_input
+
+    # Test with malformed JSON
+    malformed_json = '{"incomplete": json'
+    result = ReWOOAgentGraph._parse_tool_input(malformed_json)
+    assert result == malformed_json  # Should fall back to raw string
+
+
+def test_configuration_integration_with_additional_instructions():
+    """Test integration with ReWOOAgentWorkflowConfig for additional instructions."""
+    from nat.agent.rewoo_agent.register import ReWOOAgentWorkflowConfig
+
+    # Test config with additional planner instructions
+    config = ReWOOAgentWorkflowConfig(tool_names=["test_tool"],
+                                      llm_name="test_llm",
+                                      additional_planner_instructions="Be extra careful with planning.")
+    assert config.additional_planner_instructions == "Be extra careful with planning."
+
+    # Test config with additional solver instructions
+    config_solver = ReWOOAgentWorkflowConfig(tool_names=["test_tool"],
+                                             llm_name="test_llm",
+                                             additional_solver_instructions="Provide detailed explanations.")
+    assert config_solver.additional_solver_instructions == "Provide detailed explanations."
+
+    # Test config with both
+    config_both = ReWOOAgentWorkflowConfig(tool_names=["test_tool"],
+                                           llm_name="test_llm",
+                                           additional_planner_instructions="Plan carefully.",
+                                           additional_solver_instructions="Solve thoroughly.")
+    assert config_both.additional_planner_instructions == "Plan carefully."
+    assert config_both.additional_solver_instructions == "Solve thoroughly."
+
+    # Test that the validation_alias for additional_planner_instructions works
+    # We can't directly test the alias in the constructor since it's used at validation time
+    # But we can verify that both field names exist and work correctly
+    assert hasattr(config_both, 'additional_planner_instructions')
+    assert hasattr(config_both, 'additional_solver_instructions')
+    assert config_both.additional_planner_instructions == "Plan carefully."
+    assert config_both.additional_solver_instructions == "Solve thoroughly."


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Fix the broken `additional_instructions` options for `ReWOO` agent by:

- Add an `additional_solver_instructions` option.
- Rename the original `additional_instructions` to `additional_planner_instruction`. Ensure backward compatibility by using `AliasChoices`.
- Ensure the additional instructions are appended no matter the system prompts are customized.
- Add unit tests to the changes above.

Closes #633 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
