### PR TITLE
Fix problem with displaying MCP tools via the client CLI commands

### DIFF
--- a/src/nat/cli/commands/mcp/mcp.py
+++ b/src/nat/cli/commands/mcp/mcp.py
@@ -297,7 +297,7 @@ async def list_tools_via_function_group(
             if fn is not None:
                 tools.append(to_tool_entry(full, fn))
         else:
-            for full, fn in (await fns).items():
+            for full, fn in fns.items():
                 tools.append(to_tool_entry(full, fn))
 
     return tools


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Command was failing with the following exception -
```
nat mcp client tool list --url http://localhost:9901/mcp

None of PyTorch, TensorFlow >= 2.0, or Flax have been found. Models won't be available and only tokenizers, configuration and file/data utilities can be used.
2025-10-01 09:32:08,068 - nat.plugins.mcp.client_impl - INFO - Configured to use MCP server at streamable-http:http://localhost:9901/mcp
2025-10-01 09:32:08,332 - mcp.client.streamable_http - INFO - Received session ID: d37fbec957d8484caebf69a8767d5498
2025-10-01 09:32:08,336 - mcp.client.streamable_http - INFO - Negotiated protocol version: 2025-06-18
2025-10-01 09:32:08,453 - nat.builder.function_info - WARNING - Using provided input_schema for multi-argument function
2025-10-01 09:32:08,471 - nat.plugins.mcp.client_impl - INFO - Adding tool calculator_multiply to group
2025-10-01 09:32:08,497 - nat.builder.function_info - WARNING - Using provided input_schema for multi-argument function
2025-10-01 09:32:08,526 - nat.plugins.mcp.client_impl - INFO - Adding tool calculator_inequality to group
2025-10-01 09:32:08,540 - nat.builder.function_info - WARNING - Using provided input_schema for multi-argument function
2025-10-01 09:32:08,550 - nat.plugins.mcp.client_impl - INFO - Adding tool current_datetime to group
2025-10-01 09:32:08,572 - nat.builder.function_info - WARNING - Using provided input_schema for multi-argument function
2025-10-01 09:32:08,580 - nat.plugins.mcp.client_impl - INFO - Adding tool calculator_divide to group
2025-10-01 09:32:08,594 - nat.builder.function_info - WARNING - Using provided input_schema for multi-argument function
2025-10-01 09:32:08,608 - nat.plugins.mcp.client_impl - INFO - Adding tool calculator_subtract to group
2025-10-01 09:32:08,624 - nat.builder.function_info - WARNING - Using provided input_schema for multi-argument function
2025-10-01 09:32:08,630 - nat.plugins.mcp.client_impl - INFO - Adding tool react_agent to group
Traceback (most recent call last):
  File "/home/devcontainers/dev/forks/nat/.venv/bin/nat", line 10, in <module>
    sys.exit(run_cli())
             ~~~~~~~^^
  File "/home/devcontainers/dev/forks/nat/src/nat/cli/main.py", line 40, in run_cli
    cli(obj={}, auto_envvar_prefix='NAT', show_default=True, prog_name="nat")
    ~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/devcontainers/dev/forks/nat/.venv/lib/python3.13/site-packages/click/core.py", line 1442, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/devcontainers/dev/forks/nat/.venv/lib/python3.13/site-packages/click/core.py", line 1363, in main
    rv = self.invoke(ctx)
  File "/home/devcontainers/dev/forks/nat/.venv/lib/python3.13/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/devcontainers/dev/forks/nat/.venv/lib/python3.13/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/devcontainers/dev/forks/nat/.venv/lib/python3.13/site-packages/click/core.py", line 1830, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  [Previous line repeated 1 more time]
  File "/home/devcontainers/dev/forks/nat/.venv/lib/python3.13/site-packages/click/core.py", line 1226, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/devcontainers/dev/forks/nat/.venv/lib/python3.13/site-packages/click/core.py", line 794, in invoke
    return callback(*args, **kwargs)
  File "/home/devcontainers/dev/forks/nat/.venv/lib/python3.13/site-packages/click/decorators.py", line 34, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/home/devcontainers/dev/forks/nat/src/nat/cli/commands/mcp/mcp.py", line 574, in mcp_client_tool_list
    tools = asyncio.run(
        list_tools_via_function_group(command,
    ...<6 lines>...
                                      auth_user_id=auth_user_id,
                                      auth_scopes=auth_scopes_list))
  File "/home/devcontainers/dev/forks/nat/.venv/lib/python3.13/site-packages/nest_asyncio.py", line 30, in run
    return loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/devcontainers/dev/forks/nat/.venv/lib/python3.13/site-packages/nest_asyncio.py", line 98, in run_until_complete
    return f.result()
           ~~~~~~~~^^
  File "/home/devcontainers/.local/share/uv/python/cpython-3.13.1-linux-x86_64-gnu/lib/python3.13/asyncio/futures.py", line 199, in result
    raise self._exception.with_traceback(self._exception_tb)
  File "/home/devcontainers/.local/share/uv/python/cpython-3.13.1-linux-x86_64-gnu/lib/python3.13/asyncio/tasks.py", line 306, in __step_run_and_handle_result
    result = coro.throw(exc)
  File "/home/devcontainers/dev/forks/nat/src/nat/cli/commands/mcp/mcp.py", line 300, in list_tools_via_function_group
    for full, fn in (await fns).items():
                     ^^^^^^^^^
TypeError: object dict can't be used in 'await' expression
```

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added LiteLLM provider support across AGNO, CrewAI, LangChain, and LlamaIndex.
- Documentation
  - Quoted extras in install commands for better shell/Windows compatibility.
  - Added MCP Authentication guide; linked from MCP client/server and noted limitations.
  - Documented LiteLLM provider and configuration.
  - Expanded evaluation/profiling outputs description.
- Improvements
  - CLI now suppresses Transformers warnings.
- Examples
  - ADK demo tools registered for ADK framework; MCP and RAG examples updated with quoted installs.
- Chores
  - Nightly test summary now includes branch name and date.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->