### PR TITLE
fix: ensure registration of adk demo functions; reduce warnings

### DIFF
--- a/examples/frameworks/adk_demo/src/nat_adk_demo/nat_time_mcp_tool.py
+++ b/examples/frameworks/adk_demo/src/nat_adk_demo/nat_time_mcp_tool.py
@@ -19,6 +19,7 @@ from collections.abc import AsyncIterator
 from zoneinfo import ZoneInfo
 
 from nat.builder.builder import Builder
+from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
 from nat.data_models.function import FunctionBaseConfig
@@ -30,7 +31,7 @@ class TimeMCPToolConfig(FunctionBaseConfig, name="get_city_time_tool"):
     """Configuration for the get_city_time tool."""
 
 
-@register_function(config_type=TimeMCPToolConfig)
+@register_function(config_type=TimeMCPToolConfig, framework_wrappers=[LLMFrameworkEnum.ADK])
 async def get_city_time(_config: TimeMCPToolConfig, _builder: Builder) -> AsyncIterator[FunctionInfo]:
     """
     Register a get_city_time(city: str) -> str tool for ADK.

--- a/examples/frameworks/adk_demo/src/nat_adk_demo/weather_update_tool.py
+++ b/examples/frameworks/adk_demo/src/nat_adk_demo/weather_update_tool.py
@@ -17,6 +17,7 @@
 from collections.abc import AsyncIterator
 
 from nat.builder.builder import Builder
+from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
 from nat.data_models.function import FunctionBaseConfig
@@ -26,7 +27,7 @@ class WeatherToolConfig(FunctionBaseConfig, name="weather_update"):
     pass
 
 
-@register_function(config_type=WeatherToolConfig)
+@register_function(config_type=WeatherToolConfig, framework_wrappers=[LLMFrameworkEnum.ADK])
 async def weather_update(_config: WeatherToolConfig, _builder: Builder) -> AsyncIterator[FunctionInfo]:
 
     async def _weather_update(city: str) -> str:


### PR DESCRIPTION
## Description
Updates the ADK Demo example to work.

* add missing registration imports
* exactly specify `framework_wrappers`

Closes nvbugs-5554110

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled ADK framework support in the demo: City Time and Weather Update tools are now registered for ADK, making them discoverable and usable in ADK-based workflows and integrations.
  * Improves out-of-the-box experience for ADK users running the examples by ensuring these tools are available without additional configuration.

* **Chores**
  * Updated tool registrations to target the ADK framework while keeping existing function behavior and signatures unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->