### PR TITLE
Refactor to make `model_name` an optimizable field across LLMs

### DIFF
--- a/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/configs/config_optimizer.yml
+++ b/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/configs/config_optimizer.yml
@@ -27,8 +27,8 @@ general:
 functions:
   email_phishing_analyzer:
     _type: email_phishing_analyzer
+    llm: phishing_llm
     optimizable_params:
-      - llm
       - prompt
   prompt_init:
     _type: prompt_init
@@ -40,7 +40,7 @@ functions:
     system_objective: Agent that triages an email to see if it is a phishing attempt or not.
 
 llms:
-  llama_3_405:
+  phishing_llm:
     _type: nim
     model_name: meta/llama-3.1-405b-instruct
     temperature: 0.0
@@ -49,14 +49,13 @@ llms:
       - temperature
       - top_p
       - max_tokens
-  llama_3_70:
-    _type: nim
-    model_name: meta/llama-3.1-70b-instruct
-    max_tokens: 1024
-    optimizable_params:
-      - temperature
-      - top_p
-      - max_tokens
+      - model_name
+    search_space:
+      model_name:
+        values:
+          - meta/llama-3.1-405b-instruct
+          - meta/llama-3.1-70b-instruct
+
   prompt_optimizer:
     _type: nim
     model_name: meta/llama-3.1-70b-instruct

--- a/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/register.py
+++ b/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/register.py
@@ -17,6 +17,8 @@ import json
 import logging
 from typing import Any
 
+from pydantic import Field
+
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
@@ -35,9 +37,7 @@ logger = logging.getLogger(__name__)
 
 class EmailPhishingAnalyzerConfig(FunctionBaseConfig, OptimizableMixin, name="email_phishing_analyzer"):
     _type: str = "email_phishing_analyzer"
