### PR TITLE
Set `StreamHandler` to use `sys.stdout` in `console` registered logging method

### DIFF
--- a/src/nat/observability/register.py
+++ b/src/nat/observability/register.py
@@ -72,8 +72,10 @@ async def console_logging_method(config: ConsoleLoggingMethodConfig, builder: Bu
     """
     Build and return a StreamHandler for console-based logging.
     """
+    import sys
+
     level = getattr(logging, config.level.upper(), logging.INFO)
-    handler = logging.StreamHandler()
+    handler = logging.StreamHandler(stream=sys.stdout)
     handler.setLevel(level)
     yield handler
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR sets the `StreamHandler` to use `sys.stdout` in the `console` registered logging method to improve log classification when integrating external log aggregation systems (e.g. DataDog)

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Console logs are now directed to standard output, ensuring consistent visibility in terminals and containerized environments.
  * Improves compatibility with log collectors and platforms that monitor stdout, reducing missed or misrouted log messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->