### PR TITLE
Ensure CI uses `--first-parent` when calling `git describe`

### DIFF
--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -24,12 +24,6 @@ WHEELS_DIR="${WHEELS_BASE_DIR}/nvidia-nat"
 
 create_env extra:all
 
-
-function get_git_tag() {
-    # Get the latest Git tag, sorted by version, excluding lightweight tags
-    git describe --tags --abbrev=0 2>/dev/null || echo "no-tag"
-}
-
 GIT_TAG=$(get_git_tag)
 rapids-logger "Git Version: ${GIT_TAG}"
 

--- a/ci/scripts/github/common.sh
+++ b/ci/scripts/github/common.sh
@@ -20,9 +20,13 @@ source ${SCRIPT_DIR}/common.sh
 
 install_rapids_gha_tools
 
-
 # Ensure the workspace tmp directory exists
 mkdir -p ${WORKSPACE_TMP}
 
 rapids-logger "Environment Variables"
 printenv | sort
+
+function get_git_tag() {
+    # Get the latest Git tag, sorted by version, excluding lightweight tags
+    git describe --first-parent --tags --abbrev=0 2>/dev/null || echo "no-tag"
+}

--- a/ci/scripts/github/tests.sh
+++ b/ci/scripts/github/tests.sh
@@ -24,7 +24,7 @@ mkdir -p ${REPORTS_DIR}
 get_lfs_files
 
 create_env group:dev extra:all
-rapids-logger "Git Version: $(git describe)"
+rapids-logger "Git Version: $(get_git_tag)"
 
 rapids-logger "Running tests with Python version $(python --version) and pytest version $(pytest --version) on $(arch)"
 set +e

--- a/ci/scripts/gitlab/common.sh
+++ b/ci/scripts/gitlab/common.sh
@@ -26,7 +26,7 @@ function get_git_tag() {
     FT=$(git fetch --all --tags)
 
     # Get the latest Git tag, sorted by version, excluding lightweight tags
-    GIT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "no-tag")
+    GIT_TAG=$(git describe --first-parent --tags --abbrev=0 2>/dev/null || echo "no-tag")
 
     if [[ "${CI_CRON_NIGHTLY}" == "1" ]]; then
         if [[ ${GIT_TAG} == "no-tag" ]]; then
@@ -48,7 +48,7 @@ function get_git_tag() {
 function is_current_commit_release_tagged() {
     # Check if the current commit is tagged for release, either an RC tag or the release tag
     set +e
-    GIT_TAG=$(git describe --tags --exact-match HEAD 2>/dev/null)
+    GIT_TAG=$(git describe --first-parent --tags --exact-match HEAD 2>/dev/null)
     local status_code=$?
     set -e
 

--- a/ci/scripts/gitutils.py
+++ b/ci/scripts/gitutils.py
@@ -82,7 +82,7 @@ class GitWrapper:
         str
             The full version of the repo in the format 'v#.#.#{a|b|rc}'
         """
-        return _git("describe", "--tags", "--abbrev=0")
+        return _git("describe", "--first-parent", "--tags", "--abbrev=0")
 
     @functools.lru_cache
     @staticmethod


### PR DESCRIPTION
## Description
* Fixes an issue where the `develop` branch is incorrectly reporting itself as v.13

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved version detection to use first-parent tags, yielding more accurate and consistent version reporting in builds and test logs.
  * Added a safe fallback when no tag is present, preventing failures and showing a clear “no-tag” indicator.

* **Chores**
  * Unified tag retrieval across CI scripts to a single helper, simplifying maintenance and reducing inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->