### PR TITLE
Fix workflow create documentation and command

### DIFF
--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -23,7 +23,7 @@ export PROJ_TOML="${PROJECT_ROOT}/pyproject.toml"
 export PY_DIRS="${PY_ROOT} ${PROJECT_ROOT}/packages ${PROJECT_ROOT}/tests ${PROJECT_ROOT}/ci/scripts "
 
 # Determine the commits to compare against. If running in CI, these will be set. Otherwise, diff with main
-export NAT_LOG_LEVEL=WARN
+export NAT_LOG_LEVEL=WARNING
 export CI_MERGE_REQUEST_TARGET_BRANCH_NAME=${CI_MERGE_REQUEST_TARGET_BRANCH_NAME:-"develop"}
 
 if [[ "${GITLAB_CI}" == "true" ]]; then

--- a/docs/source/tutorials/create-a-new-workflow.md
+++ b/docs/source/tutorials/create-a-new-workflow.md
@@ -40,7 +40,7 @@ nat workflow delete text_file_ingest
 
 Each workflow created in this way also creates a Python project, and by default, this will also install the project into the environment. If you want to avoid installing it into the environment you can use the `--no-install` flag.
 
-<!-- path-check-skip-next-line -->
+<!-- path-check-skip-begin -->
 This creates a new directory `examples/text_file_ingest` with the following layout:
 ```
 examples/
@@ -57,6 +57,7 @@ examples/
             ├── register.py
             └── text_file_ingest_function.py
 ```
+<!-- path-check-skip-end -->
 
 :::{note}
 The completed code for this example can be found in the `examples/documentation_guides/workflows/text_file_ingest` directory of the NeMo Agent toolkit repository.
