### PR TITLE
docs: use https GitHub URL for easier installation and contribution

### DIFF
--- a/docs/source/quick-start/installing.md
+++ b/docs/source/quick-start/installing.md
@@ -62,7 +62,7 @@ NVIDIA NeMo Agent toolkit is a Python library that doesn't require a GPU to run 
 
 1. Clone the NeMo Agent toolkit repository to your local machine.
     ```bash
-    git clone -b main git@github.com:NVIDIA/NeMo-Agent-Toolkit.git nemo-agent-toolkit
+    git clone -b main https://github.com/NVIDIA/NeMo-Agent-Toolkit.git nemo-agent-toolkit
     cd nemo-agent-toolkit
     ```
 

--- a/docs/source/resources/contributing.md
+++ b/docs/source/resources/contributing.md
@@ -59,7 +59,7 @@ NeMo Agent toolkit is a Python library that doesn’t require a GPU to run the w
 
     Then, set the upstream to the main repository and fetch the latest changes:
     ```bash
-    git remote add upstream git@github.com:NVIDIA/NeMo-Agent-Toolkit.git
+    git remote add upstream https://github.com/NVIDIA/NeMo-Agent-Toolkit.git
     git fetch --all
     ```
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
The SSH protocol for GitHub URLs requires setting up an SSH key, even for public repositories, which increases the barrier to entry for quick installation. In contrast, the HTTPS version of GitHub URLs does not require authentication for public repositories, making it easier to get started. It also improves the contribution workflow for developers who prefer using Git over HTTPS.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide to use HTTPS for git clone, simplifying setup without requiring SSH keys.
  * Revised contributing guide to use HTTPS for adding the upstream remote, reducing authentication friction.
  * Clarified commands to ensure a smoother onboarding experience for new users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->