### PR TITLE
Add Dynatrace as otel export destination

### DIFF
--- a/ci/vale/styles/config/vocabularies/nat/accept.txt
+++ b/ci/vale/styles/config/vocabularies/nat/accept.txt
@@ -49,6 +49,7 @@ DB(s?)
 [Dd]ev
 [Dd]evcontainer(s?)
 [Dd]ocstring(s?)
+Dynatrace
 [Ee]mbedder(s?)
 [Ee]ngineerable
 [Ee]val

--- a/docs/source/workflows/observe/observe-workflow-with-otel-collector.md
+++ b/docs/source/workflows/observe/observe-workflow-with-otel-collector.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Observing a Workflow with OpenTelemetry Collector
 
-This guide shows how to stream OpenTelemetry (OTel) traces from your NeMo Agent toolkit workflows to the [generic OTel collector](https://opentelemetry.io/docs/collector/quick-start/), which in turn provides the ability to export those traces to many different places including file stores (like [S3](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter)), [Datadog](https://docs.datadoghq.com/opentelemetry/setup/collector_exporter/), and others.
+This guide shows how to stream OpenTelemetry (OTel) traces from your NeMo Agent toolkit workflows to the [generic OTel collector](https://opentelemetry.io/docs/collector/quick-start/), which in turn provides the ability to export those traces to many different places including file stores (like [S3](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/awss3exporter)), [Datadog](https://docs.datadoghq.com/opentelemetry/setup/collector_exporter/), [Dynatrace](https://docs.dynatrace.com/docs/ingest-from/opentelemetry/getting-started/otlp-export), and others.
 
 In this guide, you will learn how to:
 


### PR DESCRIPTION
- Small edit to add Dynatrace as Otel Export destination
- Closes #734 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded “Observing a Workflow with OpenTelemetry Collector” guide to include Dynatrace as a supported exporter option alongside S3, Datadog, and others. No functional changes.
* **Chores**
  * Updated writing/style checks to accept "Dynatrace" as a recognized product name to prevent false positives in documentation linting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->