### PR TITLE
docs: prevent coderabbit from applying common labels

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -123,56 +123,19 @@ reviews:
       instructions: >-
         You should only apply this label when the source branch has a name matching the regex pattern `release/\d+\.\d+`
         and the target branch is `main`.
-    - label: breaking
-      instructions: >-
-        Apply this label when the PR introduces changes that break backward compatibility, modify existing APIs in
-        incompatible ways, creates a behavioral change, or require users to update their code when upgrading. If you
-        apply this label, do not apply the "non-breaking" label. Do not apply this label if the PR already has either
-        the "breaking" or "non-breaking" label.
-    - label: bug
-      instructions: >-
-        Apply this label when the PR fixes a defect, error, or unexpected behavior in the existing codebase. If you
-        apply this label do not apply the "doc", "feature request", or "improvement" labels. Do not apply this label if
-        the PR already has either the "bug", "doc", "feature request", or "improvement" labels.
     - label: DO NOT MERGE
       instructions: >-
         Apply this label to PRs that should not be merged due to critical issues, incomplete work, or other blocking
         concerns. Check the PR description for specific details about why it should not be merged. There is no need to
         apply this label to draft PRs.
-    - label: doc
-      instructions: >-
-        Apply this label when the PR primarily adds, updates, or improves documentation including README files. If you
-        apply this label do not apply the "bug", "feature request", or "improvement" labels. Do not apply this label if
-        the PR already has either the "bug", "doc", "feature request", or "improvement" labels.
     - label: duplicate
       instructions: >-
         Apply this label when the PR addresses the same issue or implements the same feature as another existing
         PR or issue.
-    - label: external
-      instructions: >-
-        Apply this label when the PR author is not an organization OWNER or MEMBER (i.e., author_association is
-        COLLABORATOR, CONTRIBUTOR, FIRST_TIMER, FIRST_TIME_CONTRIBUTOR, or NONE).
-    - label: feature request
-      instructions: >-
-        Apply this label when the PR implements new functionality, adds new features, or introduces new capabilities
-        to the toolkit. If you apply this label do not apply the "bug", "doc", or "improvement" labels. Do not apply
-        this label if  the PR already has either the "bug", "doc", "feature request", or "improvement" labels.
-    - label: improvement
-      instructions: >-
-        Apply this label when the PR enhances existing functionality without adding completely new features, such as
-        performance optimizations, code refactoring, or usability enhancements. If you apply this label do not apply
-        the "bug", "doc", or "feature request" labels. Do not apply this label if the PR already has either the "bug",
-        "doc", "feature request", or "improvement" labels.
     - label: invalid
       instructions: >-
         Apply this label when the PR contains invalid changes, doesn't follow project guidelines, or has fundamental
         issues that make it unsuitable for the project.
-    - label: non-breaking
-      instructions: >-
-        Apply this label when the PR introduces changes that maintain backward compatibility, does not create a
-        behavioral change, and does not require users to modify their existing code. If you apply this label, do not
-        apply the "breaking" label. Do not apply this label if the PR already has either the "breaking" or
-        "non-breaking" label.
 
   tools:
     ruff:


### PR DESCRIPTION
## Description
This has caused more harm than good in the battle between AI and developer sanity.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal development configuration for code review processes. No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->