### PR TITLE
Fix misplaced sample output in the MCP client doc

### DIFF
--- a/docs/source/workflows/mcp/mcp-auth.md
+++ b/docs/source/workflows/mcp/mcp-auth.md
@@ -94,7 +94,7 @@ function_groups:
     server:
       transport: streamable-http
       url: ${CORPORATE_MCP_JIRA_URL}
-    auth_provider: mcp_oauth2_jira
+      auth_provider: mcp_oauth2_jira
 
 authentication:
   mcp_oauth2_jira:

--- a/docs/source/workflows/mcp/mcp-client.md
+++ b/docs/source/workflows/mcp/mcp-client.md
@@ -289,25 +289,6 @@ To get detailed information about a specific tool, use the `--tool` flag:
 nat mcp client tool list --url http://localhost:9901/mcp --tool calculator_multiply
 ```
 
-### Call a Tool
-
-To call a tool and get its output:
-
-```bash
-# Pass arguments as JSON
-nat mcp client tool call calculator_multiply \
-  --url http://localhost:9901/mcp \
-  --json-args '{"text": "2 * 3"}'
-```
-
-### Using Protected MCP Servers
-
-To use a protected MCP server, you need to provide the `--auth` flag:
-```bash
-nat mcp client tool list --url http://example.com/mcp --auth
-```
-This will use the `mcp_oauth2` authentication provider to authenticate the user. For more information, refer to [MCP Authentication](./mcp-auth.md).
-
 Sample output:
 ```text
 Tool: calculator_multiply
@@ -329,6 +310,24 @@ Input Schema:
 }
 ------------------------------------------------------------
 ```
+### Call a Tool
+
+To call a tool and get its output:
+
+```bash
+# Pass arguments as JSON
+nat mcp client tool call calculator_multiply \
+  --url http://localhost:9901/mcp \
+  --json-args '{"text": "2 * 3"}'
+```
+
+### Using Protected MCP Servers
+
+To use a protected MCP server, you need to provide the `--auth` flag:
+```bash
+nat mcp client tool list --url http://example.com/mcp --auth
+```
+This will use the `mcp_oauth2` authentication provider to authenticate the user. For more information, refer to [MCP Authentication](./mcp-auth.md).
 
 ## List MCP Client Tools using the HTTP endpoint
 This is useful when you want to inspect the tools configured on the client side and whether each tool is available on the connected server.


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This PR includes two doc updates:
1. Fixes misplaced sample output
2. Fix formatting in the sample auth config
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP authentication configuration documentation structure for improved organization.
  * Restored documentation sections on calling tools and protecting MCP server access with practical examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->