### PR TITLE
docs: clarify the need for a separate venv for local vLLM

### DIFF
--- a/docs/source/workflows/llms/using-local-llms.md
+++ b/docs/source/workflows/llms/using-local-llms.md
@@ -138,8 +138,13 @@ nat run --config_file examples/documentation_guides/locally_hosted_llms/nim_conf
 
 ## Using vLLM
 
+
+vLLM provides an [OpenAI-Compatible Server](https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-compatible-server) allowing us to re-use our existing OpenAI clients.
+
+If you have not already done so, install vLLM following the [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html) guide. It is recommended to use a **separate** virtual environment for vLLM due to the potential conflicts with NAT's dependencies.
+
 <!-- path-check-skip-next-line -->
-vLLM provides an [OpenAI-Compatible Server](https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-compatible-server) allowing us to re-use our existing OpenAI clients. If you have not already done so, install vLLM following the [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html) guide. Similar to the previous example we will be using the same [`nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1`](https://huggingface.co/nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1) LLM model. Along with the [`ssmits/Qwen2-7B-Instruct-embed-base`](https://huggingface.co/ssmits/Qwen2-7B-Instruct-embed-base) embedding model.
+Similar to the previous example we will be using the same [`nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1`](https://huggingface.co/nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1) LLM model. Along with the [`ssmits/Qwen2-7B-Instruct-embed-base`](https://huggingface.co/ssmits/Qwen2-7B-Instruct-embed-base) embedding model.
 
 ### Install the Simple Web Query Example
 

--- a/docs/source/workflows/llms/using-local-llms.md
+++ b/docs/source/workflows/llms/using-local-llms.md
@@ -141,7 +141,7 @@ nat run --config_file examples/documentation_guides/locally_hosted_llms/nim_conf
 
 vLLM provides an [OpenAI-Compatible Server](https://docs.vllm.ai/en/latest/getting_started/quickstart.html#openai-compatible-server) allowing us to re-use our existing OpenAI clients.
 
-If you have not already done so, install vLLM following the [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html) guide. It is recommended to use a **separate** virtual environment for vLLM due to the potential conflicts with NAT's dependencies.
+If you have not already done so, install vLLM following the [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html) guide. It is recommended to use a **separate** virtual environment for vLLM due to potential conflicts with NeMo Agent toolkit dependencies.
 
 <!-- path-check-skip-next-line -->
 Similar to the previous example we will be using the same [`nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1`](https://huggingface.co/nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1) LLM model. Along with the [`ssmits/Qwen2-7B-Instruct-embed-base`](https://huggingface.co/ssmits/Qwen2-7B-Instruct-embed-base) embedding model.


### PR DESCRIPTION
## Description

Newer versions of NAT support the latest numpy while vLLM does not.
Since vLLM is not a true dependency of NAT, we should encourage users running vLLM locally to use a separate virtual environment.

Closes nvbugs-5566124

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded “Using vLLM” guidance with details on its OpenAI-compatible server.
  * Added recommendation to install vLLM in a separate virtual environment.
  * Reorganized and clarified content: split a combined paragraph, trimmed references to specific models, and moved related details into notes.
  * Improved readability without changing any functionality or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->