### PR TITLE
fix: Dockerfiles must not use any arg expansion on `COPY --from` lines

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,17 +16,15 @@
 ARG BASE_IMAGE_URL=nvcr.io/nvidia/base/ubuntu
 ARG BASE_IMAGE_TAG=22.04_20240212
 ARG PYTHON_VERSION=3.13
-ARG UV_VERSION=0.8.15
 # Specified on the command line with --build-arg NAT_VERSION=$(python -m setuptools_scm)
 ARG NAT_VERSION
 
 FROM --platform=$TARGETPLATFORM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
 
 ARG PYTHON_VERSION
-ARG UV_VERSION
 ARG NAT_VERSION
 
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /uvx /bin/
 
 ENV PYTHONDONTWRITEBYTECODE=1
 

--- a/examples/evaluation_and_profiling/email_phishing_analyzer/Dockerfile
+++ b/examples/evaluation_and_profiling/email_phishing_analyzer/Dockerfile
@@ -16,17 +16,15 @@
 ARG BASE_IMAGE_URL=nvcr.io/nvidia/base/ubuntu
 ARG BASE_IMAGE_TAG=22.04_20240212
 ARG PYTHON_VERSION=3.13
-ARG UV_VERSION=0.8.15
 # Specified on the command line with --build-arg NAT_VERSION=$(python -m setuptools_scm)
 ARG NAT_VERSION
 
 FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
 
 ARG PYTHON_VERSION
-ARG UV_VERSION
 ARG NAT_VERSION
 
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /uvx /bin/
 
 ENV PYTHONDONTWRITEBYTECODE=1
 

--- a/examples/frameworks/agno_personal_finance/Dockerfile
+++ b/examples/frameworks/agno_personal_finance/Dockerfile
@@ -16,17 +16,15 @@
 ARG BASE_IMAGE_URL=nvcr.io/nvidia/base/ubuntu
 ARG BASE_IMAGE_TAG=22.04_20240212
 ARG PYTHON_VERSION=3.13
-ARG UV_VERSION=0.8.15
 # Specified on the command line with --build-arg NAT_VERSION=$(python -m setuptools_scm)
 ARG NAT_VERSION
 
 FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
 
 ARG PYTHON_VERSION
-ARG UV_VERSION
 ARG NAT_VERSION
 
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /uvx /bin/
 
 ENV PYTHONDONTWRITEBYTECODE=1
 

--- a/examples/getting_started/simple_calculator/Dockerfile
+++ b/examples/getting_started/simple_calculator/Dockerfile
@@ -16,17 +16,15 @@
 ARG BASE_IMAGE_URL=nvcr.io/nvidia/base/ubuntu
 ARG BASE_IMAGE_TAG=22.04_20240212
 ARG PYTHON_VERSION=3.13
-ARG UV_VERSION=0.8.15
 # Specified on the command line with --build-arg NAT_VERSION=$(python -m setuptools_scm)
 ARG NAT_VERSION
 
 FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
 
 ARG PYTHON_VERSION
-ARG UV_VERSION
 ARG NAT_VERSION
 
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /uvx /bin/
 
 ENV PYTHONDONTWRITEBYTECODE=1
 

--- a/examples/getting_started/simple_web_query/Dockerfile
+++ b/examples/getting_started/simple_web_query/Dockerfile
@@ -16,17 +16,15 @@
 ARG BASE_IMAGE_URL=nvcr.io/nvidia/base/ubuntu
 ARG BASE_IMAGE_TAG=22.04_20240212
 ARG PYTHON_VERSION=3.13
-ARG UV_VERSION=0.8.15
 # Specified on the command line with --build-arg NAT_VERSION=$(python -m setuptools_scm)
 ARG NAT_VERSION
 
 FROM ${BASE_IMAGE_URL}:${BASE_IMAGE_TAG}
 
 ARG PYTHON_VERSION
-ARG UV_VERSION
 ARG NAT_VERSION
 
-COPY --from=ghcr.io/astral-sh/uv:${UV_VERSION} /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.8.15 /uv /uvx /bin/
 
 ENV PYTHONDONTWRITEBYTECODE=1
 


### PR DESCRIPTION
## Description

Closes nvbugs-5561420, nvbugs-5563886

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Pinned the UV tool to version 0.8.15 across the main and example Dockerfiles to ensure consistent, reproducible builds.
  - Removed the UV_VERSION build argument; builds no longer accept or require this parameter. Existing build flows remain unchanged aside from the fixed version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->