### PR TITLE
Fix `TraceAdapterRegistry` lookup errors in `SpanToDFWRecordProcessor`

### DIFF
--- a/packages/nvidia_nat_data_flywheel/tests/observability/processor/test_dfw_record_processor.py
+++ b/packages/nvidia_nat_data_flywheel/tests/observability/processor/test_dfw_record_processor.py
@@ -179,7 +179,8 @@ class TestSpanToDFWRecordProcessor:
         result = await processor.process(span)
 
         # Verify span_to_dfw_record was called correctly
-        mock_span_to_dfw_record.assert_called_once_with(span=span, to_type=processor.output_type, client_id=client_id)
+        expected_type = processor.extract_non_optional_type(processor.output_type)
+        mock_span_to_dfw_record.assert_called_once_with(span=span, to_type=expected_type, client_id=client_id)
 
         assert result == mock_converted_record
 
@@ -254,7 +255,8 @@ class TestSpanToDFWRecordProcessor:
         await processor.process(span)
 
         # Verify all parameters are passed correctly
-        mock_span_to_dfw_record.assert_called_once_with(span=span, to_type=processor.output_type, client_id=client_id)
+        expected_type = processor.extract_non_optional_type(processor.output_type)
+        mock_span_to_dfw_record.assert_called_once_with(span=span, to_type=expected_type, client_id=client_id)
 
     @patch('nat.plugins.data_flywheel.observability.processor.dfw_record_processor.span_to_dfw_record')
     @patch('nat.plugins.data_flywheel.observability.processor.dfw_record_processor.logger')

--- a/src/nat/observability/mixin/type_introspection_mixin.py
+++ b/src/nat/observability/mixin/type_introspection_mixin.py
@@ -477,6 +477,7 @@ class TypeIntrospectionMixin:
             logger.warning("Item %s is not compatible with output type %s", item, self.output_type)
             return False
 
