### PR TITLE
fix: pin uvicorn to prevent nest_asyncio patch error

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "ragas~=0.2.14", # If you update ragas be sure to update github links in docs/source/workflows/evaluate.md as well
   "rich~=13.9",
   "tabulate~=0.9",
-  "uvicorn[standard]~=0.34",
+  "uvicorn[standard]<0.36", # need to limit version until nest_asyncio is resolved
   "wikipedia~=1.4",
 ]
 requires-python = ">=3.11,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -5978,7 +5978,7 @@ requires-dist = [
     { name = "rich", specifier = "~=13.9" },
     { name = "sqlalchemy", extras = ["asyncio"], marker = "extra == 'async-endpoints'", specifier = "~=2.0" },
     { name = "tabulate", specifier = "~=0.9" },
-    { name = "uvicorn", extras = ["standard"], specifier = "~=0.34" },
+    { name = "uvicorn", extras = ["standard"], specifier = "<0.36" },
     { name = "wikipedia", specifier = "~=1.4" },
 ]
 provides-extras = ["all", "adk", "agno", "crewai", "data-flywheel", "ingestion", "langchain", "llama-index", "mcp", "mem0ai", "opentelemetry", "phoenix", "profiling", "ragaai", "mysql", "redis", "s3", "semantic-kernel", "telemetry", "weave", "zep-cloud", "examples", "gunicorn", "async-endpoints", "nvidia-haystack", "litellm", "openai"]


### PR DESCRIPTION
## Description

`uvicorn` versions 0.36 and higher run into runtime errors due to `nest_asyncio`'s patching being out-of-date on Python >= 3.12

Pin `uvicorn` to a version that does not exhibit runtime errors

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the server runtime dependency uvicorn[standard] version constraint from ~=0.34 to <0.36.
  - Standardizes supported versions to reduce unexpected behavior during upgrades and improve deployment reliability.
  - No changes to application features or user interface.
  - All other dependencies remain unchanged, keeping build performance and size consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->