### PR TITLE
fix(pytest): suppress upstream pydantic warning from mem0

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,8 +28,10 @@ import os
 import sys
 import typing
 import uuid
+import warnings
 from collections.abc import AsyncGenerator
 from collections.abc import Callable
+from collections.abc import Sequence
 from unittest import mock
 
 import pytest
@@ -44,6 +46,7 @@ from langchain_core.outputs import ChatGeneration
 from langchain_core.outputs import ChatResult
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel
+from pydantic.warnings import PydanticDeprecatedSince20
 
 TESTS_DIR = os.path.dirname(__file__)
 PROJECT_DIR = os.path.dirname(TESTS_DIR)
@@ -330,7 +333,10 @@ async def mock_llm():
             generation = ChatGeneration(message=message)
             return ChatResult(generations=[generation], llm_output={'mock_llm_response': True})
 
-        def bind_tools(self, tools: list[BaseTool], **kwargs: typing.Any) -> BaseChatModel:
+        def bind_tools(
+                self,
+                tools: Sequence[dict[str, typing.Any] | type | Callable | BaseTool],  # noqa: UP006
+                **kwargs: typing.Any) -> BaseChatModel:
             return self
 
         @property
@@ -368,8 +374,14 @@ def mock_tool():
 
 @pytest.fixture(scope="function", autouse=True)
 def patched_async_memory_client(monkeypatch):
-
-    from mem0.client.main import MemoryClient
+    # Suppress Pydantic's class-based Config deprecation only during mem0 import
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            category=PydanticDeprecatedSince20,
+            module=r"^pydantic\._internal\._config$",
+        )
+        from mem0.client.main import MemoryClient
 
     mock_method = mock.MagicMock(return_value=None)
     monkeypatch.setattr(MemoryClient, "_validate_api_key", mock_method)


### PR DESCRIPTION
## Description

When running pytest, we always got a warning about class-based config being deprecated since Pydantic 2.0. The root cause is from `mem0` [here](https://github.com/mem0ai/mem0/blob/3b2d0ad0eb9b406b4d8fc36ca3b86912e0875424/mem0/client/project.py#L23). Since we cannot fix upstream, let's ignore it safely.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
