### PR TITLE
Introduce `nat mcp serve` (replace direct `nat mcp`) and align CLI structure

### DIFF
--- a/docs/source/reference/cli.md
+++ b/docs/source/reference/cli.md
@@ -140,13 +140,13 @@ Options:
 
 ### MCP
 
-The `nat start mcp` command (or simply `nat mcp`) will start a Model Context Protocol (MCP) server that exposes workflow functions as MCP tools. This allows other applications that support the MCP protocol to use your NeMo Agent toolkit functions directly. MCP is an open protocol developed by Anthropic that standardizes how applications provide context to LLMs. The MCP front-end is especially useful for integrating NeMo Agent toolkit workflows with MCP-compatible clients.
+The `nat mcp serve` command (equivalent to `nat start mcp`) starts a Model Context Protocol (MCP) server that exposes workflow functions as MCP tools. This allows other applications that support the MCP protocol to use your NeMo Agent toolkit functions directly. MCP is an open protocol developed by Anthropic that standardizes how applications provide context to LLMs. The MCP front-end is especially useful for integrating NeMo Agent toolkit workflows with MCP-compatible clients.
 
 The MCP front-end can be configured using the following options:
 
 ```console
-$ nat mcp --help
-Usage: nat mcp [OPTIONS]
+$ nat mcp serve --help
+Usage: nat mcp serve [OPTIONS]
 
 Options:
   --config_file FILE         A JSON/YAML file that sets the parameters for the
@@ -166,7 +166,7 @@ Options:
 For example, to start an MCP server with a specific workflow and expose only a particular tool:
 
 ```bash
-nat mcp --config_file examples/RAG/simple_rag/configs/milvus_rag_config.yml --tool_names mcp_retriever_tool
+nat mcp serve --config_file examples/RAG/simple_rag/configs/milvus_rag_config.yml --tool_names mcp_retriever_tool
 ```
 
 This will start an MCP server exposing the `mcp_retriever_tool` function from the workflow, which can then be accessed by any MCP-compatible client.

--- a/docs/source/workflows/mcp/mcp-auth.md
+++ b/docs/source/workflows/mcp/mcp-auth.md
@@ -26,7 +26,7 @@ This is currently a scratch pad for planning MCP auth. It will be rewritten when
 ## Steps for testing MCP auth
 1. Start the MCP server with auth enabled
 ```bash
-nat mcp --config_file examples/MCP/simple_calculator_mcp/configs/config-mcp-server-auth.yml
+nat mcp serve --config_file examples/MCP/simple_calculator_mcp/configs/config-mcp-server-auth.yml
 ```
 This starts a protected MCP server on port 9901. This MCP server has a stub token verifier that will always return success without AS introspection.
 

--- a/docs/source/workflows/mcp/mcp-client.md
+++ b/docs/source/workflows/mcp/mcp-client.md
@@ -202,7 +202,7 @@ functions:
 To run the simple calculator workflow using remote MCP tools, follow these steps:
 1. Start the example remote MCP server.
 ```bash
-nat mcp --config_file examples/getting_started/simple_calculator/configs/config.yml
+nat mcp serve --config_file examples/getting_started/simple_calculator/configs/config.yml
 ```
 This starts an MCP server on port 9901 with endpoint `/mcp` and uses `streamable-http` transport. This MCP server serves the calculator tools. See the [MCP Server](./mcp-server.md) documentation for more information.
 

--- a/docs/source/workflows/mcp/mcp-server.md
+++ b/docs/source/workflows/mcp/mcp-server.md
@@ -23,25 +23,25 @@ This guide will cover how to use NeMo Agent toolkit as an MCP Server to publish 
 
 ## MCP Server Usage
 
-The `nat mcp` command can be used to start an MCP server that publishes the functions from your workflow as MCP tools.
+The `nat mcp serve` command can be used to start an MCP server that publishes the functions from your workflow as MCP tools.
 
 To start an MCP server publishing all tools from your workflow, run the following command:
 
 ```bash