-    llm: LLMRef = OptimizableField(description="The LLM to use for email phishing analysis.",
-                                   default="llama_3_405",
-                                   space=SearchSpace(values=["llama_3_405", "llama_3_70"]))
+    llm: LLMRef = Field(description="The LLM to use for email phishing analysis.")
     prompt: str = OptimizableField(
         description="The prompt template for analyzing email phishing. Use {body} to insert the email text.",
         default=phishing_prompt,

--- a/src/nat/data_models/optimizable.py
+++ b/src/nat/data_models/optimizable.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 from pydantic import model_validator
+from pydantic_core import PydanticUndefined
 
 T = TypeVar("T", int, float, bool, str)
 
@@ -66,7 +67,7 @@ class SearchSpace(BaseModel, Generic[T]):
 
 
 def OptimizableField(
-    default: Any,
+    default: Any = PydanticUndefined,
     *,
     space: SearchSpace | None = None,
     merge_conflict: str = "overwrite",

--- a/src/nat/llm/aws_bedrock_llm.py
+++ b/src/nat/llm/aws_bedrock_llm.py
@@ -42,9 +42,9 @@ class AWSBedrockModelConfig(LLMBaseConfig,
     model_config = ConfigDict(protected_namespaces=(), extra="allow")
 
     # Completion parameters
-    model_name: str = Field(validation_alias=AliasChoices("model_name", "model"),
-                            serialization_alias="model",
-                            description="The model name for the hosted AWS Bedrock.")
+    model_name: str = OptimizableField(validation_alias=AliasChoices("model_name", "model"),
+                                       serialization_alias="model",
+                                       description="The model name for the hosted AWS Bedrock.")
     max_tokens: int = OptimizableField(default=300,
                                        description="Maximum number of tokens to generate.",
                                        space=SearchSpace(high=2176, low=128, step=512))

--- a/src/nat/llm/litellm_llm.py
+++ b/src/nat/llm/litellm_llm.py
@@ -23,6 +23,8 @@ from nat.builder.builder import Builder
 from nat.builder.llm import LLMProviderInfo
 from nat.cli.register_workflow import register_llm_provider
 from nat.data_models.llm import LLMBaseConfig
+from nat.data_models.optimizable import OptimizableField
+from nat.data_models.optimizable import OptimizableMixin
 from nat.data_models.retry_mixin import RetryMixin
 from nat.data_models.temperature_mixin import TemperatureMixin
 from nat.data_models.thinking_mixin import ThinkingMixin
@@ -31,6 +33,7 @@ from nat.data_models.top_p_mixin import TopPMixin
 
 class LiteLlmModelConfig(
         LLMBaseConfig,
+        OptimizableMixin,
         RetryMixin,
         TemperatureMixin,
         TopPMixin,
@@ -46,9 +49,9 @@ class LiteLlmModelConfig(
                                  description="Base url to the hosted model.",
                                  validation_alias=AliasChoices("base_url", "api_base"),
                                  serialization_alias="api_base")
-    model_name: str = Field(validation_alias=AliasChoices("model_name", "model"),
-                            serialization_alias="model",
-                            description="The LiteLlm hosted model name.")
+    model_name: str = OptimizableField(validation_alias=AliasChoices("model_name", "model"),
+                                       serialization_alias="model",
+                                       description="The LiteLlm hosted model name.")
     seed: int | None = Field(default=None, description="Random seed to set for generation.")
 
 

--- a/src/nat/llm/nim_llm.py
+++ b/src/nat/llm/nim_llm.py
@@ -44,9 +44,9 @@ class NIMModelConfig(LLMBaseConfig,
 
     api_key: str | None = Field(default=None, description="NVIDIA API key to interact with hosted NIM.")
     base_url: str | None = Field(default=None, description="Base url to the hosted NIM.")
-    model_name: str = Field(validation_alias=AliasChoices("model_name", "model"),
-                            serialization_alias="model",
-                            description="The model name for the hosted NIM.")
+    model_name: str = OptimizableField(validation_alias=AliasChoices("model_name", "model"),
+                                       serialization_alias="model",
+                                       description="The model name for the hosted NIM.")
     max_tokens: PositiveInt = OptimizableField(default=300,
                                                description="Maximum number of tokens to generate.",
                                                space=SearchSpace(high=2176, low=128, step=512))

--- a/src/nat/llm/openai_llm.py
+++ b/src/nat/llm/openai_llm.py
@@ -21,6 +21,7 @@ from nat.builder.builder import Builder
 from nat.builder.llm import LLMProviderInfo
 from nat.cli.register_workflow import register_llm_provider
 from nat.data_models.llm import LLMBaseConfig
+from nat.data_models.optimizable import OptimizableField
 from nat.data_models.optimizable import OptimizableMixin
 from nat.data_models.retry_mixin import RetryMixin
 from nat.data_models.temperature_mixin import TemperatureMixin
@@ -41,9 +42,9 @@ class OpenAIModelConfig(LLMBaseConfig,
 
     api_key: str | None = Field(default=None, description="OpenAI API key to interact with hosted model.")
     base_url: str | None = Field(default=None, description="Base url to the hosted model.")
-    model_name: str = Field(validation_alias=AliasChoices("model_name", "model"),
-                            serialization_alias="model",
-                            description="The OpenAI hosted model name.")
+    model_name: str = OptimizableField(validation_alias=AliasChoices("model_name", "model"),
+                                       serialization_alias="model",
+                                       description="The OpenAI hosted model name.")
     seed: int | None = Field(default=None, description="Random seed to set for generation.")
     max_retries: int = Field(default=10, description="The max number of retries for the request.")
 


### PR DESCRIPTION
Updated `model_name` to use `OptimizableField` for AWS Bedrock, OpenAI, Nvidia NIM, and LiteLLM models. Refactored phishing analyzer configurations to streamline optimization and removed deprecated model references, enhancing flexibility for optimization workflows.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LLM model name field is now optimizable for AWS Bedrock, LiteLLM, NIM, and OpenAI providers, enabling automatic model selection during optimization workflows.
  * Email phishing analyzer now enables prompt optimization and supports automatic selection between Llama 3.1 model variants (405B and 70B instances).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->