### PR TITLE
Fix `run_ci_local.sh` to not prompt for username/password

### DIFF
--- a/ci/scripts/bootstrap_local_ci.sh
+++ b/ci/scripts/bootstrap_local_ci.sh
@@ -14,14 +14,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [[ -n "${SSH_AUTH_SOCK}" ]]; then
+    # Avoids SSH host key verification prompt
+    ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts
+fi
+
 if [[ "${USE_HOST_GIT}" == "1" ]]; then
     cd nat/
     git config --global --add safe.directory /nat
 
-    # Avoids SSH host key verification prompt
-    ssh-keyscan github.com >> /etc/ssh/ssh_known_hosts
 else
-    git clone ${GIT_URL} nat
+    echo "Cloning from ${GIT_URL}"
+
+    git clone -q ${GIT_URL} nat
     cd nat/
     git remote add upstream ${GIT_UPSTREAM_URL}
     git fetch upstream

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -181,7 +181,7 @@ function get_lfs_files() {
         rapids-logger "Fetching LFS files"
         git lfs install
         rapids-logger "Calling git lfs fetch"
-        # git lfs fetch
+        git lfs fetch
         rapids-logger "Calling git lfs pull"
         git lfs pull
     fi

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -180,7 +180,9 @@ function get_lfs_files() {
     else
         rapids-logger "Fetching LFS files"
         git lfs install
+        rapids-logger "Calling git lfs fetch"
         git lfs fetch
+        rapids-logger "Calling git lfs pull"
         git lfs pull
     fi
 

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -181,7 +181,7 @@ function get_lfs_files() {
         rapids-logger "Fetching LFS files"
         git lfs install
         rapids-logger "Calling git lfs fetch"
-        git lfs fetch
+        # git lfs fetch
         rapids-logger "Calling git lfs pull"
         git lfs pull
     fi


### PR DESCRIPTION
## Description
* Pass the ssh agent auth sock to the CI container
* It appears that we can no longer perform anonymous git-lfs operations

Closes #791

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Improved local CI reliability with preemptive SSH host key handling to avoid prompts.
  - Enabled SSH-based Git operations when an SSH agent is available; falls back to HTTPS otherwise.
  - Streamlined and quieted repository cloning with a more deterministic checkout flow.
  - Added clearer logs for large file fetch/pull steps.
  - Exposed branch and commit metadata to downstream steps for better traceability.
  - Overall: smoother developer experience, fewer interruptions, and more predictable CI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->