-nat mcp --config_file examples/getting_started/simple_calculator/configs/config.yml
+nat mcp serve --config_file examples/getting_started/simple_calculator/configs/config.yml
 ```
 
 This will load the workflow configuration from the specified file, start an MCP server on the default host (localhost) and port (9901), and publish all tools from the workflow as MCP tools. The MCP server is available at `http://localhost:9901/mcp` using streamable-http transport.
 
 You can also use the `sse` (Server-Sent Events) transport for backwards compatibility via the `--transport` flag for example:
 ```bash
-nat mcp --config_file examples/getting_started/simple_calculator/configs/config.yml --transport sse
+nat mcp serve --config_file examples/getting_started/simple_calculator/configs/config.yml --transport sse
 ```
 With this configuration, the MCP server is available at `http://localhost:9901/sse` using SSE transport.
 
 You can optionally specify the server settings using the following flags:
 ```bash
-nat mcp --config_file examples/getting_started/simple_calculator/configs/config.yml \
+nat mcp serve --config_file examples/getting_started/simple_calculator/configs/config.yml \
   --host 0.0.0.0 \
   --port 9901 \
   --name "My MCP Server"
@@ -51,7 +51,7 @@ nat mcp --config_file examples/getting_started/simple_calculator/configs/config.
 You can specify a filter to only publish a subset of tools from the workflow.
 
 ```bash
-nat mcp --config_file examples/getting_started/simple_calculator/configs/config.yml \
+nat mcp serve --config_file examples/getting_started/simple_calculator/configs/config.yml \
   --tool_names calculator_multiply \
   --tool_names calculator_divide \
   --tool_names calculator_subtract \

--- a/examples/MCP/simple_calculator_mcp/README.md
+++ b/examples/MCP/simple_calculator_mcp/README.md
@@ -35,7 +35,7 @@ This example demonstrates how to integrate the NVIDIA NeMo Agent toolkit with Mo
 ## Key Features
 
 - **MCP Client Integration:** Demonstrates how to use NeMo Agent toolkit as an MCP client to connect to remote MCP servers and access distributed tools like advanced mathematical operations as well as date and time services.
-- **MCP Server Publishing:** Shows how to publish NeMo Agent toolkit functions as MCP services using the `nat mcp` command, making calculator tools available to other AI systems through the standardized MCP protocol.
+- **MCP Server Publishing:** Shows how to publish NeMo Agent toolkit functions as MCP services using the `nat mcp serve` command, making calculator tools available to other AI systems through the standardized MCP protocol.
 - **Distributed AI Tool Networks:** Enables building networks of interconnected AI tools where different capabilities can be hosted on separate systems and accessed remotely through MCP.
 - **Cross-System Interoperability:** Demonstrates integration with the broader MCP ecosystem, allowing NeMo Agent toolkit workflows to both consume and provide tools in a standardized manner.
 - **Remote Tool Access:** Shows how to securely connect to external data sources and tools through the MCP protocol while maintaining security and access control.
@@ -79,7 +79,7 @@ uv pip install -e examples/MCP/simple_calculator_mcp
 You can run the simple calculator workflow using Remote MCP tools. In this case, the workflow acts as a MCP client and connects to the MCP server running on the specified URL. Details are provided in the [MCP Client Guide](../../../docs/source/workflows/mcp/mcp-client.md).
 
 ### NeMo Agent toolkit as an MCP Server
-You can publish the simple calculator tools via MCP using the `nat mcp` command. Details are provided in the [MCP Server Guide](../../../docs/source/workflows/mcp/mcp-server.md).
+You can publish the simple calculator tools via MCP using the `nat mcp serve` command. Details are provided in the [MCP Server Guide](../../../docs/source/workflows/mcp/mcp-server.md).
 
 ## Configuration Examples
 | Configuration File | MCP Server Type | Transport | Available Tools |
