### PR TITLE
Silence several warnings being emitted by the tests

### DIFF
--- a/src/nat/builder/component_utils.py
+++ b/src/nat/builder/component_utils.py
@@ -153,7 +153,7 @@ def recursive_componentref_discovery(cls: TypedBaseModel, value: typing.Any,
         for v in value.values():
             yield from recursive_componentref_discovery(cls, v, decomposed_type.args[1])
     elif (issubclass(type(value), BaseModel)):
-        for field, field_info in value.model_fields.items():
+        for field, field_info in type(value).model_fields.items():
             field_data = getattr(value, field)
             yield from recursive_componentref_discovery(cls, field_data, field_info.annotation)
     if (decomposed_type.is_union):

--- a/tests/nat/builder/test_component_utils.py
+++ b/tests/nat/builder/test_component_utils.py
@@ -256,7 +256,7 @@ def test_recursive_componentref_discovery():
         expected_instance_id = generate_instance_id(instance_config)
 
         result_set = set()
-        for field_name, field_info in instance_config.model_fields.items():
+        for field_name, field_info in TestConfig.model_fields.items():
 
             for instance_id, value_node in recursive_componentref_discovery(
                     instance_config,

--- a/tests/nat/data_models/test_optimizable.py
+++ b/tests/nat/data_models/test_optimizable.py
@@ -71,7 +71,6 @@ class TestOptimizableField:
         class M(BaseModel):
             x: int = OptimizableField(5, space=space)
 
-        m = M()
         extras = dict(M.model_fields)["x"].json_schema_extra
         assert extras["optimizable"] is True
         assert extras["search_space"] is space
@@ -81,7 +80,6 @@ class TestOptimizableField:
         class M(BaseModel):
             x: int = OptimizableField(5)
 
-        m = M()
         extras = dict(M.model_fields)["x"].json_schema_extra
         assert extras["optimizable"] is True
         assert "search_space" not in extras
@@ -98,7 +96,6 @@ class TestOptimizableField:
                 },
             )
 
-        m = M()
         extras = dict(M.model_fields)["x"].json_schema_extra
         assert extras["optimizable"] is True
         assert extras["search_space"] is space
@@ -119,7 +116,6 @@ class TestOptimizableField:
                 },
             )
 
-        m = M()
         extras = dict(M.model_fields)["x"].json_schema_extra
         assert extras["optimizable"] is True
         assert extras["search_space"] is space
@@ -138,7 +134,6 @@ class TestOptimizableField:
                 },
             )
 
-        m = M()
         extras = dict(M.model_fields)["x"].json_schema_extra
         assert extras["optimizable"] is False
         assert extras["search_space"] == user_space

--- a/tests/nat/data_models/test_optimizable.py
+++ b/tests/nat/data_models/test_optimizable.py
@@ -72,7 +72,7 @@ class TestOptimizableField:
             x: int = OptimizableField(5, space=space)
 
         m = M()
-        extras = dict(m.model_fields)["x"].json_schema_extra
+        extras = dict(M.model_fields)["x"].json_schema_extra
         assert extras["optimizable"] is True
         assert extras["search_space"] is space
 
@@ -82,7 +82,7 @@ class TestOptimizableField:
             x: int = OptimizableField(5)
 
         m = M()
-        extras = dict(m.model_fields)["x"].json_schema_extra
+        extras = dict(M.model_fields)["x"].json_schema_extra
         assert extras["optimizable"] is True
         assert "search_space" not in extras
 
@@ -99,7 +99,7 @@ class TestOptimizableField:
             )
 
         m = M()
-        extras = dict(m.model_fields)["x"].json_schema_extra
+        extras = dict(M.model_fields)["x"].json_schema_extra
         assert extras["optimizable"] is True
         assert extras["search_space"] is space
         assert extras["note"] == "keep this"
@@ -120,7 +120,7 @@ class TestOptimizableField:
             )
 
         m = M()
-        extras = dict(m.model_fields)["x"].json_schema_extra
+        extras = dict(M.model_fields)["x"].json_schema_extra
         assert extras["optimizable"] is True
         assert extras["search_space"] is space
 
@@ -139,7 +139,7 @@ class TestOptimizableField:
             )
 
         m = M()
-        extras = dict(m.model_fields)["x"].json_schema_extra
+        extras = dict(M.model_fields)["x"].json_schema_extra
         assert extras["optimizable"] is False
         assert extras["search_space"] == user_space
 

--- a/tests/nat/mcp/test_mcp_auth_provider.py
+++ b/tests/nat/mcp/test_mcp_auth_provider.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 from unittest.mock import patch
 
 import pytest
@@ -108,7 +109,7 @@ class TestDiscoverOAuth2Endpoints:
         # Mock the protected resource metadata response
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
-            mock_resp.raise_for_status.return_value = None
+            mock_resp.raise_for_status = MagicMock(return_value=None)
             mock_resp.aread.return_value = b'{"authorization_servers": ["https://auth.example.com"]}'
             mock_client.return_value.__aenter__.return_value.get.return_value = mock_resp
 
@@ -224,7 +225,7 @@ class TestDynamicClientRegistration:
         # Mock the registration response
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
-            mock_resp.raise_for_status.return_value = None
+            mock_resp.raise_for_status = MagicMock(return_value=None)
             mock_resp.aread.return_value = b'{"client_id": "registered_client_id",\
             "client_secret": "registered_client_secret", "redirect_uris": ["https://example.com/callback"]}'
 
