### PR TITLE
Add `tool_call_max_retries` option to ReWOO agent

### DIFF
--- a/docs/source/workflows/about/rewoo-agent.md
+++ b/docs/source/workflows/about/rewoo-agent.md
@@ -87,7 +87,11 @@ functions:
 
 * `solver_prompt`: Optional. Allows us to override the solver prompt for the ReWOO agent. The prompt must have variables for plan and task.
 
+* `tool_call_max_retries`: Defaults to 3. The number of retries before raising a tool call error.
+
 * `max_history`:  Defaults to 15. Maximum number of messages to keep in the conversation history.
+
+* `log_response_max_chars`: Defaults to 1000. Maximum number of characters to display in logs when logging tool responses.
 
 * `use_openai_api`: Defaults to False. If set to True, the ReWOO agent will output in OpenAI API spec. If set to False, strings will be used.
 

--- a/examples/agents/rewoo/README.md
+++ b/examples/agents/rewoo/README.md
@@ -81,6 +81,38 @@ Prior to using the `tavily_internet_search` tool, create an account at [`tavily.
 export TAVILY_API_KEY=<YOUR_TAVILY_API_KEY>
 ```
 
+## Configuration
+
+The ReWOO agent is configured through the `config.yml` file. The following configuration options are available:
+
+### Configurable Options
+
+* `tool_names`: A list of tools that the agent can call. The tools must be functions configured in the YAML file
+
+* `llm_name`: The LLM the agent should use. The LLM must be configured in the YAML file
+
+* `verbose`: Defaults to False (useful to prevent logging of sensitive data). If set to True, the agent will log input, output, and intermediate steps.
+
+* `include_tool_input_schema_in_tool_description`: Defaults to True. If set to True, the agent will include tool input schemas in tool descriptions.
+
+* `description`: Defaults to "ReWOO Agent Workflow". When the ReWOO agent is configured as a function, this config option allows us to control the tool description (for example, when used as a tool within another agent).
+
+* `planner_prompt`: Optional. Allows us to override the planner prompt for the ReWOO agent. The prompt must have variables for tools and must instruct the LLM to output in the ReWOO planner format.
+
+* `solver_prompt`: Optional. Allows us to override the solver prompt for the ReWOO agent. The prompt must have variables for plan and task.
+
+* `tool_call_max_retries`: Defaults to 3. The number of retries before raising a tool call error.
+
+* `max_history`:  Defaults to 15. Maximum number of messages to keep in the conversation history.
+
+* `log_response_max_chars`: Defaults to 1000. Maximum number of characters to display in logs when logging tool responses.
+
+* `use_openai_api`: Defaults to False. If set to True, the ReWOO agent will output in OpenAI API spec. If set to False, strings will be used.
+
+* `additional_planner_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base planner prompt.
+
+* `additional_solver_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base solver prompt.
+
 ## Run the Workflow
 
 Run the following command from the root of the NeMo Agent toolkit repo to execute this workflow with the specified input:

--- a/examples/agents/rewoo/configs/config.yml
+++ b/examples/agents/rewoo/configs/config.yml
@@ -44,7 +44,7 @@ workflow:
   tool_names: [calculator_multiply, calculator_inequality, calculator_divide, calculator_subtract, internet_search, haystack_chitchat_agent]
   llm_name: nim_llm
   verbose: true
-  max_retries: 2
+  tool_call_max_retries: 3
 
 eval:
   general:

--- a/src/nat/agent/rewoo_agent/agent.py
+++ b/src/nat/agent/rewoo_agent/agent.py
@@ -68,7 +68,8 @@ class ReWOOAgentGraph(BaseAgent):
                  use_tool_schema: bool = True,
                  callbacks: list[AsyncCallbackHandler] | None = None,
                  detailed_logs: bool = False,
-                 log_response_max_chars: int = 1000):
+                 log_response_max_chars: int = 1000,
+                 tool_call_max_retries: int = 3):
         super().__init__(llm=llm,
                          tools=tools,
                          callbacks=callbacks,
@@ -94,6 +95,7 @@ class ReWOOAgentGraph(BaseAgent):
         self.planner_prompt = planner_prompt.partial(tools=tool_names_and_descriptions, tool_names=tool_names)
         self.solver_prompt = solver_prompt
         self.tools_dict = {tool.name: tool for tool in tools}
+        self.tool_call_max_retries = tool_call_max_retries
 
         logger.debug("%s Initialized ReWOO Agent Graph", AGENT_LOG_PREFIX)
 
@@ -269,7 +271,7 @@ class ReWOOAgentGraph(BaseAgent):
             tool_response = await self._call_tool(requested_tool,
                                                   tool_input_parsed,
                                                   RunnableConfig(callbacks=self.callbacks),
-                                                  max_retries=3)
+                                                  max_retries=self.tool_call_max_retries)
 
             if self.detailed_logs:
                 self._log_tool_response(requested_tool.name, tool_input_parsed, str(tool_response))

