### PR TITLE
fix: Update system message (if exists) for thinking injection

### DIFF
--- a/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
+++ b/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
@@ -43,6 +43,12 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
 
         @override
         def inject(self, messages: list[Message], *args, **kwargs) -> FunctionArgumentWrapper:
+            # Attempt to inject the system prompt into the first system message
+            for message in messages:
+                if message.role == "system":
+                    message.content = f"{self.system_prompt}\n\n{message.content}"
+                    return FunctionArgumentWrapper(messages, *args, **kwargs)
+            # If no system message found, prepend a new one
             new_messages = [Message(role="system", content=self.system_prompt)] + messages
             return FunctionArgumentWrapper(new_messages, *args, **kwargs)
 

--- a/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
+++ b/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
@@ -41,6 +41,12 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
 
         @override
         def inject(self, messages: list[dict[str, str]], *args, **kwargs) -> FunctionArgumentWrapper:
+            # Attempt to inject the system prompt into the first system message
+            for message in messages:
+                if message["role"] == "system":
+                    message["content"] = f"{self.system_prompt}\n\n{message['content']}"
+                    return FunctionArgumentWrapper(messages, *args, **kwargs)
+            # If no system message found, prepend a new one
             new_messages = [{"role": "system", "content": self.system_prompt}] + messages
             return FunctionArgumentWrapper(new_messages, *args, **kwargs)
 

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
@@ -44,6 +44,12 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
 
         @override
         def inject(self, messages: Sequence[ChatMessage], *args, **kwargs) -> FunctionArgumentWrapper:
+            # Attempt to inject the system prompt into the first system message
+            for message in messages:
+                if message.role == "system":
+                    message.content = f"{self.system_prompt}\n\n{message.content}"
+                    return FunctionArgumentWrapper(messages, *args, **kwargs)
+            # If no system message found, prepend a new one
             new_messages = [ChatMessage(role="system", content=self.system_prompt)] + list(messages)
             return FunctionArgumentWrapper(new_messages, *args, **kwargs)
 

--- a/packages/nvidia_nat_semantic_kernel/src/nat/plugins/semantic_kernel/llm.py
+++ b/packages/nvidia_nat_semantic_kernel/src/nat/plugins/semantic_kernel/llm.py
@@ -35,8 +35,6 @@ ModelType = TypeVar("ModelType")
 def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> ModelType:
 
     from semantic_kernel.contents.chat_history import ChatHistory
-    from semantic_kernel.contents.chat_message_content import ChatMessageContent
-    from semantic_kernel.contents.utils.author_role import AuthorRole
 
     class SemanticKernelThinkingInjector(BaseThinkingInjector):
 
@@ -61,8 +59,8 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
                 return FunctionArgumentWrapper(new_messages, *args, **kwargs)
             else:
                 new_messages = ChatHistory(
-                    [ChatMessageContent(role=AuthorRole.SYSTEM, content=self.system_prompt)] + chat_history.messages,
-                    system_message=chat_history.system_message,
+                    chat_history.messages,
+                    system_message=f"{self.system_prompt}\n\n{chat_history.system_message}",
                 )
                 return FunctionArgumentWrapper(new_messages, *args, **kwargs)
 


### PR DESCRIPTION
## Description

If a prior system prompt exists, then always update it when applying the thinking prompt.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented duplicate system prompts by updating existing system messages when present across Agno, CrewAI, LangChain, LlamaIndex, and Semantic Kernel integrations.

* **Refactor**
  * Streamlined system prompt injection to modify the first system message in-place and only insert a new one when none exists, ensuring cleaner chat histories and consistent behavior across frameworks.
  * Improved control flow for message handling, reducing unnecessary wrapping and preserving original message structures for better readability and interoperability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->