### PR TITLE
docs: clarify the need for a virtual environment in setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Before you begin using NeMo Agent Toolkit, ensure that you have Python 3.11, 3.1
 
 ### Stable Version
 
-Based on your system settings, you may need to configure and activate a python virtual environment. On macOS or Linux, you can run the following commands:
+Based on your system settings, you may need to configure and activate a Python virtual environment. On macOS or Linux, you can run the following commands:
 
 ```bash
 python3 -m venv .venv


### PR DESCRIPTION
## Description

We should clarify that a virtual environment may be needed for a "vanilla" pip install.

Closes nvbugs-5553762

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions to recommend using a Python virtual environment before installing the package.
  * Added macOS/Linux commands to create (python3 -m venv .venv) and activate (source .venv/bin/activate) the environment in the Stable Version section.
  * Clarifies setup steps to reduce dependency conflicts and streamline installation.
  * Existing pip install command remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->