+    @lru_cache
     def extract_non_optional_type(self, type_obj: type | types.UnionType) -> Any:
         """Extract the non-None type from Optional[T] or Union[T, None] types.
 

--- a/src/nat/observability/mixin/type_introspection_mixin.py
+++ b/src/nat/observability/mixin/type_introspection_mixin.py
@@ -15,6 +15,7 @@
 
 import inspect
 import logging
+import types
 from functools import lru_cache
 from typing import Any
 from typing import TypeVar
@@ -475,3 +476,20 @@ class TypeIntrospectionMixin:
         except ValidationError:
             logger.warning("Item %s is not compatible with output type %s", item, self.output_type)
             return False
+
+    def extract_non_optional_type(self, type_obj: type | types.UnionType) -> Any:
+        """Extract the non-None type from Optional[T] or Union[T, None] types.
+
+        This is useful when you need to pass a type to a system that doesn't
+        understand Optional types (like registries that expect concrete types).
+
+        Args:
+            type_obj (type | types.UnionType): The type to extract from (could be Optional[T] or Union[T, None])
+
+        Returns:
+            Any: The actual type without None, or the original type if not a union with None
+        """
+        decomposed = DecomposedType(type_obj)  # type: ignore[arg-type]
+        if decomposed.is_optional:
+            return decomposed.get_optional_type().type
+        return type_obj

--- a/tests/nat/observability/mixin/test_type_introspection_mixin.py
+++ b/tests/nat/observability/mixin/test_type_introspection_mixin.py
@@ -557,3 +557,111 @@ class TestRealWorldPatterns:
         # Should resolve single type argument to both input and output
         assert instance.input_type is MockSpan
         assert instance.output_type is MockSpan
+
+
+class TestExtractNonOptionalType:
+    """Test extract_non_optional_type method functionality"""
+
+    def test_extract_from_optional_type_int(self):
+        """Test extracting concrete type from int | None"""
+        instance = ConcreteDirectClass()
+
+        # Test with int | None
+        optional_int = int | None
+        result = instance.extract_non_optional_type(optional_int)
+        assert result is int
+
+    def test_extract_from_optional_type_str(self):
+        """Test extracting concrete type from str | None"""
+        instance = ConcreteDirectClass()
+
+        # Test with str | None
+        optional_str = str | None
+        result = instance.extract_non_optional_type(optional_str)
+        assert result is str
+
+    def test_extract_from_optional_complex_type(self):
+        """Test extracting concrete type from complex optional types"""
+        instance = ConcreteDirectClass()
+
+        # Test with dict[str, int] | None
+        optional_dict = dict[str, int] | None
+        result = instance.extract_non_optional_type(optional_dict)
+        assert result == dict[str, int]
+
+        # Test with list[str] | None
+        optional_list = list[str] | None
+        result = instance.extract_non_optional_type(optional_list)
+        assert result == list[str]
+
+    def test_extract_from_union_with_none_first(self):
+        """Test extracting when None is first in union"""
+        instance = ConcreteDirectClass()
+
+        # Test with None | str (order shouldn't matter)
+        union_type = None | str
+        result = instance.extract_non_optional_type(union_type)
+        assert result is str
+
+    def test_extract_from_non_optional_type(self):
+        """Test that non-optional types are returned unchanged"""
+        instance = ConcreteDirectClass()
+
+        # Test with concrete types that are not optional
+        assert instance.extract_non_optional_type(int) is int
+        assert instance.extract_non_optional_type(str) is str
+        assert instance.extract_non_optional_type(dict[str, int]) == dict[str, int]
+        assert instance.extract_non_optional_type(list[str]) == list[str]
+
+    def test_extract_from_union_without_none(self):
+        """Test that unions without None are returned unchanged"""
+        instance = ConcreteDirectClass()
+
+        # Test with union that doesn't include None
+        union_type = str | int
+        result = instance.extract_non_optional_type(union_type)
+        assert result == (str | int)
+
+    def test_extract_from_complex_union_with_none(self):
+        """Test extracting from complex union with None"""
+        instance = ConcreteDirectClass()
+
+        # Test with multiple types and None
+        union_type = str | int | None
+        result = instance.extract_non_optional_type(union_type)
+        # Should extract the non-None part of the union
+        assert result == (str | int)
+
+    def test_extract_from_nested_generic_optional(self):
+        """Test extracting from nested generic optional types"""
+        instance = ConcreteDirectClass()
+
+        # Test with nested generics
+        optional_nested = dict[str, list[int]] | None
+        result = instance.extract_non_optional_type(optional_nested)
+        assert result == dict[str, list[int]]
+
+        # Test with very complex nested type
+        complex_optional = dict[str, list[tuple[str, int]]] | None
+        result = instance.extract_non_optional_type(complex_optional)
+        assert result == dict[str, list[tuple[str, int]]]
+
+    def test_extract_preserves_original_type_object(self):
+        """Test that the extracted type maintains its identity"""
+        instance = ConcreteDirectClass()
+
+        # Create a specific type
+        custom_type = dict[str, int]
+        optional_custom = custom_type | None
+
+        result = instance.extract_non_optional_type(optional_custom)
+        assert result == custom_type
+        assert result is not optional_custom
+
+    def test_extract_with_direct_types(self):
+        """Test extracting with direct types (non-optional)"""
+        instance = ConcreteDirectClass()
+
+        # This tests that the method correctly handles direct types
+        result = instance.extract_non_optional_type(str)  # Direct type, not optional
+        assert result is str


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR updates `SpanToDFWRecordProcessor` based on recent fixes to `TypeIntrospectionMixin`. The data flywheel type registry does not register the optional type (e.g. `DFWRecordT | None`) and processing chains fail to execute due to registry look failures. The following are done in this PR to resolve this bug:
- Add `extract_non_optional_type` method to `TypeIntrospectionMixin` to extract the non-optional type(s)
- Update `SpanToDFWRecordProcess` to leverage this method to extract the target type
- Corresponding updates to tests

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * More robust event processing: unsupported events are now cleanly ignored.
  * Prevents passing optional types to converters, reducing type-mismatch errors.
  * Allows no record to be produced when events don’t map, avoiding misleading output.

* **Refactor**
  * Streamlined type handling to improve stability and consistency across processors.

* **Tests**
  * Added comprehensive tests covering optional/union type scenarios to ensure reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->