### PR TITLE
fix: include `thinking` in model_dump for `serve` config serialization

### DIFF
--- a/docs/source/extend/adding-an-llm-provider.md
+++ b/docs/source/extend/adding-an-llm-provider.md
@@ -179,7 +179,7 @@ async def openai_langchain(llm_config: OpenAIModelConfig, builder: Builder):
 
     from langchain_openai import ChatOpenAI
 
-    yield ChatOpenAI(**llm_config.model_dump(exclude={"type"}, by_alias=True))
+    yield ChatOpenAI(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True))
 ```
 
 Similar to the registration function for the provider, the client registration function can perform any necessary setup actions before yielding the client, along with cleanup actions after the `yield` statement.

--- a/docs/source/extend/plugins.md
+++ b/docs/source/extend/plugins.md
@@ -79,7 +79,7 @@ async def openai_langchain(llm_config: OpenAIModelConfig, builder: Builder):
 
     from langchain_openai import ChatOpenAI
 
-    yield ChatOpenAI(**llm_config.model_dump(exclude={"type"}, by_alias=True))
+    yield ChatOpenAI(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True))
 ```
 
 The `wrapper_type` parameter in the decorator specifies the LLM framework that the plugin is compatible with. This instruments the plugin with the appropriate telemetry hooks to enable observability, evaluation, and profiling.

--- a/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
+++ b/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
@@ -72,7 +72,7 @@ async def nim_agno(llm_config: NIMModelConfig, _builder: Builder):
 
     config_obj = {
         **llm_config.model_dump(
-            exclude={"type", "model_name"},
+            exclude={"type", "model_name", "thinking"},
             by_alias=True,
             exclude_none=True,
         ),
@@ -90,7 +90,7 @@ async def openai_agno(llm_config: OpenAIModelConfig, _builder: Builder):
 
     config_obj = {
         **llm_config.model_dump(
-            exclude={"type", "model_name"},
+            exclude={"type", "model_name", "thinking"},
             by_alias=True,
             exclude_none=True,
         ),

--- a/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
+++ b/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
@@ -66,15 +66,6 @@ async def azure_openai_crewai(llm_config: AzureOpenAIModelConfig, _builder: Buil
 
     # https://docs.crewai.com/en/concepts/llms#azure
 
-    config_obj = {
-        **llm_config.model_dump(exclude={
-            "type",
-            "api_key",
-            "azure_endpoint",
-            "azure_deployment",
-        }, by_alias=True),
-    }
-
     api_key = llm_config.api_key or os.environ.get("AZURE_OPENAI_API_KEY") or os.environ.get("AZURE_API_KEY")
     if api_key is None:
         raise ValueError("Azure API key is not set")
@@ -89,9 +80,20 @@ async def azure_openai_crewai(llm_config: AzureOpenAIModelConfig, _builder: Buil
     model = llm_config.azure_deployment or os.environ.get("AZURE_MODEL_DEPLOYMENT")
     if model is None:
         raise ValueError("Azure model deployment is not set")
-    config_obj["model"] = model
 
-    client = LLM(**config_obj)
+    client = LLM(
+        **llm_config.model_dump(
+            exclude={
+                "type",
+                "api_key",
+                "azure_endpoint",
+                "azure_deployment",
+                "thinking",
+            },
+            by_alias=True,
+        ),
+        model=model,
+    )
 
     yield _patch_llm_based_on_config(client, llm_config)
 
@@ -101,18 +103,16 @@ async def nim_crewai(llm_config: NIMModelConfig, _builder: Builder):
 
     from crewai import LLM
 
-    config_obj = {
-        **llm_config.model_dump(exclude={"type"}, by_alias=True),
-        "model": f"nvidia_nim/{llm_config.model_name}",
-    }
-
     # Because CrewAI uses a different environment variable for the API key, we need to set it here manually
-    if config_obj.get("api_key") is None and "NVIDIA_NIM_API_KEY" not in os.environ:
+    if llm_config.api_key is None and "NVIDIA_NIM_API_KEY" not in os.environ:
         nvidia_api_key = os.getenv("NVIDIA_API_KEY")
         if nvidia_api_key is not None:
             os.environ["NVIDIA_NIM_API_KEY"] = nvidia_api_key
 
-    client = LLM(**config_obj)
+    client = LLM(
+        **llm_config.model_dump(exclude={"type", "model_name", "thinking"}, by_alias=True),
+        model=f"nvidia_nim/{llm_config.model_name}",
+    )
 
     yield _patch_llm_based_on_config(client, llm_config)
 
@@ -122,10 +122,6 @@ async def openai_crewai(llm_config: OpenAIModelConfig, _builder: Builder):
 
     from crewai import LLM
 
-    config_obj = {
-        **llm_config.model_dump(exclude={"type"}, by_alias=True),
-    }
-
-    client = LLM(**config_obj)
+    client = LLM(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True))
 
     yield _patch_llm_based_on_config(client, llm_config)

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -117,7 +117,7 @@ async def azure_openai_langchain(llm_config: AzureOpenAIModelConfig, _builder: B
 
     from langchain_openai import AzureChatOpenAI
 
-    client = AzureChatOpenAI(**llm_config.model_dump(exclude={"type"}, by_alias=True))
+    client = AzureChatOpenAI(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True))
 
     yield _patch_llm_based_on_config(client, llm_config)
 
@@ -129,7 +129,7 @@ async def nim_langchain(llm_config: NIMModelConfig, _builder: Builder):
 
     # prefer max_completion_tokens over max_tokens
     client = ChatNVIDIA(
-        **llm_config.model_dump(exclude={"type", "max_tokens"}, by_alias=True),
+        **llm_config.model_dump(exclude={"type", "max_tokens", "thinking"}, by_alias=True),
         max_completion_tokens=llm_config.max_tokens,
     )
 
@@ -142,6 +142,6 @@ async def openai_langchain(llm_config: OpenAIModelConfig, _builder: Builder):
     from langchain_openai import ChatOpenAI
 
     # If stream_usage is specified, it will override the default value of True.
-    client = ChatOpenAI(stream_usage=True, **llm_config.model_dump(exclude={"type"}, by_alias=True))
+    client = ChatOpenAI(stream_usage=True, **llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True))
 
     yield _patch_llm_based_on_config(client, llm_config)

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
@@ -74,7 +74,7 @@ async def aws_bedrock_llama_index(llm_config: AWSBedrockModelConfig, _builder: B
     from llama_index.llms.bedrock import Bedrock
 
     # LlamaIndex uses context_size instead of max_tokens
-    llm = Bedrock(**llm_config.model_dump(exclude={"type", "top_p"}, by_alias=True), )
+    llm = Bedrock(**llm_config.model_dump(exclude={"type", "top_p", "thinking"}, by_alias=True))
 
     yield _patch_llm_based_on_config(llm, llm_config)
 
@@ -84,7 +84,7 @@ async def azure_openai_llama_index(llm_config: AzureOpenAIModelConfig, _builder:
 
     from llama_index.llms.azure_openai import AzureOpenAI
 
-    llm = AzureOpenAI(**llm_config.model_dump(exclude={"type"}, by_alias=True))
+    llm = AzureOpenAI(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True))
 
     yield _patch_llm_based_on_config(llm, llm_config)
 
@@ -94,7 +94,7 @@ async def nim_llama_index(llm_config: NIMModelConfig, _builder: Builder):
 
     from llama_index.llms.nvidia import NVIDIA
 
-    llm = NVIDIA(**llm_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True))
+    llm = NVIDIA(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True, exclude_none=True))
 
     yield _patch_llm_based_on_config(llm, llm_config)
 
@@ -104,6 +104,6 @@ async def openai_llama_index(llm_config: OpenAIModelConfig, _builder: Builder):
 
     from llama_index.llms.openai import OpenAI
 
-    llm = OpenAI(**llm_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True))
+    llm = OpenAI(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True, exclude_none=True))
 
     yield _patch_llm_based_on_config(llm, llm_config)

