### PR TITLE
fix: ensure `model_dump` excludes `None` fields when appropriate

### DIFF
--- a/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
+++ b/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
@@ -91,6 +91,7 @@ async def azure_openai_crewai(llm_config: AzureOpenAIModelConfig, _builder: Buil
                 "thinking",
             },
             by_alias=True,
+            exclude_none=True,
         ),
         model=model,
     )
@@ -110,7 +111,7 @@ async def nim_crewai(llm_config: NIMModelConfig, _builder: Builder):
             os.environ["NVIDIA_NIM_API_KEY"] = nvidia_api_key
 
     client = LLM(
-        **llm_config.model_dump(exclude={"type", "model_name", "thinking"}, by_alias=True),
+        **llm_config.model_dump(exclude={"type", "model_name", "thinking"}, by_alias=True, exclude_none=True),
         model=f"nvidia_nim/{llm_config.model_name}",
     )
 
@@ -122,6 +123,6 @@ async def openai_crewai(llm_config: OpenAIModelConfig, _builder: Builder):
 
     from crewai import LLM
 
-    client = LLM(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True))
+    client = LLM(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True, exclude_none=True))
 
     yield _patch_llm_based_on_config(client, llm_config)

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
@@ -28,7 +28,7 @@ async def azure_openai_langchain(embedder_config: AzureOpenAIEmbedderModelConfig
 
     from langchain_openai import AzureOpenAIEmbeddings
 
-    client = AzureOpenAIEmbeddings(**embedder_config.model_dump(exclude={"type"}, by_alias=True))
+    client = AzureOpenAIEmbeddings(**embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True))
 
     if isinstance(embedder_config, RetryMixin):
         client = patch_with_retry(client,
@@ -44,7 +44,7 @@ async def nim_langchain(embedder_config: NIMEmbedderModelConfig, builder: Builde
 
     from langchain_nvidia_ai_endpoints import NVIDIAEmbeddings
 
-    client = NVIDIAEmbeddings(**embedder_config.model_dump(exclude={"type"}, by_alias=True))
+    client = NVIDIAEmbeddings(**embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True))
 
     if isinstance(embedder_config, RetryMixin):
         client = patch_with_retry(client,
@@ -60,7 +60,7 @@ async def openai_langchain(embedder_config: OpenAIEmbedderModelConfig, builder: 
 
     from langchain_openai import OpenAIEmbeddings
 
-    client = OpenAIEmbeddings(**embedder_config.model_dump(exclude={"type"}, by_alias=True))
+    client = OpenAIEmbeddings(**embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True))
 
     if isinstance(embedder_config, RetryMixin):
         client = patch_with_retry(client,

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -107,7 +107,11 @@ async def aws_bedrock_langchain(llm_config: AWSBedrockModelConfig, _builder: Bui
 
     from langchain_aws import ChatBedrockConverse
 
-    client = ChatBedrockConverse(**llm_config.model_dump(exclude={"type", "context_size", "thinking"}, by_alias=True))
+    client = ChatBedrockConverse(**llm_config.model_dump(
+        exclude={"type", "context_size", "thinking"},
+        by_alias=True,
+        exclude_none=True,
+    ))
 
     yield _patch_llm_based_on_config(client, llm_config)
 
@@ -117,7 +121,7 @@ async def azure_openai_langchain(llm_config: AzureOpenAIModelConfig, _builder: B
 
     from langchain_openai import AzureChatOpenAI
 
-    client = AzureChatOpenAI(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True))
+    client = AzureChatOpenAI(**llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True, exclude_none=True))
 
     yield _patch_llm_based_on_config(client, llm_config)
 
@@ -129,7 +133,7 @@ async def nim_langchain(llm_config: NIMModelConfig, _builder: Builder):
 
     # prefer max_completion_tokens over max_tokens
     client = ChatNVIDIA(
-        **llm_config.model_dump(exclude={"type", "max_tokens", "thinking"}, by_alias=True),
+        **llm_config.model_dump(exclude={"type", "max_tokens", "thinking"}, by_alias=True, exclude_none=True),
         max_completion_tokens=llm_config.max_tokens,
     )
 
@@ -142,6 +146,11 @@ async def openai_langchain(llm_config: OpenAIModelConfig, _builder: Builder):
     from langchain_openai import ChatOpenAI
 
     # If stream_usage is specified, it will override the default value of True.
-    client = ChatOpenAI(stream_usage=True, **llm_config.model_dump(exclude={"type", "thinking"}, by_alias=True))
+    client = ChatOpenAI(stream_usage=True,
+                        **llm_config.model_dump(
+                            exclude={"type", "thinking"},
+                            by_alias=True,
+                            exclude_none=True,
+                        ))
 
     yield _patch_llm_based_on_config(client, llm_config)

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
@@ -28,7 +28,7 @@ async def azure_openai_llama_index(embedder_config: AzureOpenAIEmbedderModelConf
 
     from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
 
-    client = AzureOpenAIEmbedding(**embedder_config.model_dump(exclude={"type"}, by_alias=True))
+    client = AzureOpenAIEmbedding(**embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True))
 
     if isinstance(embedder_config, RetryMixin):
         client = patch_with_retry(client,
@@ -40,17 +40,22 @@ async def azure_openai_llama_index(embedder_config: AzureOpenAIEmbedderModelConf
 
 
 @register_embedder_client(config_type=NIMEmbedderModelConfig, wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)
-async def nim_llamaindex(embedder_config: NIMEmbedderModelConfig, _builder: Builder):
+async def nim_llama_index(embedder_config: NIMEmbedderModelConfig, _builder: Builder):
 
-    from llama_index.embeddings.nvidia import NVIDIAEmbedding
+    from llama_index.embeddings.nvidia import NVIDIAEmbedding  # pylint: disable=no-name-in-module
 
-    config_obj = {
-        **embedder_config.model_dump(exclude={"type", "model_name"}, by_alias=True),
-        "model":
-            embedder_config.model_name,
-    }
+    client = NVIDIAEmbedding(
+        **embedder_config.model_dump(exclude={"type", "model_name"}, by_alias=True, exclude_none=True),
+        model=embedder_config.model_name,
+    )
 
-    yield NVIDIAEmbedding(**config_obj)
+    if isinstance(embedder_config, RetryMixin):
+        client = patch_with_retry(client,
+                                  retries=embedder_config.num_retries,
+                                  retry_codes=embedder_config.retry_on_status_codes,
+                                  retry_on_messages=embedder_config.retry_on_errors)
+
+    yield client
 
 
 @register_embedder_client(config_type=OpenAIEmbedderModelConfig, wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)
@@ -58,7 +63,7 @@ async def openai_llama_index(embedder_config: OpenAIEmbedderModelConfig, _builde
 
     from llama_index.embeddings.openai import OpenAIEmbedding
 
-    client = OpenAIEmbedding(**embedder_config.model_dump(exclude={"type"}, by_alias=True))
+    client = OpenAIEmbedding(**embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True))
 
     if isinstance(embedder_config, RetryMixin):
         client = patch_with_retry(client,


### PR DESCRIPTION
## Description
Some APIs have non-none specifications when passing arguments.
Sometimes configurations do not specify an argument.
Reconcile this by excluding fields which are set to `None` for potentially sensitive APIs.


This PR also adds accidentally removed retry logic from the Llama Index NIM implementation.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added automatic retry handling for NVIDIA embeddings in LlamaIndex for improved reliability.
* Bug Fixes
  * Prevented errors by omitting empty/None parameters when initializing LLMs and embedders across CrewAI, LangChain, and LlamaIndex integrations.
* Refactor
  * Renamed NVIDIA LlamaIndex embedder handler to nim_llama_index (was nim_llamaindex).
  * Simplified NVIDIA embedding client construction with explicit model parameter for clearer configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->