### PR TITLE
fix: correct file paths in evaluate documentation

### DIFF
--- a/docs/source/reference/evaluate.md
+++ b/docs/source/reference/evaluate.md
@@ -394,17 +394,17 @@ This pass results in workflow interrupted warning. You can then do another pass.
 
 Pass-2:
 ```bash
-cp .tmp/nat/examples/getting_started/simple_web_query/workflow_output.json .tmp/simple_workflow_output.json
+cp .tmp/nat/examples/evaluation_and_profiling/simple_web_query_eval/eval/workflow_output.json .tmp/simple_workflow_output.json
 nat eval --config_file=examples/evaluation_and_profiling/simple_web_query_eval/configs/eval_config.yml --skip_completed_entries --dataset=.tmp/simple_workflow_output.json
 ```
 
 ## Running evaluation offline
 You can evaluate a dataset with previously generated answers via the `--skip_workflow` option. In this case the dataset has both the expected `answer` and the `generated_answer`.
 ```bash
-cp .tmp/nat/examples/getting_started/simple_web_query/workflow_output.json .tmp/simple_workflow_output.json
+cp .tmp/nat/examples/evaluation_and_profiling/simple_web_query_eval/eval/workflow_output.json .tmp/simple_workflow_output.json
 nat eval --config_file=examples/evaluation_and_profiling/simple_web_query_eval/configs/eval_config.yml --skip_workflow --dataset=.tmp/simple_workflow_output.json
 ```
-This assumes that the workflow output was previously generated and stored in `.tmp/nat/examples/getting_started/simple_web_query/workflow_output.json`
+This assumes that the workflow output was previously generated and stored in `.tmp/nat/examples/evaluation_and_profiling/simple_web_query_eval/eval/workflow_output.json`
 
 ## Running the workflow over a dataset without evaluation
 You can do this by running `nat eval` with a workflow configuration file that includes an `eval` section with no `evaluators`.


### PR DESCRIPTION
## Description

This is an artifact of the examples reorg from NAT 1.2

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated file paths in evaluation documentation examples to reflect the current project structure, ensuring users can execute provided code examples without path-related errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->