### PR TITLE
fix: langchain web ingest script must not always add CUDA documents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,7 +211,8 @@ tags
 [._]*.un~
 
 # Vector db files
-deploy/compose/volumes
+**/deploy/compose/volumes
+**/deploy/volumes
 examples/notebooks/examples/retail_sales_agent/deploy/volumes/
 
 # Mac Metadata

--- a/examples/custom_functions/automated_description_generation/src/nat_automated_description_generation/configs/config.yml
+++ b/examples/custom_functions/automated_description_generation/src/nat_automated_description_generation/configs/config.yml
@@ -18,7 +18,6 @@ llms:
   nim_llm:
     _type: nim
     model_name: meta/llama-3.1-70b-instruct
-    base_url: https://integrate.api.nvidia.com/v1
     temperature: 0.0
     max_tokens: 10000
 

--- a/examples/custom_functions/automated_description_generation/src/nat_automated_description_generation/configs/config_no_auto.yml
+++ b/examples/custom_functions/automated_description_generation/src/nat_automated_description_generation/configs/config_no_auto.yml
@@ -18,7 +18,6 @@ llms:
   nim_llm:
     _type: nim
     model_name: meta/llama-3.1-70b-instruct
-    base_url: https://integrate.api.nvidia.com/v1
     temperature: 0.0
     max_tokens: 10000
 
@@ -32,7 +31,7 @@ retrievers:
   retriever:
     _type: milvus_retriever
     uri: http://localhost:19530
-    collection_name: "wikipedia_docs"
+    collection_name: wikipedia_docs
     embedding_model: milvus_embedder
     top_k: 10
 
@@ -42,7 +41,7 @@ functions:
     retriever: retriever
     # Intentionally mislabelled to show the effects of poor descriptions
     topic: NVIDIA CUDA
-    description: Only to search about NVIDIA CUDA
+    description: This tool retrieves information about NVIDIA's CUDA library
 
 workflow:
   _type: react_agent

--- a/scripts/langchain_web_ingest.py
+++ b/scripts/langchain_web_ingest.py
@@ -124,11 +124,17 @@ if __name__ == "__main__":
     DEFAULT_URI = "http://localhost:19530"
 
     parser = argparse.ArgumentParser(formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument("--urls", default=CUDA_URLS, action="append", help="Urls to scrape for RAG context")
+    parser.add_argument("--urls",
+                        default=[],
+                        action="append",
+                        help="Urls to scrape for RAG context. Defaults to built-in URLs for NVIDIA CUDA documentation.")
     parser.add_argument("--collection_name", "-n", default=CUDA_COLLECTION_NAME, help="Collection name for the data.")
     parser.add_argument("--milvus_uri", "-u", default=DEFAULT_URI, help="Milvus host URI")
     parser.add_argument("--clean_cache", default=False, help="If true, deletes local files", action="store_true")
     args = parser.parse_args()
+
+    if len(args.urls) == 0:
+        args.urls = CUDA_URLS
 
     asyncio.run(
         main(


### PR DESCRIPTION
## Description

By default, we always consumed the CUDA docs in every collection.

This contributed toward inconsistent behavior with Automated Description Generation for retriever collections.

This PR also unifies the configuration file descriptions and properly adds docker volumes to .gitignore.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Git ignore patterns for vector database volume directories
  * Simplified configuration settings in custom function examples
  * Enhanced default parameter handling for documentation ingestion script

<!-- end of auto-generated comment: release notes by coderabbit.ai -->