### PR TITLE
Add an integration test for the custom route front-end example

### DIFF
--- a/examples/front_ends/simple_calculator_custom_routes/configs/config-metadata.yml
+++ b/examples/front_ends/simple_calculator_custom_routes/configs/config-metadata.yml
@@ -43,10 +43,6 @@ llms:
     model_name: meta/llama-3.1-70b-instruct
     temperature: 0.0
     max_tokens: 1024
-  openai_llm:
-    _type: openai
-    model_name: gpt-3.5-turbo
-    max_tokens: 2000
 
 workflow:
   _type: react_agent

--- a/examples/front_ends/simple_calculator_custom_routes/tests/test_simple_calculator_custom_routes.py
+++ b/examples/front_ends/simple_calculator_custom_routes/tests/test_simple_calculator_custom_routes.py
@@ -1,0 +1,80 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import typing
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+
+if typing.TYPE_CHECKING:
+    from nat.data_models.config import Config
+
+
+@pytest.fixture(name="simple_calculator_config_file", scope="module")
+def simple_calculator_config_file_fixture() -> Path:
+    cur_dir = Path(__file__).resolve().parent
+    example_dir = cur_dir.parent
+    config_file = example_dir / "configs/config-metadata.yml"
+    assert config_file.exists(), f"Config file {config_file} does not exist"
+    return config_file
+
+
+@pytest.fixture(name="set_nat_config_file_env_var", autouse=True)
+def fixture_set_nat_config_file_env_var(restore_environ, simple_calculator_config_file: Path) -> str:
+    str_path = str(simple_calculator_config_file.absolute())
+    os.environ["NAT_CONFIG_FILE"] = str_path
+    return str_path
+
+
+@asynccontextmanager
+async def _build_client(config: "Config", worker_class: type | None = None):
+    from asgi_lifespan import LifespanManager
+    from httpx import ASGITransport
+    from httpx import AsyncClient
+
+    from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
+
+    if worker_class is None:
+        worker_class = FastApiFrontEndPluginWorker
+
+    worker = worker_class(config)
+
+    app = worker.build_app()
+
+    async with LifespanManager(app):
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+            yield client
+
+
+@pytest.mark.usefixtures("nvidia_api_key")
+@pytest.mark.integration
+async def test_full_workflow(simple_calculator_config_file: Path):
+    from nat.runtime.loader import load_config
+    config = load_config(simple_calculator_config_file)
+
+    async with _build_client(config) as client:
+        response = await client.post("/get_request_metadata",
+                                     headers={
+                                         "accept": "application/json",
+                                         "Content-Type": "application/json",
+                                         "Authorization": "Bearer token123"
+                                     },
+                                     json={"unused": "show me request details"})
+        assert response.status_code == 200, f"Unexpected status code: {response.status_code}, {response.text}"
+        result = response.json()
+        assert "value" in result, f"Response payload missing expected `value` key: {result}"
+        assert "/get_request_metadata" in result["value"], f"Response payload missing expected route: {result}"

--- a/packages/nvidia_nat_test/src/nat/test/utils.py
+++ b/packages/nvidia_nat_test/src/nat/test/utils.py
@@ -21,6 +21,10 @@ from contextlib import asynccontextmanager
 from pathlib import Path
 
 if typing.TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
+    from httpx import AsyncClient
+
     from nat.data_models.config import Config
     from nat.utils.type_utils import StrPath
 
