### PR TITLE
fix: add missing awaits for get_memory_client

### DIFF
--- a/src/nat/tool/memory_tools/add_memory_tool.py
+++ b/src/nat/tool/memory_tools/add_memory_tool.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class AddToolConfig(FunctionBaseConfig, name="add_memory"):
     """Function to add memory to a hosted memory platform."""
 
-    description: str = Field(default=("Tool to add memory about a user's interactions to a system "
+    description: str = Field(default=("Tool to add a memory about a user's interactions to a system "
                                       "for retrieval later."),
                              description="The description of this function's use for tool calling agents.")
     memory: MemoryRef = Field(default=MemoryRef("saas_memory"),

--- a/src/nat/tool/memory_tools/delete_memory_tool.py
+++ b/src/nat/tool/memory_tools/delete_memory_tool.py
@@ -30,8 +30,7 @@ logger = logging.getLogger(__name__)
 class DeleteToolConfig(FunctionBaseConfig, name="delete_memory"):
     """Function to delete memory from a hosted memory platform."""
 
-    description: str = Field(default=("Tool to retrieve memory about a user's "
-                                      "interactions to help answer questions in a personalized way."),
+    description: str = Field(default="Tool to delete a memory from a hosted memory platform.",
                              description="The description of this function's use for tool calling agents.")
     memory: MemoryRef = Field(default=MemoryRef("saas_memory"),
                               description=("Instance name of the memory client instance from the workflow "

--- a/src/nat/tool/memory_tools/get_memory_tool.py
+++ b/src/nat/tool/memory_tools/get_memory_tool.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 class GetToolConfig(FunctionBaseConfig, name="get_memory"):
     """Function to get memory to a hosted memory platform."""
 
-    description: str = Field(default=("Tool to retrieve memory about a user's "
+    description: str = Field(default=("Tool to retrieve a memory about a user's "
                                       "interactions to help answer questions in a personalized way."),
                              description="The description of this function's use for tool calling agents.")
     memory: MemoryRef = Field(default=MemoryRef("saas_memory"),


### PR DESCRIPTION
## Description

In a prior PR (#834), we unified the `async` interface across most builder patterns.

We missed await-ing `get_memory_client` in the built-in memory_tools.

Closes nvbugs-5563968

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None

- Bug Fixes
  - Fixed inconsistent default memory selection to prevent unexpected errors.
  - Resolved occasional failures when connecting to the memory service by ensuring proper asynchronous handling.

- Refactor
  - Standardized memory tool configuration for add, delete, and get operations to improve consistency and reliability.

- Documentation
  - Clarified descriptions for memory tools to improve user-facing text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->