### PR TITLE
fix: address coderabbit feedback given from forward merge PR

### DIFF
--- a/docs/source/resources/running-tests.md
+++ b/docs/source/resources/running-tests.md
@@ -60,11 +60,11 @@ export AZURE_OPENAI_ENDPOINT="<your-custom-endpoint>"
 - `NAT_CI_ETCD_PORT`
 - `NAT_CI_MILVUS_HOST`
 - `NAT_CI_MILVUS_PORT`
+- `NAT_CI_MINIO_HOST`
 - `NAT_CI_MYSQL_HOST`
 - `NAT_CI_OPENSEARCH_URL`
 - `NAT_CI_PHOENIX_URL`
 - `NAT_CI_REDIS_HOST`
-- `NAT_CI_S3_HOST`
 
 
 ### Start the Required Services

--- a/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
+++ b/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
@@ -44,13 +44,16 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
         @override
         def inject(self, messages: list[Message], *args, **kwargs) -> FunctionArgumentWrapper:
             # Attempt to inject the system prompt into the first system message
-            for message in messages:
+            for i, message in enumerate(messages):
                 if message.role == "system":
-                    message.content = f"{self.system_prompt}\n\n{message.content}"
-                    return FunctionArgumentWrapper(messages, *args, **kwargs)
-            # If no system message found, prepend a new one
-            new_messages = [Message(role="system", content=self.system_prompt)] + messages
-            return FunctionArgumentWrapper(new_messages, *args, **kwargs)
+                    if self.system_prompt not in str(message.content):
+                        messages = list(messages)
+                        messages[i] = Message(role="system", content=f"{message.content}\n{self.system_prompt}")
+                    break
+            else:
+                messages = list(messages)
+                messages.insert(0, Message(role="system", content=self.system_prompt))
+            return FunctionArgumentWrapper(messages, *args, **kwargs)
 
     if isinstance(llm_config, RetryMixin):
         client = patch_with_retry(client,

--- a/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
+++ b/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
@@ -42,13 +42,16 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
         @override
         def inject(self, messages: list[dict[str, str]], *args, **kwargs) -> FunctionArgumentWrapper:
             # Attempt to inject the system prompt into the first system message
-            for message in messages:
+            for i, message in enumerate(messages):
                 if message["role"] == "system":
-                    message["content"] = f"{self.system_prompt}\n\n{message['content']}"
-                    return FunctionArgumentWrapper(messages, *args, **kwargs)
-            # If no system message found, prepend a new one
-            new_messages = [{"role": "system", "content": self.system_prompt}] + messages
-            return FunctionArgumentWrapper(new_messages, *args, **kwargs)
+                    if self.system_prompt not in message["content"]:
+                        messages = list(messages)
+                        messages[i] = {"role": "system", "content": f"{message['content']}\n{self.system_prompt}"}
+                    break
+            else:
+                messages = list(messages)
+                messages.insert(0, {"role": "system", "content": self.system_prompt})
+            return FunctionArgumentWrapper(messages, *args, **kwargs)
 
     if isinstance(llm_config, RetryMixin):
         client = patch_with_retry(client,


### PR DESCRIPTION
## Description

This PR addresses two issues brought up in a forward-merge PR:
- prefer immutability for system prompt injection
- update documentation related to running CI to properly reference `NAT_CI_MINIO_HOST`

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured consistent system prompt handling across Agno, CrewAI, LangChain, and LlamaIndex integrations: the first system message is augmented when needed, a system message is added if absent, and duplicate prompts are avoided. Inputs in LangChain are normalized for reliable behavior across strings, prompt values, and message lists.

* **Documentation**
  * Updated test environment variables: replaced NAT_CI_S3_HOST with NAT_CI_MINIO_HOST.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->