### PR TITLE
docs: remove duplicate line in MCP authentication documentation

### DIFF
--- a/docs/source/workflows/mcp/mcp-auth.md
+++ b/docs/source/workflows/mcp/mcp-auth.md
@@ -193,7 +193,6 @@ This will use the `mcp_oauth2` authentication provider to authenticate the user.
 
 ### Authentication Best Practices
 When using MCP authentication, consider the following security recommendations:
-When using MCP authentication, consider the following security recommendations:
 - The `default_user_id` is used to cache the authenticating user during setup and optionally for tool calls. It is recommended to set `allow_default_user_id_for_tool_calls` to `false` in the authentication configuration for multi-user workflows to avoid accidental tool calls by unauthorized users.
 - Use HTTPS redirect URIs in production environments.
 - Scope OAuth2 tokens to the minimum required permissions.


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Cleaned up the Authentication Best Practices section for MCP authentication by removing a duplicate header line.
  * Improved readability and reduced redundancy without altering the existing guidance or structure.
  * No functional or behavioral changes; content remains the same, just clearer presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->