### PR TITLE
Timezone Support for `datetime` Tool and Normalize Response Time Handling

### DIFF
--- a/nat.code-workspace
+++ b/nat.code-workspace
@@ -71,6 +71,7 @@
         "rewrap.wrappingColumn": 120,
         "yapf.args": [
             "--style=${workspaceFolder}/pyproject.toml"
-        ]
+        ],
+        "editor.formatOnSave": true
     }
 }

--- a/nat.code-workspace
+++ b/nat.code-workspace
@@ -71,7 +71,6 @@
         "rewrap.wrappingColumn": 120,
         "yapf.args": [
             "--style=${workspaceFolder}/pyproject.toml"
-        ],
-        "editor.formatOnSave": true
+        ]
     }
 }

--- a/src/nat/builder/user_interaction_manager.py
+++ b/src/nat/builder/user_interaction_manager.py
@@ -61,13 +61,13 @@ class UserInteractionManager:
 
         uuid_req = str(uuid.uuid4())
         status = InteractionStatus.IN_PROGRESS
-        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         sys_human_interaction = InteractionPrompt(id=uuid_req, status=status, timestamp=timestamp, content=content)
 
         resp = await self._context_state.user_input_callback.get()(sys_human_interaction)
 
         # Rebuild a InteractionResponse object with the response
-        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ")
+        timestamp = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
         status = InteractionStatus.COMPLETED
         sys_human_interaction = InteractionResponse(id=uuid_req, status=status, timestamp=timestamp, content=resp)
 

--- a/src/nat/tool/datetime_tools.py
+++ b/src/nat/tool/datetime_tools.py
@@ -36,7 +36,7 @@ async def current_datetime(_config: CurrentTimeToolConfig, _builder: Builder):
 
     from starlette.datastructures import Headers
 
-    async def _get_current_time(_unused: str) -> str:
+    async def _get_current_time(unused: str) -> str:
 
         from nat.builder.context import Context
         nat_context = Context.get()

--- a/src/nat/tool/datetime_tools.py
+++ b/src/nat/tool/datetime_tools.py
@@ -13,10 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import zoneinfo
+
+from starlette.datastructures import Headers
+
 from nat.builder.builder import Builder
 from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
 from nat.data_models.function import FunctionBaseConfig
+from nat.settings.global_settings import GlobalSettings
 
 
 class CurrentTimeToolConfig(FunctionBaseConfig, name="current_datetime"):
@@ -28,15 +34,31 @@ class CurrentTimeToolConfig(FunctionBaseConfig, name="current_datetime"):
     pass
 
 
+def _get_timezone_obj(headers: Headers | None) -> zoneinfo.ZoneInfo | datetime.tzinfo:
+    # Default to UTC
+    timezone_obj = zoneinfo.ZoneInfo("Etc/UTC")
+
+    if headers:
+        # If user has provided a timezone in the header, we will prioritize on using it
+        timezone_header = headers.get("x-timezone")
+        if timezone_header:
+            try:
+                timezone_obj = zoneinfo.ZoneInfo(timezone_header)
+            except Exception:
+                pass
+    else:
+        # Only if a timezone is not in the header, we will determine default timezone based on global settings
+        fallback_tz = GlobalSettings.get().fallback_timezone
+
+        if fallback_tz == "system":
+            # Use the system's local timezone. Avoid requiring external deps.
+            timezone_obj = datetime.datetime.now().astimezone().tzinfo or zoneinfo.ZoneInfo("Etc/UTC")
+
+    return timezone_obj
+
+
 @register_function(config_type=CurrentTimeToolConfig)
 async def current_datetime(_config: CurrentTimeToolConfig, _builder: Builder):
-
-    import datetime
-    import zoneinfo
-
-    from starlette.datastructures import Headers
-
-    from nat.settings.global_settings import GlobalSettings
 
     async def _get_current_time(unused: str) -> str:
 
@@ -45,26 +67,9 @@ async def current_datetime(_config: CurrentTimeToolConfig, _builder: Builder):
         from nat.builder.context import Context
         nat_context = Context.get()
 
