### PR TITLE
docs: Fix missing await in memory documentation examples

### DIFF
--- a/docs/source/extend/memory.md
+++ b/docs/source/extend/memory.md
@@ -147,7 +147,7 @@ Then either:
 **At runtime**, you typically see code like:
 
 ```python
-memory_client = builder.get_memory_client(<memory_config_name>)
+memory_client = await builder.get_memory_client(<memory_config_name>)
 await memory_client.add_items([MemoryItem(...), ...])
 ```
 
@@ -164,7 +164,7 @@ from nat.memory.models import MemoryItem
 from langchain_core.tools import ToolException
 
 async def add_memory_tool_action(item: MemoryItem, memory_name: str):
-    memory_client = builder.get_memory_client(memory_name)
+    memory_client = await builder.get_memory_client(memory_name)
     try:
         await memory_client.add_items([item])
         return "Memory added successfully"


### PR DESCRIPTION
## Summary

Fixed missing `await` keywords in documentation code examples for `builder.get_memory_client()` calls. 

This is a focused PR that addresses only the documentation aspect of the async memory client usage bug that was bundled into the larger PR #998.

## Changes

- Added `await` to `builder.get_memory_client()` call in runtime usage example (line 150)
- Added `await` to `builder.get_memory_client()` call in tool example (line 167)

## Context

PR #998 was a large PR that included many changes. One of the maintainers requested it be broken up. This PR extracts just the documentation fixes for the missing `await` keywords.

The actual code fixes were already merged in PR #935, but the documentation examples were not updated at that time.

## Test plan

- [x] Documentation builds without errors
- [x] Code examples now show correct async/await usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated memory client examples to use asynchronous retrieval (now using await).
  * Clarified that subsequent item addition remains awaited with no semantic or error-handling changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->