### PR TITLE
fix: TTC must await get_function from builder

### DIFF
--- a/src/nat/experimental/test_time_compute/functions/execute_score_select_function.py
+++ b/src/nat/experimental/test_time_compute/functions/execute_score_select_function.py
@@ -46,7 +46,7 @@ async def execute_score_select_function(config: ExecuteScoreSelectFunctionConfig
 
     from pydantic import BaseModel
 
-    executable_fn: Function = builder.get_function(name=config.augmented_fn)
+    executable_fn: Function = await builder.get_function(name=config.augmented_fn)
 
     if config.scorer:
         scorer = await builder.get_ttc_strategy(strategy_name=config.scorer,

--- a/src/nat/experimental/test_time_compute/functions/ttc_tool_wrapper_function.py
+++ b/src/nat/experimental/test_time_compute/functions/ttc_tool_wrapper_function.py
@@ -98,8 +98,8 @@ async def register_ttc_tool_wrapper_function(
 
         augmented_function_desc = config.tool_description
 
-    fn_input_schema: BaseModel = augmented_function.input_schema
-    fn_output_schema: BaseModel = augmented_function.single_output_schema
+    fn_input_schema: type[BaseModel] = augmented_function.input_schema
+    fn_output_schema: type[BaseModel] | type[None] = augmented_function.single_output_schema
 
     runnable_llm = input_llm.with_structured_output(schema=fn_input_schema)
 


### PR DESCRIPTION
## Description

This fixes a coroutine missing await when running with TTC.

It also fixes the related type hints for input+output schema.

Closes nvbugs-5560791

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Improved reliability by ensuring function resolution is awaited before execution, reducing timing-related issues.

- Refactor
  - Transitioned a function retrieval step to asynchronous execution for smoother control flow.
  - Updated schema handling to use type-based definitions, improving compatibility with dynamic structured outputs.

- Chores
  - Internal typing adjustments to align with expected schema types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->