### PR TITLE
Expanding nightly E2E tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
   MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
   NAT_CI_MYSQL_HOST: "mysql"
+  NAT_CI_S3_HOST: "minio"
   UV_CACHE_DIR: .uv-cache
   WORKSPACE_TMP: "${CI_PROJECT_DIR}/.tmp"
 
@@ -75,6 +76,9 @@ test:python_tests:
   stage: test
   services:
     - mysql:9.3
+    - name: minio/minio:RELEASE.2025-07-18T21-56-31Z
+      alias: minio
+      command: ["server", "/data", "--console-address", ":9001"]
   script:
     - echo "Running tests"
     - ./ci/scripts/gitlab/tests.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -34,11 +34,13 @@ stages:
   - upload
 
 variables:
-  UV_CACHE_DIR: .uv-cache
-  BUILD_NAT_COMPAT: "true"
-  GIT_SUBMODULE_STRATEGY: recursive
-  GIT_SUBMODULE_FORCE_HTTPS: "true"
   BUILD_AIQ_COMPAT: "true"
+  BUILD_NAT_COMPAT: "true"
+  GIT_SUBMODULE_FORCE_HTTPS: "true"
+  GIT_SUBMODULE_STRATEGY: recursive
+  MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
+  NAT_CI_MYSQL_HOST: "mysql"
+  UV_CACHE_DIR: .uv-cache
   WORKSPACE_TMP: "${CI_PROJECT_DIR}/.tmp"
 
 default:
@@ -71,6 +73,8 @@ check:style:
 
 test:python_tests:
   stage: test
+  services:
+    - mysql:9.3
   script:
     - echo "Running tests"
     - ./ci/scripts/gitlab/tests.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -40,6 +40,7 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
   MYSQL_ROOT_PASSWORD: "${MYSQL_ROOT_PASSWORD}"
   NAT_CI_MYSQL_HOST: "mysql"
+  NAT_CI_REDIS_HOST: "redis"
   NAT_CI_S3_HOST: "minio"
   UV_CACHE_DIR: .uv-cache
   WORKSPACE_TMP: "${CI_PROJECT_DIR}/.tmp"
@@ -79,6 +80,7 @@ test:python_tests:
     - name: minio/minio:RELEASE.2025-07-18T21-56-31Z
       alias: minio
       command: ["server", "/data", "--console-address", ":9001"]
+    - redis:7-alpine
   script:
     - echo "Running tests"
     - ./ci/scripts/gitlab/tests.sh

--- a/packages/nvidia_nat_redis/tests/test_redis_object_store.py
+++ b/packages/nvidia_nat_redis/tests/test_redis_object_store.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from contextlib import asynccontextmanager
 
 import pytest
@@ -31,7 +32,7 @@ def fixture_redis_server(fail_missing: bool):
     """Fixture to safely skip redis based tests if redis is not running"""
     try:
         import redis
-        client = redis.Redis(host="localhost", port=6379, db=0)
+        client = redis.Redis(host=os.environ.get("NAT_CI_REDIS_HOST", "localhost"), port=6379, db=0)
         if not client.ping():
             raise RuntimeError("Failed to connect to Redis")
         yield
@@ -54,7 +55,10 @@ class TestRedisObjectStore(ObjectStoreTests):
         async with WorkflowBuilder() as builder:
             await builder.add_object_store(
                 "object_store_name",
-                RedisObjectStoreClientConfig(bucket_name="test", host="localhost", port=6379, db=0),
+                RedisObjectStoreClientConfig(bucket_name="test",
+                                             host=os.environ.get("NAT_CI_REDIS_HOST", "localhost"),
+                                             port=6379,
+                                             db=0),
             )
 
             yield await builder.get_object_store_client("object_store_name")

--- a/packages/nvidia_nat_s3/src/nat/plugins/s3/object_store.py
+++ b/packages/nvidia_nat_s3/src/nat/plugins/s3/object_store.py
@@ -45,5 +45,5 @@ async def s3_object_store_client(config: S3ObjectStoreClientConfig, _builder: Bu
 
     from .s3_object_store import S3ObjectStore
 
-    async with S3ObjectStore(**config.model_dump(exclude={"type"}, exclude_none=True)) as store:
+    async with S3ObjectStore(**config.model_dump(exclude={"type"}, exclude_none=False)) as store:
         yield store

--- a/packages/nvidia_nat_s3/tests/test_s3_object_store.py
+++ b/packages/nvidia_nat_s3/tests/test_s3_object_store.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 from contextlib import asynccontextmanager
 
 import pytest
@@ -33,10 +34,11 @@ def fixture_s3_server(fail_missing: bool):
     try:
         import botocore.session
         session = botocore.session.get_session()
+        host = os.getenv("NAT_CI_S3_HOST", "localhost")
         client = session.create_client("s3",
                                        aws_access_key_id="minioadmin",
                                        aws_secret_access_key="minioadmin",
-                                       endpoint_url="http://localhost:9000")
+                                       endpoint_url=f"http://{host}:9000")
         client.head_bucket(Bucket="test")
         yield
     except ImportError:
@@ -59,11 +61,12 @@ class TestS3ObjectStore(ObjectStoreTests):
 
     @asynccontextmanager
     async def _get_store(self):
+        host = os.getenv("NAT_CI_S3_HOST", "localhost")
         async with WorkflowBuilder() as builder:
             await builder.add_object_store(
                 "object_store_name",
                 S3ObjectStoreClientConfig(bucket_name="test",
-                                          endpoint_url="http://localhost:9000",
+                                          endpoint_url=f"http://{host}:9000",
                                           access_key="minioadmin",
                                           secret_key="minioadmin"))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,7 @@ def mock_aiohttp_session_fixture():
 
 @pytest.fixture(name="set_test_api_keys")
 def set_test_api_keys_fixture(restore_environ):
-    for key in ("NGC_API_KEY", "NVIDIA_API_KEY", "OPENAI_API_KEY", "SERPAPI_API_KEY"):
+    for key in ("NGC_API_KEY", "NVIDIA_API_KEY", "OPENAI_API_KEY"):
         os.environ[key] = "test_key"
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -112,7 +112,7 @@ def mock_aiohttp_session_fixture():
 
 @pytest.fixture(name="set_test_api_keys")
 def set_test_api_keys_fixture(restore_environ):
-    for key in ("NGC_API_KEY", "NVD_API_KEY", "NVIDIA_API_KEY", "OPENAI_API_KEY", "SERPAPI_API_KEY"):
+    for key in ("NGC_API_KEY", "NVIDIA_API_KEY", "OPENAI_API_KEY", "SERPAPI_API_KEY"):
         os.environ[key] = "test_key"
 
 


### PR DESCRIPTION
## Description
* Enable mysql, minio and redis services to enable DB integration tests
* Sort environment variables alphabetically
* Update DB related tests to use `NAT_CI_*_HOST` environment variables.
* Set `exclude_none=False` this fixes an error where `None` is a valid value for some fields.
* Remove unused environment variables from the `set_test_api_keys` fixture.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
