### PR TITLE
feat: make built-in agents input adaptable

### DIFF
--- a/docs/source/workflows/about/react-agent.md
+++ b/docs/source/workflows/about/react-agent.md
@@ -103,8 +103,6 @@ If modifying the prompt, see the limitations section below. The prompt must have
 
 * `max_history`:  Defaults to `15`. Maximum number of messages to keep in the conversation history.
 
-* `use_openai_api`: Defaults to `False`.  If set to `True`, the ReAct agent will output in OpenAI API spec. If set to `False`, strings will be used.
-
 * `include_tool_input_schema_in_tool_description`: Defaults to `True`.  If set to `True`, the ReAct agent will inspect its tools' input schemas, and append the following to each tool description:
   >. Arguments must be provided as a valid JSON object following this format: {tool_schema}
 

--- a/docs/source/workflows/about/rewoo-agent.md
+++ b/docs/source/workflows/about/rewoo-agent.md
@@ -95,8 +95,6 @@ functions:
 
 * `log_response_max_chars`: Defaults to 1000. Maximum number of characters to display in logs when logging tool responses.
 
-* `use_openai_api`: Defaults to False. If set to True, the ReWOO agent will output in OpenAI API spec. If set to False, strings will be used.
-
 * `additional_planner_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base planner prompt.
 
 * `additional_solver_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base solver prompt.

--- a/examples/agents/react/configs/config.yml
+++ b/examples/agents/react/configs/config.yml
@@ -40,7 +40,6 @@ workflow:
   llm_name: nim_llm
   verbose: true
   parse_agent_response_max_retries: 2
-  use_openai_api: true
 
 eval:
   general:

--- a/examples/agents/rewoo/README.md
+++ b/examples/agents/rewoo/README.md
@@ -107,8 +107,6 @@ The ReWOO agent is configured through the `config.yml` file. The following confi
 
 * `log_response_max_chars`: Defaults to 1000. Maximum number of characters to display in logs when logging tool responses.
 
