### PR TITLE
Adding a Needs Triage label to issues which are created externally

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -16,7 +16,7 @@
 name: Bug Report
 description: File a bug report
 type: "Bug"
-labels: ["bug"]
+labels: ["bug", "Needs Triage"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/documentation_request_correction.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request_correction.yml
@@ -16,7 +16,7 @@
 name: Documentation - Correction/Update Request
 description: Request corrections or updates to existing documentation
 type: "Documentation"
-labels: ["doc"]
+labels: ["doc", "Needs Triage"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/documentation_request_new.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request_new.yml
@@ -16,7 +16,7 @@
 name: Documentation - New Documentation Request
 description: Request additions to NeMo Agent toolkit documentation
 type: "Documentation"
-labels: ["doc"]
+labels: ["doc", "Needs Triage"]
 
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -16,7 +16,7 @@
 name: Feature Request Form
 description: Request new or improved functionality or changes to existing functionality
 type: "Enhancement"
-labels: ["feature request"]
+labels: ["feature request", "Needs Triage"]
 
 body:
   - type: markdown


### PR DESCRIPTION
## Description
- Adds the "Needs Triage" label to help identify items which have been triaged by the team or not

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
