### PR TITLE
feat: Enable GFM-style Mermaid code blocks in Sphinx

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -141,7 +141,11 @@ set_type_checking_flag = True  # Enable 'expensive' imports for sphinx_autodoc_t
 nbsphinx_allow_errors = True  # Continue through Jupyter errors
 add_module_names = False  # Remove namespaces from class/method signatures
 myst_heading_anchors = 4  # Generate links for markdown headers
-copybutton_prompt_text = ">>> |$ |# "  # characters to be stripped from the copied text
+copybutton_prompt_text = ">>> |$ "  # characters to be stripped from the copied text
+
+# Allow GitHub-style mermaid fence code blocks to be used in markdown files
+# see https://myst-parser.readthedocs.io/en/latest/configuration.html
+myst_fence_as_directive = ["mermaid"]
 
 suppress_warnings = [
     "myst.header"  # Allow header increases from h2 to h4 (skipping h3)

--- a/docs/source/extend/telemetry-exporters.md
+++ b/docs/source/extend/telemetry-exporters.md
@@ -160,7 +160,7 @@ Telemetry exporters in NeMo Agent toolkit are responsible for:
 
 The flexible telemetry export system routes workflow events through different exporter types to various destinations:
 
-```{mermaid}
+```mermaid
 graph TD
     A[Workflow Events] --> B[Event Stream]
     B --> C[Telemetry Exporter]
@@ -182,7 +182,7 @@ graph TD
 
 NeMo Agent toolkit supports several types of exporters based on the data they handle:
 
-```{mermaid}
+```mermaid
 graph LR
     A["IntermediateStep"] --> B["Raw Exporter"]
     A --> C["Span Exporter"]

--- a/docs/source/reference/evaluate-api.md
+++ b/docs/source/reference/evaluate-api.md
@@ -23,7 +23,7 @@ It is recommended that the [Evaluating NeMo Agent toolkit Workflows](./evaluate.
 The evaluation endpoint can be used to start evaluation jobs on a remote NeMo Agent toolkit server. This endpoint is only available when the `async_endpoints` optional dependency extra is installed. For users installing from source, this can be done by running `uv pip install -e '.[async_endpoints]'` from the root directory of the NeMo Agent toolkit library. Similarly, for users installing from PyPI, this can be done by running `pip install "nvidia-nat[async_endpoints]"`.
 
 ## Evaluation Endpoint Overview
-```{mermaid}
+```mermaid
 graph TD
   A["POST /evaluate"] --> B["Background Job Created"]
   B --> C["GET /evaluate/job/{job_id}"]

--- a/docs/source/workflows/mcp/mcp-auth.md
+++ b/docs/source/workflows/mcp/mcp-auth.md
@@ -101,7 +101,7 @@ Set `CORPORATE_MCP_JIRA_URL` to your protected Jira MCP server URL, not the samp
 ### Running the Workflow in Single-User Mode (CLI)
 In this mode, the `default_user_id` is used for authentication during setup and for subsequent tool calls.
 
-```{mermaid}
+```mermaid
 flowchart LR
   U[User<br/>default-user-id] --> H[MCP Host<br/>NAT Workflow]
   H --> C[MCP Client<br/>default-user-id]
@@ -122,7 +122,7 @@ nat run --config_file examples/MCP/simple_auth_mcp/configs/config-mcp-auth-jira.
 ### Running the Workflow in Multi-User Mode (FastAPI)
 In this mode the workflow is served via a FastAPI frontend. Multiple users can access the workflow concurrently using a UI with `WebSocket` mode enabled.
 
-```{mermaid}
+```mermaid
 flowchart LR
   U0[User<br/>default-user-id] --> H2[MCP Host<br/>NAT Workflow]
   U1[User<br/>UI-User-1] --> H2


### PR DESCRIPTION
## Description

Configure Sphinx to support plain mermaid code blocks for documentation.

Advantages: renders cleanly in both GitHub and published documentation.
Disadvantages: none(?)


This PR also removes `# ` from the copybutton action because it essentially forces comments to be "uncommented" which can result in error. It has burned me more than once.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enabled GitHub-style Mermaid fences for more consistent diagram rendering.
  * Standardized Mermaid code blocks across docs for uniform formatting.
  * Improved “copy code” behavior by removing extraneous prompt characters from copied snippets.
  * Refreshed diagram layout in multi-user workflow for clearer visualization (no logic changes).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->