### PR TITLE
fix: Ensure console front-end validation is called

### DIFF
--- a/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/src/nat/front_ends/console/console_front_end_plugin.py
@@ -55,9 +55,10 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         self.auth_flow_handler = ConsoleAuthenticationFlowHandler()
 
     async def pre_run(self):
-
-        if (not self.front_end_config.input_query and not self.front_end_config.input_file):
-            raise click.UsageError("Must specify either --input_query or --input_file")
+        if (self.front_end_config.input_query is not None and self.front_end_config.input_file is not None):
+            raise click.UsageError("Must specify either --input or --input_file, not both")
+        if (self.front_end_config.input_query is None and self.front_end_config.input_file is None):
+            raise click.UsageError("Must specify either --input or --input_file")
 
     async def run_workflow(self, session_manager: SessionManager):
 

--- a/src/nat/front_ends/simple_base/simple_front_end_plugin_base.py
+++ b/src/nat/front_ends/simple_base/simple_front_end_plugin_base.py
@@ -35,6 +35,8 @@ class SimpleFrontEndPluginBase(FrontEndBase[FrontEndConfigT], ABC):
 
     async def run(self):
 
+        await self.pre_run()
+
         # Must yield the workflow function otherwise it cleans up
         async with WorkflowBuilder.from_config(config=self.full_config) as builder:
 


### PR DESCRIPTION
## Description

Running `nat run` without specifying `--input` or `--input_file` results in a long error being printed. It turns out we never called `pre_run()` anywhere, so let's call it before constructing the workflow.

Closes #843

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced exactly one input source: users must provide either --input or --input_file, not both. Clear, actionable error messages are shown for both the “both provided” and “neither provided” cases.
  * Pre-run checks now execute before the workflow starts, providing immediate validation feedback and preventing workflows from launching with invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->