### PR TITLE
Avoid calling 'git lfs install' as CI already performs this

### DIFF
--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -178,8 +178,6 @@ function get_lfs_files() {
     if [[ "${USE_HOST_GIT}" == "1" ]]; then
         rapids-logger "Using host git, skipping git-lfs install"
     else
-        rapids-logger "Fetching LFS files"
-        git lfs install
         rapids-logger "Calling git lfs fetch"
         git lfs fetch
         rapids-logger "Calling git lfs pull"


### PR DESCRIPTION
## Description
* Avoids a CI error about the LFS hooks already being installed.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Streamlined CI handling of large file assets by simplifying LFS setup, reducing redundant steps and potential points of failure in certain environments. This should yield faster, more reliable pipeline runs with cleaner logs during fetch/pull stages.
  - No impact on product features or user workflows; changes are limited to build infrastructure to improve consistency and maintainability of continuous integration processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->