### PR TITLE
Add a docker compose yaml for running integration tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,8 @@ test:python_tests:
     - mysql:9.3
     - name: arizephoenix/phoenix:latest
       alias: phoenix
-    - redis:7-alpine
+    - redis:8.0
+      alias: redis
     - name: quay.io/coreos/etcd:v3.5.5
       alias: etcd
       command: ["etcd", "--advertise-client-urls", "http://0.0.0.0:2379", "--listen-client-urls", "http://0.0.0.0:2379"]

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ test:python_tests:
     - mysql:9.3
     - name: arizephoenix/phoenix:latest
       alias: phoenix
-    - redis:8.0
+    - name: redis:8.0
       alias: redis
     - name: quay.io/coreos/etcd:v3.5.5
       alias: etcd

--- a/packages/nvidia_nat_mysql/tests/test_mysql_object_store.py
+++ b/packages/nvidia_nat_mysql/tests/test_mysql_object_store.py
@@ -25,7 +25,7 @@ from nat.test.object_store_tests import ObjectStoreTests
 
 # NOTE: This test requires a MySQL server to be running locally.
 # To launch a local server using docker, run the following command:
-# docker run --rm -ti --name test-mysql -e MYSQL_ROOT_PASSWORD=my-secret-pw -d -p 3306:3306 mysql:9.3
+# docker run --rm -ti --name test-mysql -e MYSQL_ROOT_PASSWORD=my_password -d -p 3306:3306 mysql:9.3
 
 
 @pytest_asyncio.fixture(name="mysql_server", scope="module")
@@ -36,7 +36,7 @@ async def fixture_mysql_server(fail_missing: bool):
         conn = await aiomysql.connect(host=os.environ.get('NAT_CI_MYSQL_HOST', '127.0.0.1'),
                                       port=3306,
                                       user='root',
-                                      password=os.environ.get('MYSQL_ROOT_PASSWORD', 'my-secret-pw'))
+                                      password=os.environ.get('MYSQL_ROOT_PASSWORD', 'my_password'))
         yield
         conn.close()
     except ImportError:

--- a/tests/test_data/docker-compose.services.yml
+++ b/tests/test_data/docker-compose.services.yml
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+services:
+  etcd:
+    container_name: test-etcd
+    image: quay.io/coreos/etcd:v3.5.5
+    command: etcd --advertise-client-urls=http://0.0.0.0:2379 --listen-client-urls http://0.0.0.0:2379
+    ports:
+      - "2379:2379"
+    healthcheck:
+      test: ["CMD", "etcdctl", "endpoint", "health"]
+      interval: 30s
+      timeout: 20s
+      retries: 3
+
+  milvus:
+    container_name: test-milvus-standalone
+    image: milvusdb/milvus:v2.3.1
+    command: ["milvus", "run", "standalone"]
+    environment:
+      ETCD_ENDPOINTS: etcd:2379
+      MINIO_ADDRESS: minio:9000
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9091/healthz"]
+      interval: 30s
+      start_period: 90s
+      timeout: 20s
+      retries: 3
+    ports:
+      - "19530:19530"
+      - "9091:9091"
+    depends_on:
+      - "etcd"
+      - "minio"
+
+  minio:
+    image: minio/minio:RELEASE.2025-07-18T21-56-31Z
+    container_name: test-minio
+    ports:
+      - 9000:9000
+      - 9001:9001
+    command: server /data --console-address ":9001"
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
+  mysql:
+    image: mysql:9.3
+    container_name: test-mysql
+    ports:
+      - 3306:3306
+    environment:
+      - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-my_password}
+    restart: unless-stopped
+
+  opensearch:
+    image: opensearchproject/opensearch:2.11.1
+    container_name: test-opensearch
+    ports:
+      - "9200:9200"
+      - "9600:9600"
+    environment:
+      - discovery.type=single-node
+      - plugins.security.disabled=true
+
+  phoenix:
+    image: arizephoenix/phoenix:latest
+    container_name: test-phoenix
+    ports:
+      - "6006:6006"  # UI and OTLP HTTP collector
+      - "4317:4317"  # OTLP gRPC collector
+
+  redis:
+    image: redis:8.0
+    container_name: test-redis
+    ports:
+      - 6379:6379


### PR DESCRIPTION
## Description
* Adds a docker compose yaml to bootstrap the required services needed to run integration tests locally

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
