### PR TITLE
Add fixtures allowing e2e tests to be optionally skipped upon missing environment variables

### DIFF
--- a/packages/nvidia_nat_test/src/nat/test/plugin.py
+++ b/packages/nvidia_nat_test/src/nat/test/plugin.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+
 import pytest
 
 
@@ -40,6 +42,14 @@ def pytest_addoption(parser: pytest.Parser):
         action="store_true",
         dest="run_slow",
         help="Run end to end tests that would otherwise be skipped",
+    )
+
+    parser.addoption(
+        "--fail_missing",
+        action="store_true",
+        dest="fail_missing",
+        help=("Tests requiring unmet dependencies are normally skipped. "
+              "Setting this flag will instead cause them to be reported as a failure"),
     )
 
 
@@ -94,3 +104,78 @@ def function_registry_fixture():
 
     with GlobalTypeRegistry.push() as registry:
         yield registry
+
+
+@pytest.fixture(scope="session")
+def fail_missing(pytestconfig: pytest.Config) -> bool:
+    """
+    Returns the value of the `fail_missing` flag, when false tests requiring unmet dependencies will be skipped, when
+    True they will fail.
+    """
+    yield pytestconfig.getoption("fail_missing")
+
+
+def require_env_variable(varnames: list[str], reason: str, fail_missing: bool = False) -> dict[str, str]:
+    """
+    Checks if the given environment variable is set, and returns its value if it is. If the variable is not set, and
+    `fail_missing` is False the test will ve skipped, otherwise a `RuntimeError` will be raised.
+    """
+    env_variables = {}
+    try:
+        for varname in varnames:
+            env_variables[varname] = os.environ[varname]
+    except KeyError as e:
+        if fail_missing:
+            raise RuntimeError(reason) from e
+
+        pytest.skip(reason=reason)
+
+    return env_variables
+
+
+@pytest.fixture(name="openai_api_key", scope='session')
+def openai_api_key_fixture(fail_missing: bool):
+    """
+    Use for integration tests that require an Openai API key.
+    """
+    yield require_env_variable(
+        varnames=["OPENAI_API_KEY"],
+        reason="openai integration tests require the `OPENAI_API_KEY` environment variable to be defined.",
+        fail_missing=fail_missing)
+
+
+@pytest.fixture(name="nvidia_api_key", scope='session')
+def nvidia_api_key_fixture(fail_missing: bool):
+    """
+    Use for integration tests that require an Nvidia API key.
+    """
+    yield require_env_variable(
+        varnames=["NVIDIA_API_KEY"],
+        reason="Nvidia integration tests require the `NVIDIA_API_KEY` environment variable to be defined.",
+        fail_missing=fail_missing)
+
+
+@pytest.fixture(name="aws_keys", scope='session')
+def aws_keys_fixture(fail_missing: bool):
+    """
+    Use for integration tests that require AWS credentials.
+    """
+
+    yield require_env_variable(
+        varnames=["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY"],
+        reason=
+        "AWS integration tests require the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables to be "
+        "defined.",
+        fail_missing=fail_missing)
+
+
+@pytest.fixture(name="azure_openai_keys", scope='session')
+def azure_openai_keys_fixture(fail_missing: bool):
+    """
+    Use for integration tests that require Azure OpenAI credentials.
+    """
+    yield require_env_variable(
+        varnames=["AZURE_OPENAI_API_KEY", "AZURE_OPENAI_ENDPOINT"],
+        reason="Azure integration tests require the `AZURE_OPENAI_API_KEY` and `AZURE_OPENAI_ENDPOINT` environment "
+        "variable to be defined.",
+        fail_missing=fail_missing)

--- a/tests/nat/llm_providers/test_langchain_agents.py
+++ b/tests/nat/llm_providers/test_langchain_agents.py
@@ -27,6 +27,7 @@ from nat.llm.openai_llm import OpenAIModelConfig
 
 
 @pytest.mark.integration
+@pytest.mark.usefixtures("nvidia_api_key")
 async def test_nim_langchain_agent():
     """
     Test NIM LLM with LangChain agent. Requires NVIDIA_API_KEY to be set.
@@ -50,6 +51,7 @@ async def test_nim_langchain_agent():
 
 
 @pytest.mark.integration
+@pytest.mark.usefixtures("openai_api_key")
 async def test_openai_langchain_agent():
     """
     Test OpenAI LLM with LangChain agent. Requires OPENAI_API_KEY to be set.
@@ -72,6 +74,7 @@ async def test_openai_langchain_agent():
 
 
 @pytest.mark.integration
