### PR TITLE
Switch the default value of `use_openai_api` to `true`

### DIFF
--- a/docs/source/workflows/about/react-agent.md
+++ b/docs/source/workflows/about/react-agent.md
@@ -103,7 +103,7 @@ If modifying the prompt, see the limitations section below. The prompt must have
 
 * `max_history`:  Defaults to `15`. Maximum number of messages to keep in the conversation history.
 
-* `use_openai_api`: Defaults to `False`.  If set to `True`, the ReAct agent will output in OpenAI API spec. If set to `False`, strings will be used.
+* `use_openai_api`: Defaults to `True`.  If set to `True`, the ReAct agent will output in OpenAI API spec. If set to `False`, strings will be used.
 
 * `include_tool_input_schema_in_tool_description`: Defaults to `True`.  If set to `True`, the ReAct agent will inspect its tools' input schemas, and append the following to each tool description:
   >. Arguments must be provided as a valid JSON object following this format: {tool_schema}

--- a/docs/source/workflows/about/rewoo-agent.md
+++ b/docs/source/workflows/about/rewoo-agent.md
@@ -95,7 +95,7 @@ functions:
 
 * `log_response_max_chars`: Defaults to 1000. Maximum number of characters to display in logs when logging tool responses.
 
-* `use_openai_api`: Defaults to False. If set to True, the ReWOO agent will output in OpenAI API spec. If set to False, strings will be used.
+* `use_openai_api`: Defaults to True. If set to True, the ReWOO agent will output in OpenAI API spec. If set to False, strings will be used.
 
 * `additional_planner_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base planner prompt.
 

--- a/examples/agents/react/configs/config.yml
+++ b/examples/agents/react/configs/config.yml
@@ -40,7 +40,6 @@ workflow:
   llm_name: nim_llm
   verbose: true
   parse_agent_response_max_retries: 2
-  use_openai_api: true
 
 eval:
   general:

--- a/examples/agents/rewoo/README.md
+++ b/examples/agents/rewoo/README.md
@@ -49,7 +49,7 @@ The ReWOO agent uses a unique three-node graph architecture that separates plann
 
 **Workflow Overview:**
 - **Start**: The agent begins processing with user input
-- **Planner Node**: Creates a complete execution plan with all necessary steps upfront. Plans are parsed into a Dependency Graph for parallel execution. 
+- **Planner Node**: Creates a complete execution plan with all necessary steps upfront. Plans are parsed into a Dependency Graph for parallel execution.
 - **Executor Node**: Executes tools according to the plan. Non-dependent tool calls are executed in parallel at each level.
 - **Solver Node**: Takes all execution results and generates the final answer
 - **End**: Process completes with the final response
@@ -107,7 +107,7 @@ The ReWOO agent is configured through the `config.yml` file. The following confi
 
 * `log_response_max_chars`: Defaults to 1000. Maximum number of characters to display in logs when logging tool responses.
 
-* `use_openai_api`: Defaults to False. If set to True, the ReWOO agent will output in OpenAI API spec. If set to False, strings will be used.
+* `use_openai_api`: Defaults to True. If set to True, the ReWOO agent will output in OpenAI API spec. If set to False, strings will be used.
 
 * `additional_planner_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base planner prompt.
 
@@ -131,7 +131,7 @@ nat run --config_file=examples/agents/rewoo/configs/config.yml --input "Make a j
 ------------------------------
 [AGENT]
 Agent input: Make a joke comparing Elon and Mark Zuckerberg's birthdays?
