### PR TITLE
ReWOO typing enhancements; more ruff checks; prefer `langchain-tavily`

### DIFF
--- a/ci/release/update_doc_versions1.py
+++ b/ci/release/update_doc_versions1.py
@@ -26,7 +26,7 @@ def main(versions_file: str, new_version: str):
     if new_version.count('.') != 1:
         raise ValueError("Version string must only include <major>.<minor>")
 
-    with open(versions_file, "r", encoding="utf-8") as fh:
+    with open(versions_file, encoding="utf-8") as fh:
         version_list = json.load(fh)
 
     for version_data in version_list:

--- a/ci/release/update_toml_dep.py
+++ b/ci/release/update_toml_dep.py
@@ -41,7 +41,7 @@ def main(toml_file_path: str, new_version: str, package_name: str, version_match
     version_match : str
         Version match specifier to use for the dependency.
     """
-    with open(toml_file_path, "r", encoding="utf-8") as fh:
+    with open(toml_file_path, encoding="utf-8") as fh:
         toml_data = tomlkit.load(fh)
 
     toml_project: tomlkit.items.Table = toml_data['project']

--- a/ci/scripts/copyright.py
+++ b/ci/scripts/copyright.py
@@ -17,7 +17,6 @@
 
 import argparse
 import datetime
-import io
 import logging
 import os
 import re
@@ -90,7 +89,7 @@ def replace_current_year(line, start, end):
     # first turn a simple regex into double (if applicable). then update years
     res = CheckSimple.sub(r"Copyright (c) \1-\1, NVIDIA CORPORATION", line)
 
-    res = CheckDouble.sub(r"Copyright (c) {:04d}-{:04d}, NVIDIA CORPORATION".format(start, end), res)
+    res = CheckDouble.sub(rf"Copyright (c) {start:04d}-{end:04d}, NVIDIA CORPORATION", res)
     return res
 
 
@@ -137,7 +136,7 @@ def check_copyright(f,
     cr_found = False
     apache_lic_found = not verify_apache_v2
     year_matched = False
-    with io.open(f, "r", encoding="utf-8") as file:
+    with open(f, encoding="utf-8") as file:
         lines = file.readlines()
     for line in lines:
         line_num += 1
@@ -213,7 +212,7 @@ def check_copyright(f,
             logger.info("File: %s. Changing line(s) %s", f, ', '.join(str(x[1]) for x in errs if x[-1] is not None))
             for _, line_num, __, replacement in errs_update:
                 lines[line_num - 1] = replacement
-            with io.open(f, "w", encoding="utf-8") as out_file:
+            with open(f, "w", encoding="utf-8") as out_file:
                 for new_line in lines:
                     out_file.write(new_line)
 

--- a/ci/scripts/path_checks.py
+++ b/ci/scripts/path_checks.py
@@ -280,7 +280,7 @@ def extract_paths_from_file(filename: str) -> list[PathInfo]:
         A list of PathInfo objects.
     """
     paths = []
-    with open(filename, "r", encoding="utf-8") as f:
+    with open(filename, encoding="utf-8") as f:
         section: list[str] = []
         in_skipped_section: bool = False
         skip_next_line: bool = False

--- a/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/extract_por_tool.py
+++ b/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/extract_por_tool.py
@@ -147,7 +147,7 @@ async def extract_from_por_tool(config: ExtractPORToolConfig, builder: Builder):
         if os.path.isfile(input_file):
             logger.debug("Detected file: %s", input_file)
 
-            with open(input_file, 'r', encoding='utf-8') as file:
+            with open(input_file, encoding='utf-8') as file:
                 por_content = "\n".join(line.strip() for line in file if line.strip())
         else:
             por_content = input_text
@@ -193,7 +193,7 @@ async def show_tickets_tool(config: ShowTicketsToolConfig, builder: Builder):
     async def _arun(input_text: str) -> str:
         # input_text = process_input_text(input_text)
         try:
-            with open(filename, 'r', encoding='utf-8') as json_file:
+            with open(filename, encoding='utf-8') as json_file:
                 data = json.load(json_file)
                 logger.debug("Data successfully loaded from %s", filename)
         except Exception as e:

--- a/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/jira_tickets_tool.py
+++ b/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/jira_tickets_tool.py
@@ -37,7 +37,7 @@ def get_epics_tool(root_path: str) -> str:
     """
     filename = root_path + "epics_tasks.json"
     try:
-        with open(filename, 'r', encoding='utf-8') as json_file:
+        with open(filename, encoding='utf-8') as json_file:
             data = json.load(json_file)
             logger.debug("Data successfully loaded from %s", filename)
     except Exception as e:

--- a/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/host_performance_check_tool.py
+++ b/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/host_performance_check_tool.py
@@ -103,8 +103,8 @@ async def _parse_stdout_lines(config, builder, stdout_lines) -> str:
 
         response = await utils.llm_ainvoke(config=config, builder=builder, user_prompt=prompt)
     except Exception as e:
-        response = ('{{"error": "Failed to parse stdout from the playbook run.", '
-                    '"exception": "{}", "raw_response": "{}"}}').format(str(e), response)
+        response = ('{"error": "Failed to parse stdout from the playbook run.", '
+                    f'"exception": "{str(e)}", "raw_response": "{response}"}}')
     return response
 
 

--- a/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/network_connectivity_check_tool.py
+++ b/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/network_connectivity_check_tool.py
@@ -60,7 +60,7 @@ def _check_service_banner(host: str, port: int = 80, connect_timeout: float = 10
         # 4) Decode what we got (ignore any non‑UTF8 bytes)
         return buffer.decode('utf-8', errors='ignore')
 
-    except (socket.timeout, ConnectionRefusedError, OSError):
+    except (TimeoutError, ConnectionRefusedError, OSError):
         # timed out or could not connect
         return ''
 

--- a/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/utils.py
+++ b/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/utils.py
@@ -103,7 +103,7 @@ def preload_offline_data(offline_data_path: str | None, benign_fallback_data_pat
     _DATA_CACHE['offline_data'] = pd.read_csv(offline_data_path)
     logger.info("Preloaded test data from: %s", offline_data_path)
 
-    with open(benign_fallback_data_path, "r", encoding="utf-8") as f:
+    with open(benign_fallback_data_path, encoding="utf-8") as f:
         _DATA_CACHE['benign_fallback_offline_data'] = json.load(f)
     logger.info("Preloaded benign fallback data from: %s", benign_fallback_data_path)
 

--- a/examples/advanced_agents/alert_triage_agent/tests/test_alert_triage_agent_workflow.py
+++ b/examples/advanced_agents/alert_triage_agent/tests/test_alert_triage_agent_workflow.py
@@ -38,14 +38,14 @@ async def test_full_workflow():
     config_file: Path = importlib.resources.files(package_name).joinpath("configs",
                                                                          "config_offline_mode.yml").absolute()
 
-    with open(config_file, "r", encoding="utf-8") as file:
+    with open(config_file, encoding="utf-8") as file:
         config = yaml.safe_load(file)
         input_filepath = config["eval"]["general"]["dataset"]["file_path"]
 
     input_filepath_abs = importlib.resources.files(package_name).joinpath("../../../../../", input_filepath).absolute()
 
     # Load input data
-    with open(input_filepath_abs, 'r', encoding="utf-8") as f:
+    with open(input_filepath_abs, encoding="utf-8") as f:
         input_data = json.load(f)
 
     input_data = input_data[0]  # Limit to first row for testing

--- a/examples/advanced_agents/alert_triage_agent/tests/test_maintenance_check.py
+++ b/examples/advanced_agents/alert_triage_agent/tests/test_maintenance_check.py
@@ -44,7 +44,7 @@ def test_load_maintenance_data():
     package_name = inspect.getmodule(AlertTriageAgentWorkflowConfig).__package__
     config_file: Path = importlib.resources.files(package_name).joinpath("configs",
                                                                          "config_offline_mode.yml").absolute()
-    with open(config_file, "r") as file:
+    with open(config_file) as file:
         config = yaml.safe_load(file)
         maintenance_data_path = config["functions"]["maintenance_check"]["static_data_path"]
     maintenance_data_path_abs = importlib.resources.files(package_name).joinpath("../../../../../",

--- a/examples/advanced_agents/alert_triage_agent/tests/test_network_connectivity_check_tool.py
+++ b/examples/advanced_agents/alert_triage_agent/tests/test_network_connectivity_check_tool.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import socket
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -50,7 +49,7 @@ def test_successful_banner_read(mock_create_conn, mock_sock):
 @pytest.mark.parametrize(
     "side_effect, port, conn_to, read_to",
     [
-        (socket.timeout(), 80, 10, 10),
+        (TimeoutError(), 80, 10, 10),
         (ConnectionRefusedError(), 80, 10, 10),
         (OSError(), 1234, 5, 2),
     ],

--- a/examples/advanced_agents/alert_triage_agent/tests/test_utils.py
+++ b/examples/advanced_agents/alert_triage_agent/tests/test_utils.py
@@ -96,7 +96,7 @@ def test_preload_offline_data():
     package_name = inspect.getmodule(AlertTriageAgentWorkflowConfig).__package__
     config_file: Path = importlib.resources.files(package_name).joinpath("configs",
                                                                          "config_offline_mode.yml").absolute()
-    with open(config_file, "r") as file:
+    with open(config_file) as file:
         config = yaml.safe_load(file)
         offline_data_path = config["workflow"]["offline_data_path"]
         benign_fallback_data_path = config["workflow"]["benign_fallback_data_path"]

--- a/examples/custom_functions/plot_charts/src/nat_plot_charts/plot_chat.py
+++ b/examples/custom_functions/plot_charts/src/nat_plot_charts/plot_chat.py
@@ -48,7 +48,7 @@ def load_data_from_file(file_path: str) -> dict[str, Any]:
             else:
                 raise FileNotFoundError(f"Could not find data file: {file_path}")
 
-        with open(file_path, "r", encoding="utf-8") as f:
+        with open(file_path, encoding="utf-8") as f:
             data = json.load(f)
         logger.info("Successfully loaded data from %s", file_path)
         return data

--- a/examples/evaluation_and_profiling/simple_calculator_eval/src/nat_simple_calculator_eval/scripts/custom_dataset_parser.py
+++ b/examples/evaluation_and_profiling/simple_calculator_eval/src/nat_simple_calculator_eval/scripts/custom_dataset_parser.py
@@ -49,7 +49,7 @@ def extract_nested_questions(file_path: Path, difficulty: str | None = None, max
     """
 
     # Load the nested JSON
-    with open(file_path, 'r', encoding='utf-8') as f:
+    with open(file_path, encoding='utf-8') as f:
         data = json.load(f)
 
     # Extract questions array from the nested structure

--- a/examples/evaluation_and_profiling/simple_calculator_eval/src/nat_simple_calculator_eval/scripts/custom_post_process.py
+++ b/examples/evaluation_and_profiling/simple_calculator_eval/src/nat_simple_calculator_eval/scripts/custom_post_process.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import logging
+from datetime import UTC
 from datetime import datetime
-from datetime import timezone
 
 from nat.eval.evaluator.evaluator_model import EvalInputItem
 
@@ -45,7 +45,7 @@ def add_metadata_and_filter(item: EvalInputItem) -> EvalInputItem:
 
     # Add metadata to the full_dataset_entry
     enhanced_entry = item.full_dataset_entry.copy() if item.full_dataset_entry else {}
-    enhanced_entry['pre_eval_process_timestamp'] = datetime.now(timezone.utc).isoformat()
+    enhanced_entry['pre_eval_process_timestamp'] = datetime.now(UTC).isoformat()
     enhanced_entry['pre_eval_process_version'] = "1.0"
     enhanced_entry['has_output'] = bool(item.output_obj)
 

--- a/examples/evaluation_and_profiling/simple_web_query_eval/tests/test_simple_web_query_eval.py
+++ b/examples/evaluation_and_profiling/simple_web_query_eval/tests/test_simple_web_query_eval.py
@@ -38,7 +38,7 @@ def validate_workflow_output(workflow_output_file: Path):
 
     # Read and validate the workflow_output.json file
     try:
-        with open(workflow_output_file, "r", encoding="utf-8") as f:
+        with open(workflow_output_file, encoding="utf-8") as f:
             result_json = json.load(f)
     except json.JSONDecodeError:
         pytest.fail("Failed to parse workflow_output.json as valid JSON")
@@ -62,7 +62,7 @@ def validate_rag_accuracy(rag_metric_output_file: Path, score: float):
     # Ensure the ile exists
     assert rag_metric_output_file and rag_metric_output_file.exists(), \
         f"The {rag_metric_output_file} was not created"
-    with open(rag_metric_output_file, "r", encoding="utf-8") as f:
+    with open(rag_metric_output_file, encoding="utf-8") as f:
         result = f.read()
         # load the json file
         try:
@@ -87,7 +87,7 @@ def validate_trajectory_accuracy(trajectory_output_file: Path):
     assert trajectory_output_file and trajectory_output_file.exists(), "The trajectory_output.json file was not created"
 
     trajectory_score_min = 0.1
-    with open(trajectory_output_file, "r", encoding="utf-8") as f:
+    with open(trajectory_output_file, encoding="utf-8") as f:
         result = f.read()
         # load the json file
         try:

--- a/examples/evaluation_and_profiling/swe_bench/src/nat_swe_bench/predictors/predict_full/tools/ast_tool.py
+++ b/examples/evaluation_and_profiling/swe_bench/src/nat_swe_bench/predictors/predict_full/tools/ast_tool.py
@@ -57,7 +57,7 @@ async def ast_tool(tool_config: AstToolConfig, builder: Builder):
         logger.info("Analyzing file: %s", file_path)
 
         try:
-            with open(file_path, 'r', encoding='utf-8') as f:
+            with open(file_path, encoding='utf-8') as f:
                 source_code = f.read()
 
             tree = ast.parse(source_code)
@@ -89,7 +89,7 @@ async def ast_tool(tool_config: AstToolConfig, builder: Builder):
                     })
                     logger.info("Found class: %s with methods: %s", node.name, methods)
 