+@pytest.mark.usefixtures("aws_keys")
 async def test_aws_bedrock_langchain_agent():
     """
     Test AWS Bedrock LLM with LangChain agent.
@@ -99,6 +102,7 @@ async def test_aws_bedrock_langchain_agent():
 
 
 @pytest.mark.integration
+@pytest.mark.usefixtures("azure_openai_keys")
 async def test_azure_openai_langchain_agent():
     """
     Test Azure OpenAI LLM with LangChain agent.

--- a/tests/nat/llm_providers/test_llama_index_agents.py
+++ b/tests/nat/llm_providers/test_llama_index_agents.py
@@ -62,6 +62,7 @@ async def create_minimal_agent(llm_name: str, llm_config: Any) -> ReActAgent:
 
 
 @pytest.mark.integration
+@pytest.mark.usefixtures("nvidia_api_key")
 async def test_nim_minimal_agent():
     """Test NIM LLM with minimal LlamaIndex agent. Requires NVIDIA_API_KEY to be set."""
     llm_config = NIMModelConfig(model_name="meta/llama-3.1-70b-instruct", temperature=0.0)
@@ -74,6 +75,7 @@ async def test_nim_minimal_agent():
 
 
 @pytest.mark.integration
+@pytest.mark.usefixtures("openai_api_key")
 async def test_openai_minimal_agent():
     """Test OpenAI LLM with minimal LlamaIndex agent. Requires OPENAI_API_KEY to be set."""
     llm_config = OpenAIModelConfig(model_name="gpt-3.5-turbo", temperature=0.0)
@@ -86,6 +88,7 @@ async def test_openai_minimal_agent():
 
 
 @pytest.mark.integration
+@pytest.mark.usefixtures("aws_keys")
 async def test_aws_bedrock_minimal_agent():
     """
     Test AWS Bedrock LLM with LangChain agent.
@@ -106,6 +109,7 @@ async def test_aws_bedrock_minimal_agent():
 
 
 @pytest.mark.integration
+@pytest.mark.usefixtures("azure_openai_keys")
 async def test_azure_openai_minimal_agent():
     """
     Test Azure OpenAI LLM with minimal LlamaIndex agent.

--- a/tests/nat/server/test_unified_api_server.py
+++ b/tests/nat/server/test_unified_api_server.py
@@ -306,6 +306,7 @@ async def client_fixture(config):
 
 
 @pytest.mark.e2e
+@pytest.mark.usefixtures("nvidia_api_key")
 async def test_generate_endpoint(client: httpx.AsyncClient, config: Config):
     """Tests generate endpoint to verify it responds successfully."""
     input_message = {"input_message": f"{config.app.input}"}
@@ -314,6 +315,7 @@ async def test_generate_endpoint(client: httpx.AsyncClient, config: Config):
 
 
 @pytest.mark.e2e
+@pytest.mark.usefixtures("nvidia_api_key")
 async def test_generate_stream_endpoint(client: httpx.AsyncClient, config: Config):
     """Tests generate stream endpoint to verify it responds successfully."""
     input_message = {"input_message": f"{config.app.input}"}
@@ -322,6 +324,7 @@ async def test_generate_stream_endpoint(client: httpx.AsyncClient, config: Confi
 
 
 @pytest.mark.e2e
+@pytest.mark.usefixtures("nvidia_api_key")
 async def test_chat_endpoint(client: httpx.AsyncClient, config: Config):
     """Tests chat endpoint to verify it responds successfully."""
     input_message = {"messages": [{"role": "user", "content": f"{config.app.input}"}], "use_knowledge_base": True}
@@ -332,6 +335,7 @@ async def test_chat_endpoint(client: httpx.AsyncClient, config: Config):
 
 
 @pytest.mark.e2e
+@pytest.mark.usefixtures("nvidia_api_key")
 async def test_chat_stream_endpoint(client: httpx.AsyncClient, config: Config):
     """Tests chat stream endpoint to verify it responds successfully."""
     input_message = {"messages": [{"role": "user", "content": f"{config.app.input}"}], "use_knowledge_base": True}
@@ -346,6 +350,7 @@ async def test_chat_stream_endpoint(client: httpx.AsyncClient, config: Config):
 
 
 @pytest.mark.e2e
+@pytest.mark.usefixtures("nvidia_api_key")
 async def test_user_attributes_from_http_request(client: httpx.AsyncClient, config: Config):
     """Tests setting user attributes from HTTP request."""
     input_message = {"input_message": f"{config.app.input}"}


### PR DESCRIPTION
## Description
* Use-case allow someone who has an `NVIDIA_API_KEY` to run `pytest --run_e2e --run_integration` and skip the tests requiring additional keys.
* Add a `--fail_missing` flag which will prevent this and fail a test due to a missing key.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