@@ -67,6 +68,7 @@ By convention, tool implementations are defined within or imported into the `reg
 
 <!-- path-check-skip-begin -->
 Many of these tools contain an associated workflow configuration file stored in a `config` directory, along with example data stored in a `data` directory. Since these tools are installable Python packages and the workflow configuration file and data must be included in the package, they need to be located under the `examples/text_file_ingest/src/text_file_ingest` directory. For convenience, symlinks are created at the root of the project directory pointing to the actual directories. Lastly, a `README.md` file is often included in the root of the project.
+<!-- path-check-skip-end -->
 
 ## Customizing the Configuration Object
 Given that the purpose of this tool will be similar to that of the `webpage_query` tool, you can use it as a reference and starting point. Examining the `webpage_query` tool configuration object from `examples/getting_started/simple_web_query/src/nat_simple_web_query/register.py`:

--- a/docs/source/tutorials/create-a-new-workflow.md
+++ b/docs/source/tutorials/create-a-new-workflow.md
@@ -157,7 +157,7 @@ Next, update the retrieval tool definition changing the `name` parameter to `tex
     )
 ```
 
-The rest of the code largely remains the same resulting in the following code, the full code of this example is located at `examples/documentation_guides/workflows/text_file_ingest/src/text_file_ingest/register.py` in the NeMo Agent toolkit repository:
+The rest of the code largely remains the same resulting in the following code, the full code of this example is located at `examples/documentation_guides/workflows/text_file_ingest/src/text_file_ingest/text_file_ingest_function.py` in the NeMo Agent toolkit repository:
 ```python
 @register_function(config_type=TextFileIngestFunctionConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def text_file_ingest_function(config: TextFileIngestFunctionConfig, builder: Builder):

--- a/docs/source/tutorials/create-a-new-workflow.md
+++ b/docs/source/tutorials/create-a-new-workflow.md
@@ -46,11 +46,14 @@ This creates a new directory `examples/text_file_ingest` with the following layo
 ```
 examples/
 └── text_file_ingest/
+    ├── configs -> src/text_file_ingest/configs
+    |── data   -> src/text_file_ingest/data
     ├── pyproject.toml
     └── src/
         └── text_file_ingest/
             ├── configs
             │   └── config.yml
+            ├── data
             ├── __init__.py
             ├── register.py
             └── text_file_ingest_function.py
@@ -64,34 +67,7 @@ The completed code for this example can be found in the `examples/documentation_
 By convention, tool implementations are defined within or imported into the `register.py` file. In this example, the tool implementation exists within the `text_file_ingest_function.py` file and is imported into the `register.py` file. The `pyproject.toml` file contains the package metadata and dependencies for the tool. The `text_file_ingest_function.py` that was created for us will contain a configuration object (`TextFileIngestFunctionConfig`) along with the tool function (`text_file_ingest_function`). The next two sections will walk through customizing these.
 
 <!-- path-check-skip-begin -->
-Many of these tools contain an associated workflow configuration file stored in a `config` directory, along with example data stored in a `data` directory. Since these tools are installable Python packages and the workflow configuration file and data must be included in the package, they need to be located under the `examples/text_file_ingest/src/text_file_ingest` directory. For convenience, symlinks can be created at the root of the project directory pointing to the actual directories. Lastly, a `README.md` file is often included in the root of the project. Resulting in a directory structure similar to the following:
-```
-examples/
-└── text_file_ingest/
-    ├── README.md
-    ├── config -> src/text_file_ingest/configs
-    |── data   -> src/text_file_ingest/data
-    ├── pyproject.toml
-    └── src/
-        └── text_file_ingest/
-            ├── __init__.py
-            ├── configs/
-            |   └── config.yml
-            ├── data/
-            ├── register.py
-            └── text_file_ingest_function.py
-```
-
-<!-- Remove this once #559 is completed -->
-For our purposes we will need a `data` directory, along with the above mentioned symlinks which can be created with the following commands:
-```bash
-mkdir examples/text_file_ingest/src/text_file_ingest/data
-pushd examples/text_file_ingest
-ln -s src/text_file_ingest/data
-ln -s src/text_file_ingest/configs
-popd
-```
-<!-- path-check-skip-end -->
+Many of these tools contain an associated workflow configuration file stored in a `config` directory, along with example data stored in a `data` directory. Since these tools are installable Python packages and the workflow configuration file and data must be included in the package, they need to be located under the `examples/text_file_ingest/src/text_file_ingest` directory. For convenience, symlinks are created at the root of the project directory pointing to the actual directories. Lastly, a `README.md` file is often included in the root of the project.
 
 ## Customizing the Configuration Object
 Given that the purpose of this tool will be similar to that of the `webpage_query` tool, you can use it as a reference and starting point. Examining the `webpage_query` tool configuration object from `examples/getting_started/simple_web_query/src/nat_simple_web_query/register.py`:

--- a/docs/source/tutorials/create-a-new-workflow.md
+++ b/docs/source/tutorials/create-a-new-workflow.md
@@ -38,7 +38,6 @@ nat workflow delete text_file_ingest
 ```
 :::
 
-<!-- This section needs to be updated once #559 is completed -->
 Each workflow created in this way also creates a Python project, and by default, this will also install the project into the environment. If you want to avoid installing it into the environment you can use the `--no-install` flag.
 
 <!-- path-check-skip-next-line -->

--- a/src/nat/cli/commands/workflow/workflow_commands.py
+++ b/src/nat/cli/commands/workflow/workflow_commands.py
@@ -217,15 +217,13 @@ def create_command(workflow_name: str, install: bool, workflow_dir: str, descrip
         else:
             install_cmd = ['pip', 'install', '-e', str(new_workflow_dir)]
 
-        config_source = configs_dir / 'config.yml'
-
         # List of templates and their destinations
         files_to_render = {
             'pyproject.toml.j2': new_workflow_dir / 'pyproject.toml',
             'register.py.j2': base_dir / 'register.py',
             'workflow.py.j2': base_dir / f'{workflow_name}_function.py',
             '__init__.py.j2': base_dir / '__init__.py',
-            'config.yml.j2': config_source,
+            'config.yml.j2': configs_dir / 'config.yml',
         }
 
         # Render templates
@@ -245,10 +243,6 @@ def create_command(workflow_name: str, install: bool, workflow_dir: str, descrip
             content = template.render(context)
             with open(output_path, 'w', encoding="utf-8") as f:
                 f.write(content)
-
-        # Create symlink for config.yml
-        config_link = new_workflow_dir / 'configs' / 'config.yml'
-        os.symlink(config_source, config_link)
 
         # Create symlinks for config and data directories
         config_dir_source = configs_dir

--- a/tests/nat/cli/commands/test_workflow_commands.py
+++ b/tests/nat/cli/commands/test_workflow_commands.py
@@ -19,8 +19,8 @@ from unittest.mock import patch
 
 import pytest
 
-from nat.cli.commands.workflow.workflow_commands import (_get_nat_dependency,
-                                                         get_repo_root)
+from nat.cli.commands.workflow.workflow_commands import _get_nat_dependency
+from nat.cli.commands.workflow.workflow_commands import get_repo_root
 
 
 def test_get_repo_root(project_dir: str):
@@ -72,22 +72,12 @@ def test_nat_workflow_create(tmp_path):
         assert expected_output_path.exists()
 
     # Define expected symlinks
-    expected_symlinks = [
-        workflow_root / "configs",
-        workflow_root / "data",
+    expected_symlinks_and_targets = [
+        (workflow_root / "configs", test_workflow_src / "configs"),
+        (workflow_root / "data", test_workflow_src / "data"),
     ]
 
     # Verify symlinks exist and are symlinks
-    for expected_symlink in expected_symlinks:
+    for expected_symlink, target in expected_symlinks_and_targets:
         assert expected_symlink.is_symlink()
-
-    # Verify symlink targets
-    configs_symlink = workflow_root / "configs"
-    data_symlink = workflow_root / "data"
-    assert configs_symlink.resolve() == \
-        (test_workflow_src / "configs").resolve(), \
-        "configs symlink should point to src/test_workflow/configs"
-    assert data_symlink.resolve() == \
-        (test_workflow_src / "data").resolve(), \
-        "data symlink should point to src/test_workflow/data"
-        "data symlink should point to src/test_workflow/data"
+        assert expected_symlink.resolve() == target.resolve()

--- a/tests/nat/cli/commands/test_workflow_commands.py
+++ b/tests/nat/cli/commands/test_workflow_commands.py
@@ -41,10 +41,11 @@ def test_get_nat_dependency(mock_get_version, versioned, expected_dep):
 def test_nat_workflow_create(tmp_path):
     """Test that 'nat workflow create' command creates expected structure."""
     # Run the nat workflow create command
-    result = subprocess.run(["nat", "workflow", "create", "--workflow-dir", str(tmp_path), "test_workflow"],
-                            capture_output=True,
-                            text=True,
-                            check=True)
+    result = subprocess.run(
+        ["nat", "workflow", "create", "--no-install", "--workflow-dir", str(tmp_path), "test_workflow"],
+        capture_output=True,
+        text=True,
+        check=True)
 
     # Verify the command succeeded
     assert result.returncode == 0


### PR DESCRIPTION
## Description
* Fix traceback occurring in `workflow create` command (#789)
* Add a test to ensure the command completes successfully with the expected directory/file structure
* Update documentation to reflect that the function definitions are in `text_file_ingest_function.py` not `register.py` (#206)
* Update documentation to reflect that the command now creates symlinks for the `configs` and `data` directories

Closes #206
Closes #789


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Workflow creation now symlinks the entire configs directory (not a single file) and aligns root-level configs/data symlinks to their source locations, updating the generated layout.
- Documentation
  - Tutorial revised to reflect the simplified example directory layout, removed lengthy shell examples, updated example references, and added path-check markers around filesystem guidance.
- Tests
  - Added an integration test verifying CLI workflow creation, the new layout, and symlink targets.
- Chores
  - CI default log level changed from WARN to WARNING.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->