--- a/src/nat/data_models/thinking_mixin.py
+++ b/src/nat/data_models/thinking_mixin.py
@@ -20,9 +20,9 @@ from pydantic import Field
 
 from nat.data_models.gated_field_mixin import GatedFieldMixin
 
-# The system prompt format for thinking is different for these, so we need to distinguish them here with two separate
-# regex patterns
+# Currently the control logic for thinking is only implemented for Nemotron models
 _NEMOTRON_REGEX = re.compile(r"^nvidia/(llama|nvidia).*nemotron", re.IGNORECASE)
+# The keys are the fields that are used to determine if the model supports thinking
 _MODEL_KEYS = ("model_name", "model", "azure_deployment")
 
 
@@ -43,7 +43,6 @@ class ThinkingMixin(
     thinking: bool | None = Field(
         default=None,
         description="Whether to enable thinking. Defaults to None when supported on the model.",
-        exclude=True,
     )
 
     @property


### PR DESCRIPTION
## Description
Originally, `thinking` (part of `ThinkingMixin`) had its field exposition set to False. This would result in any model_dump always omitting thinking. This was done originally because it made no sense to expose this.

However, it turns out that `nat serve` serializes the current configuration before passing it to a separate worker. To this end, we must expose `thinking` to ensure no loss of configuration data.

To accomodate this, model dumping for LLM instantiation must now exclude `thinking` explicitly. The logic has been unified across most LLM providers and frameworks to reduce the dancing between config objects created via `model_dump()` and the original LLM configs.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