-* `use_openai_api`: Defaults to False. If set to True, the ReWOO agent will output in OpenAI API spec. If set to False, strings will be used.
-
 * `additional_planner_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base planner prompt.
 
 * `additional_solver_instructions`: Optional. Defaults to `None`. Additional instructions to provide to the agent in addition to the base solver prompt.

--- a/src/nat/agent/react_agent/register.py
+++ b/src/nat/agent/react_agent/register.py
@@ -24,6 +24,7 @@ from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
 from nat.data_models.agent import AgentBaseConfig
 from nat.data_models.api_server import ChatRequest
+from nat.data_models.api_server import ChatRequestOrMessage
 from nat.data_models.api_server import ChatResponse
 from nat.data_models.api_server import Usage
 from nat.data_models.component_ref import FunctionGroupRef
@@ -70,9 +71,6 @@ class ReActAgentWorkflowConfig(AgentBaseConfig, OptimizableMixin, name="react_ag
         default=None,
         description="Provides the SYSTEM_PROMPT to use with the agent")  # defaults to SYSTEM_PROMPT in prompt.py
     max_history: int = Field(default=15, description="Maximum number of messages to keep in the conversation history.")
-    use_openai_api: bool = Field(default=False,
-                                 description=("Use OpenAI API for the input/output types to the function. "
-                                              "If False, strings will be used."))
     additional_instructions: str | None = OptimizableField(
         default=None,
         description="Additional instructions to provide to the agent in addition to the base prompt.",
@@ -118,21 +116,23 @@ async def react_agent_workflow(config: ReActAgentWorkflowConfig, builder: Builde
         pass_tool_call_errors_to_agent=config.pass_tool_call_errors_to_agent,
         normalize_tool_input_quotes=config.normalize_tool_input_quotes).build_graph()
 
-    async def _response_fn(input_message: ChatRequest) -> ChatResponse:
+    async def _response_fn(chat_request_or_message: ChatRequestOrMessage) -> ChatResponse | str:
         """
         Main workflow entry function for the ReAct Agent.
 
         This function invokes the ReAct Agent Graph and returns the response.
 
         Args:
-            input_message (ChatRequest): The input message to process
+            chat_request_or_message (ChatRequestOrMessage): The input message to process
 
         Returns:
-            ChatResponse: The response from the agent or error message
+            ChatResponse | str: The response from the agent or error message
         """
         try:
+            message = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequest)
+
             # initialize the starting state with the user query
-            messages: list[BaseMessage] = trim_messages(messages=[m.model_dump() for m in input_message.messages],
+            messages: list[BaseMessage] = trim_messages(messages=[m.model_dump() for m in message.messages],
                                                         max_tokens=config.max_history,
                                                         strategy="last",
                                                         token_counter=len,
@@ -153,25 +153,16 @@ async def react_agent_workflow(config: ReActAgentWorkflowConfig, builder: Builde
             content = str(output_message.content)
 
             # Create usage statistics for the response
-            prompt_tokens = sum(len(str(msg.content).split()) for msg in input_message.messages)
+            prompt_tokens = sum(len(str(msg.content).split()) for msg in message.messages)
             completion_tokens = len(content.split()) if content else 0
             total_tokens = prompt_tokens + completion_tokens
             usage = Usage(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens, total_tokens=total_tokens)
-            return ChatResponse.from_string(content, usage=usage)
-
+            response = ChatResponse.from_string(content, usage=usage)
+            if chat_request_or_message.is_string:
+                return GlobalTypeConverter.get().convert(response, to_type=str)
+            return response
         except Exception as ex:
             logger.exception("%s ReAct Agent failed with exception: %s", AGENT_LOG_PREFIX, str(ex))
             raise RuntimeError
 
-    if (config.use_openai_api):
-        yield FunctionInfo.from_fn(_response_fn, description=config.description)
-    else:
-
-        async def _str_api_fn(input_message: str) -> str:
-            oai_input = GlobalTypeConverter.get().try_convert(input_message, to_type=ChatRequest)
-
-            oai_output = await _response_fn(oai_input)
-
-            return GlobalTypeConverter.get().try_convert(oai_output, to_type=str)
-
-        yield FunctionInfo.from_fn(_str_api_fn, description=config.description)
+    yield FunctionInfo.from_fn(_response_fn, description=config.description)

--- a/src/nat/agent/rewoo_agent/register.py
+++ b/src/nat/agent/rewoo_agent/register.py
@@ -25,6 +25,7 @@ from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
 from nat.data_models.agent import AgentBaseConfig
 from nat.data_models.api_server import ChatRequest
+from nat.data_models.api_server import ChatRequestOrMessage
 from nat.data_models.api_server import ChatResponse
 from nat.data_models.api_server import Usage
 from nat.data_models.component_ref import FunctionGroupRef
@@ -54,9 +55,6 @@ class ReWOOAgentWorkflowConfig(AgentBaseConfig, name="rewoo_agent"):
                                                description="The number of retries before raising a tool call error.",
                                                ge=1)
     max_history: int = Field(default=15, description="Maximum number of messages to keep in the conversation history.")
-    use_openai_api: bool = Field(default=False,
-                                 description=("Use OpenAI API for the input/output types to the function. "
-                                              "If False, strings will be used."))
     additional_planner_instructions: str | None = Field(
         default=None,
         validation_alias=AliasChoices("additional_planner_instructions", "additional_instructions"),
@@ -125,21 +123,23 @@ async def rewoo_agent_workflow(config: ReWOOAgentWorkflowConfig, builder: Builde
         tool_call_max_retries=config.tool_call_max_retries,
         raise_tool_call_error=config.raise_tool_call_error).build_graph()
 
-    async def _response_fn(input_message: ChatRequest) -> ChatResponse:
+    async def _response_fn(chat_request_or_message: ChatRequestOrMessage) -> ChatResponse | str:
         """
         Main workflow entry function for the ReWOO Agent.
 
         This function invokes the ReWOO Agent Graph and returns the response.
 
         Args:
-            input_message (ChatRequest): The input message to process
+            chat_request_or_message (ChatRequestOrMessage): The input message to process
 
         Returns:
-            ChatResponse: The response from the agent or error message
+            ChatResponse | str: The response from the agent or error message
         """
         try:
+            message = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequest)
+
             # initialize the starting state with the user query
-            messages: list[BaseMessage] = trim_messages(messages=[m.model_dump() for m in input_message.messages],
+            messages: list[BaseMessage] = trim_messages(messages=[m.model_dump() for m in message.messages],
                                                         max_tokens=config.max_history,
                                                         strategy="last",
                                                         token_counter=len,
@@ -160,25 +160,16 @@ async def rewoo_agent_workflow(config: ReWOOAgentWorkflowConfig, builder: Builde
                 output_message = str(output_message)
 
             # Create usage statistics for the response
-            prompt_tokens = sum(len(str(msg.content).split()) for msg in input_message.messages)
+            prompt_tokens = sum(len(str(msg.content).split()) for msg in message.messages)
             completion_tokens = len(output_message.split()) if output_message else 0
             total_tokens = prompt_tokens + completion_tokens
             usage = Usage(prompt_tokens=prompt_tokens, completion_tokens=completion_tokens, total_tokens=total_tokens)
-            return ChatResponse.from_string(output_message, usage=usage)
-
+            response = ChatResponse.from_string(output_message, usage=usage)
+            if chat_request_or_message.is_string:
+                return GlobalTypeConverter.get().convert(response, to_type=str)
+            return response
         except Exception as ex:
             logger.exception("ReWOO Agent failed with exception: %s", ex)
             raise RuntimeError
 
-    if (config.use_openai_api):
-        yield FunctionInfo.from_fn(_response_fn, description=config.description)
-
-    else:
-
-        async def _str_api_fn(input_message: str) -> str:
-            oai_input = GlobalTypeConverter.get().try_convert(input_message, to_type=ChatRequest)
-            oai_output = await _response_fn(oai_input)
-
-            return GlobalTypeConverter.get().try_convert(oai_output, to_type=str)
-
-        yield FunctionInfo.from_fn(_str_api_fn, description=config.description)
+    yield FunctionInfo.from_fn(_response_fn, description=config.description)

--- a/src/nat/agent/tool_calling_agent/register.py
+++ b/src/nat/agent/tool_calling_agent/register.py
@@ -23,8 +23,10 @@ from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
 from nat.data_models.agent import AgentBaseConfig
 from nat.data_models.api_server import ChatRequest
+from nat.data_models.api_server import ChatRequestOrMessage
 from nat.data_models.component_ref import FunctionGroupRef
 from nat.data_models.component_ref import FunctionRef
+from nat.utils.type_converter import GlobalTypeConverter
 
 logger = logging.getLogger(__name__)
 
@@ -81,21 +83,23 @@ async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, build
                                                          handle_tool_errors=config.handle_tool_errors,
                                                          return_direct=return_direct_tools).build_graph()
 
-    async def _response_fn(input_message: ChatRequest) -> str:
+    async def _response_fn(chat_request_or_message: ChatRequestOrMessage) -> str:
         """
         Main workflow entry function for the Tool Calling Agent.
 
         This function invokes the Tool Calling Agent Graph and returns the response.
 
         Args:
-            input_message (ChatRequest): The input message to process
+            chat_request_or_message (ChatRequestOrMessage): The input message to process
 
         Returns:
             str: The response from the agent or error message
         """
         try:
+            message = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequest)
+
             # initialize the starting state with the user query
-            messages: list[BaseMessage] = trim_messages(messages=[m.model_dump() for m in input_message.messages],
+            messages: list[BaseMessage] = trim_messages(messages=[m.model_dump() for m in message.messages],
                                                         max_tokens=config.max_history,
                                                         strategy="last",
                                                         token_counter=len,

--- a/src/nat/data_models/api_server.py
+++ b/src/nat/data_models/api_server.py
@@ -28,6 +28,7 @@ from pydantic import HttpUrl
 from pydantic import conlist
 from pydantic import field_serializer
 from pydantic import field_validator
+from pydantic import model_validator
 from pydantic_core.core_schema import ValidationInfo
 
 from nat.data_models.interactive import HumanPrompt
@@ -120,15 +121,7 @@ class Message(BaseModel):
     role: UserMessageContentRoleType
 
 
-class ChatRequest(BaseModel):
-    """
-    ChatRequest is a data model that represents a request to the NAT chat API.
-    Fully compatible with OpenAI Chat Completions API specification.
-    """
-
-    # Required fields
-    messages: typing.Annotated[list[Message], conlist(Message, min_length=1)]
-
+class ChatRequestOptionals(BaseModel):
     # Optional fields (OpenAI Chat Completions API compatible)
     model: str | None = Field(default=None, description="name of the model to use")
     frequency_penalty: float | None = Field(default=0.0,
@@ -152,6 +145,16 @@ class ChatRequest(BaseModel):
     tool_choice: str | dict[str, typing.Any] | None = Field(default=None, description="Controls which tool is called")
     parallel_tool_calls: bool | None = Field(default=True, description="Whether to enable parallel function calling")
     user: str | None = Field(default=None, description="Unique identifier representing end-user")
+
+
+class ChatRequest(ChatRequestOptionals):
+    """
+    ChatRequest is a data model that represents a request to the NAT chat API.
+    Fully compatible with OpenAI Chat Completions API specification.
+    """
+
+    # Required fields
+    messages: typing.Annotated[list[Message], conlist(Message, min_length=1)]
 
     model_config = ConfigDict(extra="allow",
                               json_schema_extra={
@@ -192,6 +195,42 @@ class ChatRequest(BaseModel):
                            temperature=temperature,
                            max_tokens=max_tokens,
                            top_p=top_p)
+
+
+class ChatRequestOrMessage(ChatRequestOptionals):
+    """
+    ChatRequestOrMessage is a data model that represents either a conversation or a string input.
+    This is useful for functions that can handle either type of input.
+
+    `messages` is compatible with the OpenAI Chat Completions API specification.
+
+    `input_string` is a string input that can be used for functions that do not require a conversation.
+    """
+
+    messages: typing.Annotated[list[Message] | None, conlist(Message, min_length=1)] = Field(
+        default=None, description="The conversation messages to process.")
+
+    input_string: str | None = Field(default=None, alias="input_message", description="The input message to process.")
+
+    @property
+    def is_string(self) -> bool:
+        return self.input_string is not None
+
+    @property
+    def is_conversation(self) -> bool:
+        return self.messages is not None
+
+    @model_validator(mode="after")
+    def validate_messages_or_input_string(self):
+        if self.messages is not None and self.input_string is not None:
+            raise ValueError("Either messages or input_message/input_string must be provided, not both")
+        if self.messages is None and self.input_string is None:
+            raise ValueError("Either messages or input_message/input_string must be provided")
+        if self.input_string is not None:
+            extra_fields = self.model_dump(exclude={"input_string"}, exclude_none=True, exclude_unset=True)
+            if len(extra_fields) > 0:
+                raise ValueError("no extra fields are permitted when input_message/input_string is provided")
+        return self
 
 
 class ChoiceMessage(BaseModel):
@@ -659,6 +698,36 @@ def _string_to_nat_chat_request(data: str) -> ChatRequest:
 
 
 GlobalTypeConverter.register_converter(_string_to_nat_chat_request)
+
+
+def _chat_request_or_message_to_chat_request(data: ChatRequestOrMessage) -> ChatRequest:
+    if data.input_string is not None:
+        return _string_to_nat_chat_request(data.input_string)
+    return ChatRequest(**data.model_dump(exclude={"input_string"}))
+
+
+GlobalTypeConverter.register_converter(_chat_request_or_message_to_chat_request)
+
+
+def _chat_request_to_chat_request_or_message(data: ChatRequest) -> ChatRequestOrMessage:
+    return ChatRequestOrMessage(**data.model_dump(by_alias=True))
+
+
+GlobalTypeConverter.register_converter(_chat_request_to_chat_request_or_message)
+
+
+def _chat_request_or_message_to_string(data: ChatRequestOrMessage) -> str:
+    return data.input_string or ""
+
+
+GlobalTypeConverter.register_converter(_chat_request_or_message_to_string)
+
+
+def _string_to_chat_request_or_message(data: str) -> ChatRequestOrMessage:
+    return ChatRequestOrMessage(input_message=data)
+
+
+GlobalTypeConverter.register_converter(_string_to_chat_request_or_message)
 
 
 # ======== ChatResponse Converters ========

--- a/src/nat/utils/type_converter.py
+++ b/src/nat/utils/type_converter.py
@@ -93,6 +93,14 @@ class TypeConverter:
         if to_type is None or decomposed.is_instance(data):
             return data
 
+        # 2) If data is a union type, try to convert to each type in the union
+        if decomposed.is_union:
+            for union_type in decomposed.args:
+                result = self._convert(data, union_type)
+                if result is not None:
+                    return result
+            return None
+
         root = decomposed.root
 
         # 2) Attempt direct in *this* converter


### PR DESCRIPTION
## Description

`use_openai_api` was previously a configuration option which controlled the input and output schema of agents.

This PR removes this configuration variable by replacing the input type with a new Union-like type which can either be a `ChatRequest` or a `str`.

- Adds converters for the new type
- Adds support for unions in the global conversion logic
- Updates all agents to use this new dynamic type
- Add documentation to the `ChatRequestOrMessage` to aid user understanding

Advantages:
- Still strongly typed for input and output schemas
- Enables dynamic input validation and return
- Keep example documentation the same
- Provides flexibility to use `input_message` in manual cURL calls while using the conversation history option in NAT UI

Disadvantages:
- Slightly more cumbersome to use
- One additional mandatory conversion

<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes nvbugs-5563797

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Agents now accept either a chat conversation or a single input string, returning plain text when a string is provided.
  - Improved message history trimming for more reliable context handling.

- Documentation
  - Removed the deprecated “use_openai_api” configuration from ReAct and ReWOO docs and README.
  - Updated configuration guidance to reflect simplified input/response behavior.

- Chores
  - Cleaned up example configs by removing the “use_openai_api” flag to align with the new unified input flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->