@@ -88,16 +92,8 @@ async def run_workflow(
     return result
 
 
-from typing import TYPE_CHECKING
-
-if TYPE_CHECKING:
-    from collections.abc import AsyncIterator
-    from httpx import AsyncClient
-
 @asynccontextmanager
-async def build_nat_client(
-    config: "Config", worker_class: type | None = None
-) -> "AsyncIterator[AsyncClient]":
+async def build_nat_client(config: "Config", worker_class: type | None = None) -> "AsyncIterator[AsyncClient]":
     """
     Build a NAT client for testing purposes.
 
@@ -115,9 +111,7 @@ async def build_nat_client(
     from httpx import ASGITransport
     from httpx import AsyncClient
 
-    from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import (
-        FastApiFrontEndPluginWorker,
-    )
+    from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 
     if worker_class is None:
         worker_class = FastApiFrontEndPluginWorker
@@ -126,7 +120,5 @@ async def build_nat_client(
     app = worker.build_app()
 
     async with LifespanManager(app):
-        async with AsyncClient(
-            transport=ASGITransport(app=app), base_url="http://test"
-        ) as client:
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
             yield client

--- a/packages/nvidia_nat_test/src/nat/test/utils.py
+++ b/packages/nvidia_nat_test/src/nat/test/utils.py
@@ -26,6 +26,7 @@ if typing.TYPE_CHECKING:
     from httpx import AsyncClient
 
     from nat.data_models.config import Config
+    from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
     from nat.utils.type_utils import StrPath
 
 
@@ -93,7 +94,9 @@ async def run_workflow(
 
 
 @asynccontextmanager
-async def build_nat_client(config: "Config", worker_class: type | None = None) -> "AsyncIterator[AsyncClient]":
+async def build_nat_client(
+        config: "Config",
+        worker_class: "type[FastApiFrontEndPluginWorker] | None" = None) -> "AsyncIterator[AsyncClient]":
     """
     Build a NAT client for testing purposes.
 

--- a/tests/nat/front_ends/fastapi/test_fastapi_front_end_plugin.py
+++ b/tests/nat/front_ends/fastapi/test_fastapi_front_end_plugin.py
@@ -15,13 +15,9 @@
 
 import io
 import time
-from contextlib import asynccontextmanager
 
 import pytest
-from asgi_lifespan import LifespanManager
 from fastapi import FastAPI
-from httpx import ASGITransport
-from httpx import AsyncClient
 from httpx_sse import aconnect_sse
 
 from _utils.dask_utils import await_job
@@ -37,6 +33,7 @@ from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontE
 from nat.object_store.in_memory_object_store import InMemoryObjectStoreConfig
 from nat.test.functions import EchoFunctionConfig
 from nat.test.functions import StreamingEchoFunctionConfig
+from nat.test.utils import build_nat_client
 from nat.utils.type_utils import override
 
 
@@ -51,18 +48,6 @@ class CustomWorker(FastApiFrontEndPluginWorker):
         @app.get("/custom")
         async def custom_route():
             return {"message": "This is a custom route"}
-
-
-@asynccontextmanager
-async def _build_client(config: Config, worker_class: type[FastApiFrontEndPluginWorker] = FastApiFrontEndPluginWorker):
-
-    worker = worker_class(config)
-
-    app = worker.build_app()
-
-    async with LifespanManager(app):
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            yield client
 
 
 @pytest.mark.parametrize("fn_use_openai_api", [True, False])
@@ -81,7 +66,7 @@ async def test_generate_and_openai_single(fn_use_openai_api: bool):
     assert workflow_path is not None
     assert oai_path is not None
 
-    async with _build_client(config) as client:
+    async with build_nat_client(config) as client:
 
         # Test both the function accepting OAI and also using the OAI API
         if (fn_use_openai_api):
@@ -126,7 +111,7 @@ async def test_generate_and_openai_stream(fn_use_openai_api: bool):
     assert workflow_path is not None
     assert oai_path is not None
 
-    async with _build_client(config) as client:
+    async with build_nat_client(config) as client:
 
         response = []
 
@@ -172,7 +157,7 @@ async def test_custom_endpoint():
         workflow=EchoFunctionConfig(),
     )
 
-    async with _build_client(config, worker_class=CustomWorker) as client:
+    async with build_nat_client(config, worker_class=CustomWorker) as client:
         response = await client.get("/custom")
 
         assert response.status_code == 200
@@ -195,7 +180,7 @@ async def test_specified_endpoints():
         workflow=EchoFunctionConfig(),
     )
 
-    async with _build_client(config) as client:
+    async with build_nat_client(config) as client:
         # response = await client.get("/constant_get")
 
         # assert response.status_code == 200
@@ -224,7 +209,7 @@ async def test_generate_async(fn_use_openai_api: bool, use_sync_timeout: bool):
 
     workflow_path = f"{front_end_config.workflow.path}/async"
     # oai_path = front_end_config.workflow.openai_api_path
-    async with _build_client(config) as client:
+    async with build_nat_client(config) as client:
 
         # Test both the function accepting OAI and also using the OAI API
         if (fn_use_openai_api):
@@ -281,7 +266,7 @@ async def test_async_job_status_not_found():
 
     workflow_path = f"{front_end_config.workflow.path}/async"
 
-    async with _build_client(config) as client:
+    async with build_nat_client(config) as client:
         status_path = f"{workflow_path}/job/non_existent_job"
 
         response = await client.get(status_path)
@@ -303,7 +288,7 @@ async def test_static_file_endpoints():
         workflow=EchoFunctionConfig(),  # Dummy workflow, not used here
     )
 
-    async with _build_client(config) as client:
+    async with build_nat_client(config) as client:
         # POST: Upload a new file
         response = await client.post(
             f"/static/{file_path}",


### PR DESCRIPTION
## Description
* Adds a new test for `examples/front_ends/simple_calculator_custom_routes`
* Removes unused LLM in `config-metadata.yml`
* Move/rename the `_build_client` helper method to `build_nat_client` in the tests package to be shared among tests

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a reusable test client helper to simplify starting the app and making HTTP requests in tests.

- Tests
  - Migrated FastAPI front-end and OpenAI-compatibility tests to the new client helper for cleaner setup and lifecycle management.
  - Added an integration test for the simple calculator with custom routes, validating request metadata handling.

- Chores
  - Removed the OpenAI LLM option from the example calculator configuration, leaving only the NVIDIA NIM LLM.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->