### PR TITLE
Update RedisEditor to retrieve full document data from Redis when using get_memory tool

### DIFF
--- a/packages/nvidia_nat_redis/src/nat/plugins/redis/redis_editor.py
+++ b/packages/nvidia_nat_redis/src/nat/plugins/redis/redis_editor.py
@@ -171,17 +171,12 @@ class RedisEditor(MemoryEditor):
             for i, doc in enumerate(results.docs):
                 try:
                     logger.debug("Processing result %d/%d", i + 1, len(results.docs))
-                    # Get the document data from the correct attribute
-                    memory_data = {
-                        "conversation": getattr(doc, 'conversation', []),
-                        "user_id": getattr(doc, 'user_id', user_id),
-                        "tags": getattr(doc, 'tags', []),
-                        "metadata": getattr(doc, 'metadata', {}),
-                        "memory": getattr(doc, 'memory', "")
-                    }
                     logger.debug("Similarity score: %d", getattr(doc, 'score', 0))
-                    logger.debug("Extracted data for result %d: %s", i + 1, memory_data)
-                    memory_item = self._create_memory_item(memory_data, user_id)
+
+                    # Get the full document data
+                    full_doc = await self._client.json().get(doc.id)
+                    logger.debug("Extracted data for result %d: %s", i + 1, full_doc)
+                    memory_item = self._create_memory_item(dict(full_doc), user_id)
                     memories.append(memory_item)
                     logger.debug("Successfully created MemoryItem for result %d", i + 1)
                 except Exception as e:

--- a/packages/nvidia_nat_redis/src/nat/plugins/redis/schema.py
+++ b/packages/nvidia_nat_redis/src/nat/plugins/redis/schema.py
@@ -56,10 +56,11 @@ def create_schema(embedding_dim: int = DEFAULT_DIM):
     logger.info("Created embedding field with dimension %d", embedding_dim)
 
     schema = (
+        # Redis search can't directly index complex objects (e.g. conversation and metadata) in return_fields
+        # They need to be retrieved via json().get() for full object access
         TextField("$.user_id", as_name="user_id"),
         TagField("$.tags[*]", as_name="tags"),
         TextField("$.memory", as_name="memory"),
-        # TextField("$.conversations[*]", as_name="conversations"), # TODO: figure out if/how this should be done
         embedding_field)
 
     # Log the schema details

--- a/packages/nvidia_nat_redis/tests/test_redis_editor.py
+++ b/packages/nvidia_nat_redis/tests/test_redis_editor.py
@@ -151,6 +151,15 @@ async def test_search_success(redis_editor: RedisEditor, mock_redis_client: Asyn
     # Set up the client mock to return the ft mock
     mock_redis_client.ft = MagicMock(return_value=mock_ft_index)
 
+    # Mock Redis JSON get to return document data
+    mock_redis_client.json().get.return_value = {
+        "conversation": mock_doc.conversation,
+        "user_id": mock_doc.user_id,
+        "tags": mock_doc.tags,
+        "metadata": mock_doc.metadata,
+        "memory": mock_doc.memory
+    }
+
     result = await redis_editor.search(query="test query", user_id="user123", top_k=1)
 
     assert len(result) == 1


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Updates RedisEditor search method to retrieve full document data from Redis. Previously, search results only included indexable fields including id, payload, score, user_id, tags, memory. Conversations and metadata fields would be lost when returning the search results. This bugfix will fetch and return the full document object using the document ID.

Closes #821

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