-        # Default to UTC
-        timezone_obj = zoneinfo.ZoneInfo("Etc/UTC")
-
         headers: Headers | None = nat_context.metadata.headers
 
-        if headers:
-            # If user has provided a timezone in the header, we will prioritize on using it
-            timezone_header = headers.get("x-timezone")
-            if timezone_header:
-                try:
-                    timezone_obj = zoneinfo.ZoneInfo(timezone_header)
-                except Exception:
-                    pass
-        else:
-            # Only if a timezone is not in the header, we will determine default timezone based on global settings
-            fallback_tz = GlobalSettings.get().fallback_timezone
-
-            if fallback_tz == "system":
-                # Use the system's local timezone. Avoid requiring external deps.
-                timezone_obj = datetime.datetime.now().astimezone().tzinfo or zoneinfo.ZoneInfo("Etc/UTC")
+        timezone_obj = _get_timezone_obj(headers)
 
         now = datetime.datetime.now(timezone_obj)
         now_machine_readable = now.strftime(("%Y-%m-%d %H:%M:%S %z"))

--- a/src/nat/tool/datetime_tools.py
+++ b/src/nat/tool/datetime_tools.py
@@ -21,7 +21,7 @@ from nat.data_models.function import FunctionBaseConfig
 
 class CurrentTimeToolConfig(FunctionBaseConfig, name="current_datetime"):
     """
-    Simple tool which returns the current date and time in human readable format.
+    Simple tool which returns the current date and time in human readable format in UTC timezone.
     """
     pass
 
@@ -31,12 +31,14 @@ async def current_datetime(config: CurrentTimeToolConfig, builder: Builder):
 
     import datetime
 
+    import pytz
+
     async def _get_current_time(unused: str) -> str:
 
-        now = datetime.datetime.now()  # Get current time
+        now = datetime.datetime.now(pytz.utc)  # Get current time in UTC
         now_human_readable = now.strftime(("%Y-%m-%d %H:%M:%S"))
 
         return f"The current time of day is {now_human_readable}"  # Format time in H:MM AM/PM format
 
-    yield FunctionInfo.from_fn(_get_current_time,
-                               description="Returns the current date and time in human readable format.")
+    yield FunctionInfo.from_fn(
+        _get_current_time, description="Returns the current date and time in human readable format in UTC timezone.")

--- a/src/nat/tool/datetime_tools.py
+++ b/src/nat/tool/datetime_tools.py
@@ -29,14 +29,14 @@ class CurrentTimeToolConfig(FunctionBaseConfig, name="current_datetime"):
 
 
 @register_function(config_type=CurrentTimeToolConfig)
-async def current_datetime(config: CurrentTimeToolConfig, builder: Builder):
+async def current_datetime(_config: CurrentTimeToolConfig, _builder: Builder):
 
     import datetime
     import zoneinfo
 
     from starlette.datastructures import Headers
 
-    async def _get_current_time(unused: str) -> str:
+    async def _get_current_time(_unused: str) -> str:
 
         from nat.builder.context import Context
         nat_context = Context.get()

--- a/src/nat/tool/datetime_tools.py
+++ b/src/nat/tool/datetime_tools.py
@@ -29,7 +29,8 @@ class CurrentTimeToolConfig(FunctionBaseConfig, name="current_datetime"):
 
 
 @register_function(config_type=CurrentTimeToolConfig)
-async def current_datetime(_config: CurrentTimeToolConfig, _builder: Builder):
+async def current_datetime(config: CurrentTimeToolConfig, builder: Builder):
+    del config, builder  # Unused parameters to avoid linting error
 
     import datetime
     import zoneinfo
@@ -38,7 +39,7 @@ async def current_datetime(_config: CurrentTimeToolConfig, _builder: Builder):
 
     async def _get_current_time(unused: str) -> str:
 
-        del unused  # Unused parameter to avoid type checking error
+        del unused  # Unused parameter to avoid linting error
 
         from nat.builder.context import Context
         nat_context = Context.get()

