### PR TITLE
Skip some tests in `test_mcp_client_base.py` to avoid blocking CI

### DIFF
--- a/tests/nat/mcp/test_mcp_client_base.py
+++ b/tests/nat/mcp/test_mcp_client_base.py
@@ -315,6 +315,7 @@ async def test_reconnect_max_attempts_exceeded():
             await client.get_tools()
 
 
+@pytest.mark.skip(reason="This test might fail in CI due to race conditions")
 async def test_reconnect_backoff_timing():
     """Test that reconnect backoff timing works correctly."""
     client = MockMCPClient(transport="streamable-http",
@@ -358,6 +359,7 @@ async def test_reconnect_backoff_timing():
             assert attempt_times[1] == 0.2
 
 
+@pytest.mark.skip(reason="This test might fail in CI due to race conditions")
 async def test_reconnect_max_backoff_limit():
     """Test that backoff doesn't exceed maximum."""
     client = MockMCPClient(


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Some tests with `asyncio.sleep()` is randomly failing in CI tasks. Skip those to avoid them blocking CI.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
