### PR TITLE
Fix: Remove `pickle` from MySQL-based Object Store

### DIFF
--- a/examples/object_store/user_report/serialize_file.py
+++ b/examples/object_store/user_report/serialize_file.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import pickle
+import base64
+import json
+import mimetypes
 import sys
-
-from nat.object_store.models import ObjectStoreItem
 
 # Usage: python serialize_file.py <file_path>
 
@@ -29,7 +29,11 @@ file_path = sys.argv[1]
 with open(file_path, "rb") as f:
     data = f.read()
 
-item = ObjectStoreItem(data=data, )
+payload = {
+    "data": base64.b64encode(data).decode("ascii"),
+    "content_type": mimetypes.guess_type(file_path)[0],
+    "metadata": {},
+}
 
-with open(file_path + ".pkl", "wb") as f:
-    pickle.dump(item, f)
+with open(file_path + ".json", "w", encoding="utf-8") as f:
+    json.dump(payload, f, ensure_ascii=False)

--- a/examples/object_store/user_report/src/nat_user_report/user_report_tools.py
+++ b/examples/object_store/user_report/src/nat_user_report/user_report_tools.py
@@ -37,7 +37,7 @@ async def get_user_report(config: GetUserReportConfig, builder: Builder):
 
     async def _inner(user_id: str, date: str | None = None) -> str:
         date = date or "latest"
-        key = f"/reports/{user_id}/{date}.json"
+        key = f"reports/{user_id}/{date}.json"
         logger.info("Fetching report from %s", key)
         item = await object_store.get_object(key=key)
         return item.data.decode("utf-8")
@@ -56,7 +56,7 @@ async def put_user_report(config: PutUserReportConfig, builder: Builder):
 
     async def _inner(report: str, user_id: str, date: str | None = None) -> str:
         date = date or "latest"
-        key = f"/reports/{user_id}/{date}.json"
+        key = f"reports/{user_id}/{date}.json"
         logger.info("Putting new report into %s for user %s with date %s", key, user_id, date)
         try:
             await object_store.put_object(key=key,
@@ -80,7 +80,7 @@ async def update_user_report(config: UpdateUserReportConfig, builder: Builder):
 
     async def _inner(report: str, user_id: str, date: str | None = None) -> str:
         date = date or "latest"
-        key = f"/reports/{user_id}/{date}.json"
+        key = f"reports/{user_id}/{date}.json"
         logger.info("Update or insert report into %s for user %s with date %s", key, user_id, date)
         await object_store.upsert_object(key=key,
                                          item=ObjectStoreItem(data=report.encode("utf-8"),
@@ -101,7 +101,7 @@ async def delete_user_report(config: DeleteUserReportConfig, builder: Builder):
 
     async def _inner(user_id: str, date: str | None = None) -> str:
         date = date or "latest"
-        key = f"/reports/{user_id}/{date}.json"
+        key = f"reports/{user_id}/{date}.json"
         logger.info("Delete report from %s for user %s with date %s", key, user_id, date)
         await object_store.delete_object(key=key)
         return f"User report for {user_id} with date {date} deleted"

--- a/examples/object_store/user_report/upload_to_mysql.sh
+++ b/examples/object_store/user_report/upload_to_mysql.sh
@@ -72,19 +72,18 @@ find "$DIR" -type f | while IFS= read -r filepath; do
 
   echo "Processing file: ${relpath}"
   fsize=$(stat -c%s "$filepath")
-  # Serialize the file
   python serialize_file.py "$filepath"
-  serialized_file="${filepath}.pkl"
+  serialized_file="${filepath}.json"
 
   ${MYSQL[@]} <<EOF
 USE \`$DB\`;
 START TRANSACTION;
 
 INSERT INTO object_meta (path, size)
-VALUES ('/${relpath}', ${fsize})
+VALUES ('${relpath}', ${fsize})
 ON DUPLICATE KEY UPDATE size=VALUES(size), created_at=CURRENT_TIMESTAMP;
 
-SET @obj_id := (SELECT id FROM object_meta WHERE path='/${relpath}' FOR UPDATE);
+SET @obj_id := (SELECT id FROM object_meta WHERE path='${relpath}' FOR UPDATE);
 
 REPLACE INTO object_data (id, data)
 VALUES (


### PR DESCRIPTION
## Description

Using pickle for SerDe is not secure, so switch to JSON + Base64 encode/decode for Object Store backing in MySQL.

This PR also updates necessary files under the `examples/object_store/user_report` example. The leading `/` was removed as it never should have been added in the first place.

<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

Closes AIQ-1724

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
