### PR TITLE
Suppress error log generated when terminating NAT MCP server with `ctrl + C`

### DIFF
--- a/src/nat/front_ends/mcp/mcp_front_end_plugin.py
+++ b/src/nat/front_ends/mcp/mcp_front_end_plugin.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import asyncio
 import logging
 import typing
 
@@ -113,5 +112,5 @@ class MCPFrontEndPlugin(FrontEndBase[MCPFrontEndConfig]):
                 else:  # streamable-http
                     logger.info("Starting MCP server with streamable-http endpoint at /mcp/")
                     await mcp.run_streamable_http_async()
-            except (KeyboardInterrupt, asyncio.CancelledError):
+            except KeyboardInterrupt:
                 logger.info("MCP server shutdown requested (Ctrl+C). Shutting down gracefully.")


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server shutdown handling so interrupt signals (e.g., Ctrl+C) are caught and logged, allowing the server to stop gracefully instead of terminating abruptly. This provides clearer shutdown messages and reduces risk of leaving processes in an inconsistent state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->