### PR TITLE
Adding `.nspect-allowlist.toml` to remediate false positives found by scanner

### DIFF
--- a/.nspect-allowlist.toml
+++ b/.nspect-allowlist.toml
@@ -1,0 +1,26 @@
+version = "1.2.0"
+
+[oss]
+[[pulse-trufflehog.files]]
+file = "packages/nvidia_nat_mysql/tests/test_mysql_object_store.py"
+
+[[pulse-trufflehog.files.secrets]]
+# Fake password string used for unittests
+type = "Password"
+values = ["pas****************-pw\""]
+
+[[pulse-trufflehog.files]]
+file = "tests/nat/authentication/test_http_basic_auth_exchanger.py"
+
+[[pulse-trufflehog.files.secrets]]
+# Fake password string used for unittests
+type = "Password"
+values = ["\"pa***********ass\"", "\"pa******** \"b\""]
+
+[[pulse-trufflehog.files]]
+file = "tests/nat/authentication/test_data_models.py"
+
+[[pulse-trufflehog.files.secrets]]
+# Fake passwords and credentials used for unittests
+type = "Password"
+values = ["pas**************and\"", "\"pa******** \"p\""]


### PR DESCRIPTION
## Description
* These are all fake strings used by unittests such as "pass"

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
