### PR TITLE
Enable the forward merger plugin of the rapids ops bot

### DIFF
--- a/.github/ops-bot.yaml
+++ b/.github/ops-bot.yaml
@@ -20,4 +20,4 @@ auto_merger: true
 branch_checker: true
 label_checker: true
 release_drafter: true
-forward_merger: false # Disabled for now, re-enable if needed
+forward_merger: true


### PR DESCRIPTION
## Description
* Enable the forward merger plugin of the ops-bot

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
