### PR TITLE
Fix `test_azure_openai_minimal_agent` test

### DIFF
--- a/tests/nat/llm_providers/test_langchain_agents.py
+++ b/tests/nat/llm_providers/test_langchain_agents.py
@@ -112,7 +112,9 @@ async def test_azure_openai_langchain_agent():
     """
     prompt = ChatPromptTemplate.from_messages([("system", "You are a helpful AI assistant."), ("human", "{input}")])
 
-    llm_config = AzureOpenAIModelConfig(azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1"))
+    llm_config = AzureOpenAIModelConfig(azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1"),
+                                        azure_endpoint=os.environ.get("AZURE_OPENAI_ENDPOINT"),
+                                        api_key=os.environ.get("AZURE_OPENAI_API_KEY"))
 
     async with WorkflowBuilder() as builder:
         await builder.add_llm("azure_openai_llm", llm_config)

--- a/tests/nat/llm_providers/test_langchain_agents.py
+++ b/tests/nat/llm_providers/test_langchain_agents.py
@@ -112,9 +112,7 @@ async def test_azure_openai_langchain_agent():
     """
     prompt = ChatPromptTemplate.from_messages([("system", "You are a helpful AI assistant."), ("human", "{input}")])
 
-    llm_config = AzureOpenAIModelConfig(azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1"),
-                                        azure_endpoint=os.environ.get("AZURE_OPENAI_ENDPOINT"),
-                                        api_key=os.environ.get("AZURE_OPENAI_API_KEY"))
+    llm_config = AzureOpenAIModelConfig(azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1"))
 
     async with WorkflowBuilder() as builder:
         await builder.add_llm("azure_openai_llm", llm_config)

--- a/tests/nat/llm_providers/test_llama_index_agents.py
+++ b/tests/nat/llm_providers/test_llama_index_agents.py
@@ -117,7 +117,9 @@ async def test_azure_openai_minimal_agent():
     The model can be changed by setting AZURE_OPENAI_DEPLOYMENT.
     See https://learn.microsoft.com/en-us/azure/ai-foundry/openai/quickstart for more information.
     """
-    llm_config = AzureOpenAIModelConfig(azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1"))
+    llm_config = AzureOpenAIModelConfig(azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1"),
+                                        azure_endpoint=os.environ.get("AZURE_OPENAI_ENDPOINT"),
+                                        api_key=os.environ.get("AZURE_OPENAI_API_KEY"))
     agent = await create_minimal_agent("azure_openai_llm", llm_config)
 
     response = await agent.achat("What is 1+2?")


### PR DESCRIPTION
## Description
* Since this test uses the `create_minimal_agent` helper method and not an actual production agent, we need to explicitly fetch the Azure environment variables

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
