### PR TITLE
docs: add notes on `nat eval` requiring `[profiling]` sub-package

### DIFF
--- a/docs/source/quick-start/installing.md
+++ b/docs/source/quick-start/installing.md
@@ -35,6 +35,7 @@ To install these first-party plugin libraries, you can use the full distribution
 
 - `nvidia-nat[agno]` or `nvidia-nat-agno` - [Agno](https://agno.com/)
 - `nvidia-nat[crewai]` or `nvidia-nat-crewai` - [CrewAI](https://www.crewai.com/)
+- `nvidia-nat[data-flywheel]` or `nvidia-nat-data-flywheel` - [NeMo DataFlywheel](https://github.com/NVIDIA-AI-Blueprints/data-flywheel)
 - `nvidia-nat[langchain]` or `nvidia-nat-langchain` - [LangChain](https://www.langchain.com/)
 - `nvidia-nat[llama-index]` or `nvidia-nat-llama-index` - [LlamaIndex](https://www.llamaindex.ai/)
 - `nvidia-nat[mem0ai]` or `nvidia-nat-mem0ai` - [Mem0](https://mem0.ai/)
@@ -108,7 +109,7 @@ NVIDIA NeMo Agent toolkit is a Python library that doesn't require a GPU to run 
     Many of the example workflows require plugins, and following the documented steps in one of these examples will in turn install the necessary plugins. For example following the steps in the `examples/getting_started/simple_web_query/README.md` guide will install the `nvidia-nat-langchain` plugin if you haven't already done so.
     :::
 
-    In addition to plugins, there are optional dependencies needed for profiling. To install these dependencies, run the following:
+    In addition to plugins, there are optional dependencies needed for profiling. Installing the `profiling` sub-package is required for evaluation and profiling workflows using `nat eval`. To install these dependencies, run the following:
     ```bash
     uv pip install -e '.[profiling]'
     ```

--- a/docs/source/workflows/evaluate.md
+++ b/docs/source/workflows/evaluate.md
@@ -23,6 +23,20 @@ limitations under the License.
 
 NeMo Agent toolkit provides a set of evaluators to run and evaluate workflows. In addition to the built-in evaluators, the toolkit provides a plugin system to add custom evaluators.
 
+## Prerequisites
+
+In addition to the base `nvidia-nat` package, you need to install the `profiling` sub-package to use the `nat eval` command.
+
+If you are installing from source, you can install the sub-package by running the following command from the root directory of the NeMo Agent toolkit repository:
+```bash
+uv pip install -e '.[profiling]'
+```
+
+If you are installing from a package, you can install the sub-package by running the following command:
+```bash
+uv pip install nvidia-nat[profiling]
+```
+
 ## Evaluating a Workflow
 To evaluate a workflow, you can use the `nat eval` command. The `nat eval` command takes a workflow configuration file as input. It runs the workflow using the dataset specified in the configuration file. The workflow output is then evaluated using the evaluators specified in the configuration file.
 

--- a/docs/source/workflows/profiler.md
+++ b/docs/source/workflows/profiler.md
@@ -34,9 +34,14 @@ Will allow for features such as offline-replay or simulation of workflow runs wi
 
 The NeMo Agent toolkit profiler requires additional dependencies not installed by default.
 
-Install these dependencies by running the following command:
+Install these dependencies by running the following command from the root directory of the NeMo Agent toolkit repository:
 ```bash
-uv pip install -e .[profiling]
+uv pip install -e ".[profiling]"
+```
+
+If you are installing from a package, you need to install the `nvidia-nat[profiling]` package by running the following command:
+```bash
+uv pip install nvidia-nat[profiling]
 ```
 
 ## Current Profiler Architecture

--- a/packages/nvidia_nat_profiling/pyproject.toml
+++ b/packages/nvidia_nat_profiling/pyproject.toml
@@ -20,8 +20,8 @@ dependencies = [
   # Keep package version constraints as open as possible to avoid conflicts with other packages. Always define a minimum
   # version when adding a new package. If unsure, default to using `~=` instead of `==`. Does not apply to nvidia-nat packages.
   # Keep sorted!!!
-  "matplotlib~=3.9",
   "nvidia-nat~=1.3",
+  "matplotlib~=3.9",
   "prefixspan~=0.5.2",
   "scikit-learn~=1.6",
 ]


### PR DESCRIPTION
## Description

Add explicit notes to documentation, quick start, and evaluate pages that `[profiling]` sub-package is required.

Unrelated:
* add missing `nvidia-nat[data-flywheel]` description to first-party packages list
* add missing quotes around `.[profiling]` under "profiling"

Closes AIQ-1794
Closes nvbugs-5438525

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added installation option for NeMo DataFlywheel integration.
- Documentation
  - Clarified prerequisites for evaluation and profiling workflows, including required profiling extras.
  - Provided installation paths for both source and packaged installs, with corrected command formatting.
  - Added explicit guidance on running dependency installation from the repository root.
- Chores
  - Minor dependency ordering cleanup in profiling package configuration (no functional impact).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->