### PR TITLE
Make workflow name and description configurable as MCP tools

### DIFF
--- a/docs/source/workflows/about/react-agent.md
+++ b/docs/source/workflows/about/react-agent.md
@@ -75,6 +75,9 @@ functions:
 ```
 
 ### Configurable Options:
+
+* `workflow_alias`: Defaults to `None`. The alias of the workflow. Useful when the ReAct agent is configured as a workflow and need to expose a customized name as a tool.
+
 * `tool_names`: A list of tools that the agent can call. The tools must be functions configured in the YAML file.
 
 * `llm_name`: The LLM the agent should use. The LLM must be configured in the YAML file.

--- a/docs/source/workflows/about/reasoning-agent.md
+++ b/docs/source/workflows/about/reasoning-agent.md
@@ -46,6 +46,9 @@ workflow:
 ```
 
 ### Configurable Options:
+
+* `workflow_alias`: Defaults to `None`. The alias of the workflow. Useful when the Reasoning agent is configured as a workflow and need to expose a customized name as a tool.
+
 * `llm_name`: The LLM the agent should use. The LLM must be configured in the YAML file
 
 * `verbose`: Defaults to False (useful to prevent logging of sensitive data). If set to True, the agent will log input, output, and intermediate steps.

--- a/docs/source/workflows/about/rewoo-agent.md
+++ b/docs/source/workflows/about/rewoo-agent.md
@@ -73,6 +73,8 @@ functions:
 
 ### Configurable Options:
 
+* `workflow_alias`: Defaults to `None`. The alias of the workflow. Useful when the ReWOO agent is configured as a workflow and need to expose a customized name as a tool.
+
 * `tool_names`: A list of tools that the agent can call. The tools must be functions configured in the YAML file
 
 * `llm_name`: The LLM the agent should use. The LLM must be configured in the YAML file

--- a/docs/source/workflows/about/router-agent.md
+++ b/docs/source/workflows/about/router-agent.md
@@ -80,6 +80,8 @@ functions:
 
 #### Required Options
 
+* `workflow_alias`: Defaults to `None`. The alias of the workflow. Useful when the Router agent is configured as a workflow and need to expose a customized name as a tool.
+
 * `branches`: A list of available tools, functions, or agents that the router can direct requests to. These branches must be configured in the YAML file.
 
 * `llm_name`: The language model used for request analysis and routing decisions. The LLM must be configured in the YAML file.

--- a/docs/source/workflows/about/tool-calling-agent.md
+++ b/docs/source/workflows/about/tool-calling-agent.md
@@ -76,6 +76,8 @@ functions:
 
 ### Configurable Options
 
+* `workflow_alias`: Defaults to `None`. The alias of the workflow. Useful when the Tool Calling agent is configured as a workflow and need to expose a customized name as a tool.
+
 * `tool_names`: A list of tools that the agent can call. The tools must be functions configured in the YAML file
 
 * `llm_name`: The LLM the agent should use. The LLM must be configured in the YAML file

--- a/examples/getting_started/simple_calculator/src/nat_simple_calculator/configs/config.yml
+++ b/examples/getting_started/simple_calculator/src/nat_simple_calculator/configs/config.yml
@@ -39,6 +39,7 @@ llms:
 
 workflow:
   _type: react_agent
+  workflow_alias: calculator_agent
   tool_names:
     - calculator_multiply
     - calculator_inequality
@@ -48,3 +49,5 @@ workflow:
   llm_name: nim_llm
   verbose: true
   parse_agent_response_max_retries: 3
+  description: "This is a simple calculator agent that can perform basic arithmetic operations. When using as a MCP tool, this
+      MUST be the entry point agent that should be called before calling any other tools."

