### PR TITLE
fix: custom plot charts function should error on invalid chart types

### DIFF
--- a/examples/custom_functions/plot_charts/src/nat_plot_charts/plot_chat.py
+++ b/examples/custom_functions/plot_charts/src/nat_plot_charts/plot_chat.py
@@ -152,18 +152,19 @@ def create_scatter_plot(data: dict[str, Any], output_path: str, figure_size: tup
 
 def determine_chart_type(user_request: str, available_types: list[str]) -> str:
     """Determine the best chart type based on user request."""
-    request_lower = user_request.lower()
+    requested_type = user_request.lower()
 
     # Simple keyword matching for chart type detection
-    if any(word in request_lower for word in ["line", "trend", "over time", "timeline"]):
-        if "line" in available_types:
-            return "line"
-    elif any(word in request_lower for word in ["bar", "column", "compare", "comparison"]):
-        if "bar" in available_types:
-            return "bar"
-    elif any(word in request_lower for word in ["scatter", "correlation", "relationship"]):
-        if "scatter" in available_types:
-            return "scatter"
+    if any(word in requested_type for word in ["line", "trend", "over time", "timeline"]):
+        requested_type = "line"
+    elif any(word in requested_type for word in ["bar", "column", "compare", "comparison"]):
+        requested_type = "bar"
+    elif any(word in requested_type for word in ["scatter", "correlation", "relationship"]):
+        requested_type = "scatter"
+
+    # make sure the requested type is in the available types
+    if requested_type in available_types:
+        return requested_type
 
     raise ValueError(f"No chart type found for user request: {user_request}")
 

--- a/examples/custom_functions/plot_charts/src/nat_plot_charts/register.py
+++ b/examples/custom_functions/plot_charts/src/nat_plot_charts/register.py
@@ -90,16 +90,13 @@ async def plot_charts_function(config: PlotChartsWorkflowConfig, builder: Builde
             filename = f"{chart_type}_chart_{timestamp}.png"
             output_path = output_dir / filename
 
-            # Create the appropriate chart
-            if chart_type == "line":
-                saved_path = create_line_plot(data, str(output_path), config.figure_size)
-            elif chart_type == "bar":
-                saved_path = create_bar_plot(data, str(output_path), config.figure_size)
-            elif chart_type == "scatter":
-                saved_path = create_scatter_plot(data, str(output_path), config.figure_size)
-            else:
+            create_function_mapping = {"line": create_line_plot, "bar": create_bar_plot, "scatter": create_scatter_plot}
+            if chart_type not in create_function_mapping:
                 return (f"Error: Unsupported chart type '{chart_type}'. "
                         f"Available types: {config.chart_types}")
+
+            # Create the appropriate chart
+            saved_path = create_function_mapping[chart_type](data, str(output_path), config.figure_size)
 
             # Generate description using LLM
             description = await generate_chart_description(llm, data, chart_type)


### PR DESCRIPTION
## Description

The original behavior was to fall back to a line chart. Instead, we should raise an error.

Also improves configuration for the example function.

Closes nvbugs-5566144

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  - Clearer validation and error messages when an unsupported chart type is requested.
  - Configuration options now include descriptive metadata and sensible defaults.

* Refactor
  - Streamlined chart type resolution with earlier detection and consistent canonical types.
  - Behavior change: invalid chart requests now error out instead of defaulting to a first available type.

* Bug Fixes
  - Prevents unintended chart selection by enforcing explicit, supported chart types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->