### PR TITLE
fix: ensure console logging is configurable

### DIFF
--- a/examples/front_ends/simple_auth/src/nat_simple_auth/configs/config.yml
+++ b/examples/front_ends/simple_auth/src/nat_simple_auth/configs/config.yml
@@ -14,10 +14,11 @@
 # limitations under the License.
 
 general:
-  logging:
-    console:
-      _type: console
-      level: WARN
+  telemetry:
+    logging:
+      console:
+        _type: console
+        level: WARN
   front_end:
     _type: fastapi
     cors:

--- a/src/nat/builder/workflow_builder.py
+++ b/src/nat/builder/workflow_builder.py
@@ -222,16 +222,16 @@ class WorkflowBuilder(Builder, AbstractAsyncContextManager):
             # If a console handler is configured, adjust or remove default CLI handlers
             # to avoid duplicate output while preserving workflow visibility
             if has_console_handler:
-                # Adjust existing StreamHandler levels to match minimum configured level
+                # Remove existing StreamHandlers that are not the newly configured ones
                 for handler in root_logger.handlers[:]:
-                    if isinstance(handler, logging.StreamHandler) and handler not in self._logging_handlers.values():
+                    if type(handler) is logging.StreamHandler and handler not in self._logging_handlers.values():
                         self._removed_root_handlers.append((handler, handler.level))
                         root_logger.removeHandler(handler)
             else:
                 # No console handler configured, but adjust existing handler levels
                 # to respect the minimum configured level for file/other handlers
                 for handler in root_logger.handlers[:]:
-                    if isinstance(handler, logging.StreamHandler):
+                    if type(handler) is logging.StreamHandler:
                         old_level = handler.level
                         handler.setLevel(min_handler_level)
                         self._removed_root_handlers.append((handler, old_level))

--- a/src/nat/cli/entrypoint.py
+++ b/src/nat/cli/entrypoint.py
@@ -52,7 +52,11 @@ nest_asyncio.apply()
 def setup_logging(log_level: str):
     """Configure logging with the specified level"""
     numeric_level = LOG_LEVELS.get(log_level.upper(), logging.INFO)
