### PR TITLE
Fix notebook link to install instructions

### DIFF
--- a/examples/notebooks/1_getting_started.ipynb
+++ b/examples/notebooks/1_getting_started.ipynb
@@ -18,7 +18,7 @@
     "Ensure you meet the following prerequisites:\n",
     "1. Git\n",
     "2. [uv](https://docs.astral.sh/uv/getting-started/installation/)\n",
-    "3. NeMo-Agent-Toolkit installed from source following [these instructions](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/release/1.3/docs/source/quick-start/installing.md#installation-from-source)\n"
+    "3. NeMo-Agent-Toolkit installed from source following [these instructions](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/main/docs/source/quick-start/installing.md#installation-from-source)\n"
    ]
   },
   {

--- a/examples/notebooks/1_getting_started.ipynb
+++ b/examples/notebooks/1_getting_started.ipynb
@@ -18,7 +18,7 @@
     "Ensure you meet the following prerequisites:\n",
     "1. Git\n",
     "2. [uv](https://docs.astral.sh/uv/getting-started/installation/)\n",
-    "3. NeMo-Agent-Toolkit installed from source following [these instructions](https://github.com/cdgamarose-nv/NeMo-Agent-Toolkit/tree/develop?tab=readme-ov-file#install-from-source)\n"
+    "3. NeMo-Agent-Toolkit installed from source following [these instructions](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/release/1.3/docs/source/quick-start/installing.md#installation-from-source)\n"
    ]
   },
   {


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the prerequisite installation link in the getting-started tutorial to the official NVIDIA NeMo installation guide.
  * Instructions now reflect the current source repository and install-from-source steps.
  * This change affects only the tutorial text; code cells are unchanged.
  * No behavioral or API changes; notebooks continue to run as before.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->