### PR TITLE
Configure coderabbit not to apply conflicting labels

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -121,11 +121,13 @@ reviews:
       instructions: >-
         Apply this label when the PR introduces changes that break backward compatibility, modify existing APIs in
         incompatible ways, creates a behavioral change, or require users to update their code when upgrading. If you
-        apply this label, do not apply the "non-breaking" label.
+        apply this label, do not apply the "non-breaking" label. If the PR already has either the "breaking" or
+        "non-breaking" label, do not apply this label.
     - label: bug
       instructions: >-
         Apply this label when the PR fixes a defect, error, or unexpected behavior in the existing codebase. If you
-        apply this label do not apply the "doc", "feature request", or "improvement" labels.
+        apply this label do not apply the "doc", "feature request", or "improvement" labels. If the PR already has
+        either the "bug", "doc", "feature request", or "improvement" label, do not apply this label.
     - label: DO NOT MERGE
       instructions: >-
         Apply this label to PRs that should not be merged due to critical issues, incomplete work, or other blocking
@@ -134,7 +136,8 @@ reviews:
     - label: doc
       instructions: >-
         Apply this label when the PR primarily adds, updates, or improves documentation including README files. If you
-        apply this label do not apply the "bug", "feature request", or "improvement" labels.
+        apply this label do not apply the "bug", "feature request", or "improvement" labels.  If the PR already has
+        either the "bug", "doc", "feature request", or "improvement" label, do not apply this label.
     - label: duplicate
       instructions: >-
         Apply this label when the PR addresses the same issue or implements the same feature as another existing
@@ -146,12 +149,14 @@ reviews:
     - label: feature request
       instructions: >-
         Apply this label when the PR implements new functionality, adds new features, or introduces new capabilities
-        to the toolkit. If you apply this label do not apply the "bug", "doc", or "improvement" labels.
+        to the toolkit. If you apply this label do not apply the "bug", "doc", or "improvement" labels. If the PR
+        already has either the "bug", "doc", "feature request", or "improvement" label, do not apply this label.
     - label: improvement
       instructions: >-
         Apply this label when the PR enhances existing functionality without adding completely new features, such as
         performance optimizations, code refactoring, or usability enhancements. If you apply this label do not apply
-        the "bug", "doc", or "feature request" labels.
+        the "bug", "doc", or "feature request" labels.  If the PR already has either the "bug", "doc",
+        "feature request", or "improvement" label, do not apply this label.
     - label: invalid
       instructions: >-
         Apply this label when the PR contains invalid changes, doesn't follow project guidelines, or has fundamental
@@ -160,7 +165,8 @@ reviews:
       instructions: >-
         Apply this label when the PR introduces changes that maintain backward compatibility, does not create a
         behavioral change, and does not require users to modify their existing code. If you apply this label, do not
-        apply the "breaking" label.
+        apply the "breaking" label.  If the PR already has either the "breaking" or "non-breaking" label, do not apply
+        this label.
 
   tools:
     ruff:


### PR DESCRIPTION
## Description
* Tell coderabbit not to apply conflicting labels if they already exist on a PR

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Added centralized configuration for automated PR reviews, ensuring consistent quality checks across code, documentation, and tests.
  * Enabled automatic labeling and pre-merge validations to streamline triage and improve release readiness.
  * Integrated linters and security scanners to catch formatting, style, and potential vulnerability issues early.
  * Standardized review guidance across project paths to align with best practices.
  * No impact on runtime behavior; user-facing functionality remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->