### PR TITLE
Limit when we upload to artifactory

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -158,7 +158,5 @@ upload:artifactory:
   needs:
     - job: package:wheel
   rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-    - if: $CI_COMMIT_BRANCH == 'main'
     - if: $CI_COMMIT_TAG
-    - if: $CI_COMMIT_BRANCH =~ /^release\/.*$/
+    - if: $CI_CRON_NIGHTLY == "1"


### PR DESCRIPTION
## Description
* Only for nightly and tagged commits

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Adjusted release pipeline to trigger uploads only for tagged releases and nightly scheduled runs.
  * Nightly builds will be generated regularly; branch-based builds will no longer publish artifacts.
  * Improves reliability and predictability of downloadable artifacts for users following nightly or tagged releases.
  * Existing tagged release flow remains unchanged; no action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->