### PR TITLE
chore: additional workflow template cleanup

### DIFF
--- a/src/nat/cli/commands/workflow/templates/config.yml.j2
+++ b/src/nat/cli/commands/workflow/templates/config.yml.j2
@@ -1,15 +1,3 @@
-general:
-  logging:
-    console:
-      _type: console
-      level: WARN
-
-  front_end:
-    _type: fastapi
-
-  front_end:
-    _type: console
-
 functions:
   current_datetime:
     _type: current_datetime
@@ -27,4 +15,3 @@ workflow:
   _type: react_agent
   llm_name: nim_llm
   tool_names: [current_datetime, {{python_safe_workflow_name}}]
-  parse_agent_response_max_retries: 3

--- a/src/nat/cli/commands/workflow/templates/register.py.j2
+++ b/src/nat/cli/commands/workflow/templates/register.py.j2
@@ -1,4 +1,4 @@
 # flake8: noqa
 
 # Import the generated workflow function to trigger registration
-from {{package_name}} import {{ python_safe_workflow_name }}_function
+from .{{package_name}} import {{ python_safe_workflow_name }}_function

--- a/src/nat/cli/commands/workflow/templates/register.py.j2
+++ b/src/nat/cli/commands/workflow/templates/register.py.j2
@@ -1,4 +1,4 @@
 # flake8: noqa
 
 # Import the generated workflow function to trigger registration
-from {{package_name}} import {{ python_safe_workflow_name }}
+from {{package_name}} import {{ python_safe_workflow_name }}_function

--- a/src/nat/cli/commands/workflow/templates/workflow.py.j2
+++ b/src/nat/cli/commands/workflow/templates/workflow.py.j2
@@ -20,13 +20,31 @@ class {{ workflow_class_name }}(FunctionBaseConfig, name="{{ workflow_name }}"):
 
 @register_function(config_type={{ workflow_class_name }}, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def {{ python_safe_workflow_name }}_function(config: {{ workflow_class_name }}, builder: Builder):
+    """
+    Registers a function (addressable via `{{ workflow_name }}` in the configuration).
+    This registration ensures a static mapping of the function type, `{{ workflow_name }}`, to the `{{ workflow_class_name }}` configuration object.
 
+    Args:
+        config ({{ workflow_class_name }}): The configuration for the function.
+        builder (Builder): The builder object.
+
+    Returns:
+        FunctionInfo: The function info object for the function.
+    """
+
+    # Define the function that will be registered.
     async def _echo(text: str) -> str:
         """
-        This is the part where all the logic for the function goes.
+        Takes a text input and echos back with a pre-defined prefix.
+
+        Args:
+            text (str): The text to echo back.
+
+        Returns:
+            str: The text with the prefix.
         """
         return f"{config.prefix} {text}"
 
-    # This is the part where the function is registered. The description parameter is used to describe the function.
-    yield FunctionInfo.from_fn(
-        _echo, description="This is a function that takes an input and echos back with a pre-defined prefix.")
+    # The callable is wrapped in a FunctionInfo object.
+    # The description parameter is used to describe the function.
+    yield FunctionInfo.from_fn(_echo, description=_echo.__doc__)

--- a/src/nat/cli/commands/workflow/templates/workflow.py.j2
+++ b/src/nat/cli/commands/workflow/templates/workflow.py.j2
@@ -35,7 +35,7 @@ async def {{ python_safe_workflow_name }}_function(config: {{ workflow_class_nam
     # Define the function that will be registered.
     async def _echo(text: str) -> str:
         """
-        Takes a text input and echos back with a pre-defined prefix.
+        Takes a text input and echoes back with a pre-defined prefix.
 
         Args:
             text (str): The text to echo back.


### PR DESCRIPTION
## Description
Cleans up the default configuration + workflow template a little more

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None
- Refactor
  - Simplified generated workflow configuration by removing redundant logging and frontend blocks and a deprecated retry option.
  - Aligned workflow registration naming to a consistent convention.
- Documentation
  - Added comprehensive docstrings to the workflow and helper to improve clarity and editor hints.
- Chores
  - Cleaned up default config output to reduce noise and simplify generated templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->