### PR TITLE
fix: ensure workflows set a `FunctionGroup`s `instance_name`

### DIFF
--- a/src/nat/builder/function.py
+++ b/src/nat/builder/function.py
@@ -637,3 +637,14 @@ class FunctionGroup:
         if name not in self._functions:
             raise ValueError(f"Function {name} not found in function group {self._instance_name}")
         self._per_function_filter_fn[name] = filter_fn
+
+    def set_instance_name(self, instance_name: str):
+        """
+        Sets the instance name for the function group.
+
+        Parameters
+        ----------
+        instance_name : str
+            The instance name to set for the function group.
+        """
+        self._instance_name = instance_name

--- a/src/nat/builder/workflow_builder.py
+++ b/src/nat/builder/workflow_builder.py
@@ -415,6 +415,8 @@ class WorkflowBuilder(Builder, AbstractAsyncContextManager):
             raise ValueError("Expected a FunctionGroup object to be returned from the function group builder. "
                              f"Got {type(build_result)}")
 
+        # set the instance name for the function group based on the workflow-provided name
+        build_result.set_instance_name(name)
         return ConfiguredFunctionGroup(config=config, instance=build_result)
 
     @override


### PR DESCRIPTION
## Description

Functions have their corresponding "name" be whatever what specified in the workflow.
Function Groups should do the same.

This PR addresses an overlooked feature parity with Functions by automatically setting the `instance_name` (e.g. what is presented to the tools / user) based on the workflow component's name.

### Example
```
function-group:
  my-group:
    type: my_fn_group
    include: [foo, bar]
```

**Before:**

Would expose as: `my_fn_group.foo` and `my_fn_group.bar`

**After:**

Will expose as: `my-group.foo` and `my-group.bar`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
