### PR TITLE
Fix `aiq` compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = ["setuptools >= 64", "setuptools-scm>=8"]
 
 [tool.setuptools.packages.find]
 where = ["src"]
-include = ["aiq.*", "nat.*"]
+include = ["aiq", "nat.*"]
 
 [tool.setuptools_scm]
 # intentionally empty, the section is required for setuptools_scm to work but we don't need to set anything

--- a/src/aiq/__init__.py
+++ b/src/aiq/__init__.py
@@ -13,15 +13,53 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+import importlib
+import importlib.abc
+import importlib.util
 import warnings
 
-import nat
 
-# Provide a compatibility alias for the old aiq namespace
-__path__ = nat.__path__
+class CompatFinder(importlib.abc.MetaPathFinder):
+
+    def __init__(self, alias_prefix, target_prefix):
+        self.alias_prefix = alias_prefix
+        self.target_prefix = target_prefix
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname == self.alias_prefix or fullname.startswith(self.alias_prefix + "."):
+            # Map aiq.something -> nat.something
+            target_name = self.target_prefix + fullname[len(self.alias_prefix):]
+            spec = importlib.util.find_spec(target_name)
+            if spec is None:
+                return None
+            # Wrap the loader so it loads under the alias name
+            return importlib.util.spec_from_loader(fullname, CompatLoader(fullname, target_name))
+        return None
+
+
+class CompatLoader(importlib.abc.Loader):
+
+    def __init__(self, alias_name, target_name):
+        self.alias_name = alias_name
+        self.target_name = target_name
+
+    def create_module(self, spec):
+        # Reuse the actual module so there's only one instance
+        target_module = importlib.import_module(self.target_name)
+        sys.modules[self.alias_name] = target_module
+        return target_module
+
+    def exec_module(self, module):
+        # Nothing to execute since the target is already loaded
+        pass
+
+
+# Register the compatibility finder
+sys.meta_path.insert(0, CompatFinder("aiq", "nat"))
 
 warnings.warn(
-    "The 'aiq' namespace is deprecated and will be removed in a future release. "
+    "!!! The 'aiq' namespace is deprecated and will be removed in a future release. "
     "Please use the 'nat' namespace instead.",
     DeprecationWarning,
     stacklevel=2,

--- a/src/aiq/__init__.py
+++ b/src/aiq/__init__.py
@@ -26,7 +26,7 @@ class CompatFinder(importlib.abc.MetaPathFinder):
         self.alias_prefix = alias_prefix
         self.target_prefix = target_prefix
 
-    def find_spec(self, fullname, path, target=None):
+    def find_spec(self, fullname, path, target=None):  # pylint: disable=unused-argument
         if fullname == self.alias_prefix or fullname.startswith(self.alias_prefix + "."):
             # Map aiq.something -> nat.something
             target_name = self.target_prefix + fullname[len(self.alias_prefix):]

--- a/tests/nat/compat/test_compatibility_aliases.py
+++ b/tests/nat/compat/test_compatibility_aliases.py
@@ -18,8 +18,11 @@ import subprocess
 
 import pytest
 
+# Prevent isort from removing the pylint disable comments
+# isort:skip_file
 
-def test_aiq_sublass_is_nat_subclass():
+
+def test_aiq_subclass_is_nat_subclass():
     with pytest.deprecated_call():
         from aiq.data_models import function as aiq_function  # pylint: disable=no-name-in-module
 

--- a/tests/nat/compat/test_compatibility_aliases.py
+++ b/tests/nat/compat/test_compatibility_aliases.py
@@ -19,14 +19,15 @@ import subprocess
 import pytest
 
 
-def test_namespace_compat():
-    import nat
-
+def test_aiq_sublass_is_nat_subclass():
     with pytest.deprecated_call():
-        import aiq
+        from aiq.data_models import function as aiq_function
 
-        # Check that the aiq namespace is an alias for nat
-        assert aiq.__path__ == nat.__path__
+        class MyAIQFunctionConfig(aiq_function.FunctionBaseConfig):
+            pass
+
+        from nat.data_models import function as nat_function
+        assert issubclass(MyAIQFunctionConfig, nat_function.FunctionBaseConfig)
 
 
 def test_cli_compat():

--- a/tests/nat/compat/test_compatibility_aliases.py
+++ b/tests/nat/compat/test_compatibility_aliases.py
@@ -21,7 +21,7 @@ import pytest
 
 def test_aiq_sublass_is_nat_subclass():
     with pytest.deprecated_call():
-        from aiq.data_models import function as aiq_function # pylint: disable=no-name-in-module
+        from aiq.data_models import function as aiq_function  # pylint: disable=no-name-in-module
 
         class MyAIQFunctionConfig(aiq_function.FunctionBaseConfig):
             pass

--- a/tests/nat/compat/test_compatibility_aliases.py
+++ b/tests/nat/compat/test_compatibility_aliases.py
@@ -21,7 +21,7 @@ import pytest
 
 def test_aiq_sublass_is_nat_subclass():
     with pytest.deprecated_call():
-        from aiq.data_models import function as aiq_function
+        from aiq.data_models import function as aiq_function # pylint: disable=no-name-in-module
 
         class MyAIQFunctionConfig(aiq_function.FunctionBaseConfig):
             pass


### PR DESCRIPTION
## Description
* Ensure that `aiq/__init__.py` is installed into the wheel
* Replace namespace compatibility alias with custom `importlib.abc.MetaPathFinder` and `importlib.abc.Loader` this solves the issue where a subclass of `aiq.<submodule>.SomeClass` would not be seen as a valid subclass of `nat.<submodule>.SomeClass`. Special thanks to @willkill07  for this!

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
