### PR TITLE
docs: add note about increasing file descriptor limit

### DIFF
--- a/docs/source/resources/contributing.md
+++ b/docs/source/resources/contributing.md
@@ -82,6 +82,12 @@ NeMo Agent toolkit is a Python library that doesn’t require a GPU to run the w
     source .venv/bin/activate
     uv sync --all-groups --all-extras
     ```
+   :::{note}
+   You may encounter `Too many open files (os error 24)`. This error occurs when your system’s file descriptor limit is too low.
+
+   You can fix it by increasing the limit before running the build.
+   On Linux and macOS you can issue `ulimit -n 4096` in your current shell to increase your open file limit to 4096.
+   :::
 
 1. Install and configure pre-commit hooks (optional these can also be run manually).
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Added a note in CONTRIBUTIONS.md mentioning that contributors
may need to run `ulimit -n 4096` when building with uv to
avoid "Too many open files (os error 24)" errors.

## Breaking Changes
None - this is an addition.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added an inline troubleshooting note to the setup instructions addressing the “Too many open files (os error 24)” issue and recommending increasing the file descriptor limit (example: ulimit -n 4096 on Linux/macOS) before building; the note is integrated into the primary setup flow.
* **Bug Fixes**
  * Fixed a minor typo in the command example, changing “ulmit” to “ulimit.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->