### PR TITLE
fix: ensure mcp client can load exported function group functions

### DIFF
--- a/src/nat/builder/function.py
+++ b/src/nat/builder/function.py
@@ -416,7 +416,7 @@ class FunctionGroup:
         """
         if not name.strip():
             raise ValueError("Function name cannot be empty or blank")
-        if not re.match(r"^[a-zA-Z0-9_-.]+$", name):
+        if not re.match(r"^[a-zA-Z0-9_.-]+$", name):
             raise ValueError(
                 f"Function name can only contain letters, numbers, underscores, periods, and hyphens: {name}")
         if name in self._functions:

--- a/tests/nat/builder/test_builder.py
+++ b/tests/nat/builder/test_builder.py
@@ -1200,7 +1200,8 @@ async def test_function_group_add_function_validation():
         group.add_function("", dummy_func)
 
     # Test function name with whitespace
-    with pytest.raises(ValueError, match="Function name can only contain letters, numbers, underscores, and hyphens"):
+    with pytest.raises(ValueError,
+                       match="Function name can only contain letters, numbers, underscores, periods, and hyphens"):
 
         async def dummy_func2(x: int) -> int:
             return x

--- a/tests/nat/builder/test_function_group.py
+++ b/tests/nat/builder/test_function_group.py
@@ -76,10 +76,12 @@ def test_function_group_add_function_validation():
         group.add_function("   ", test_fn)
 
     # Test invalid character validation
-    with pytest.raises(ValueError, match="Function name can only contain letters, numbers, underscores, and hyphens"):
+    with pytest.raises(ValueError,
+                       match="Function name can only contain letters, numbers, underscores, periods, and hyphens"):
         group.add_function("func@name", test_fn)
 
-    with pytest.raises(ValueError, match="Function name can only contain letters, numbers, underscores, and hyphens"):
+    with pytest.raises(ValueError,
+                       match="Function name can only contain letters, numbers, underscores, periods, and hyphens"):
         group.add_function("func name", test_fn)
 
     # Test duplicate function names


### PR DESCRIPTION
## Description

Prior to this PR if `nat mcp serve` was invoked on a workflow that exported functions from function groups, the MCP client would fail on the inability to load a function since it contained a `.`.

This PR fixes that.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
