### PR TITLE
fix: documentation CLI tree update

### DIFF
--- a/docs/source/reference/cli.md
+++ b/docs/source/reference/cli.md
@@ -36,6 +36,24 @@ nat
 ├── info
 │   ├── channels
 │   └── components
+├── mcp
+│   ├── client
+│   │   ├── ping
+│   │   └── tool
+│   │       ├── call
+│   │       └── list
+│   └── serve
+├── object-store
+│   ├── mysql
+│   │   ├── delete
+│   │   └── upload
+│   ├── redis
+│   │   ├── delete
+│   │   └── upload
+│   └── s3
+│       ├── delete
+│       └── upload
+├── optimize
 ├── registry
 │   ├── publish
 │   ├── pull
@@ -43,22 +61,18 @@ nat
 │   └── search
 ├── run
 ├── serve
+├── sizing
+│   └── calc
 ├── start
 │   ├── console
 │   ├── fastapi
 │   └── mcp
-│       ├── serve
-│       └── client
-│           ├── ping
-│           └── tool
-│               ├── list
-│               └── call
 ├── uninstall
 ├── validate
 └── workflow
     ├── create
-    ├── reinstall
-    └── delete
+    ├── delete
+    └── reinstall
 ```
 
 ## Start


### PR DESCRIPTION
## Description
Update the CLI tree based on features since 1.2 release
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded CLI reference with new top-level groups: mcp (client, serve), object-store (mysql, redis, s3), and sizing (calc).
  * Reorganized structure: promoted sizing to top-level; removed nested serve/client subtree from Start workflow.
  * Adjusted Workflow ordering: “delete” now precedes “reinstall” under Reinstall/Delete.
  * Updated navigation and anchors for clarity and discoverability.
  * Content-only changes; no impact on command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->