### PR TITLE
Add a note that the transport on the MCP client andMCP  server need to match

### DIFF
--- a/docs/source/workflows/mcp/mcp-client.md
+++ b/docs/source/workflows/mcp/mcp-client.md
@@ -262,6 +262,7 @@ nat mcp client tool list --transport stdio --command "python" --args "-m mcp_ser
 # For sse transport
 nat mcp client tool list --url http://localhost:9901/sse --transport sse
 ```
+For SSE transport, ensure the MCP server is started with the `--transport sse` flag. The transport type on the client and server needs to match for MCP communication to work. The default transport type is `streamable-http`.
 
 Sample output:
 ```text


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Documentation
  * Clarified MCP transport configuration in client workflow docs: when using Server-Sent Events (SSE), start the MCP server with the --transport sse flag, and ensure the client and server transport types match. Documented that the default transport is streamable-http, requiring an explicit override for SSE to ensure compatibility. This guidance is now included in the MCP client documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->