-                elif isinstance(node, (ast.Import, ast.ImportFrom)):
+                elif isinstance(node, ast.Import | ast.ImportFrom):
                     for alias in node.names:
                         import_info = {
                             'name': alias.name,

--- a/examples/evaluation_and_profiling/swe_bench/tests/test_swe_bench_eval.py
+++ b/examples/evaluation_and_profiling/swe_bench/tests/test_swe_bench_eval.py
@@ -38,7 +38,7 @@ def validate_workflow_output(workflow_output_file: Path):
 
     # Read and validate the workflow_output.json file
     try:
-        with open(workflow_output_file, "r", encoding="utf-8") as f:
+        with open(workflow_output_file, encoding="utf-8") as f:
             result_json = json.load(f)
     except json.JSONDecodeError:
         pytest.fail("Failed to parse workflow_output.json as valid JSON")
@@ -64,7 +64,7 @@ def validate_evaluation_output(eval_output_file: Path):
     # Ensure the file exists
     assert eval_output_file and eval_output_file.exists(), \
         f"The {eval_output_file} file was not created"
-    with open(eval_output_file, "r", encoding="utf-8") as f:
+    with open(eval_output_file, encoding="utf-8") as f:
         result = f.read()
         # load the json file
         try:

--- a/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
+++ b/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
@@ -61,7 +61,7 @@ async def test_full_workflow_e2e() -> None:
 def test_config_yaml_loads_and_has_keys() -> None:
     config_file = (Path(__file__).resolve().parents[1] / "configs" / "config.yml")
 
-    with open(config_file, "r", encoding="utf-8") as f:
+    with open(config_file, encoding="utf-8") as f:
         text = f.read()
 
     assert "workflow:" in text

--- a/examples/frameworks/semantic_kernel_demo/src/nat_semantic_kernel_demo/hotel_price_tool.py
+++ b/examples/frameworks/semantic_kernel_demo/src/nat_semantic_kernel_demo/hotel_price_tool.py
@@ -44,7 +44,7 @@ async def hotel_price(tool_config: HotelPriceToolConfig, builder: Builder):
 
     import json
 
-    with open(tool_config.data_path, 'r', encoding='utf-8') as f:
+    with open(tool_config.data_path, encoding='utf-8') as f:
         hotel_prices = json.load(f)
 
     search_date_format = tool_config.date_format

--- a/examples/frameworks/semantic_kernel_demo/src/nat_semantic_kernel_demo/local_events_tool.py
+++ b/examples/frameworks/semantic_kernel_demo/src/nat_semantic_kernel_demo/local_events_tool.py
@@ -40,7 +40,7 @@ async def local_events(tool_config: LocalEventsToolConfig, builder: Builder):
 
     import json
 
-    with open(tool_config.data_path, "r") as f:
+    with open(tool_config.data_path) as f:
         events = LocalEventsResponse.model_validate({"events": json.load(f)}).events
 
     async def _local_events(city: str) -> LocalEventsResponse:

--- a/examples/notebooks/first_search_agent/src/nat_first_search_agent/first_search_agent_function.py
+++ b/examples/notebooks/first_search_agent/src/nat_first_search_agent/first_search_agent_function.py
@@ -40,12 +40,12 @@ async def first_search_agent_function(_config: FirstSearchAgentFunctionConfig, _
     from langchain import hub
     from langchain.agents import AgentExecutor
     from langchain.agents import create_react_agent
-    from langchain_community.tools.tavily_search import TavilySearchResults
     from langchain_nvidia_ai_endpoints import ChatNVIDIA
+    from langchain_tavily import TavilySearch
 
     # Initialize a tool to search the web
     tavily_kwargs = {"max_results": 2, "api_key": os.getenv("TAVILY_API_KEY")}
-    search = TavilySearchResults(**tavily_kwargs)
+    search = TavilySearch(**tavily_kwargs)
 
     # Create a list of tools for the agent
     tools = [search]

--- a/examples/notebooks/langchain_sample/langchain_agent.py
+++ b/examples/notebooks/langchain_sample/langchain_agent.py
@@ -17,12 +17,12 @@ import os
 from langchain import hub
 from langchain.agents import AgentExecutor
 from langchain.agents import create_react_agent
-from langchain_community.tools.tavily_search import TavilySearchResults
 from langchain_nvidia_ai_endpoints import ChatNVIDIA
+from langchain_tavily import TavilySearch
 
 # Initialize a tool to search the web
 tavily_kwargs = {"max_results": 2, "api_key": os.getenv("TAVILY_API_KEY")}
-search = TavilySearchResults(**tavily_kwargs)
+search = TavilySearch(**tavily_kwargs)
 
 # Create a list of tools for the agent
 tools = [search]

--- a/examples/notebooks/launchables/GPU_Cluster_Sizing_with_NeMo_Agent_Toolkit.ipynb
+++ b/examples/notebooks/launchables/GPU_Cluster_Sizing_with_NeMo_Agent_Toolkit.ipynb
@@ -437,7 +437,7 @@
     "if os.path.exists(source_config):\n",
     "    print(\"Current configuration file content:\")\n",
     "    print(\"=\" * 50)\n",
-    "    with open(source_config, 'r') as f:\n",
+    "    with open(source_config) as f:\n",
     "        config_content = f.read()\n",
     "        print(config_content)\n",
     "    print(\"=\" * 50)\n",

--- a/packages/nvidia_nat_agno/src/nat/plugins/agno/tool_wrapper.py
+++ b/packages/nvidia_nat_agno/src/nat/plugins/agno/tool_wrapper.py
@@ -17,10 +17,9 @@ import asyncio
 import json
 import logging
 import textwrap
+from collections.abc import Awaitable
+from collections.abc import Callable
 from typing import Any
-from typing import Awaitable
-from typing import Callable
-from typing import List
 
 from agno.tools import tool
 
@@ -133,7 +132,7 @@ async def process_result(result: Any, name: str) -> str:
 
 def execute_agno_tool(name: str,
                       coroutine_fn: Callable[..., Awaitable[Any]],
-                      required_fields: List[str],
+                      required_fields: list[str],
                       loop: asyncio.AbstractEventLoop,
                       **kwargs: Any) -> Any:
     """
@@ -145,7 +144,7 @@ def execute_agno_tool(name: str,
         The name of the tool
     coroutine_fn : Callable
         The async function to invoke
-    required_fields : List[str]
+    required_fields : list[str]
         List of required fields for validation
     loop : asyncio.AbstractEventLoop
         The event loop to use for async execution

--- a/packages/nvidia_nat_data_flywheel/src/nat/plugins/data_flywheel/observability/utils/deserialize.py
+++ b/packages/nvidia_nat_data_flywheel/src/nat/plugins/data_flywheel/observability/utils/deserialize.py
@@ -34,7 +34,7 @@ def deserialize_span_attribute(value: dict[str, Any] | list[Any] | str) -> JSONV
         ValueError: If parsing fails
     """
     try:
-        if isinstance(value, (dict, list)):
+        if isinstance(value, dict | list):
             return value
         deserialized_attribute = json.loads(value)
         return deserialized_attribute

--- a/packages/nvidia_nat_data_flywheel/tests/observability/processor/trace_conversion/test_trace_adapter_registry.py
+++ b/packages/nvidia_nat_data_flywheel/tests/observability/processor/trace_conversion/test_trace_adapter_registry.py
@@ -611,10 +611,8 @@ class TestTraceAdapterRegistryEdgeCases:
     def test_complex_return_type_annotation(self):
         """Test registration with complex return type annotations."""
 
-        from typing import Optional
-
         @register_adapter(MockSourceTypeA)
-        def convert_with_optional(trace: TraceContainer) -> Optional[MockTargetType1]:
+        def convert_with_optional(trace: TraceContainer) -> MockTargetType1 | None:
             return MockTargetType1(target_id="test", converted_data={}, source_info="A")
 
         # Should register successfully

--- a/packages/nvidia_nat_langchain/pyproject.toml
+++ b/packages/nvidia_nat_langchain/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
   "langchain-milvus~=0.2.1",
   "langchain-nvidia-ai-endpoints~=0.3.17",
   "langchain-openai~=0.3.32",
+  "langchain-tavily~=0.2.11",
   "langgraph~=0.6.7",
 ]
 requires-python = ">=3.11,<3.14"

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tools/tavily_internet_search.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tools/tavily_internet_search.py
@@ -33,7 +33,7 @@ class TavilyInternetSearchToolConfig(FunctionBaseConfig, name="tavily_internet_s
 async def tavily_internet_search(tool_config: TavilyInternetSearchToolConfig, builder: Builder):
     import os
 
-    from langchain_community.tools import TavilySearchResults
+    from langchain_tavily import TavilySearch
 
     if not os.environ.get("TAVILY_API_KEY"):
         os.environ["TAVILY_API_KEY"] = tool_config.api_key
@@ -41,20 +41,24 @@ async def tavily_internet_search(tool_config: TavilyInternetSearchToolConfig, bu
     # Refer to create_customize_workflow.md for instructions of getting the API key
 
     async def _tavily_internet_search(question: str) -> str:
+        """This tool retrieves relevant contexts from web search (using Tavily) for the given question.
+
+        Args:
+            question (str): The question to be answered.
+
+        Returns:
+            str: The web search results.
+        """
         # Search the web and get the requested amount of results
-        tavily_search = TavilySearchResults(max_results=tool_config.max_results)
+        tavily_search = TavilySearch(max_results=tool_config.max_results)
         search_docs = await tavily_search.ainvoke({'query': question})
         # Format
         web_search_results = "\n\n---\n\n".join(
-            [f'<Document href="{doc["url"]}"/>\n{doc["content"]}\n</Document>' for doc in search_docs])
+            [f'<Document href="{doc["url"]}"/>\n{doc["content"]}\n</Document>' for doc in search_docs["results"]])
         return web_search_results
 
     # Create a Generic NAT tool that can be used with any supported LLM framework
     yield FunctionInfo.from_fn(
         _tavily_internet_search,
-        description=("""This tool retrieves relevant contexts from web search (using Tavily) for the given question.
-
-                        Args:
-                            question (str): The question to be answered.
-                    """),
+        description=_tavily_internet_search.__doc__,
     )

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_flow_handler.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_flow_handler.py
@@ -127,7 +127,7 @@ class MCPAuthenticationFlowHandler(ConsoleAuthenticationFlowHandler):
         try:
             token = await asyncio.wait_for(flow_state.future, timeout=timeout)
             logger.info("MCP authentication successful, token obtained")
-        except asyncio.TimeoutError as exc:
+        except TimeoutError as exc:
             logger.error("MCP authentication timed out")
             raise RuntimeError(f"MCP authentication timed out ({timeout} seconds). Please try again.") from exc
         finally:

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider.py
@@ -15,7 +15,7 @@
 
 import logging
 from collections.abc import Awaitable
-from typing import Callable
+from collections.abc import Callable
 from urllib.parse import urljoin
 from urllib.parse import urlparse
 

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client_base.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client_base.py
@@ -281,7 +281,7 @@ class MCPBaseClient(ABC):
             raise
 
     @mcp_exception_handler
-    async def get_tools(self) -> dict[str, "MCPToolClient"]:
+    async def get_tools(self) -> dict[str, MCPToolClient]:
         """
         Retrieve a dictionary of all tools served by the MCP server.
         Uses unauthenticated session for discovery.
@@ -546,7 +546,7 @@ class MCPToolClient:
 
     def __init__(self,
                  session: ClientSession,
-                 parent_client: "MCPBaseClient",
+                 parent_client: MCPBaseClient,
                  tool_name: str,
                  tool_description: str | None,
                  tool_input_schema: dict | None = None,
@@ -640,6 +640,6 @@ class MCPToolClient:
 
         except MCPError as e:
             format_mcp_error(e, include_traceback=False)
-            result_str = "MCPToolClient tool call failed: %s" % e.original_exception
+            result_str = f"MCPToolClient tool call failed: {e.original_exception}"
 
         return result_str

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/exception_handler.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/exception_handler.py
@@ -94,7 +94,7 @@ def extract_primary_exception(exceptions: list[Exception]) -> Exception:
     """
     # Prioritize connection errors
     for exc in exceptions:
-        if isinstance(exc, (httpx.ConnectError, ConnectionError)):
+        if isinstance(exc, httpx.ConnectError | ConnectionError):
             return exc
 
     # Then timeout errors

--- a/packages/nvidia_nat_opentelemetry/src/nat/plugins/opentelemetry/register.py
+++ b/packages/nvidia_nat_opentelemetry/src/nat/plugins/opentelemetry/register.py
@@ -49,7 +49,7 @@ async def langfuse_telemetry_exporter(config: LangfuseTelemetryExporter, builder
     if not secret_key or not public_key:
         raise ValueError("secret and public keys are required for langfuse")
 
-    credentials = f"{public_key}:{secret_key}".encode("utf-8")
+    credentials = f"{public_key}:{secret_key}".encode()
     auth_header = base64.b64encode(credentials).decode("utf-8")
     headers = {"Authorization": f"Basic {auth_header}"}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -311,6 +311,8 @@ select = [
   "I",
   # Enable partial pylint support
   "PL",
+  # Enable pyupgrade support
+  "UP"
 ]
 
 extend-ignore = [

--- a/src/nat/agent/base.py
+++ b/src/nat/agent/base.py
@@ -192,7 +192,7 @@ class BaseAgent(ABC):
                 await asyncio.sleep(sleep_time)
 
         # All retries exhausted, return error message
-        error_content = "Tool call failed after all retry attempts. Last error: %s" % str(last_exception)
+        error_content = f"Tool call failed after all retry attempts. Last error: {str(last_exception)}"
         logger.error("%s %s", AGENT_LOG_PREFIX, error_content, exc_info=True)
         return ToolMessage(name=tool.name, tool_call_id=tool.name, content=error_content, status="error")
 

--- a/src/nat/agent/rewoo_agent/register.py
+++ b/src/nat/agent/rewoo_agent/register.py
@@ -71,8 +71,8 @@ class ReWOOAgentWorkflowConfig(AgentBaseConfig, name="rewoo_agent"):
 
 @register_function(config_type=ReWOOAgentWorkflowConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def rewoo_agent_workflow(config: ReWOOAgentWorkflowConfig, builder: Builder):
-    from langchain.schema import BaseMessage
     from langchain_core.messages import trim_messages
+    from langchain_core.messages.base import BaseMessage
     from langchain_core.messages.human import HumanMessage
     from langchain_core.prompts import ChatPromptTemplate
     from langgraph.graph.state import CompiledStateGraph
@@ -154,6 +154,9 @@ async def rewoo_agent_workflow(config: ReWOOAgentWorkflowConfig, builder: Builde
             # get and return the output from the state
             state = ReWOOGraphState(**state)
             output_message = state.result.content
+            # Ensure output_message is a string
+            if isinstance(output_message, list | dict):
+                output_message = str(output_message)
             return ChatResponse.from_string(output_message)
 
         except Exception as ex:

--- a/src/nat/authentication/oauth2/oauth2_auth_code_flow_provider.py
+++ b/src/nat/authentication/oauth2/oauth2_auth_code_flow_provider.py
@@ -14,9 +14,9 @@
 # limitations under the License.
 
 import logging
+from collections.abc import Callable
+from datetime import UTC
 from datetime import datetime
-from datetime import timezone
-from typing import Callable
 
 import httpx
 from authlib.integrations.httpx_client import OAuth2Client as AuthlibOAuth2Client
@@ -52,8 +52,8 @@ class OAuth2AuthCodeFlowProvider(AuthProviderBase[OAuth2AuthCodeFlowProviderConf
             ) as client:
                 new_token_data = client.refresh_token(self.config.token_url, refresh_token=refresh_token)
 
-            expires_at_ts = new_token_data.get("expires_at")
-            new_expires_at = datetime.fromtimestamp(expires_at_ts, tz=timezone.utc) if expires_at_ts else None
+                expires_at_ts = new_token_data.get("expires_at")
+                new_expires_at = datetime.fromtimestamp(expires_at_ts, tz=UTC) if expires_at_ts else None
 
             new_auth_result = AuthResult(
                 credentials=[BearerTokenCred(token=SecretStr(new_token_data["access_token"]))],

--- a/src/nat/builder/builder.py
+++ b/src/nat/builder/builder.py
@@ -56,7 +56,7 @@ if typing.TYPE_CHECKING:
     from nat.experimental.test_time_compute.models.strategy_base import StrategyBase
 
 
-class UserManagerHolder():
+class UserManagerHolder:
 
     def __init__(self, context: Context) -> None:
         self._context = context

--- a/src/nat/builder/context.py
+++ b/src/nat/builder/context.py
@@ -40,12 +40,12 @@ from nat.utils.reactive.subject import Subject
 class Singleton(type):
 
     def __init__(cls, name, bases, dict):
-        super(Singleton, cls).__init__(name, bases, dict)
+        super().__init__(name, bases, dict)
         cls.instance = None
 
     def __call__(cls, *args, **kw):
         if cls.instance is None:
-            cls.instance = super(Singleton, cls).__call__(*args, **kw)
+            cls.instance = super().__call__(*args, **kw)
         return cls.instance
 
 

--- a/src/nat/builder/front_end.py
+++ b/src/nat/builder/front_end.py
@@ -37,7 +37,7 @@ class FrontEndBase(typing.Generic[FrontEndConfigT], ABC):
 
         super().__init__()
 
-        self._full_config: "Config" = full_config
+        self._full_config: Config = full_config
         self._front_end_config: FrontEndConfigT = typing.cast(FrontEndConfigT, full_config.general.front_end)
 
     @property

--- a/src/nat/cli/cli_utils/config_override.py
+++ b/src/nat/cli/cli_utils/config_override.py
@@ -84,7 +84,7 @@ class LayeredConfig:
                     if lower_value not in ['true', 'false']:
                         raise ValueError(f"Boolean value must be 'true' or 'false', got '{value}'")
                     value = lower_value == 'true'
-                elif isinstance(original_value, (int, float)):
+                elif isinstance(original_value, int | float):
                     value = type(original_value)(value)
                 elif isinstance(original_value, list):
                     value = [v.strip() for v in value.split(',')]

--- a/src/nat/cli/commands/mcp/mcp.py
+++ b/src/nat/cli/commands/mcp/mcp.py
@@ -443,7 +443,7 @@ async def ping_mcp_server(url: str,
         # Apply timeout to the entire ping operation
         return await asyncio.wait_for(_ping_operation(), timeout=timeout)
 
-    except asyncio.TimeoutError:
+    except TimeoutError:
         return MCPPingResult(url=url,
                              status="unhealthy",
                              response_time_ms=None,

--- a/src/nat/cli/commands/start.py
+++ b/src/nat/cli/commands/start.py
@@ -111,7 +111,7 @@ class StartCommandGroup(click.Group):
             elif (issubclass(decomposed_type.root, Path)):
                 param_type = click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path)
 
-            elif (issubclass(decomposed_type.root, (list, tuple, set))):
+            elif (issubclass(decomposed_type.root, list | tuple | set)):
                 if (len(decomposed_type.args) == 1):
                     inner = DecomposedType(decomposed_type.args[0])
                     # Support containers of Literal values -> multiple Choice

--- a/src/nat/cli/type_registry.py
+++ b/src/nat/cli/type_registry.py
@@ -992,7 +992,7 @@ class TypeRegistry:
             if (short_names[key.local_name] == 1):
                 type_list.append((key.local_name, key.config_type))
 
-        return typing.Union[tuple(typing.Annotated[x_type, Tag(x_id)] for x_id, x_type in type_list)]
+        return typing.Union[*tuple(typing.Annotated[x_type, Tag(x_id)] for x_id, x_type in type_list)]
 
     def compute_annotation(self, cls: type[TypedBaseModelT]):
 

--- a/src/nat/control_flow/router_agent/register.py
+++ b/src/nat/control_flow/router_agent/register.py
@@ -81,7 +81,7 @@ async def router_agent_workflow(config: RouterAgentWorkflowConfig, builder: Buil
             logger.exception("%s Router Agent failed with exception: %s", AGENT_LOG_PREFIX, ex)
             if config.verbose:
                 return str(ex)
-            return "Router agent failed with exception: %s" % ex
+            return f"Router agent failed with exception: {ex}"
 
     try:
         yield FunctionInfo.from_fn(_response_fn, description=config.description)

--- a/src/nat/data_models/api_server.py
+++ b/src/nat/data_models/api_server.py
@@ -273,7 +273,7 @@ class ChatResponse(ResponseBaseModelOutput):
         if model is None:
             model = ""
         if created is None:
-            created = datetime.datetime.now(datetime.timezone.utc)
+            created = datetime.datetime.now(datetime.UTC)
 
         return ChatResponse(id=id_,
                             object=object_,
@@ -317,7 +317,7 @@ class ChatResponseChunk(ResponseBaseModelOutput):
         if id_ is None:
             id_ = str(uuid.uuid4())
         if created is None:
-            created = datetime.datetime.now(datetime.timezone.utc)
+            created = datetime.datetime.now(datetime.UTC)
         if model is None:
             model = ""
         if object_ is None:
@@ -343,7 +343,7 @@ class ChatResponseChunk(ResponseBaseModelOutput):
         if id_ is None:
             id_ = str(uuid.uuid4())
         if created is None:
-            created = datetime.datetime.now(datetime.timezone.utc)
+            created = datetime.datetime.now(datetime.UTC)
         if model is None:
             model = ""
 
@@ -485,7 +485,7 @@ class WebSocketUserMessage(BaseModel):
     security: Security = Security()
     error: Error = Error()
     schema_version: str = "1.0.0"
-    timestamp: str = str(datetime.datetime.now(datetime.timezone.utc))
+    timestamp: str = str(datetime.datetime.now(datetime.UTC))
 
 
 class WebSocketUserInteractionResponseMessage(BaseModel):
@@ -501,7 +501,7 @@ class WebSocketUserInteractionResponseMessage(BaseModel):
     security: Security = Security()
     error: Error = Error()
     schema_version: str = "1.0.0"
-    timestamp: str = str(datetime.datetime.now(datetime.timezone.utc))
+    timestamp: str = str(datetime.datetime.now(datetime.UTC))
 
 
 class SystemIntermediateStepContent(BaseModel):
@@ -527,7 +527,7 @@ class WebSocketSystemIntermediateStepMessage(BaseModel):
     conversation_id: str | None = None
     content: SystemIntermediateStepContent
     status: WebSocketMessageStatus
-    timestamp: str = str(datetime.datetime.now(datetime.timezone.utc))
+    timestamp: str = str(datetime.datetime.now(datetime.UTC))
 
 
 class SystemResponseContent(BaseModel):
@@ -551,7 +551,7 @@ class WebSocketSystemResponseTokenMessage(BaseModel):
     conversation_id: str | None = None
     content: SystemResponseContent | Error | GenerateResponse
     status: WebSocketMessageStatus
-    timestamp: str = str(datetime.datetime.now(datetime.timezone.utc))
+    timestamp: str = str(datetime.datetime.now(datetime.UTC))
 
     @field_validator("content")
     @classmethod
@@ -560,7 +560,7 @@ class WebSocketSystemResponseTokenMessage(BaseModel):
             raise ValueError(f"Field: content must be 'Error' when type is {WebSocketMessageType.ERROR_MESSAGE}")
 
         if info.data.get("type") == WebSocketMessageType.RESPONSE_MESSAGE and not isinstance(
-                value, (SystemResponseContent, GenerateResponse)):
+                value, SystemResponseContent | GenerateResponse):
             raise ValueError(
                 f"Field: content must be 'SystemResponseContent' when type is {WebSocketMessageType.RESPONSE_MESSAGE}")
         return value
@@ -582,7 +582,7 @@ class WebSocketSystemInteractionMessage(BaseModel):
     conversation_id: str | None = None
     content: HumanPrompt
     status: WebSocketMessageStatus
-    timestamp: str = str(datetime.datetime.now(datetime.timezone.utc))
+    timestamp: str = str(datetime.datetime.now(datetime.UTC))
 
 
 # ======== GenerateResponse Converters ========

--- a/src/nat/data_models/authentication.py
+++ b/src/nat/data_models/authentication.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 
 import typing
+from datetime import UTC
 from datetime import datetime
-from datetime import timezone
 from enum import Enum
 
 import httpx
@@ -166,13 +166,7 @@ class BearerTokenCred(_CredBase):
 
 
 Credential = typing.Annotated[
-    typing.Union[
-        HeaderCred,
-        QueryCred,
-        CookieCred,
-        BasicAuthCred,
-        BearerTokenCred,
-    ],
+    HeaderCred | QueryCred | CookieCred | BasicAuthCred | BearerTokenCred,
     Field(discriminator="kind"),
 ]
 
@@ -213,7 +207,7 @@ class AuthResult(BaseModel):
         """
         Checks if the authentication token has expired.
         """
-        return bool(self.token_expires_at and datetime.now(timezone.utc) >= self.token_expires_at)
+        return bool(self.token_expires_at and datetime.now(UTC) >= self.token_expires_at)
 
     def as_requests_kwargs(self) -> dict[str, typing.Any]:
         """

--- a/src/nat/data_models/dataset_handler.py
+++ b/src/nat/data_models/dataset_handler.py
@@ -80,7 +80,7 @@ class EvalDatasetJsonConfig(EvalDatasetBaseConfig, name="json"):
 
 
 def read_jsonl(file_path: FilePath):
-    with open(file_path, 'r', encoding='utf-8') as f:
+    with open(file_path, encoding='utf-8') as f:
         data = [json.loads(line) for line in f]
     return pd.DataFrame(data)
 

--- a/src/nat/eval/evaluator/base_evaluator.py
+++ b/src/nat/eval/evaluator/base_evaluator.py
@@ -71,7 +71,7 @@ class BaseEvaluator(ABC):
             TqdmPositionRegistry.release(tqdm_position)
 
         # Compute average if possible
-        numeric_scores = [item.score for item in output_items if isinstance(item.score, (int, float))]
+        numeric_scores = [item.score for item in output_items if isinstance(item.score, int | float)]
         avg_score = round(sum(numeric_scores) / len(numeric_scores), 2) if numeric_scores else None
 
         return EvalOutput(average_score=avg_score, eval_output_items=output_items)

--- a/src/nat/eval/swe_bench_evaluator/evaluate.py
+++ b/src/nat/eval/swe_bench_evaluator/evaluate.py
@@ -204,7 +204,7 @@ class SweBenchEvaluator:
         # if report file is not present, return empty EvalOutput
         avg_score = 0.0
         if report_file.exists():
-            with open(report_file, "r", encoding="utf-8") as f:
+            with open(report_file, encoding="utf-8") as f:
                 report = json.load(f)
                 resolved_instances = report.get("resolved_instances", 0)
                 total_instances = report.get("total_instances", 0)

--- a/src/nat/eval/tunable_rag_evaluator/evaluate.py
+++ b/src/nat/eval/tunable_rag_evaluator/evaluate.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging
-from typing import Callable
+from collections.abc import Callable
 
 from langchain.output_parsers import ResponseSchema
 from langchain.output_parsers import StructuredOutputParser

--- a/src/nat/experimental/decorators/experimental_warning_decorator.py
+++ b/src/nat/experimental/decorators/experimental_warning_decorator.py
@@ -137,8 +137,7 @@ def experimental(func: Any = None, *, feature_name: str | None = None, metadata:
         @functools.wraps(func)
         def sync_gen_wrapper(*args, **kwargs) -> Generator[Any, Any, Any]:
             issue_experimental_warning(function_name, feature_name, metadata)
-            for item in func(*args, **kwargs):
-                yield item  # yield the original item
+            yield from func(*args, **kwargs)  # yield the original item
 
         return sync_gen_wrapper
 

--- a/src/nat/experimental/test_time_compute/selection/llm_based_output_merging_selector.py
+++ b/src/nat/experimental/test_time_compute/selection/llm_based_output_merging_selector.py
@@ -71,7 +71,7 @@ class LLMBasedOutputMergingSelector(StrategyBase):
             raise ImportError("langchain-core is not installed. Please install it to use SingleShotMultiPlanPlanner.\n"
                               "This error can be resolved by installing nvidia-nat-langchain.")
 
-        from typing import Callable
+        from collections.abc import Callable
 
         from pydantic import BaseModel
 

--- a/src/nat/front_ends/console/authentication_flow_handler.py
+++ b/src/nat/front_ends/console/authentication_flow_handler.py
@@ -199,7 +199,7 @@ class ConsoleAuthenticationFlowHandler(FlowHandlerBase):
         # Wait for the redirect to land
         try:
             token = await asyncio.wait_for(flow_state.future, timeout=300)
-        except asyncio.TimeoutError as exc:
+        except TimeoutError as exc:
             raise RuntimeError("Authentication timed out (5 min).") from exc
         finally:
             async with self._server_lock:

--- a/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/src/nat/front_ends/console/console_front_end_plugin.py
@@ -88,7 +88,7 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         elif (self.front_end_config.input_file):
 
             # Run the workflow
-            with open(self.front_end_config.input_file, "r", encoding="utf-8") as f:
+            with open(self.front_end_config.input_file, encoding="utf-8") as f:
 
                 async with session_manager.workflow.run(f) as runner:
                     runner_outputs = await runner.result(to_type=str)

--- a/src/nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py
+++ b/src/nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py
@@ -130,7 +130,7 @@ class WebSocketAuthenticationFlowHandler(FlowHandlerBase):
                                                                         )
         try:
             token = await asyncio.wait_for(flow_state.future, timeout=300)
-        except asyncio.TimeoutError as exc:
+        except TimeoutError as exc:
             raise RuntimeError("Authentication flow timed out after 5 minutes.") from exc
         finally:
 

--- a/src/nat/front_ends/fastapi/job_store.py
+++ b/src/nat/front_ends/fastapi/job_store.py
@@ -370,7 +370,7 @@ class JobStore(DaskClientMixin):
                 # Convert BaseModel to JSON string for storage
                 output = output.model_dump_json(round_trip=True)
 
-            if isinstance(output, (dict, list)):
+            if isinstance(output, dict | list):
                 # Convert dict or list to JSON string for storage
                 output = json.dumps(output)
 
@@ -555,7 +555,7 @@ class JobStore(DaskClientMixin):
                         logger.exception("Failed to expire %s", job_id)
 
                 await session.execute(
-                    (update(JobInfo).where(JobInfo.job_id.in_(successfully_expired)).values(is_expired=True)))
+                    update(JobInfo).where(JobInfo.job_id.in_(successfully_expired)).values(is_expired=True))
 
 
 def get_db_engine(db_url: str | None = None, echo: bool = False, use_async: bool = True) -> "Engine | AsyncEngine":

--- a/src/nat/front_ends/fastapi/message_handler.py
+++ b/src/nat/front_ends/fastapi/message_handler.py
@@ -105,10 +105,10 @@ class WebSocketMessageHandler:
                 if (isinstance(validated_message, WebSocketUserMessage)):
                     await self.process_workflow_request(validated_message)
 
-                elif isinstance(validated_message,
-                                (WebSocketSystemResponseTokenMessage,
-                                 WebSocketSystemIntermediateStepMessage,
-                                 WebSocketSystemInteractionMessage)):
+                elif isinstance(
+                        validated_message,
+                        WebSocketSystemResponseTokenMessage | WebSocketSystemIntermediateStepMessage
+                        | WebSocketSystemInteractionMessage):
                     # These messages are already handled by self.create_websocket_message(data_model=value, …)
                     # No further processing is needed here.
                     pass

--- a/src/nat/front_ends/fastapi/message_validator.py
+++ b/src/nat/front_ends/fastapi/message_validator.py
@@ -139,7 +139,7 @@ class MessageValidator:
                     text_content: str = str(data_model.payload)
                 validated_message_content = SystemResponseContent(text=text_content)
 
-            elif (isinstance(data_model, (ChatResponse, ChatResponseChunk))):
+            elif (isinstance(data_model, ChatResponse | ChatResponseChunk)):
                 validated_message_content = SystemResponseContent(text=data_model.choices[0].message.content)
 
             elif (isinstance(data_model, ResponseIntermediateStep)):
@@ -204,7 +204,7 @@ class MessageValidator:
 
         validated_message_type: str = ""
         try:
-            if (isinstance(data_model, (ResponsePayloadOutput, ChatResponse, ChatResponseChunk))):
+            if (isinstance(data_model, ResponsePayloadOutput | ChatResponse | ChatResponseChunk)):
                 validated_message_type = WebSocketMessageType.RESPONSE_MESSAGE
 
             elif (isinstance(data_model, ResponseIntermediateStep)):
@@ -241,7 +241,7 @@ class MessageValidator:
         content: SystemResponseContent
         | Error = SystemResponseContent(),
         status: WebSocketMessageStatus = WebSocketMessageStatus.IN_PROGRESS,
-        timestamp: str = str(datetime.datetime.now(datetime.timezone.utc))
+        timestamp: str = str(datetime.datetime.now(datetime.UTC))
     ) -> WebSocketSystemResponseTokenMessage | None:
         """
         Creates a system response token message with default values.
@@ -280,7 +280,7 @@ class MessageValidator:
         conversation_id: str | None = None,
         content: SystemIntermediateStepContent = SystemIntermediateStepContent(name="default", payload="default"),
         status: WebSocketMessageStatus = WebSocketMessageStatus.IN_PROGRESS,
-        timestamp: str = str(datetime.datetime.now(datetime.timezone.utc))
+        timestamp: str = str(datetime.datetime.now(datetime.UTC))
     ) -> WebSocketSystemIntermediateStepMessage | None:
         """
         Creates a system intermediate step message with default values.
@@ -320,7 +320,7 @@ class MessageValidator:
         conversation_id: str | None = None,
         content: HumanPrompt,
         status: WebSocketMessageStatus = WebSocketMessageStatus.IN_PROGRESS,
-        timestamp: str = str(datetime.datetime.now(datetime.timezone.utc))
+        timestamp: str = str(datetime.datetime.now(datetime.UTC))
     ) -> WebSocketSystemInteractionMessage | None:
         """
         Creates a system interaction message with default values.

--- a/src/nat/front_ends/mcp/tool_converter.py
+++ b/src/nat/front_ends/mcp/tool_converter.py
@@ -175,7 +175,7 @@ def create_function_wrapper(
                 # Handle different result types for proper formatting
                 if isinstance(result, str):
                     return result
-                if isinstance(result, (dict, list)):
+                if isinstance(result, dict | list):
                     return json.dumps(result, default=str)
                 return str(result)
             except Exception as e:

--- a/src/nat/llm/utils/thinking.py
+++ b/src/nat/llm/utils/thinking.py
@@ -19,10 +19,10 @@ import logging
 import types
 from abc import abstractmethod
 from collections.abc import AsyncGenerator
+from collections.abc import Callable
 from collections.abc import Iterable
 from dataclasses import dataclass
 from typing import Any
-from typing import Callable
 from typing import TypeVar
 
 ModelType = TypeVar("ModelType")

--- a/src/nat/observability/exporter/base_exporter.py
+++ b/src/nat/observability/exporter/base_exporter.py
@@ -372,7 +372,7 @@ class BaseExporter(Exporter):
         try:
             # Wait for all tasks to complete with a timeout
             await asyncio.wait_for(asyncio.gather(*self._tasks, return_exceptions=True), timeout=timeout)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             logger.warning("%s: Some tasks did not complete within %s seconds", self.name, timeout)
         except Exception as e:
             logger.exception("%s: Error while waiting for tasks: %s", self.name, e)

--- a/src/nat/observability/exporter/span_exporter.py
+++ b/src/nat/observability/exporter/span_exporter.py
@@ -252,7 +252,7 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
 
         end_metadata = event.payload.metadata or {}
 
-        if not isinstance(end_metadata, (dict, TraceMetadata)):
+        if not isinstance(end_metadata, dict | TraceMetadata):
             logger.warning("Invalid metadata type for step %s", event.UUID)
             return
 

--- a/src/nat/observability/exporter_manager.py
+++ b/src/nat/observability/exporter_manager.py
@@ -184,7 +184,7 @@ class ExporterManager:
             try:
                 await asyncio.wait_for(asyncio.gather(*cleanup_tasks, return_exceptions=True),
                                        timeout=self._shutdown_timeout)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning("Some isolated exporters did not clean up within timeout")
 
         self._active_isolated_exporters.clear()
@@ -301,7 +301,7 @@ class ExporterManager:
             try:
                 task.cancel()
                 await asyncio.wait_for(task, timeout=self._shutdown_timeout)
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning("Exporter '%s' task did not shut down in time and may be stuck.", name)
                 stuck_tasks.append(name)
             except asyncio.CancelledError:

--- a/src/nat/observability/processor/batching_processor.py
+++ b/src/nat/observability/processor/batching_processor.py
@@ -241,7 +241,7 @@ class BatchingProcessor(CallbackProcessor[T, list[T]], Generic[T]):
             try:
                 await asyncio.wait_for(self._shutdown_complete_event.wait(), timeout=self._shutdown_timeout)
                 logger.debug("Shutdown completion detected via event")
-            except asyncio.TimeoutError:
+            except TimeoutError:
                 logger.warning("Shutdown completion timeout exceeded (%s seconds)", self._shutdown_timeout)
             return
 

--- a/src/nat/profiler/decorators/function_tracking.py
+++ b/src/nat/profiler/decorators/function_tracking.py
@@ -40,10 +40,10 @@ def _serialize_data(obj: Any) -> Any:
 
     if isinstance(obj, dict):
         return {str(k): _serialize_data(v) for k, v in obj.items()}
-    if isinstance(obj, (list, tuple, set)):
+    if isinstance(obj, list | tuple | set):
         return [_serialize_data(item) for item in obj]
 
-    if isinstance(obj, (str, int, float, bool, type(None))):
+    if isinstance(obj, str | int | float | bool | type(None)):
         return obj
 
     # Fallback

--- a/src/nat/profiler/parameter_optimization/parameter_selection.py
+++ b/src/nat/profiler/parameter_optimization/parameter_selection.py
@@ -13,8 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Optional
-from typing import Sequence
+from collections.abc import Sequence
 
 import numpy as np
 import optuna
@@ -41,8 +40,8 @@ def pick_trial(
     study: Study,
     mode: str = "harmonic",
     *,
-    weights: Optional[Sequence[float]] = None,
-    ref_point: Optional[Sequence[float]] = None,
+    weights: Sequence[float] | None = None,
+    ref_point: Sequence[float] | None = None,
     eps: float = 1e-12,
 ) -> optuna.trial.FrozenTrial:
     """

--- a/src/nat/profiler/parameter_optimization/pareto_visualizer.py
+++ b/src/nat/profiler/parameter_optimization/pareto_visualizer.py
@@ -324,7 +324,7 @@ def create_pareto_visualization(data_source: optuna.Study | Path | pd.DataFrame,
     if hasattr(data_source, 'trials_dataframe'):
         # Optuna study object
         trials_df, pareto_trials_df = load_trials_from_study(data_source)
-    elif isinstance(data_source, (str, Path)):
+    elif isinstance(data_source, str | Path):
         # CSV file path
         trials_df, pareto_trials_df = load_trials_from_csv(Path(data_source), metric_names, directions)
     elif isinstance(data_source, pd.DataFrame):

--- a/src/nat/retriever/milvus/retriever.py
+++ b/src/nat/retriever/milvus/retriever.py
@@ -214,7 +214,7 @@ def _wrap_milvus_results(res: list[Hit], content_field: str):
 
 
 def _wrap_milvus_single_results(res: Hit | dict, content_field: str) -> Document:
-    if not isinstance(res, (Hit, dict)):
+    if not isinstance(res, Hit | dict):
         raise ValueError(f"Milvus search returned object of type {type(res)}. Expected 'Hit' or 'dict'.")
 
     if isinstance(res, Hit):

--- a/src/nat/settings/global_settings.py
+++ b/src/nat/settings/global_settings.py
@@ -124,7 +124,7 @@ class Settings(HashableBaseModel):
                 if (short_names[key.local_name] == 1):
                     type_list.append((key.local_name, key.config_type))
 
-            return typing.Union[tuple(typing.Annotated[x_type, Tag(x_id)] for x_id, x_type in type_list)]
+            return typing.Union[*tuple(typing.Annotated[x_type, Tag(x_id)] for x_id, x_type in type_list)]
 
         RegistryHandlerAnnotation = dict[
             str,
@@ -169,7 +169,7 @@ class Settings(HashableBaseModel):
         if (not os.path.exists(configuration_file)):
             loaded_config = {}
         else:
-            with open(file_path, mode="r", encoding="utf-8") as f:
+            with open(file_path, encoding="utf-8") as f:
                 try:
                     loaded_config = json.load(f)
                 except Exception as e:

--- a/src/nat/tool/code_execution/local_sandbox/local_sandbox_server.py
+++ b/src/nat/tool/code_execution/local_sandbox/local_sandbox_server.py
@@ -62,7 +62,7 @@ class CodeExecutionResponse(Response):
         super().__init__(status=status_code, mimetype="application/json", response=result.model_dump_json())
 
     @classmethod
-    def with_error(cls, status_code: int, error_message: str) -> 'CodeExecutionResponse':
+    def with_error(cls, status_code: int, error_message: str) -> CodeExecutionResponse:
         return cls(status_code,
                    CodeExecutionResult(process_status=CodeExecutionStatus.ERROR, stdout="", stderr=error_message))
 

--- a/src/nat/tool/datetime_tools.py
+++ b/src/nat/tool/datetime_tools.py
@@ -72,7 +72,7 @@ async def current_datetime(_config: CurrentTimeToolConfig, _builder: Builder):
         timezone_obj = _get_timezone_obj(headers)
 
         now = datetime.datetime.now(timezone_obj)
-        now_machine_readable = now.strftime(("%Y-%m-%d %H:%M:%S %z"))
+        now_machine_readable = now.strftime("%Y-%m-%d %H:%M:%S %z")
 
         # Returns the current time in machine readable format with timezone offset.
         return f"The current time of day is {now_machine_readable}"

--- a/src/nat/utils/data_models/schema_validator.py
+++ b/src/nat/utils/data_models/schema_validator.py
@@ -52,7 +52,7 @@ def validate_yaml(ctx, param, value):
     if value is None:
         return None
 
-    with open(value, 'r', encoding="utf-8") as f:
+    with open(value, encoding="utf-8") as f:
         yaml.safe_load(f)
 
     return value

--- a/src/nat/utils/exception_handlers/automatic_retries.py
+++ b/src/nat/utils/exception_handlers/automatic_retries.py
@@ -310,7 +310,7 @@ def patch_with_retry(
         descriptor = inspect.getattr_static(cls, name)
 
         # Skip dunders, privates and all descriptors we must not wrap
-        if (name.startswith("_") or isinstance(descriptor, (property, staticmethod, classmethod))):
+        if (name.startswith("_") or isinstance(descriptor, property | staticmethod | classmethod)):
             continue
 
         original = descriptor.__func__ if isinstance(descriptor, types.MethodType) else descriptor

--- a/src/nat/utils/io/yaml_tools.py
+++ b/src/nat/utils/io/yaml_tools.py
@@ -57,7 +57,7 @@ def yaml_load(config_path: StrPath) -> dict:
     """
 
     # Read YAML file
-    with open(config_path, "r", encoding="utf-8") as stream:
+    with open(config_path, encoding="utf-8") as stream:
         config_str = stream.read()
 
     return yaml_loads(config_str)

--- a/src/nat/utils/type_utils.py
+++ b/src/nat/utils/type_utils.py
@@ -250,7 +250,7 @@ class DecomposedType:
         remaining_args = tuple(arg for arg in self.args if arg is not types.NoneType)
 
         if (len(remaining_args) > 1):
-            return DecomposedType(typing.Union[remaining_args])
+            return DecomposedType(typing.Union[*remaining_args])
         if (len(remaining_args) == 1):
             return DecomposedType(remaining_args[0])
 

--- a/tests/nat/authentication/test_data_models.py
+++ b/tests/nat/authentication/test_data_models.py
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
-from datetime import timezone
 
 import pytest
 from pydantic import TypeAdapter
@@ -207,7 +207,7 @@ def test_is_expired(delta, expected):
     if delta is None:
         res = AuthResult(credentials=[])
     else:
-        expires = datetime.now(timezone.utc) + timedelta(seconds=delta)
+        expires = datetime.now(UTC) + timedelta(seconds=delta)
         res = AuthResult(credentials=[], token_expires_at=expires)
     assert res.is_expired() is expected
 

--- a/tests/nat/authentication/test_oauth_exchanger.py
+++ b/tests/nat/authentication/test_oauth_exchanger.py
@@ -13,11 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Awaitable
+from collections.abc import Callable
+from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
-from datetime import timezone
-from typing import Awaitable
-from typing import Callable
 
 import pytest
 
@@ -100,7 +100,7 @@ async def test_authenticate_success(monkeypatch, cfg):
         assert flow is AuthFlowType.OAUTH2_AUTHORIZATION_CODE
         return _bearer_ctx(
             token="tok",
-            expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+            expires_at=datetime.now(UTC) + timedelta(minutes=10),
         )
 
     _patch_context(monkeypatch, cb)
@@ -125,7 +125,7 @@ async def test_authenticate_caches(monkeypatch, cfg):
         calls["n"] += 1
         return _bearer_ctx(
             token="tok",
-            expires_at=datetime.now(timezone.utc) + timedelta(minutes=10),
+            expires_at=datetime.now(UTC) + timedelta(minutes=10),
         )
 
     _patch_context(monkeypatch, cb)
@@ -141,7 +141,7 @@ async def test_authenticate_caches(monkeypatch, cfg):
 # 4. Token refresh succeeds
 # --------------------------------------------------------------------------- #
 async def test_refresh_expired_token(monkeypatch, cfg):
-    future_ts = int((datetime.now(timezone.utc) + timedelta(minutes=20)).timestamp())
+    future_ts = int((datetime.now(UTC) + timedelta(minutes=20)).timestamp())
 
     class _DummyAuthlibClient:
 
@@ -172,7 +172,7 @@ async def test_refresh_expired_token(monkeypatch, cfg):
     _patch_context(monkeypatch, fail_cb)
 
     client = OAuth2AuthCodeFlowProvider(cfg)
-    past = datetime.now(timezone.utc) - timedelta(seconds=1)
+    past = datetime.now(UTC) - timedelta(seconds=1)
     client._authenticated_tokens["bob"] = AuthResult(
         credentials=[BearerTokenCred(token="stale")],  # type: ignore[arg-type]
         token_expires_at=past,
@@ -215,13 +215,13 @@ async def test_refresh_fallback_to_callback(monkeypatch, cfg):
         hits["n"] += 1
         return _bearer_ctx(
             token="fallbackTok",
-            expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+            expires_at=datetime.now(UTC) + timedelta(minutes=5),
         )
 
     _patch_context(monkeypatch, cb)
 
     client = OAuth2AuthCodeFlowProvider(cfg)
-    past = datetime.now(timezone.utc) - timedelta(minutes=1)
+    past = datetime.now(UTC) - timedelta(minutes=1)
     client._authenticated_tokens["eve"] = AuthResult(
         credentials=[BearerTokenCred(token="old")],  # type: ignore[arg-type]
         token_expires_at=past,

--- a/tests/nat/cli/commands/mcp/test_mcp_cli.py
+++ b/tests/nat/cli/commands/mcp/test_mcp_cli.py
@@ -513,7 +513,7 @@ def test_ping_mcp_server_timeout(monkeypatch, transport):
         except Exception:
             pass
         # Simulate asyncio.wait_for timing out
-        raise asyncio.TimeoutError
+        raise TimeoutError
 
     monkeypatch.setattr("nat.cli.commands.mcp.mcp.asyncio.wait_for", _raise_timeout)
     res = asyncio.run(ping_mcp_server(url="http://u", timeout=0, transport=transport))

--- a/tests/nat/data_models/test_common.py
+++ b/tests/nat/data_models/test_common.py
@@ -50,7 +50,7 @@ def test_hashable_base_model_write_json_schema(tmp_path: Path):
     assert schema_path.exists()
     assert schema_path.is_file()
 
-    with open(schema_path, "r", encoding="utf-8") as f:
+    with open(schema_path, encoding="utf-8") as f:
         schema = json.load(f)
         assert schema == ԊashableTĕstModel.generate_json_schema()
 

--- a/tests/nat/eval/dataset_handler/test_dataset_handler.py
+++ b/tests/nat/eval/dataset_handler/test_dataset_handler.py
@@ -224,7 +224,7 @@ def sample_custom_parser(file_path: Path, difficulty: str = "") -> EvalInput:
     """
     Test implementation of a custom dataset parser that:
     """
-    with open(file_path, 'r', encoding='utf-8') as f:
+    with open(file_path, encoding='utf-8') as f:
         data = json.load(f)
 
     # Extract questions array from the nested structure

--- a/tests/nat/eval/test_remote_evaluate.py
+++ b/tests/nat/eval/test_remote_evaluate.py
@@ -66,7 +66,7 @@ def stream_response_app(rag_eval_input, rag_streamed_intermediate_payloads):
 
         # Intermediate steps
         for line in rag_streamed_intermediate_payloads:
-            await resp.write(f"{line}\n".encode("utf-8"))
+            await resp.write(f"{line}\n".encode())
 
         await resp.write_eof()
         return resp
@@ -127,14 +127,14 @@ async def test_run_workflow_remote_single_with_invalid_intermediate_data(rag_eva
         await resp.prepare(request)
 
         # Valid final output
-        await resp.write(f"data: {json.dumps({'value': final_output})}\n\n".encode("utf-8"))
+        await resp.write(f"data: {json.dumps({'value': final_output})}\n\n".encode())
 
         # Malformed intermediate step (invalid JSON)
         await resp.write(b"intermediate_data: {not a valid json string}\n")
 
         # Malformed intermediate step (payload is not a stringified JSON)
         bad_payload = {"id": "xyz", "payload": {"event_type": "TOOL_START"}}
-        await resp.write(f"intermediate_data: {json.dumps(bad_payload)}\n".encode("utf-8"))
+        await resp.write(f"intermediate_data: {json.dumps(bad_payload)}\n".encode())
 
         await resp.write_eof()
         return resp

--- a/tests/nat/experimental/test_decorator.py
+++ b/tests/nat/experimental/test_decorator.py
@@ -74,8 +74,7 @@ def test_sync_generator_logs_and_yields(caplog):
 
     @experimental
     def gen(n):
-        for i in range(n):
-            yield i
+        yield from range(n)
 
     # iterate first time
     out = list(gen(3))

--- a/tests/nat/front_ends/auth_flow_handlers/mock_oauth2_server.py
+++ b/tests/nat/front_ends/auth_flow_handlers/mock_oauth2_server.py
@@ -21,9 +21,9 @@ import string
 import threading
 import time
 from dataclasses import dataclass
+from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
-from datetime import timezone
 
 import uvicorn
 from fastapi import FastAPI
@@ -206,7 +206,7 @@ class MockOAuth2Server:
                 redirect_uri=redirect_uri,
                 scope=scope,
                 state=state,
-                expires_at=(datetime.now(timezone.utc) + timedelta(minutes=10)).timestamp(),
+                expires_at=(datetime.now(UTC) + timedelta(minutes=10)).timestamp(),
                 code_challenge=code_challenge,
                 code_challenge_method=code_challenge_method,
             )
@@ -235,7 +235,7 @@ class MockOAuth2Server:
                 client_id=client_id,
                 scope=scope,
                 interval=interval,
-                expires_at=(datetime.now(timezone.utc) + timedelta(minutes=5)).timestamp(),
+                expires_at=(datetime.now(UTC) + timedelta(minutes=5)).timestamp(),
             )
             return {
                 "device_code": dc,

--- a/tests/nat/front_ends/fastapi/test_openai_compatibility.py
+++ b/tests/nat/front_ends/fastapi/test_openai_compatibility.py
@@ -166,7 +166,7 @@ def test_nat_chat_response_timestamp_serialization():
     import datetime
 
     # Create response with known timestamp
-    test_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+    test_time = datetime.datetime(2024, 1, 1, 12, 0, 0, tzinfo=datetime.UTC)
     response = ChatResponse.from_string("Hello", created=test_time)
 
     # Serialize to JSON

--- a/tests/nat/observability/exporter/test_file_exporter.py
+++ b/tests/nat/observability/exporter/test_file_exporter.py
@@ -163,7 +163,7 @@ class TestFileExporterFunctionality:
         await exporter.export_processed(test_string)
 
         # Verify file content
-        with open(temp_file, 'r', encoding='utf-8') as f:
+        with open(temp_file, encoding='utf-8') as f:
             content = f.read()
             assert content == test_string + '\n'
 
@@ -175,7 +175,7 @@ class TestFileExporterFunctionality:
         await exporter.export_processed(test_strings)
 
         # Verify file content
-        with open(temp_file, 'r', encoding='utf-8') as f:
+        with open(temp_file, encoding='utf-8') as f:
             lines = f.readlines()
             assert len(lines) == 2
             assert lines[0].strip() == test_strings[0]
@@ -189,7 +189,7 @@ class TestFileExporterFunctionality:
         await exporter.export_processed('{"line": 2}')
 
         # Verify file content
-        with open(temp_file, 'r', encoding='utf-8') as f:
+        with open(temp_file, encoding='utf-8') as f:
             lines = f.readlines()
             assert len(lines) == 2
             assert lines[0].strip() == '{"line": 1}'
@@ -200,7 +200,7 @@ class TestFileExporterFunctionality:
                                                         invalid_file_path):
         """Test error handling when file operations fail."""
         # Mock file operation to raise an exception
-        mock_aiofiles_open.side_effect = IOError("File write error")
+        mock_aiofiles_open.side_effect = OSError("File write error")
 
         exporter = FileExporter(context_state=mock_context_state,
                                 output_path=str(invalid_file_path),
@@ -303,7 +303,7 @@ class TestFileExporterEdgeCases:
         await exporter.export_processed('')
 
         # Verify file content
-        with open(temp_file, 'r', encoding='utf-8') as f:
+        with open(temp_file, encoding='utf-8') as f:
             content = f.read()
             assert content == '\n'
 
@@ -314,7 +314,7 @@ class TestFileExporterEdgeCases:
         await exporter.export_processed([])
 
         # Verify file is empty (no writes for empty list)
-        with open(temp_file, 'r', encoding='utf-8') as f:
+        with open(temp_file, encoding='utf-8') as f:
             content = f.read()
             assert content == ''
 
@@ -328,7 +328,7 @@ class TestFileExporterEdgeCases:
         await asyncio.gather(*tasks)
 
         # Verify all lines were written
-        with open(temp_file, 'r', encoding='utf-8') as f:
+        with open(temp_file, encoding='utf-8') as f:
             lines = f.readlines()
             assert len(lines) == 5
             # All lines should be valid (no corruption from concurrent writes)

--- a/tests/nat/observability/mixin/test_file_mixin.py
+++ b/tests/nat/observability/mixin/test_file_mixin.py
@@ -136,7 +136,7 @@ class TestFileExportMixin:
         await exporter.export_processed(test_data)
 
         # Verify the data was written to the file
-        async with aiofiles.open(output_path, mode='r') as f:
+        async with aiofiles.open(output_path) as f:
             content = await f.read()
 
         assert test_data + "\n" == content
@@ -152,7 +152,7 @@ class TestFileExportMixin:
         await exporter.export_processed(test_data)
 
         # Verify all strings were written to the file
-        async with aiofiles.open(output_path, mode='r') as f:
+        async with aiofiles.open(output_path) as f:
             content = await f.read()
 
         expected_content = "first line\nsecond line\nthird line\n"
@@ -169,7 +169,7 @@ class TestFileExportMixin:
         await exporter.export_processed(test_data)
 
         # Verify no content was written for empty list
-        async with aiofiles.open(output_path, mode='r') as f:
+        async with aiofiles.open(output_path) as f:
             content = await f.read()
 
         assert content == ""
@@ -187,7 +187,7 @@ class TestFileExportMixin:
         await exporter.export_processed(second_data)
 
         # Verify both writes were appended
-        async with aiofiles.open(output_path, mode='r') as f:
+        async with aiofiles.open(output_path) as f:
             content = await f.read()
 
         expected_content = "first write\nsecond write\n"
@@ -208,7 +208,7 @@ class TestFileExportMixin:
         await asyncio.gather(*tasks)
 
         # Verify all strings were written
-        async with aiofiles.open(output_path, mode='r') as f:
+        async with aiofiles.open(output_path) as f:
             content = await f.read()
 
         lines = content.strip().split('\n')
@@ -246,7 +246,7 @@ class TestFileExportMixin:
         await asyncio.gather(*tasks)
 
         # Verify all lines were written
-        async with aiofiles.open(output_path, mode='r') as f:
+        async with aiofiles.open(output_path) as f:
             content = await f.read()
 
         lines = content.strip().split('\n')
@@ -292,7 +292,7 @@ class TestFileExportMixin:
         await exporter.export_processed("string with\nnewlines")
 
         # Verify content was written (not counting lines due to embedded newlines)
-        async with aiofiles.open(output_path, mode='r') as f:
+        async with aiofiles.open(output_path) as f:
             content = await f.read()
 
         # Just verify all content is present in some form
@@ -316,7 +316,7 @@ class TestFileExportMixin:
         await exporter.export_processed(["", "", ""])  # list of empty strings
 
         # Verify the file content
-        async with aiofiles.open(output_path, mode='r') as f:
+        async with aiofiles.open(output_path) as f:
             content = await f.read()
 
         # Empty list should write nothing, single item should write one line + \n,
@@ -337,7 +337,7 @@ class TestFileExportMixin:
         await exporter.export_processed(large_list)
 
         # Verify all lines were written
-        async with aiofiles.open(output_path, mode='r') as f:
+        async with aiofiles.open(output_path) as f:
             content = await f.read()
 
         lines = content.strip().split('\n')

--- a/tests/nat/observability/mixin/test_type_introspection_mixin.py
+++ b/tests/nat/observability/mixin/test_type_introspection_mixin.py
@@ -417,11 +417,10 @@ class TestUnionTypes:
 
     def test_union_input_detection(self):
         """Test detection of union input types"""
-        from typing import Union
 
         class UnionInputClass(TypeIntrospectionMixin):
 
-            async def process(self, item: Union[str, int]) -> str:
+            async def process(self, item: str | int) -> str:
                 return str(item)
 
         instance = UnionInputClass()
@@ -433,11 +432,10 @@ class TestUnionTypes:
 
     def test_union_output_detection(self):
         """Test detection of union output types"""
-        from typing import Union
 
         class UnionOutputClass(TypeIntrospectionMixin):
 
-            async def process(self, item: str) -> Union[int, float]:
+            async def process(self, item: str) -> int | float:
                 return len(item) if len(item) > 5 else float(len(item))
 
         instance = UnionOutputClass()
@@ -484,13 +482,12 @@ class TestRecursiveTypeVarResolution:
 
     def test_deeply_nested_generics(self):
         """Test recursive resolution of deeply nested generic types"""
-        from typing import Optional
 
         NestedT = TypeVar('NestedT')
 
         class DeepGeneric(TypeIntrospectionMixin, Generic[NestedT]):
 
-            async def process(self, item: dict[str, list[Optional[NestedT]]]) -> list[dict[str, NestedT]]:
+            async def process(self, item: dict[str, list[NestedT | None]]) -> list[dict[str, NestedT]]:
                 # This is a test method, the implementation doesn't need to be perfect
                 return [{"result": val} for val in item.get("data", []) if val is not None]
 

--- a/tests/nat/observability/processor/test_batching_processor.py
+++ b/tests/nat/observability/processor/test_batching_processor.py
@@ -724,7 +724,7 @@ class TestBatchingProcessorIntegration:
         # Wait for background task to complete
         try:
             await asyncio.wait_for(background_task, timeout=1.0)
-        except asyncio.TimeoutError:
+        except TimeoutError:
             background_task.cancel()
 
         # Verify shutdown completed properly

--- a/tests/nat/profiler/decorators/test_function_tracking.py
+++ b/tests/nat/profiler/decorators/test_function_tracking.py
@@ -86,8 +86,7 @@ async def test_sync_generator(reactive_stream: Subject):
 
     @track_function
     def number_generator(n):
-        for i in range(n):
-            yield i
+        yield from range(n)
 
     nums = list(number_generator(3))
     assert nums == [0, 1, 2]
@@ -334,8 +333,7 @@ class TestTrackUnregisteredFunction:
 
         @track_unregistered_function
         def count_up_to(n: int) -> Generator[int, None, None]:
-            for i in range(n):
-                yield i
+            yield from range(n)
 
         results = list(count_up_to(3))
 

--- a/tests/nat/profiler/test_profiler.py
+++ b/tests/nat/profiler/test_profiler.py
@@ -224,7 +224,7 @@ async def test_average_workflow_runtime(minimal_eval_config):
     metrics_path = os.path.join(minimal_eval_config.general.output_dir, "inference_optimization.json")
     assert os.path.exists(metrics_path), "ProfilerRunner did not produce an simple_inference_metrics.json file."
 
-    with open(metrics_path, "r", encoding="utf-8") as f:
+    with open(metrics_path, encoding="utf-8") as f:
         metrics = json.load(f)
 
     # Grab the 90/95/99 intervals object for workflow run time
@@ -297,7 +297,7 @@ async def test_average_llm_latency(minimal_eval_config):
     metrics_path = os.path.join(minimal_eval_config.general.output_dir, "inference_optimization.json")
     assert os.path.exists(metrics_path), "ProfilerRunner did not produce an simple_inference_metrics.json file."
 
-    with open(metrics_path, "r", encoding="utf-8") as f:
+    with open(metrics_path, encoding="utf-8") as f:
         metrics = json.load(f)
 
     llm_stats = metrics["confidence_intervals"].get("llm_latency_confidence_intervals", {})

--- a/tests/nat/profiler/test_prompt_optimizer.py
+++ b/tests/nat/profiler/test_prompt_optimizer.py
@@ -175,7 +175,7 @@ async def test_optimize_prompts_happy_path_with_recombine(tmp_path: Path):
     assert ckpt_path.exists()
 
     # Final JSON structure contains our prompt param with [prompt, purpose]
-    with open(final_path, "r", encoding="utf-8") as f:
+    with open(final_path, encoding="utf-8") as f:
         best_prompts = json.load(f)
     assert "prompt_param" in best_prompts
     val = best_prompts["prompt_param"]

--- a/tests/nat/retriever/test_retrievers.py
+++ b/tests/nat/retriever/test_retrievers.py
@@ -104,7 +104,7 @@ class CustomMilvusClient:
             assert isinstance(output_fields, list)
             assert len(output_fields) > 0
         if timeout:
-            assert isinstance(timeout, (float, int))
+            assert isinstance(timeout, float | int)
         assert isinstance(search_params, dict)
         assert isinstance(anns_field, str)
         to_return = min(limit, 4)

--- a/tests/nat/server/test_unified_api_server.py
+++ b/tests/nat/server/test_unified_api_server.py
@@ -291,7 +291,7 @@ system_interaction_multiple_choice_dropdown_message = {
 @pytest.fixture(name="config")
 def server_config(restore_environ, file_path: str = "tests/nat/server/config.yml") -> BaseModel:
     data = None
-    with open(file_path, "r", encoding="utf-8") as file:
+    with open(file_path, encoding="utf-8") as file:
         data = yaml.safe_load(file)
 
     os.environ["NAT_CONFIG_FILE"] = file_path
@@ -461,12 +461,12 @@ async def test_invalid_websocket_message():
 nat_response_payload_output_test = ResponsePayloadOutput(payload="TEST")
 nat_chat_response_test = ChatResponse(id="default",
                                       object="default",
-                                      created=datetime.datetime.now(datetime.timezone.utc),
+                                      created=datetime.datetime.now(datetime.UTC),
                                       choices=[Choice(message=ChoiceMessage(), index=0)],
                                       usage=None)
 nat_chat_response_chunk_test = ChatResponseChunk(id="default",
                                                  choices=[Choice(message=ChoiceMessage(), index=0)],
-                                                 created=datetime.datetime.now(datetime.timezone.utc))
+                                                 created=datetime.datetime.now(datetime.UTC))
 nat_response_intermediate_step_test = ResponseIntermediateStep(id="default", name="default", payload="default")
 
 validated_response_data_models = [

--- a/tests/nat/utils/test_yaml_tools.py
+++ b/tests/nat/utils/test_yaml_tools.py
@@ -151,7 +151,7 @@ def test_yaml_dump():
         temp_file_path = temp_file.name
 
     try:
-        with open(temp_file_path, 'r', encoding='utf-8') as f:
+        with open(temp_file_path, encoding='utf-8') as f:
             content = f.read()
             assert "key1: value1" in content
             assert "key2: value2" in content

--- a/uv.lock
+++ b/uv.lock
@@ -3951,6 +3951,21 @@ wheels = [
 ]
 
 [[package]]
+name = "langchain-tavily"
+version = "0.2.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiohttp" },
+    { name = "langchain" },
+    { name = "langchain-core" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/17/bb/63ce4058684dddf525af3c8e5dcfab15c5f17515d20241ef6e726ac9e8b7/langchain_tavily-0.2.11.tar.gz", hash = "sha256:ab4f5d0f7fcb276a3905aef2e38c21a334b6cbfc86b405a3238fdc9c6eae1290", size = 22382, upload-time = "2025-07-25T17:26:33.41Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/5a/9326f125b4d3055a96200a5035016efe1aac46149cdafc7182e56710fcfe/langchain_tavily-0.2.11-py3-none-any.whl", hash = "sha256:358317c18fbb26500bca665301450e38945f1f4f6a6f4e06406c7674a76c8d5c", size = 26187, upload-time = "2025-07-25T17:26:32.324Z" },
+]
+
+[[package]]
 name = "langchain-text-splitters"
 version = "0.3.11"
 source = { registry = "https://pypi.org/simple" }
@@ -6350,6 +6365,7 @@ dependencies = [
     { name = "langchain-milvus" },
     { name = "langchain-nvidia-ai-endpoints" },
     { name = "langchain-openai" },
+    { name = "langchain-tavily" },
     { name = "langgraph" },
     { name = "nvidia-nat" },
 ]
@@ -6361,6 +6377,7 @@ requires-dist = [
     { name = "langchain-milvus", specifier = "~=0.2.1" },
     { name = "langchain-nvidia-ai-endpoints", specifier = "~=0.3.17" },
     { name = "langchain-openai", specifier = "~=0.3.32" },
+    { name = "langchain-tavily", specifier = "~=0.2.11" },
     { name = "langgraph", specifier = "~=0.6.7" },
     { name = "nvidia-nat", editable = "." },
 ]


### PR DESCRIPTION
## Description

This PR:
- Makes ReWOO more "type safe"
- Prefers `langchain-tavily` over `langchain_community.tools.tavily_search` (This was done because of deprecation warnings appearing)
- Adds more static checks to ruff (to ensure modern python practices are adhered to)
- Updates code based on added static checks

Some of the code added in #861 did not adhere to repository style guidelines (documentation, usage of deprecated `List`, `Dict`, `Tuple`).

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ReWOO agent: added structured types for evidence and plan steps to improve workflow clarity.

* **Refactor**
  * Modernized type syntax across the codebase (PEP 604/3.10+).
  * Unified timeout handling to use the built-in TimeoutError.
  * Simplified file reads by removing redundant explicit read-mode arguments.
  * Adjusted type-origin imports to modern stdlib locations.

* **Bug Fixes**
  * Standardized UTC time handling for timestamps.

* **Chores**
  * Added langchain-tavily dependency; enabled pyupgrade integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->