--- a/src/nat/tool/datetime_tools.py
+++ b/src/nat/tool/datetime_tools.py
@@ -37,7 +37,7 @@ async def current_datetime(config: CurrentTimeToolConfig, builder: Builder):
         now = datetime.datetime.now(zoneinfo.ZoneInfo("UTC"))  # Get current time in UTC
         now_human_readable = now.strftime(("%Y-%m-%d %H:%M:%S"))
 
-        return f"The current time of day is {now_human_readable}"  # Format time in H:MM AM/PM format
+        return f"The current time of day is {now_human_readable} UTC"  # Format time in H:MM AM/PM format
 
     yield FunctionInfo.from_fn(
         _get_current_time, description="Returns the current date and time in human readable format in UTC timezone.")

--- a/src/nat/tool/datetime_tools.py
+++ b/src/nat/tool/datetime_tools.py
@@ -30,12 +30,11 @@ class CurrentTimeToolConfig(FunctionBaseConfig, name="current_datetime"):
 async def current_datetime(config: CurrentTimeToolConfig, builder: Builder):
 
     import datetime
-
-    import pytz
+    import zoneinfo
 
     async def _get_current_time(unused: str) -> str:
 
-        now = datetime.datetime.now(pytz.utc)  # Get current time in UTC
+        now = datetime.datetime.now(zoneinfo.ZoneInfo("UTC"))  # Get current time in UTC
         now_human_readable = now.strftime(("%Y-%m-%d %H:%M:%S"))
 
         return f"The current time of day is {now_human_readable}"  # Format time in H:MM AM/PM format

--- a/src/nat/tool/datetime_tools.py
+++ b/src/nat/tool/datetime_tools.py
@@ -38,6 +38,8 @@ async def current_datetime(_config: CurrentTimeToolConfig, _builder: Builder):
 
     async def _get_current_time(unused: str) -> str:
 
+        del unused  # Unused parameter to avoid type checking error
+
         from nat.builder.context import Context
         nat_context = Context.get()
 

--- a/src/nat/tool/datetime_tools.py
+++ b/src/nat/tool/datetime_tools.py
@@ -29,8 +29,7 @@ class CurrentTimeToolConfig(FunctionBaseConfig, name="current_datetime"):
 
 
 @register_function(config_type=CurrentTimeToolConfig)
-async def current_datetime(config: CurrentTimeToolConfig, builder: Builder):
-    del config, builder  # Unused parameters to avoid linting error
+async def current_datetime(_config: CurrentTimeToolConfig, _builder: Builder):
 
     import datetime
     import zoneinfo


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->

- Added timezone support for the `datetime_tools`, so now it will automatically extract the `x-timezone` from the headers from context, which will be used to format the current time. 
    - If the `x-timezone`  is not present in the headers, default UTC time is used. 
    - The documentations should also be clear now.

- Fixed a small issue in `NeMo-Agent-Toolkit/src/nat/builder/user_interaction_manager.py`. Before the timestamp is in UTC (as seen by the `Z` suffix in the timestamp), but the timestamp is in the local timezone, which is most likely not in UTC timezone.

- Made a tiny change for the `NeMo-Agent-Toolkit-UI` repository. So now the front-end also stores the timezone in IANA format in its header to be sent to the backend.
    - The change: [https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/pull/38](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/pull/38)
## FAQs

### Q: why did you use UTC time by default?
- A: UTC is industry standard's default timezone.

### Q: why did you use IANA format for timezone?
- A: IANA time zone (like "America/New_York" or "Etc/UTC") provides a standardized identifier that encodes daylight-saving rules and ensures consistent behavior across platforms and regions, and also widely accepted in industry.

## Demo
<img width="1728" height="1117" alt="Screenshot 2025-08-16 at 1 46 57 PM" src="https://github.com/user-attachments/assets/afd843df-18b2-4615-83a3-0013bb760a7c" />



Closes #445

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