@@ -98,7 +98,7 @@ You can publish the simple calculator tools via MCP using the `nat mcp` command.
    ```
 
 **Math Server Example:**
-1. **Start the MCP server**: Use `nat mcp --config_file ./examples/getting_started/simple_calculator/configs/config.yml` to serve calculator tools on port 9901
+1. **Start the MCP server**: Use `nat mcp serve --config_file ./examples/getting_started/simple_calculator/configs/config.yml` to serve calculator tools on port 9901
 2. **Run the workflow**:
    ```bash
    nat run --config_file examples/MCP/simple_calculator_mcp/configs/config-mcp-math.yml --input "What is the product of 2 * 4?"
@@ -107,7 +107,7 @@ You can publish the simple calculator tools via MCP using the `nat mcp` command.
 **Combined Example:**
 1. **Start both MCP servers**: Keep both servers running simultaneously:
    - **Docker container MCP server**: Follow the setup instructions in [README](./deploy_external_mcp/README.md) to start the containerized time server on port 8080
-   - **NeMo Agent Toolkit MCP server**: Use `nat mcp --config_file examples/getting_started/simple_calculator/configs/config.yml` to serve calculator tools on port 9901
+   - **NeMo Agent Toolkit MCP server**: Use `nat mcp serve --config_file examples/getting_started/simple_calculator/configs/config.yml` to serve calculator tools on port 9901
 2. **Run the workflow**:
    ```bash
    nat run --config_file examples/MCP/simple_calculator_mcp/configs/config-combined.yml --input "Is the product of 2 * 4 greater than the current hour of the day?"
@@ -116,7 +116,7 @@ You can publish the simple calculator tools via MCP using the `nat mcp` command.
 **Combined Example with STDIO:**
 1. **Start the MCP math server**:
    ```bash
-   nat mcp --config_file examples/getting_started/simple_calculator/configs/config.yml
+   nat mcp serve --config_file examples/getting_started/simple_calculator/configs/config.yml
    ```
    This starts the MCP server on port 9901 with endpoint `/mcp`.
 2. **Run the workflow**:

--- a/src/nat/cli/commands/mcp/__init__.py
+++ b/src/nat/cli/commands/mcp/__init__.py
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/nat/cli/commands/mcp/mcp.py
+++ b/src/nat/cli/commands/mcp/mcp.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import logging
+
+import click
+
+from nat.cli.commands.start import start_command
+
+logger = logging.getLogger(__name__)
+
+
+@click.group(name=__name__, invoke_without_command=False, help="MCP-related commands.")
+def mcp_command():
+    """
+    MCP-related commands.
+    """
+    return None
+
+
+# nat mcp serve: reuses the start/mcp frontend command
+mcp_command.add_command(start_command.get_command(None, "mcp"), name="serve")  # type: ignore

--- a/src/nat/cli/entrypoint.py
+++ b/src/nat/cli/entrypoint.py
@@ -33,6 +33,7 @@ import nest_asyncio
 from .commands.configure.configure import configure_command
 from .commands.evaluate import eval_command
 from .commands.info.info import info_command
+from .commands.mcp.mcp import mcp_command
 from .commands.object_store.object_store import object_store_command
 from .commands.optimize import optimizer_command
 from .commands.registry.registry import registry_command
@@ -111,11 +112,11 @@ cli.add_command(workflow_command, name="workflow")
 cli.add_command(sizing, name="sizing")
 cli.add_command(optimizer_command, name="optimize")
 cli.add_command(object_store_command, name="object-store")
+cli.add_command(mcp_command, name="mcp")
 
 # Aliases
 cli.add_command(start_command.get_command(None, "console"), name="run")  # type: ignore
 cli.add_command(start_command.get_command(None, "fastapi"), name="serve")  # type: ignore
-cli.add_command(start_command.get_command(None, "mcp"), name="mcp")  # type: ignore
 
 
 @cli.result_callback()


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes AIQ-1885

- Adds a proper mcp CLI group with a serve subcommand (nat mcp serve ...) and removes the old top-level nat mcp alias. Updates docs and examples accordingly.

### Commands
- Before: `nat mcp --config_file ...`
- After: `nat mcp serve --config_file ...`



## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
