### PR TITLE
Fix the `test_unified_api_server` integration tests

### DIFF
--- a/ci/scripts/github/tests.sh
+++ b/ci/scripts/github/tests.sh
@@ -30,9 +30,7 @@ rapids-logger "Running tests with Python version $(python --version) and pytest 
 set +e
 
 REPORT_IDENT_SLUG="$(arch)-py${PYTHON_VERSION}"
-# DO NOT MERGE remove the --run_slow --run_e2e --run_integration flags
 pytest --junit-xml=${REPORTS_DIR}/report-${REPORT_IDENT_SLUG}_pytest.xml \
-       --run_slow --run_e2e --run_integration \
        --cov=nat --cov-report term-missing \
        --cov-report=xml:${REPORTS_DIR}/report-${REPORT_IDENT_SLUG}_pytest_coverage.xml
 PYTEST_RESULTS=$?

--- a/ci/scripts/github/tests.sh
+++ b/ci/scripts/github/tests.sh
@@ -30,7 +30,9 @@ rapids-logger "Running tests with Python version $(python --version) and pytest 
 set +e
 
 REPORT_IDENT_SLUG="$(arch)-py${PYTHON_VERSION}"
+# DO NOT MERGE remove the --run_slow --run_e2e --run_integration flags
 pytest --junit-xml=${REPORTS_DIR}/report-${REPORT_IDENT_SLUG}_pytest.xml \
+       --run_slow --run_e2e --run_integration \
        --cov=nat --cov-report term-missing \
        --cov-report=xml:${REPORTS_DIR}/report-${REPORT_IDENT_SLUG}_pytest_coverage.xml
 PYTEST_RESULTS=$?

--- a/ci/scripts/gitlab/report_test_results.py
+++ b/ci/scripts/gitlab/report_test_results.py
@@ -134,13 +134,16 @@ def build_messages(junit_data: dict[str, typing.Any], coverage_data: str) -> Rep
         add_text(f"*Failed Tests ({num_errors_and_failures}):*", failure_blocks, failure_text)
 
         failed_tests = junit_data['failed_tests']
-        for (i, failed_test) in enumerate(failed_tests):
+        for failed_test in failed_tests:
             test_name = failed_test['test_name']
             message = failed_test['message']
             add_text(f"`{test_name}`\n```\n{message}\n```", failure_blocks, failure_text)
-            if i < len(failed_tests) - 1:
-                failure_text.append("---\n")
-                failure_blocks.append({"type": "divider"})
+            failure_text.append("---\n")
+            failure_blocks.append({"type": "divider"})
+
+        job_url = os.environ.get("CI_JOB_URL")
+        if job_url is not None:
+            add_text(f"Full details available at: {job_url}", failure_blocks, failure_text)
 
     return ReportMessages(plain_text=plain_text,
                           blocks=blocks,

--- a/ci/scripts/gitlab/report_test_results.py
+++ b/ci/scripts/gitlab/report_test_results.py
@@ -171,7 +171,10 @@ def main():
                                        text="\n".join(report_messages.plain_text),
                                        blocks=report_messages.blocks,
                                        link_names=report_messages.failure_text is not None)
+
     if report_messages.failure_text is not None:
+        # Since potentially a large number of failures could occur, we will post them in a thread to the original
+        # message to avoid spamming the channel.
         client.chat_postMessage(channel=slack_channel,
                                 text="\n".join(report_messages.failure_text),
                                 blocks=report_messages.failure_blocks,

--- a/ci/scripts/gitlab/report_test_results.py
+++ b/ci/scripts/gitlab/report_test_results.py
@@ -98,7 +98,7 @@ def add_text(text: str, blocks: list[dict], plain_text: list[str]) -> None:
     plain_text.append(text)
 
 
-def build_message(junit_data: dict[str, typing.Any], coverage_data: str) -> ReportMessages:
+def build_messages(junit_data: dict[str, typing.Any], coverage_data: str) -> ReportMessages:
     num_errors = junit_data['num_errors']
     num_failures = junit_data['num_failures']
 
@@ -164,7 +164,7 @@ def main():
     junit_data = parse_junit(args.junit_file)
     coverage_data = parse_coverage(args.coverage_file)
 
-    report_messages = build_message(junit_data, coverage_data)
+    report_messages = build_messages(junit_data, coverage_data)
 
     client = WebClient(token=slack_token)
     response = client.chat_postMessage(channel=slack_channel,

--- a/ci/scripts/gitlab/tests.sh
+++ b/ci/scripts/gitlab/tests.sh
@@ -22,9 +22,6 @@ source ${GITLAB_SCRIPT_DIR}/common.sh
 
 create_env group:dev extra:all
 
-# Since this dependency is specific to only this script, we will just install it here
-rapids-logger "Installing slack-sdk"
-uv pip install "slack-sdk~=3.36"
 rapids-logger "Git Version: $(git describe)"
 
 rapids-logger "Running tests"
@@ -48,6 +45,10 @@ pytest ${PYTEST_ARGS}  \
 PYTEST_RESULTS=$?
 
 if [ "${CI_CRON_NIGHTLY}" == "1" ]; then
+       # Since this dependency is specific to only this script, we will just install it here
+       rapids-logger "Installing slack-sdk"
+       uv pip install "slack-sdk~=3.36"
+
        rapids-logger "Reporting test results"
        ${GITLAB_SCRIPT_DIR}/report_test_results.py ${REPORT_NAME} ${COV_REPORT_NAME}
        REPORT_RESULT=$?

--- a/tests/nat/server/test_unified_api_server.py
+++ b/tests/nat/server/test_unified_api_server.py
@@ -15,6 +15,7 @@
 
 import datetime
 import json
+import os
 import re
 
 import httpx
@@ -284,11 +285,13 @@ system_interaction_multiple_choice_dropdown_message = {
 }
 
 
-@pytest.fixture(scope="session", name="config")
-def server_config(file_path: str = "tests/nat/server/config.yml") -> BaseModel:
+@pytest.fixture(name="config")
+def server_config(restore_environ, file_path: str = "tests/nat/server/config.yml") -> BaseModel:
     data = None
     with open(file_path, "r", encoding="utf-8") as file:
         data = yaml.safe_load(file)
+
+    os.environ["NAT_CONFIG_FILE"] = file_path
     return Config(**data)
 
 


### PR DESCRIPTION
## Description
* Also includes improved error reporting

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Chores
  - Nightly Slack test reports now include clearer summaries, human-readable test names, and a threaded detailed failure breakdown with improved formatting.
  - Slack reporting is run only during scheduled nightly jobs.

- Tests
  - Test config now supports selecting the config file via environment variables and improves isolation by using function-scoped fixtures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->