### PR TITLE
fix: correct logic for `test_unified_api_server.py`

### DIFF
--- a/tests/nat/server/test_unified_api_server.py
+++ b/tests/nat/server/test_unified_api_server.py
@@ -17,6 +17,8 @@ import datetime
 import json
 import os
 import re
+from collections.abc import Mapping
+from unittest.mock import patch
 
 import httpx
 import pytest
@@ -62,6 +64,7 @@ from nat.data_models.interactive import MultipleChoiceOption
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 from nat.front_ends.fastapi.message_validator import MessageValidator
 from nat.runtime.loader import load_config
+from nat.runtime.session import SessionManager
 
 
 class AppConfig(BaseModel):
@@ -359,16 +362,38 @@ async def test_user_attributes_from_http_request(client: httpx.AsyncClient, conf
     input_message = {"input_message": f"{config.app.input}"}
     headers = {"Header-Test": "application/json"}
     query_params = {"param1": "value1"}
-    response = await client.post(
-        f"{config.endpoint.generate}",
-        json=input_message,
-        headers=headers,
-        params=query_params,
-    )
-    nat_context = Context.get()
-    assert nat_context.metadata.headers['header-test'] == headers["Header-Test"]
-    assert nat_context.metadata.query_params['param1'] == query_params["param1"]
+
+    # Capture the metadata that gets set during the request
+    actual_headers: list[Mapping[str, str] | None] = [None]
+    actual_query_params: list[Mapping[str, str] | None] = [None]
+
+    # Store reference to original method before patching
+    original_method = SessionManager.set_metadata_from_http_request
+
+    def mock_set_metadata_from_http_request(self, request):
+        """Mock the metadata setting to capture what would be set."""
+        original_method(self, request)
+        actual_headers[0] = Context.get().metadata.headers
+        actual_query_params[0] = Context.get().metadata.query_params
+
+    # Patch the method to capture metadata
+    with patch("nat.runtime.session.SessionManager.set_metadata_from_http_request",
+               mock_set_metadata_from_http_request):
+        response = await client.post(
+            f"{config.endpoint.generate}",
+            json=input_message,
+            headers=headers,
+            params=query_params,
+        )
+
     assert response.status_code == 200
+
+    # Verify the metadata was captured correctly
+    assert actual_headers[0] is not None
+    assert actual_query_params[0] is not None
+
+    assert actual_headers[0]["header-test"] == headers["Header-Test"]
+    assert actual_query_params[0]["param1"] == query_params["param1"]
 
 
 async def test_valid_user_message():


### PR DESCRIPTION
## Description

The `test_user_attributes_from_http_request` test within `test_unified_api_server.py` incorrectly assumed that the context would be directly accessible. However, due to how `ContextVar`s actually work, this would be impossible.

Correct the logic of the test by patching the function to ensure that the metadata is properly set, the surface the interesting metadata back to the test for introspection.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Reworked metadata-capture test to validate that HTTP request headers and query parameters are correctly recorded via a mocked callback, avoiding direct context inspection.
  * Simplifies verification flow and reduces coupling, improving reliability and maintainability of the test suite.
  * Supports future refactors by isolating assertions from implementation details.
  * No changes to runtime behavior or public APIs; end users will not see functional differences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->