### PR TITLE
Enable running e2e tests for nightly CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -78,10 +78,10 @@ test:python_tests:
   artifacts:
     when: always
     reports:
-      junit: report_*.xml
+      junit: pytest_junit_report*.xml
       coverage_report:
         coverage_format: cobertura  # or jacoco
-        path: report_pytest_coverage.xml
+        path: pytest_coverage_report*.xml
 
 docs:build:
   stage: docs

--- a/ci/scripts/gitlab/tests.sh
+++ b/ci/scripts/gitlab/tests.sh
@@ -27,14 +27,20 @@ rapids-logger "Running tests"
 set +e
 
 PYTEST_ARGS=""
+REPORT_NAME="${CI_PROJECT_DIR}/pytest_junit_report.xml"
+COV_REPORT_NAME="${CI_PROJECT_DIR}/pytest_coverage_report.xml"
 if [ "${CI_CRON_NIGHTLY}" == "1" ]; then
        PYTEST_ARGS="--run_slow --run_e2e --run_integration"
+
+       DATE_TAG=$(date +"%Y%m%d")
+       REPORT_NAME="${CI_PROJECT_DIR}/pytest_junit_report_${DATE_TAG}.xml"
+       COV_REPORT_NAME="${CI_PROJECT_DIR}/pytest_coverage_report_${DATE_TAG}.xml"
 fi
 
 pytest ${PYTEST_ARGS}  \
-       --junit-xml=${CI_PROJECT_DIR}/report_pytest.xml \
+       --junit-xml=${REPORT_NAME} \
        --cov=nat --cov-report term-missing \
-       --cov-report=xml:${CI_PROJECT_DIR}/report_pytest_coverage.xml
+       --cov-report=xml:${COV_REPORT_NAME}
 PYTEST_RESULTS=$?
 
 exit ${PYTEST_RESULTS}


### PR DESCRIPTION
* Enable tests for nightly CI
* Add the `--run_slow --run_e2e --run_integration` flags for nightly CI.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Nightly pipelines now run slow, end-to-end, and integration tests automatically.
  * Nightly test reports (junit and coverage) are emitted with date-stamped filenames.
  * Regular pipelines continue running the standard test suite without change.

* **Chores**
  * CI updated so the Python test job is no longer limited to merge-request-only pipelines and follows general workflow rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->