@@ -247,7 +248,7 @@ class TestDynamicClientRegistration:
 
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
-            mock_resp.raise_for_status.return_value = None
+            mock_resp.raise_for_status = MagicMock(return_value=None)
             mock_resp.aread.return_value = b'{"client_id": "registered_client_id", "redirect_uris": ["https://example.com/callback"]}'
             mock_client.return_value.__aenter__.return_value.post.return_value = mock_resp
 
@@ -265,7 +266,7 @@ class TestDynamicClientRegistration:
 
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
-            mock_resp.raise_for_status.return_value = None
+            mock_resp.raise_for_status = MagicMock(return_value=None)
             mock_resp.aread.return_value = b'invalid json'
             mock_client.return_value.__aenter__.return_value.post.return_value = mock_resp
 
@@ -278,7 +279,7 @@ class TestDynamicClientRegistration:
 
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
-            mock_resp.raise_for_status.return_value = None
+            mock_resp.raise_for_status = MagicMock(return_value=None)
             mock_resp.aread.return_value = b'{"client_secret": "secret", "redirect_uris": ["https://example.com/callback"]}'
             mock_client.return_value.__aenter__.return_value.post.return_value = mock_resp
 
@@ -435,7 +436,7 @@ class TestMCPOAuth2Provider:
 
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
-            mock_resp.raise_for_status.return_value = None
+            mock_resp.raise_for_status = MagicMock(return_value=None)
             mock_resp.aread.return_value = b'{"resource": "https://example.com/api", "authorization_servers": ["https://auth.example.com"]}'
             mock_client.return_value.__aenter__.return_value.get.return_value = mock_resp
 
@@ -449,7 +450,7 @@ class TestMCPOAuth2Provider:
 
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
-            mock_resp.raise_for_status.return_value = None
+            mock_resp.raise_for_status = MagicMock(return_value=None)
             mock_resp.aread.return_value = b'invalid json'
             mock_client.return_value.__aenter__.return_value.get.return_value = mock_resp
 
@@ -463,7 +464,7 @@ class TestMCPOAuth2Provider:
 
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
-            mock_resp.raise_for_status.return_value = None
+            mock_resp.raise_for_status = MagicMock(return_value=None)
             mock_resp.aread.return_value = b'{"resource": "https://example.com/api", "other_field": "value"}'
             mock_client.return_value.__aenter__.return_value.get.return_value = mock_resp
 
@@ -499,6 +500,7 @@ class TestMCPOAuth2Provider:
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
             mock_resp.status_code = 200
+            mock_resp.headers = {"content-type": "application/json"}
             mock_resp.aread.return_value = b'{"token_endpoint": "https://auth.example.com/token"}'
             mock_client.return_value.__aenter__.return_value.get.return_value = mock_resp
 
@@ -564,7 +566,7 @@ class TestMCPOAuth2Provider:
 
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
-            mock_resp.raise_for_status.return_value = None
+            mock_resp.raise_for_status = MagicMock(return_value=None)
             mock_resp.aread.return_value = b'{"client_id": "test_client_id", "client_secret": "test_secret",\
                 "redirect_uris": ["https://example.com/callback"]}'
 
@@ -582,7 +584,7 @@ class TestMCPOAuth2Provider:
 
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
-            mock_resp.raise_for_status.return_value = None
+            mock_resp.raise_for_status = MagicMock(return_value=None)
             mock_resp.aread.return_value = b'{"client_id": "test_client_id", "client_secret": "test_secret",\
                 "redirect_uris": ["https://example.com/callback"]}'
 

--- a/tests/nat/mcp/test_mcp_auth_provider.py
+++ b/tests/nat/mcp/test_mcp_auth_provider.py
@@ -515,6 +515,7 @@ class TestMCPOAuth2Provider:
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
             mock_resp.status_code = 200
+            mock_resp.headers = {"content-type": "application/json"}
             mock_resp.aread.return_value = b'{"authorization_endpoint": "https://auth.example.com/authorize"}'
             mock_client.return_value.__aenter__.return_value.get.return_value = mock_resp
 
@@ -529,6 +530,7 @@ class TestMCPOAuth2Provider:
         with patch("httpx.AsyncClient") as mock_client:
             mock_resp = AsyncMock()
             mock_resp.status_code = 200
+            mock_resp.headers = {"content-type": "application/json"}
             mock_resp.aread.return_value = b'invalid json'
             mock_client.return_value.__aenter__.return_value.get.return_value = mock_resp
 

--- a/tests/nat/mcp/test_mcp_token_storage.py
+++ b/tests/nat/mcp/test_mcp_token_storage.py
@@ -344,6 +344,7 @@ class TestTokenStorageIntegration:
                    ) as mock_provider_class:
             mock_instance = AsyncMock()
             mock_instance.authenticate = AsyncMock(return_value=sample_auth_result)
+            mock_instance._set_custom_auth_callback = MagicMock()
             mock_provider_class.return_value = mock_instance
 
             await provider._nat_oauth2_authenticate(user_id="test_user")


### PR DESCRIPTION
## Description
* When using `AyncMock` all attributes return another `AyncMock`, there were a few cases where a method was being called  on an AsyncMock that was expected to be blocking (yielding an `... was never awaited` warning). In these situations I explicitly set a blocking mock object.
* Use the `model_fields` attribute on the class not the instance, avoids Pydantic deprecation warning

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Improved component reference discovery by using class-level metadata for more consistent behavior. No API changes or user-facing differences expected.

- Tests
  - Updated tests to align with metadata handling changes.
  - Enhanced HTTP response mocks (including headers and status behavior) for more realistic scenarios.
  - Expanded authentication tests to cover callback setup in token flows.

- Chores
  - General reliability and consistency improvements, with no impact on existing workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->