-    logging.basicConfig(level=numeric_level, format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    logging.basicConfig(
+        level=numeric_level,
+        format="%(asctime)s - %(levelname)-8s - %(name)s:%(lineno)d - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
     return numeric_level
 
 

--- a/src/nat/data_models/config.py
+++ b/src/nat/data_models/config.py
@@ -187,7 +187,7 @@ class TelemetryConfig(BaseModel):
 
 class GeneralConfig(BaseModel):
 
-    model_config = ConfigDict(protected_namespaces=())
+    model_config = ConfigDict(protected_namespaces=(), extra="forbid")
 
     use_uvloop: bool | None = Field(
         default=None,

--- a/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/src/nat/front_ends/console/console_front_end_plugin.py
@@ -95,16 +95,6 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         else:
             assert False, "Should not reach here. Should have been caught by pre_run"
 
-        # Always log the result at INFO level
+        # Always log the result at CRITICAL level so it is always visible
         result_message = f"\n{'-' * 50}\n{Fore.GREEN}Workflow Result:\n%s{Fore.RESET}\n{'-' * 50}"
-        logger.info(result_message, runner_outputs)
-
-        # Additionally print to stdout if console handlers are set to a level higher than INFO
-        # This ensures workflow results are always visible regardless of logging configuration
-        root_logger = logging.getLogger()
-        console_level_too_high = all(
-            type(handler) is not logging.StreamHandler or handler.level > logging.INFO
-            for handler in root_logger.handlers)
-
-        if console_level_too_high:
-            print(f"\n{'-' * 50}\n{Fore.GREEN}Workflow Result:\n{runner_outputs}{Fore.RESET}\n{'-' * 50}")
+        logger.critical(result_message, runner_outputs)

--- a/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/src/nat/front_ends/console/console_front_end_plugin.py
@@ -95,5 +95,16 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         else:
             assert False, "Should not reach here. Should have been caught by pre_run"
 
-        # Print result
-        logger.info(f"\n{'-' * 50}\n{Fore.GREEN}Workflow Result:\n%s{Fore.RESET}\n{'-' * 50}", runner_outputs)
+        # Always log the result at INFO level
+        result_message = f"\n{'-' * 50}\n{Fore.GREEN}Workflow Result:\n%s{Fore.RESET}\n{'-' * 50}"
+        logger.info(result_message, runner_outputs)
+
+        # Additionally print to stdout if console handlers are set to a level higher than INFO
+        # This ensures workflow results are always visible regardless of logging configuration
+        root_logger = logging.getLogger()
+        console_level_too_high = any(
+            isinstance(handler, logging.StreamHandler) and handler.level > logging.INFO
+            for handler in root_logger.handlers)
+
+        if console_level_too_high:
+            print(f"\n{'-' * 50}\n{Fore.GREEN}Workflow Result:\n{runner_outputs}{Fore.RESET}\n{'-' * 50}")

--- a/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/src/nat/front_ends/console/console_front_end_plugin.py
@@ -95,6 +95,14 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         else:
             assert False, "Should not reach here. Should have been caught by pre_run"
 
-        # Always log the result at CRITICAL level so it is always visible
-        result_message = f"\n{'-' * 50}\n{Fore.GREEN}Workflow Result:\n%s{Fore.RESET}\n{'-' * 50}"
-        logger.critical(result_message, runner_outputs)
+        line = f"{'-' * 50}"
+        prefix = f"{line}\n{Fore.GREEN}Workflow Result:\n"
+        suffix = f"{Fore.RESET}\n{line}"
+
+        logger.info(f"{prefix}%s{suffix}", runner_outputs)
+
+        # (handler is a stream handler) => (level > INFO)
+        effective_level_too_high = all(
+            type(h) is not logging.StreamHandler or h.level > logging.INFO for h in logging.getLogger().handlers)
+        if effective_level_too_high:
+            print(f"{prefix}{runner_outputs}{suffix}")

--- a/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/src/nat/front_ends/console/console_front_end_plugin.py
@@ -102,8 +102,8 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         # Additionally print to stdout if console handlers are set to a level higher than INFO
         # This ensures workflow results are always visible regardless of logging configuration
         root_logger = logging.getLogger()
-        console_level_too_high = any(
-            isinstance(handler, logging.StreamHandler) and handler.level > logging.INFO
+        console_level_too_high = all(
+            type(handler) is not logging.StreamHandler or handler.level > logging.INFO
             for handler in root_logger.handlers)
 
         if console_level_too_high:

--- a/src/nat/observability/register.py
+++ b/src/nat/observability/register.py
@@ -77,6 +77,14 @@ async def console_logging_method(config: ConsoleLoggingMethodConfig, builder: Bu
     level = getattr(logging, config.level.upper(), logging.INFO)
     handler = logging.StreamHandler(stream=sys.stdout)
     handler.setLevel(level)
+
+    # Set formatter to match the default CLI format
+    formatter = logging.Formatter(
+        fmt="%(asctime)s - %(levelname)-8s - %(name)s:%(lineno)d - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+
     yield handler
 
 
@@ -95,4 +103,12 @@ async def file_logging_method(config: FileLoggingMethod, builder: Builder):
     level = getattr(logging, config.level.upper(), logging.INFO)
     handler = logging.FileHandler(filename=config.path, mode="a", encoding="utf-8")
     handler.setLevel(level)
+
+    # Set formatter to match the default CLI format
+    formatter = logging.Formatter(
+        fmt="%(asctime)s - %(levelname)-8s - %(name)s:%(lineno)d - %(message)s",
+        datefmt="%Y-%m-%d %H:%M:%S",
+    )
+    handler.setFormatter(formatter)
+
     yield handler


### PR DESCRIPTION
## Description
User specification of console logging did nothing. The root issue was we had multiple logger handlers. This PR addresses this bug and fixes it via the following:

- Fixed logging configuration not being applied - Workflow builder now properly manages console handlers to respect configured log levels
- Added `extra="forbid"` to `GeneralConfig` - Invalid configuration fields are now rejected with clear validation errors
- Ensured workflow results always visible - If console log level is greater than info, print the workflow results. If <= INFO, then log the results
- Fixed example config structure - Updated simple_auth config to use correct general.telemetry.logging format
- Improved logging format to have the level come after the time. Also added line number of file/module

Default level:
```
<snipped for brevity>
...
------------------------------
2025-10-07 21:05:36 - INFO     - nat.agent.rewoo_agent.agent:373 - [AGENT] Completed level 1 with 1 tools
2025-10-07 21:05:37 - INFO     - nat.agent.rewoo_agent.agent:493 - ReWOO agent solver output: 
------------------------------
[AGENT]
Agent input: Make a joke comparing Elon and Mark Zuckerberg's birthdays?
Agent's thoughts: 
Why did Elon Musk and Mark Zuckerberg's birthdays go to therapy? Because Elon's birthday (June 28) was feeling a little "spacey" and Mark's birthday (May 14) was having some "social" anxiety!
------------------------------
2025-10-07 21:05:37 - WARNING  - nat.builder.intermediate_step_manager:94 - Step id a1b24e96-0fdd-4fc5-9a07-a6b3c0699e80 not found in outstanding start steps
2025-10-07 21:05:37 - CRITICAL - nat.front_ends.console.console_front_end_plugin:100 - 
--------------------------------------------------
Workflow Result:
['Why did Elon Musk and Mark Zuckerberg\'s birthdays go to therapy? Because Elon\'s birthday (June 28) was feeling a little "spacey" and Mark\'s birthday (May 14) was having some "social" anxiety!']
--------------------------------------------------
```

Error level (when set in workflow config):
```
2025-10-07 21:07:59 - INFO     - nat.cli.commands.start:192 - Starting NAT from config file: 'examples/agents/rewoo/configs/config.yml'

Configuration Summary:
--------------------
Workflow Type: rewoo_agent
Number of Functions: 6
Number of Function Groups: 0
Number of LLMs: 1
Number of Embedders: 0
Number of Memory: 0
Number of Object Stores: 0
Number of Retrievers: 0
Number of TTC Strategies: 0
Number of Authentication Providers: 0

2025-10-07 21:07:11 - CRITICAL - nat.front_ends.console.console_front_end_plugin:100 - 
--------------------------------------------------
Workflow Result:
["Why did Elon Musk and Mark Zuckerberg have different birthday parties? Because Elon's was a 'rocket' success on June 28, while Mark's was a 'social' gathering on May 14! Guess you could say their birthdays were 'launched' on different trajectories!"]
--------------------------------------------------
```

Error level (when set as envvar):
```
2025-10-07 21:07:11 - CRITICAL - nat.front_ends.console.console_front_end_plugin:100 - 
--------------------------------------------------
Workflow Result:
["Why did Elon Musk and Mark Zuckerberg have different birthday parties? Because Elon's was a 'rocket' success on June 28, while Mark's was a 'social' gathering on May 14! Guess you could say their birthdays were 'launched' on different trajectories!"]
--------------------------------------------------
```


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Result messages are now always surfaced (logged at a higher severity) so workflow outputs are visible regardless of INFO-level settings.

* **Refactor**
  * Logging settings reorganized under a telemetry namespace while preserving console type and level.
  * Root-level logging management unified to prevent duplicate handlers and restore prior console behavior on exit.

* **Bug Fixes**
  * Log formatting standardized to include timestamp, level, logger name and line number.

* **Chores**
  * Configuration validation tightened: unknown config fields are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->