### PR TITLE
Fix reasoning models ending with v1 to use detailed thinking format

### DIFF
--- a/src/nat/data_models/thinking_mixin.py
+++ b/src/nat/data_models/thinking_mixin.py
@@ -51,7 +51,7 @@ class ThinkingMixin(
         Returns the system prompt to use for thinking.
         For NVIDIA Nemotron, returns "/think" if enabled, else "/no_think".
         For Llama Nemotron v1.5, returns "/think" if enabled, else "/no_think".
-        For Llama Nemotron v1.0, returns "detailed thinking on" if enabled, else "detailed thinking off".
+        For Llama Nemotron v1.0 or v1.1, returns "detailed thinking on" if enabled, else "detailed thinking off".
         If thinking is not supported on the model, returns None.
 
         Returns:
@@ -72,7 +72,7 @@ class ThinkingMixin(
                 return "/think" if self.thinking else "/no_think"
 
             if model.startswith("nvidia/llama"):
-                if "v1-0" in model or "v1-1" in model:
+                if "v1-0" in model or "v1-1" in model or model.endswith("v1"):
                     return f"detailed thinking {'on' if self.thinking else 'off'}"
 
                 if "v1-5" in model:

--- a/tests/nat/data_models/test_thinking_mixin.py
+++ b/tests/nat/data_models/test_thinking_mixin.py
@@ -56,6 +56,12 @@ class TestThinkingMixin:
         m_false = Model(model_name="NVIDIA/LLaMa-3.1-Nemotron-v1-5", thinking=False)
         assert m_false.thinking_system_prompt == "/no_think"
 
+        m_true = Model(model_name="NVIDIA/LLaMa-3.1-Nemotron-v1", thinking=True)
+        assert m_true.thinking_system_prompt == "detailed thinking on"
+
+        m_false = Model(model_name="NVIDIA/LLaMa-3.1-Nemotron-v1", thinking=False)
+        assert m_false.thinking_system_prompt == "detailed thinking off"
+
     def test_supported_default_remains_none(self):
 
         class Model(ThinkingMixin):


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Fix the thinking tag for models starting with ```nvidia/llama``` and ending with ```v1``` (e.g., [nvidia/llama-3.1-nemotron-nano-8b-v1](https://build.nvidia.com/nvidia/llama-3_1-nemotron-nano-8b-v1)) to use ```detailed thinking on/detailed thinking off``` instead of ```/think```/```/no_think```.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Models with names ending in "v1" now consistently receive the correct "detailed thinking on/off" system prompts when thinking is toggled, matching other v1-era variants.

* **Tests**
  * Added tests verifying a v1-named model variant uses the correct prompts for both thinking enabled and disabled states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->