### PR TITLE
Add opensearch service to CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,6 +42,7 @@ variables:
   NAT_CI_ETCD_HOST: "etcd"
   NAT_CI_MILVUS_HOST: "milvus"
   NAT_CI_MYSQL_HOST: "mysql"
+  NAT_CI_OPENSEARCH_URL: "https://opensearch:9200"
   NAT_CI_REDIS_HOST: "redis"
   NAT_CI_S3_HOST: "minio"
   UV_CACHE_DIR: .uv-cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -42,7 +42,7 @@ variables:
   NAT_CI_ETCD_HOST: "etcd"
   NAT_CI_MILVUS_HOST: "milvus"
   NAT_CI_MYSQL_HOST: "mysql"
-  NAT_CI_OPENSEARCH_URL: "https://opensearch:9200"
+  NAT_CI_OPENSEARCH_URL: "http://opensearch:9200"
   NAT_CI_REDIS_HOST: "redis"
   NAT_CI_S3_HOST: "minio"
   UV_CACHE_DIR: .uv-cache

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,6 +94,11 @@ test:python_tests:
         ETCD_ENDPOINTS: etcd:2379
         MINIO_ADDRESS: minio:9000
       command: ["milvus", "run", "standalone"]
+    - name: opensearchproject/opensearch:2.11.1
+      alias: opensearch
+      variables:
+        discovery.type: "single-node"
+        plugins.security.disabled: "true"
 
   script:
     - echo "Running tests"


### PR DESCRIPTION
## Description
* Enables running the `examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py` integration test.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated CI pipeline to provision an OpenSearch service container (opensearchproject/opensearch:2.11.1) with single-node mode and security disabled for CI execution.
  - Added a CI environment variable for the OpenSearch endpoint (http://opensearch:9200).
  - These changes standardize the CI environment and improve consistency of pipeline runs involving search-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->