### PR TITLE
fix: Improved model detection/rules for `ThinkingMixin`

### DIFF
--- a/src/nat/data_models/thinking_mixin.py
+++ b/src/nat/data_models/thinking_mixin.py
@@ -62,13 +62,14 @@ class ThinkingMixin(
             return None
 
         for key in _MODEL_KEYS:
-            if not hasattr(self, key):
+            model = getattr(self, key, None)
+            if not isinstance(model, str) or model is None:
                 continue
 
             # Normalize name to reduce checks
-            model = getattr(self, key).lower().translate(str.maketrans("_.", "--"))
+            model = model.lower().translate(str.maketrans("_.", "--"))
 
-            if model.startswith("nvidia/nvidia-nemotron"):
+            if model.startswith("nvidia/nvidia"):
                 return "/think" if self.thinking else "/no_think"
 
             if model.startswith("nvidia/llama"):
@@ -78,6 +79,9 @@ class ThinkingMixin(
                 if "v1-5" in model:
                     # v1.5 models are updated to use the /think and /no_think system prompts
                     return "/think" if self.thinking else "/no_think"
+
+                # Assume any other model is a newer model that uses the /think and /no_think system prompts
+                return "/think" if self.thinking else "/no_think"
 
         # Unknown model
         return None

--- a/src/nat/data_models/thinking_mixin.py
+++ b/src/nat/data_models/thinking_mixin.py
@@ -22,8 +22,7 @@ from nat.data_models.gated_field_mixin import GatedFieldMixin
 
 # The system prompt format for thinking is different for these, so we need to distinguish them here with two separate
 # regex patterns
-_NVIDIA_NEMOTRON_REGEX = re.compile(r"^nvidia/nvidia.*nemotron", re.IGNORECASE)
-_LLAMA_NEMOTRON_REGEX = re.compile(r"^nvidia/llama.*nemotron", re.IGNORECASE)
+_NEMOTRON_REGEX = re.compile(r"^nvidia/(llama|nvidia).*nemotron", re.IGNORECASE)
 _MODEL_KEYS = ("model_name", "model", "azure_deployment")
 
 
@@ -33,7 +32,7 @@ class ThinkingMixin(
         field_name="thinking",
         default_if_supported=None,
         keys=_MODEL_KEYS,
-        supported=(_NVIDIA_NEMOTRON_REGEX, _LLAMA_NEMOTRON_REGEX),
+        supported=(_NEMOTRON_REGEX, ),
 ):
     """
     Mixin class for thinking configuration. Only supported on Nemotron models.
@@ -52,7 +51,8 @@ class ThinkingMixin(
         """
         Returns the system prompt to use for thinking.
         For NVIDIA Nemotron, returns "/think" if enabled, else "/no_think".
-        For Llama Nemotron, returns "detailed thinking on" if enabled, else "detailed thinking off".
+        For Llama Nemotron v1.5, returns "/think" if enabled, else "/no_think".
+        For Llama Nemotron v1.0, returns "detailed thinking on" if enabled, else "detailed thinking off".
         If thinking is not supported on the model, returns None.
 
         Returns:
@@ -60,9 +60,24 @@ class ThinkingMixin(
         """
         if self.thinking is None:
             return None
+
         for key in _MODEL_KEYS:
-            if hasattr(self, key):
-                if _NVIDIA_NEMOTRON_REGEX.match(getattr(self, key)):
-                    return "/think" if self.thinking else "/no_think"
-                elif _LLAMA_NEMOTRON_REGEX.match(getattr(self, key)):
+            if not hasattr(self, key):
+                continue
+
+            # Normalize name to reduce checks
+            model = getattr(self, key).lower().translate(str.maketrans("_.", "--"))
+
+            if model.startswith("nvidia/nvidia-nemotron"):
+                return "/think" if self.thinking else "/no_think"
+
+            if model.startswith("nvidia/llama"):
+                if "v1-0" in model or "v1-1" in model:
                     return f"detailed thinking {'on' if self.thinking else 'off'}"
+
+                if "v1-5" in model:
+                    # v1.5 models are updated to use the /think and /no_think system prompts
+                    return "/think" if self.thinking else "/no_think"
+
+        # Unknown model
+        return None

--- a/tests/nat/data_models/test_thinking_mixin.py
+++ b/tests/nat/data_models/test_thinking_mixin.py
@@ -38,11 +38,23 @@ class TestThinkingMixin:
         class Model(ThinkingMixin):
             model_name: str
 
-        m_true = Model(model_name="NVIDIA/LLaMa-3.1-Nemotron", thinking=True)
+        m_true = Model(model_name="NVIDIA/LLaMa-3.1-Nemotron-v1.0", thinking=True)
         assert m_true.thinking_system_prompt == "detailed thinking on"
 
-        m_false = Model(model_name="nvidia/llama-nemotron", thinking=False)
+        m_false = Model(model_name="NVIDIA/LLaMa-3.1-Nemotron-v1-0", thinking=False)
         assert m_false.thinking_system_prompt == "detailed thinking off"
+
+        m_true = Model(model_name="NVIDIA/LLaMa-3.1-Nemotron-v1.1", thinking=True)
+        assert m_true.thinking_system_prompt == "detailed thinking on"
+
+        m_false = Model(model_name="NVIDIA/LLaMa-3.1-Nemotron-v1.1", thinking=False)
+        assert m_false.thinking_system_prompt == "detailed thinking off"
+
+        m_true = Model(model_name="NVIDIA/LLaMa-3.1-Nemotron-v1-5", thinking=True)
+        assert m_true.thinking_system_prompt == "/think"
+
+        m_false = Model(model_name="NVIDIA/LLaMa-3.1-Nemotron-v1-5", thinking=False)
+        assert m_false.thinking_system_prompt == "/no_think"
 
     def test_supported_default_remains_none(self):
 
@@ -83,7 +95,7 @@ class TestThinkingMixin:
         class Model(ThinkingMixin):
             azure_deployment: str
 
-        m = Model(azure_deployment="nvidia/llama3-nemotron", thinking=True)
+        m = Model(azure_deployment="nvidia/llama3-nemotron-v1-0", thinking=True)
         assert m.thinking_system_prompt == "detailed thinking on"
 
     def test_no_keys_present_defaults_supported_and_prompt_none(self):


### PR DESCRIPTION
## Description
Llama Nemotron v1.5 models use `/think` and `/no_think`. Let's generalize the logic a bit and set up to handle more models.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Unified detection for Nemotron model variants for more reliable behavior and explicit fallback when a model isn’t supported.
  * Safer handling when model identifiers are missing.

* **Refactor**
  * Simplified supported-model configuration and normalized model name parsing to reduce inconsistencies.

* **Documentation**
  * Clarified: Llama Nemotron v1.5 uses “/think”/“/no_think”; v1.0/v1.1 use “detailed thinking on/off.”

* **Tests**
  * Added tests covering additional Nemotron version/name variants and casing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->