### PR TITLE
fix: re-add litellm after accidental removal

### DIFF
--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/llm.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/llm.py
@@ -20,6 +20,7 @@ from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.cli.register_workflow import register_llm_client
 from nat.llm.azure_openai_llm import AzureOpenAIModelConfig
+from nat.llm.litellm_llm import LiteLlmModelConfig
 from nat.llm.nim_llm import NIMModelConfig
 from nat.llm.openai_llm import OpenAIModelConfig
 
@@ -45,6 +46,16 @@ async def azure_openai_adk(config: AzureOpenAIModelConfig, _builder: Builder):
         config_dict["api_base"] = config.azure_endpoint
 
     yield LiteLlm(f"azure/{config.azure_deployment}", **config_dict)
+
+
+@register_llm_client(config_type=LiteLlmModelConfig, wrapper_type=LLMFrameworkEnum.ADK)
+async def litellm_adk(litellm_config: LiteLlmModelConfig, _builder: Builder):
+    from google.adk.models.lite_llm import LiteLlm
+    yield LiteLlm(**litellm_config.model_dump(
+        exclude={"type", "max_retries", "thinking"},
+        by_alias=True,
+        exclude_none=True,
+    ))
 
 
 @register_llm_client(config_type=NIMModelConfig, wrapper_type=LLMFrameworkEnum.ADK)

--- a/src/nat/llm/litellm_llm.py
+++ b/src/nat/llm/litellm_llm.py
@@ -1,0 +1,69 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import AsyncIterator
+
+from pydantic import AliasChoices
+from pydantic import ConfigDict
+from pydantic import Field
+
+from nat.builder.builder import Builder
+from nat.builder.llm import LLMProviderInfo
+from nat.cli.register_workflow import register_llm_provider
+from nat.data_models.llm import LLMBaseConfig
+from nat.data_models.retry_mixin import RetryMixin
+from nat.data_models.temperature_mixin import TemperatureMixin
+from nat.data_models.thinking_mixin import ThinkingMixin
+from nat.data_models.top_p_mixin import TopPMixin
+
+
+class LiteLlmModelConfig(
+        LLMBaseConfig,
+        RetryMixin,
+        TemperatureMixin,
+        TopPMixin,
+        ThinkingMixin,
+        name="litellm",
+):
+    """A LiteLlm provider to be used with an LLM client."""
+
+    model_config = ConfigDict(protected_namespaces=(), extra="allow")
+
+    api_key: str | None = Field(default=None, description="API key to interact with hosted model.")
+    base_url: str | None = Field(default=None,
+                                 description="Base url to the hosted model.",
+                                 validation_alias=AliasChoices("base_url", "api_base"),
+                                 serialization_alias="api_base")
+    model_name: str = Field(validation_alias=AliasChoices("model_name", "model"),
+                            serialization_alias="model",
+                            description="The LiteLlm hosted model name.")
+    seed: int | None = Field(default=None, description="Random seed to set for generation.")
+
+
+@register_llm_provider(config_type=LiteLlmModelConfig)
+async def litellm_model(
+    config: LiteLlmModelConfig,
+    _builder: Builder,
+) -> AsyncIterator[LLMProviderInfo]:
+    """Litellm model provider.
+
+    Args:
+        config (LiteLlmModelConfig): The LiteLlm model configuration.
+        _builder (Builder): The NAT builder instance.
+
+    Returns:
+        AsyncIterator[LLMProviderInfo]: An async iterator that yields an LLMProviderInfo object.
+    """
+    yield LLMProviderInfo(config=config, description="A LiteLlm model for use with an LLM client.")

--- a/src/nat/llm/register.py
+++ b/src/nat/llm/register.py
@@ -22,5 +22,6 @@ This module is imported by the NeMo Agent Toolkit runtime to ensure providers ar
 # Import any providers which need to be automatically registered here
 from . import aws_bedrock_llm
 from . import azure_openai_llm
+from . import litellm_llm
 from . import nim_llm
 from . import openai_llm


### PR DESCRIPTION
## Description
In #848 I improved the Google ADK structure but mistakenly committed the removal of litellm.

This PR re-adds the original contribution from #726

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
