### PR TITLE
Enable Chat History for WebSocket Messages

### DIFF
--- a/src/nat/front_ends/fastapi/message_validator.py
+++ b/src/nat/front_ends/fastapi/message_validator.py
@@ -240,8 +240,7 @@ class MessageValidator:
         thread_id: str = "default",
         parent_id: str = "default",
         conversation_id: str | None = None,
-        content: SystemResponseContent
-        | Error = SystemResponseContent(),
+        content: SystemResponseContent | Error = SystemResponseContent(),
         status: WebSocketMessageStatus = WebSocketMessageStatus.IN_PROGRESS,
         timestamp: str = str(datetime.datetime.now(datetime.UTC))
     ) -> WebSocketSystemResponseTokenMessage | None:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This PR updates the WebSocket message handler to pass the correct payload to the agent, enabling chat history for supported workflow types.
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced WebSocket handling for multi-message chats and unified Chat/Generate streams with consistent outputs.
  * Improved human-in-the-loop prompts and responses, returning clearer, consistent message content.

* **Bug Fixes**
  * Prevents workflows from starting while another task runs, reducing race conditions.
  * More robust message creation and error handling for fewer failed interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->