### PR TITLE
Update Migration Guide with Guidance on API data model changes

### DIFF
--- a/docs/source/resources/migration-guide.md
+++ b/docs/source/resources/migration-guide.md
@@ -27,6 +27,19 @@ It is strongly encouraged to migrate any existing code to the latest conventions
 
 ## Version Specific Changes
 
+### v1.3.0
+
+#### API Changes
+
+The {py:mod}`nat.data_models.api_server` module has been updated to improve type safety and OpenAI API compatibility.
+
+* {py:class}`nat.data_models.api_server.Choice` has been split into two specialized models:
+  * {py:class}`nat.data_models.api_server.ChatResponseChoice` - for non-streaming responses (contains `message` field)
+  * {py:class}`nat.data_models.api_server.ChatResponseChunkChoice` - for streaming responses (contains `delta` field)
+  * {py:class}`nat.data_models.api_server.Choice` remains as a backward compatibility alias for `ChatResponseChoice`
+
+* {py:class}`nat.data_models.api_server.ChatResponse` now requires `usage` field (no longer optional)
+
 ### v1.2.0
 
 #### Package Changes


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Added a new v1.3.0 section to the migration guide documenting the new changes in the `nat.data_models.api_server` module. The key changes include the restructuring of the `Choice` class into specialized `ChatResponseChoice` and 
`ChatResponseChunkChoice` models to improve type safety and OpenAI API compatibility.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a Version 1.3.0 section to the migration guide detailing chat response API updates: separate types for streaming vs non‑streaming choices, with a compatibility alias retained. Clarifies that the usage field is now required and flags this as a breaking change. Includes guidance and examples to assist with upgrades.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->