--- a/src/nat/agent/rewoo_agent/register.py
+++ b/src/nat/agent/rewoo_agent/register.py
@@ -52,6 +52,7 @@ class ReWOOAgentWorkflowConfig(FunctionBaseConfig, name="rewoo_agent"):
     solver_prompt: str | None = Field(
         default=None,
         description="Provides the SOLVER_PROMPT to use with the agent")  # defaults to SOLVER_PROMPT in prompt.py
+    tool_call_max_retries: int = Field(default=3, description="The number of retries before raising a tool call error.")
     max_history: int = Field(default=15, description="Maximum number of messages to keep in the conversation history.")
     log_response_max_chars: PositiveInt = Field(
         default=1000, description="Maximum number of characters to display in logs when logging tool responses.")

--- a/src/nat/agent/rewoo_agent/register.py
+++ b/src/nat/agent/rewoo_agent/register.py
@@ -52,7 +52,9 @@ class ReWOOAgentWorkflowConfig(FunctionBaseConfig, name="rewoo_agent"):
     solver_prompt: str | None = Field(
         default=None,
         description="Provides the SOLVER_PROMPT to use with the agent")  # defaults to SOLVER_PROMPT in prompt.py
-    tool_call_max_retries: int = Field(default=3, description="The number of retries before raising a tool call error.")
+    tool_call_max_retries: PositiveInt = Field(default=3,
+                                               description="The number of retries before raising a tool call error.",
+                                               ge=1)
     max_history: int = Field(default=15, description="Maximum number of messages to keep in the conversation history.")
     log_response_max_chars: PositiveInt = Field(
         default=1000, description="Maximum number of characters to display in logs when logging tool responses.")

--- a/src/nat/agent/rewoo_agent/register.py
+++ b/src/nat/agent/rewoo_agent/register.py
@@ -119,7 +119,8 @@ async def rewoo_agent_workflow(config: ReWOOAgentWorkflowConfig, builder: Builde
         tools=tools,
         use_tool_schema=config.include_tool_input_schema_in_tool_description,
         detailed_logs=config.verbose,
-        log_response_max_chars=config.log_response_max_chars).build_graph()
+        log_response_max_chars=config.log_response_max_chars,
+        tool_call_max_retries=config.tool_call_max_retries).build_graph()
 
     async def _response_fn(input_message: ChatRequest) -> ChatResponse:
         try:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Update the hard-coded tool call retry count to be a configurable option for ReWOO agent.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a configurable option to control tool-call retry attempts (tool_call_max_retries, default: 3).

- Documentation
  - Expanded ReWOO agent docs and README with configuration details, including tool_call_max_retries and log_response_max_chars (defaults and usage).

- Tests
  - Added tests validating default/custom tool_call_max_retries and that the retry value is applied at runtime.

- Chores
  - Reorganized docs for clearer configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->