### PR TITLE
fix: improve agent-to-agent calling by simplifying pydantic model

### DIFF
--- a/src/nat/data_models/api_server.py
+++ b/src/nat/data_models/api_server.py
@@ -196,17 +196,54 @@ class ChatRequest(BaseModel):
 
 class ChatRequestOrMessage(BaseModel):
     """
-    ChatRequestOrMessage is a data model that represents either a conversation or a string input.
+    `ChatRequestOrMessage` is a data model that represents either a conversation or a string input.
     This is useful for functions that can handle either type of input.
 
-    `messages` is compatible with the OpenAI Chat Completions API specification.
-
-    `input_message` is a string input that can be used for functions that do not require a conversation.
+    - `messages` is compatible with the OpenAI Chat Completions API specification.
+    - `input_message` is a string input that can be used for functions that do not require a conversation.
 
     Note: When `messages` is provided, extra fields are allowed to enable lossless round-trip
     conversion with ChatRequest. When `input_message` is provided, no extra fields are permitted.
     """
-    model_config = ConfigDict(extra="allow")
+    model_config = ConfigDict(
+        extra="allow",
+        json_schema_extra={
+            "examples": [
+                {
+                    "input_message": "What can you do?"
+                },
+                {
+                    "messages": [{
+                        "role": "user", "content": "What can you do?"
+                    }],
+                    "model": "nvidia/nemotron",
+                    "temperature": 0.7
+                },
+            ],
+            "oneOf": [
+                {
+                    "required": ["input_message"],
+                    "properties": {
+                        "input_message": {
+                            "type": "string"
+                        },
+                    },
+                    "additionalProperties": {
+                        "not": True, "errorMessage": 'remove additional property ${0#}'
+                    },
+                },
+                {
+                    "required": ["messages"],
+                    "properties": {
+                        "messages": {
+                            "type": "array"
+                        },
+                    },
+                    "additionalProperties": True
+                },
+            ]
+        },
+    )
 
     messages: typing.Annotated[list[Message] | None, conlist(Message, min_length=1)] = Field(
         default=None, description="A non-empty conversation of messages to process.")


### PR DESCRIPTION
## Description

With agents like ReAct, ReWOO, and Tool Calling, they may potentially call other agents as functions. When they do, LLMs have a tough time discerning what to send due to the complex payload requirement of `ChatRequestOrMessage`.

This PR addresses this problem in the following ways:
- Avoids any field aliases (would always try the field name rather than the alias name)
- Reverts implementation of `ChatRequest` to contain all optional fields
- Simplifies representation of `ChatRequestOrMessage` to either be an optional list of messages or a single input message. Extra fields are permitted so we can do a round-trip conversion cycle of `ChatRequest` -> `ChatRequestOrMessage` -> `ChatRequest` without loss of information.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Chat request format now requires messages (min 1) and still supports single-message submissions via input_message.

- Refactor
  - Consolidated request fields into a single public request model for simpler, more predictable payloads.
  - Renamed input_string to input_message and streamlined validation and error messages for clearer behavior.
  - Conversion and compatibility paths updated to align with the new field naming while preserving backward compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->