-Agent's thoughts: 
+Agent's thoughts:
 [
   {
     "plan": "Find Elon Musk's birthday",
@@ -162,20 +162,20 @@ Agent's thoughts:
 2025-09-27 20:12:14,522 - nat.agent.rewoo_agent.agent - INFO - ReWOO agent execution levels: [['#E1', '#E2'], ['#E3']]
 /raid/binfeng/workspace/NeMo-Agent-Toolkit/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tools/tavily_internet_search.py:45: LangChainDeprecationWarning: The class `TavilySearchResults` was deprecated in LangChain 0.3.25 and will be removed in 1.0. An updated version of the class exists in the :class:`~langchain-tavily package and should be used instead. To use it run `pip install -U :class:`~langchain-tavily` and import as `from :class:`~langchain_tavily import TavilySearch``.
   tavily_search = TavilySearchResults(max_results=tool_config.max_results)
-2025-09-27 20:12:15,939 - nat.agent.base - INFO - 
+2025-09-27 20:12:15,939 - nat.agent.base - INFO -
 ------------------------------
 [AGENT]
 Calling tools: internet_search
 Tool's input: {'question': 'Elon Musk birthday'}
-Tool's response: 
+Tool's response:
 content='<Document href="https://www.ebsco.com/research-starters/biography/elon-musk"/>\nElon Musk was born on June 28, 1971, in Pretoria, Transvaal (now Gauteng), South Africa, one of three children born to Canadian model and dietitian Maye Musk (née Haldeman) and South African engineer Errol Musk, now divorced. He left high school and emigrated from South Africa to Canada in 1988 at the age of seventeen, primarily because he objected philosophically to mandatory conscription into the South African military, which at the time was the primary enforcement vehicle for apartheid.\n</Document>\n\n---\n\n<Document href="https://www.jagranjosh.com/general-knowledge/elon-reeve-musk-1588776062-1"/>\nElon Musk, born on June 28, 1971, in Pretoria, South Africa, is a prominent entrepreneur known for his roles in companies like Tesla, SpaceX, and Neuralink. Recently, he welcomed his 14th child, Seldon Lycurgus, with Shivon Zilis, an executive at Neuralink.\n\nThe name "Seldon" is believed to be in...(rest of response truncated)
 ------------------------------
-2025-09-27 20:12:17,757 - nat.agent.base - INFO - 
+2025-09-27 20:12:17,757 - nat.agent.base - INFO -
 ------------------------------
 [AGENT]
 Calling tools: internet_search
 Tool's input: {'question': 'Mark Zuckerberg birthday'}
-Tool's response: 
+Tool's response:
 content='<Document href="https://simple.wikipedia.org/wiki/Mark_Zuckerberg"/>\n| Mark Zuckerberg | |\n --- |\n| Zuckerberg in 2020 | |\n| Born | Mark Elliot Zuckerberg   (1984-05-14) May 14, 1984 (age 41)  White Plains, New York, USA |\n| Education | Harvard University (no degree) |\n| Occupations |  Internet entrepreneur")  philanthropist  media mogul |\n| Years active | 2004–present |\n| Known for | Co-founding and leading Meta, Inc. |\n| Height | 171 cm (5 ft 7 in) |\n| Title |  Founder and CEO of Meta, Inc.  Co-founder and co-CEO of Chan Zuckerberg Initiative | [...] Mark Elliot Zuckerberg (born White Plains, New York, 1984) is an American who created Facebook when he was still studying computer science. The founding of Facebook made Zuckerberg a billionaire, one of the youngest and richest billionaires of all time according to Forbes.\n\nBesides computer programming, Zuckerberg is also interested in foreign languages, especially Mandarin Chinese. Mark Zuckerberg was born at White ...(rest of response truncated)
 ------------------------------
 2025-09-27 20:12:17,757 - nat.agent.rewoo_agent.agent - INFO - [AGENT] Completed level 0 with 2 tools
@@ -189,23 +189,23 @@ Here's a joke:
 Why did Elon Musk and Mark Zuckerberg go to therapy together?
 
 Because Elon was feeling a little "spacey" (get it? SpaceX?) and Mark was having a "facebook" identity crisis... but in the end, they just realized they were born to be different - 13 years and 44 days apart, to be exact!
-2025-09-27 20:12:23,318 - nat.agent.base - INFO - 
+2025-09-27 20:12:23,318 - nat.agent.base - INFO -
 ------------------------------
 [AGENT]
 Calling tools: haystack_chitchat_agent
 Tool's input: {'inputs': 'Compare the birthdays of Elon Musk (<Document href="https://www.ebsco.com/research-starters/biography/elon-musk"/>\nElon Musk was born on June 28, 1971, in Pretoria, Transvaal (now Gauteng), South Africa, one of three children born to Canadian model and dietitian Maye Musk (née Haldeman) and South African engineer Errol Musk, now divorced. He left high school and emigrated from South Africa to Canada in 1988 at the age of seventeen, primarily because he objected philosophically to mandatory conscription into the South African military, which at the time was the primary enforcement vehicle for apartheid.\n</Document>\n\n---\n\n<Document href="https://www.jagranjosh.com/general-knowledge/elon-reeve-musk-1588776062-1"/>\nElon Musk, born on June 28, 1971, in Pretoria, South Africa, is a prominent entrepreneur known for his roles in companies like Tesla, SpaceX, and Neuralink. Recently, he welcomed his 14th child, Seldon Lycurgus, with Shivon Zilis, an executive at Neuralink.\n\nThe name "Seldon" is believed to be inspired by Hari Seldon, a character from Isaac Asimov\'s "Foundation" series, while "Lycurgus" refers to the ancient Spartan lawgiver. [...] Elon Reeve Musk was born on June 28, 1971, in Pretoria, South Africa. He is the eldest of three siblings in a family with diverse talents and interests.\n\nHis early life was marked by intellectual curiosity but also challenges, including bullying at school and a difficult relationship with his father. Musk showed an early aptitude for technology and entrepreneurship, creating and selling a video game called Blastar at the age of 12.\n\n### Parents [...] +\n\n  Elon Reeve Musk was born on June 28, 1971, in Pretoria, South Africa to Maye Musk and Errol Musk.\n\nGet here current GK and GK quiz questions in English and Hindi for India, World, Sports and Competitive exam preparation. Download the Jagran Josh Current Affairs App.\n\n## Trending\n</Document>\n\n---\n\n<Document href="https://en.wikipedia.org/wiki/Elon_Musk"/>\nElon Reeve Musk was born on June 28, 1971, in Pretoria, South Africa\'s administrative capital.( He is of British and Pennsylvania Dutch ancestry.( His mother, Maye (néeHaldeman), is a model and dietitian born in Saskatchewan, Canada, and raised in South Africa.( Musk therefore holds both South African and Canadian citizenship from birth.( His father, Errol Musk, is a South African electromechanical engineer, pilot, sailor, consultant, emerald dealer, and property developer, who partly owned a [...] Elon Reeve Musk (/ˈ iː l ɒ n/_EE-lon_; born June 28, 1971) is an international businessman and entrepreneur known for his leadership of Tesla, SpaceX, X (formerly Twitter) "X (formerly Twitter)"), and the Department of Government Efficiency (DOGE). Musk has been the wealthiest person in the world since 2021; as of May 2025,( estimates his net worth to be US$424.7 billion. [...] | Image 5_(cropped).jpg) Musk in 2022 |\n|  |\n| Senior Advisor to the President |\n| In office January 20, 2025– May 30, 2025 Serving with Massad Boulos |\n| President | Donald Trump |\n| Preceded by | Tom Perez |\n|  |\n| Personal details |\n| Born | Elon Reeve Musk (1971-06-28) June 28, 1971 (age 54) Pretoria, South Africa |\n| Citizenship |  South Africa  Canada  United States |\n| Political party | Independent |\n</Document>) and Mark Zuckerberg (<Document href="https://simple.wikipedia.org/wiki/Mark_Zuckerberg"/>\n| Mark Zuckerberg | |\n --- |\n| Zuckerberg in 2020 | |\n| Born | Mark Elliot Zuckerberg   (1984-05-14) May 14, 1984 (age 41)  White Plains, New York, USA |\n| Education | Harvard University (no degree) |\n| Occupations |  Internet entrepreneur")  philanthropist  media mogul |\n| Years active | 2004–present |\n| Known for | Co-founding and leading Meta, Inc. |\n| Height | 171 cm (5 ft 7 in) |\n| Title |  Founder and CEO of Meta, Inc.  Co-founder and co-CEO of Chan Zuckerberg Initiative | [...] Mark Elliot Zuckerberg (born White Plains, New York, 1984) is an American who created Facebook when he was still studying computer science. The founding of Facebook made Zuckerberg a billionaire, one of the youngest and richest billionaires of all time according to Forbes.\n\nBesides computer programming, Zuckerberg is also interested in foreign languages, especially Mandarin Chinese. Mark Zuckerberg was born at White Plains Hospital in White Plains, New York but now he lives in California.\n</Document>\n\n---\n\n<Document href="https://en.wikipedia.org/wiki/Mark_Zuckerberg"/>\nMark Elliot Zuckerberg (/ˈzʌkərbɜːrɡ/; born May 14, 1984) is an American businessman who co-founded the social media service Facebook and its parent company Meta Platforms, of which he is the chairman, chief executive officer, and controlling shareholder. [...] ## Early life\n\nMark Elliot Zuckerberg was born on May 14, 1984, in White Plains, New York, to psychiatrist Karen (née Kempner) and dentist Edward Zuckerberg. He and his three sisters (Arielle, Randi, and Donna) were raised in a Reform Jewish household in Dobbs Ferry, New York. Their great-grandparents were emigrants from Austria, Germany, and Poland. Zuckerberg initially attended Ardsley High School before transferring to Phillips Exeter Academy. He was captain of the fencing team.\n</Document>\n\n---\n\n<Document href="https://www.biography.com/business-leaders/mark-zuckerberg"/>\nMark Elliot Zuckerberg was born on May 14, 1984, in White Plains, New York, into a comfortable, well-educated family. His father, Edward, ran a dental practice attached to the family’s home, and his mother, Karen, worked as a psychiatrist before becoming a stay-at-home mom. He was raised in the Westchester village of Dobbs Ferry with his three siblings Randi, Donna, and Arielle. [...] ## Quick Facts\n\nFULL NAME: Mark Elliot Zuckerberg BORN: May 14, 1984BIRTHPLACE: White Plains, New YorkSPOUSE: Priscilla Chan (2012-present)CHILDREN: Maxima, August, and AureliaASTROLOGICAL SIGN: Taurus\n\n## Early Life [...] In December 2015, the couple welcomed their first child, a daughter named Maxima, Max for short. Zuckerberg and Chan had two more daughters together: August (named after her birth month), born in August 2017, and Aurelia, born in March 2023.\n\n## Net Worth\n</Document>) and create a joke'}
-Tool's response: 
+Tool's response:
 content='After comparing the birthdays of Elon Musk and Mark Zuckerberg, I found that:\n\nElon Musk was born on June 28, 1971\nMark Zuckerberg was born on May 14, 1984\n\nHere\'s a joke:\n\nWhy did Elon Musk and Mark Zuckerberg go to therapy together?\n\nBecause Elon was feeling a little "spacey" (get it? SpaceX?) and Mark was having a "facebook" identity crisis... but in the end, they just realized they were born to be different - 13 years and 44 days apart, to be exact!' name='haystack_chitchat_agent' tool_call_id='haystack_chitchat_agent'
 ------------------------------
 2025-09-27 20:12:23,319 - nat.agent.rewoo_agent.agent - INFO - [AGENT] Completed level 1 with 1 tools
-2025-09-27 20:12:24,472 - nat.agent.rewoo_agent.agent - INFO - ReWOO agent solver output: 
+2025-09-27 20:12:24,472 - nat.agent.rewoo_agent.agent - INFO - ReWOO agent solver output:
 ------------------------------
 [AGENT]
 Agent input: Make a joke comparing Elon and Mark Zuckerberg's birthdays?
-Agent's thoughts: 
+Agent's thoughts:
 Why did Elon Musk and Mark Zuckerberg go to therapy together? Because Elon was feeling a little "spacey" and Mark was having a "facebook" identity crisis... but in the end, they just realized they were born to be different - 13 years and 44 days apart, to be exact!
 ------------------------------
-2025-09-27 20:12:24,473 - nat.front_ends.console.console_front_end_plugin - INFO - 
+2025-09-27 20:12:24,473 - nat.front_ends.console.console_front_end_plugin - INFO -
 --------------------------------------------------
 Workflow Result:
 ['Why did Elon Musk and Mark Zuckerberg go to therapy together? Because Elon was feeling a little "spacey" and Mark was having a "facebook" identity crisis... but in the end, they just realized they were born to be different - 13 years and 44 days apart, to be exact!']

--- a/src/nat/agent/react_agent/register.py
+++ b/src/nat/agent/react_agent/register.py
@@ -70,9 +70,10 @@ class ReActAgentWorkflowConfig(AgentBaseConfig, OptimizableMixin, name="react_ag
         default=None,
         description="Provides the SYSTEM_PROMPT to use with the agent")  # defaults to SYSTEM_PROMPT in prompt.py
     max_history: int = Field(default=15, description="Maximum number of messages to keep in the conversation history.")
-    use_openai_api: bool = Field(default=False,
-                                 description=("Use OpenAI API for the input/output types to the function. "
-                                              "If False, strings will be used."))
+    use_openai_api: bool = Field(
+        default=True,
+        description=("Default to True, using OpenAI API for the input/output types to the function. "
+                     "If False, strings will be used."))
     additional_instructions: str | None = OptimizableField(
         default=None,
         description="Additional instructions to provide to the agent in addition to the base prompt.",

--- a/src/nat/agent/rewoo_agent/register.py
+++ b/src/nat/agent/rewoo_agent/register.py
@@ -54,9 +54,10 @@ class ReWOOAgentWorkflowConfig(AgentBaseConfig, name="rewoo_agent"):
                                                description="The number of retries before raising a tool call error.",
                                                ge=1)
     max_history: int = Field(default=15, description="Maximum number of messages to keep in the conversation history.")
-    use_openai_api: bool = Field(default=False,
-                                 description=("Use OpenAI API for the input/output types to the function. "
-                                              "If False, strings will be used."))
+    use_openai_api: bool = Field(
+        default=True,
+        description=("Default to True, using OpenAI API for the input/output types to the function. "
+                     "If False, strings will be used."))
     additional_planner_instructions: str | None = Field(
         default=None,
         validation_alias=AliasChoices("additional_planner_instructions", "additional_instructions"),

--- a/tests/nat/agent/test_react.py
+++ b/tests/nat/agent/test_react.py
@@ -652,6 +652,12 @@ def test_config_alias_default_values():
     assert config.max_tool_calls == 15
 
 
+def test_config_use_openai_api_default_value():
+    """Test that use_openai_api defaults to True."""
+    config = ReActAgentWorkflowConfig(tool_names=['test'], llm_name='test')
+    assert config.use_openai_api is True
+
+
 def test_config_alias_json_serialization():
     """Test that configuration with aliases can be serialized and deserialized."""
     config = ReActAgentWorkflowConfig(tool_names=['test'],

--- a/tests/nat/agent/test_rewoo.py
+++ b/tests/nat/agent/test_rewoo.py
@@ -481,6 +481,12 @@ def test_rewoo_config_tool_call_max_retries():
     assert config_custom.tool_call_max_retries == 7
 
 
+def test_rewoo_config_use_openai_api_default_value():
+    """Test that use_openai_api defaults to True."""
+    config = ReWOOAgentWorkflowConfig(tool_names=["test_tool"], llm_name="test_llm")  # type: ignore
+    assert config.use_openai_api is True
+
+
 def test_json_output_parsing_valid_format():
     """Test that the planner can parse valid JSON output correctly."""
     import json


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Currently `ReAct`, `ReWOO` and `Tool Calling` agents support retaining chat history ONLY if `use_openai_api` is set to `true`. Since the default value if `false`, this causes confusion to users since the option needs to be explicitly set to enable chat history. This PR switch the default value of `use_openai_api` to `true` to reduce future confusion.

Closes nvbugs-5563797

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - ReAct and ReWOO agents now default to using the OpenAI API.

- Documentation
  - Updated guides to reflect the new default for API usage.
  - Refreshed example outputs and minor formatting improvements.
  - Simplified configuration instructions.

- Chores
  - Removed the explicit API flag from example configuration to align with the new default.

- Tests
  - Added tests to validate the new default behavior for API usage in both agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->