--- a/src/nat/agent/react_agent/register.py
+++ b/src/nat/agent/react_agent/register.py
@@ -42,7 +42,7 @@ class ReActAgentWorkflowConfig(FunctionBaseConfig, OptimizableMixin, name="react
     Defines a NAT function that uses a ReAct Agent performs reasoning inbetween tool calls, and utilizes the
     tool names and descriptions to select the optimal tool.
     """
-
+    workflow_alias: str | None = Field(default=None, description="The alias of the workflow.")
     tool_names: list[FunctionRef | FunctionGroupRef] = Field(
         default_factory=list, description="The list of tools to provide to the react agent.")
     llm_name: LLMRef = Field(description="The LLM model to use with the react agent.")

--- a/src/nat/agent/react_agent/register.py
+++ b/src/nat/agent/react_agent/register.py
@@ -42,7 +42,10 @@ class ReActAgentWorkflowConfig(FunctionBaseConfig, OptimizableMixin, name="react
     Defines a NAT function that uses a ReAct Agent performs reasoning inbetween tool calls, and utilizes the
     tool names and descriptions to select the optimal tool.
     """
-    workflow_alias: str | None = Field(default=None, description="The alias of the workflow.")
+    workflow_alias: str | None = Field(default=None,
+                                       description="The alias of the workflow. Useful when the ReAct"
+                                       "agent is configured as a workflow and need to expose a customized name as a"
+                                       "tool.")
     tool_names: list[FunctionRef | FunctionGroupRef] = Field(
         default_factory=list, description="The list of tools to provide to the react agent.")
     llm_name: LLMRef = Field(description="The LLM model to use with the react agent.")

--- a/src/nat/agent/reasoning_agent/reasoning_agent.py
+++ b/src/nat/agent/reasoning_agent/reasoning_agent.py
@@ -38,7 +38,10 @@ class ReasoningFunctionConfig(FunctionBaseConfig, name="reasoning_agent"):
 
     Designed to be used with an InterceptingFunction.
     """
-
+    workflow_alias: str | None = Field(default=None,
+                                       description="The alias of the workflow. Useful when the Reasoning"
+                                       "agent is configured as a workflow and need to expose a customized name as a"
+                                       "tool.")
     llm_name: LLMRef = Field(description="The name of the LLM to use for reasoning.")
     augmented_fn: FunctionRef = Field(description="The name of the function to reason on.")
     verbose: bool = Field(default=False, description="Whether to log detailed information.")

--- a/src/nat/agent/rewoo_agent/register.py
+++ b/src/nat/agent/rewoo_agent/register.py
@@ -40,6 +40,10 @@ class ReWOOAgentWorkflowConfig(FunctionBaseConfig, name="rewoo_agent"):
     tool names and descriptions to select the optimal tool.
     """
 
+    workflow_alias: str | None = Field(default=None,
+                                       description="The alias of the workflow. Useful when the ReWOO"
+                                       "agent is configured as a workflow and need to expose a customized name as a"
+                                       "tool.")
     tool_names: list[FunctionRef | FunctionGroupRef] = Field(
         default_factory=list, description="The list of tools to provide to the rewoo agent.")
     llm_name: LLMRef = Field(description="The LLM model to use with the rewoo agent.")

--- a/src/nat/agent/router_agent/register.py
+++ b/src/nat/agent/router_agent/register.py
@@ -34,6 +34,11 @@ class RouterAgentWorkflowConfig(FunctionBaseConfig, name="router_agent"):
     A router agent takes in the incoming message, combines it with a prompt and the list of branches,
     and ask a LLM about which branch to take.
     """
+
+    workflow_alias: str | None = Field(default=None,
+                                       description="The alias of the workflow. Useful when the Router"
+                                       "agent is configured as a workflow and need to expose a customized name as a"
+                                       "tool.")
     branches: list[FunctionRef] = Field(default_factory=list,
                                         description="The list of branches to provide to the router agent.")
     llm_name: LLMRef = Field(description="The LLM model to use with the routing agent.")

--- a/src/nat/agent/tool_calling_agent/register.py
+++ b/src/nat/agent/tool_calling_agent/register.py
@@ -36,6 +36,10 @@ class ToolCallAgentWorkflowConfig(FunctionBaseConfig, name="tool_calling_agent")
     input parameters to select the optimal tool.  Supports handling tool errors.
     """
 
+    workflow_alias: str | None = Field(default=None,
+                                       description="The alias of the workflow. Useful when the Tool Calling"
+                                       "agent is configured as a workflow and need to expose a customized name as a"
+                                       "tool.")
     tool_names: list[FunctionRef | FunctionGroupRef] = Field(
         default_factory=list, description="The list of tools to provide to the tool calling agent.")
     llm_name: LLMRef = Field(description="The LLM model to use with the tool calling agent.")

--- a/src/nat/front_ends/mcp/mcp_front_end_config.py
+++ b/src/nat/front_ends/mcp/mcp_front_end_config.py
@@ -25,7 +25,7 @@ from nat.data_models.front_end import FrontEndBaseConfig
 class MCPFrontEndConfig(FrontEndBaseConfig, name="mcp"):
     """MCP front end configuration.
 
-    A simple MCP (Modular Communication Protocol) front end for NeMo Agent toolkit.
+    A simple MCP (Model Context Protocol) front end for NeMo Agent toolkit.
     """
 
     name: str = Field(default="NeMo Agent Toolkit MCP",

--- a/src/nat/front_ends/mcp/mcp_front_end_plugin_worker.py
+++ b/src/nat/front_ends/mcp/mcp_front_end_plugin_worker.py
@@ -98,7 +98,10 @@ class MCPFrontEndPluginWorkerBase(ABC):
         for function_group in workflow.function_groups.values():
             functions.update(function_group.get_accessible_functions())
 
-        functions[workflow.config.workflow.type] = workflow
+        if workflow.config.workflow.workflow_alias:
+            functions[workflow.config.workflow.workflow_alias] = workflow
+        else:
+            functions[workflow.config.workflow.type] = workflow
 
         return functions
 

--- a/src/nat/front_ends/mcp/tool_converter.py
+++ b/src/nat/front_ends/mcp/tool_converter.py
@@ -229,6 +229,9 @@ def get_function_description(function: FunctionBase) -> str:
         # Try to get anything that might be a description
         elif hasattr(config, "topic") and config.topic:
             function_description = config.topic
+        # Try to get description from the workflow config
+        elif hasattr(config, "workflow") and config.workflow.description:
+            function_description = config.workflow.description
 
     elif isinstance(function, Function):
         function_description = function.description


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
When a NAT function is configured as the workflow and wrapped as a MCP tool, the tool name is always bound to the `_type` field (ambiguous to the agent and also causing duplication issue), and the customized tool description is not passed into the MCP tool wrapper. This PR addresses the issue by making both the workflow name (using `workflow_alias` option, align with the existing option name in NAT `eval` config) and the workflow description configurable and expose them to the MCP tool wrapper. 

For example, the `ReAct` agent configured as a workflow can be customized as below:
```yaml
workflow:
  _type: react_agent
  workflow_alias: calculator_agent
  description: "This is a simple calculator agent that can perform basic arithmetic operations. "
  tool_names:
    - calculator_multiply
    - calculator_inequality
    - current_datetime
    - calculator_divide
    - calculator_subtract
  llm_name: nim_llm
  verbose: true
  parse_agent_response_max_retries: 3
```
Then it can be discovered as a MCP tool with name "calculator_agent" and the corresponding tool description.

Closes #805 
Closes AIQ-1928

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
