### PR TITLE
fix: explicitly add `tool.uv.managed = true` to pyproject.toml files

### DIFF
--- a/packages/nvidia_nat_adk/pyproject.toml
+++ b/packages/nvidia_nat_adk/pyproject.toml
@@ -57,6 +57,7 @@ documentation = "https://docs.nvidia.com/nemo/agent-toolkit/latest/"
 source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_agno/pyproject.toml
+++ b/packages/nvidia_nat_agno/pyproject.toml
@@ -44,6 +44,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_all/pyproject.toml
+++ b/packages/nvidia_nat_all/pyproject.toml
@@ -60,6 +60,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_crewai/pyproject.toml
+++ b/packages/nvidia_nat_crewai/pyproject.toml
@@ -43,6 +43,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_data_flywheel/pyproject.toml
+++ b/packages/nvidia_nat_data_flywheel/pyproject.toml
@@ -43,6 +43,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_ingestion/pyproject.toml
+++ b/packages/nvidia_nat_ingestion/pyproject.toml
@@ -43,6 +43,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_langchain/pyproject.toml
+++ b/packages/nvidia_nat_langchain/pyproject.toml
@@ -50,6 +50,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_llama_index/pyproject.toml
+++ b/packages/nvidia_nat_llama_index/pyproject.toml
@@ -55,6 +55,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_mcp/pyproject.toml
+++ b/packages/nvidia_nat_mcp/pyproject.toml
@@ -44,6 +44,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_mem0ai/pyproject.toml
+++ b/packages/nvidia_nat_mem0ai/pyproject.toml
@@ -43,6 +43,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_mysql/pyproject.toml
+++ b/packages/nvidia_nat_mysql/pyproject.toml
@@ -43,6 +43,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_opentelemetry/pyproject.toml
+++ b/packages/nvidia_nat_opentelemetry/pyproject.toml
@@ -45,6 +45,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_phoenix/pyproject.toml
+++ b/packages/nvidia_nat_phoenix/pyproject.toml
@@ -44,6 +44,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_profiling/pyproject.toml
+++ b/packages/nvidia_nat_profiling/pyproject.toml
@@ -45,6 +45,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_ragaai/pyproject.toml
+++ b/packages/nvidia_nat_ragaai/pyproject.toml
@@ -43,6 +43,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_redis/pyproject.toml
+++ b/packages/nvidia_nat_redis/pyproject.toml
@@ -43,6 +43,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_s3/pyproject.toml
+++ b/packages/nvidia_nat_s3/pyproject.toml
@@ -43,6 +43,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_semantic_kernel/pyproject.toml
+++ b/packages/nvidia_nat_semantic_kernel/pyproject.toml
@@ -43,6 +43,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_test/pyproject.toml
+++ b/packages/nvidia_nat_test/pyproject.toml
@@ -44,6 +44,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_weave/pyproject.toml
+++ b/packages/nvidia_nat_weave/pyproject.toml
@@ -47,6 +47,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/packages/nvidia_nat_zep_cloud/pyproject.toml
+++ b/packages/nvidia_nat_zep_cloud/pyproject.toml
@@ -43,6 +43,7 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,7 @@ openai = [
 ]
 
 [tool.uv]
+managed = true
 config-settings = { editable_mode = "compat" }
 
 


### PR DESCRIPTION
## Description

Help BlackDuck discover the project as a uv-managed project.

This is a no-op as `uv`'s default of `tool.uv.managed` is already true.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Standardized project tooling by enabling managed mode across packages.
  - Consolidated configuration for consistent builds without altering runtime behavior.
  - No changes to features, APIs, or user workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->