### PR TITLE
Add ADK to TestLLM

### DIFF
--- a/packages/nvidia_nat_test/tests/test_test_llm.py
+++ b/packages/nvidia_nat_test/tests/test_test_llm.py
@@ -23,7 +23,10 @@ import pytest
 
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.workflow_builder import WorkflowBuilder
+from nat.data_models.component_ref import LLMRef
+from nat.plugins.adk.agent import ADKFunctionConfig
 from nat.runtime.loader import load_workflow
+from nat.test.llm import TestLLMConfig
 
 
 @pytest.fixture(autouse=True, scope="module")
@@ -396,3 +399,46 @@ async def test_builder_framework_cycle(wrapper: str, seq: list[str], test_llm_co
             pytest.skip(f"Unsupported wrapper: {wrapper}")
 
     assert outs == seq
+
+
+async def test_adk_function_integration_returns_deterministic_text():
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("main", TestLLMConfig(response_seq=["tool-free"], delay_ms=0))
+
+        # Build a NAT function that uses the ADK integration
+        fn_cfg = ADKFunctionConfig(
+            name="nat_adk_test_agent_fn",
+            description="ADK agent function test",
+            prompt="Always reply with a short word",
+            llm=LLMRef("main"),
+            tool_names=[],
+            workflow_alias="adk_agent",
+            user_id="nat",
+        )
+
+        function = await builder.add_function("adk_agent_fn", fn_cfg)
+        result = await function.ainvoke("hello")
+        assert result == "tool-free"
+
+
+async def test_adk_function_integration_multiple_invokes_cycle():
+    async with WorkflowBuilder() as builder:
+        await builder.add_llm("main", TestLLMConfig(response_seq=["A", "B"], delay_ms=0))
+
+        fn_cfg = ADKFunctionConfig(
+            name="nat_adk_test_agent_fn",
+            description="ADK agent function cycling test",
+            prompt="Respond",
+            llm=LLMRef("main"),
+            tool_names=[],
+            workflow_alias="adk_agent",
+            user_id="nat",
+        )
+
+        function = await builder.add_function("adk_agent_fn2", fn_cfg)
+        r1 = await function.ainvoke("first")
+        r2 = await function.ainvoke("second")
+        r3 = await function.ainvoke("third")
+        assert r1 == "A"
+        assert r2 == "B"
+        assert r3 == "A"


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes 

This is a small PR that adds the test_llm as a LLM Client for Google ADK, with related tests. Because in NAT we use ADK's LiteLLM, I did check what public functions/fields were implemented by LiteLLM and overrode them properly.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
