### PR TITLE
Console Auth Flow Exception Improvement

### DIFF
--- a/src/nat/front_ends/console/authentication_flow_handler.py
+++ b/src/nat/front_ends/console/authentication_flow_handler.py
@@ -189,11 +189,11 @@ class ConsoleAuthenticationFlowHandler(FlowHandlerBase):
             self._flows[state] = flow_state
             self._active_flows += 1
 
-        click.echo("Your browser has been opened for authentication.")
         try:
             webbrowser.open(auth_url)
+            click.echo("Your browser has been opened for authentication.")
         except Exception as e:
-            logger.warning("Browser open failed: %s", e)
+            logger.error("Browser open failed: %s", e)
             raise RuntimeError(f"Browser open failed: {e}") from e
 
         # Wait for the redirect to land


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Implement fail-fast exception handling when the browser fails to open during console auth flows.
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth sign-in now fails immediately with a clear error if the system cannot open a browser, instead of only logging a warning.
  * Prevents partial login attempts and confusing states; improves reliability in headless or restricted environments and gives actionable feedback to users and admins.
  * Admins receive immediate clues to resolve environment issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->