### PR TITLE
Document clearly that auth is not supported on the MCP server side

### DIFF
--- a/docs/source/workflows/mcp/mcp-server.md
+++ b/docs/source/workflows/mcp/mcp-server.md
@@ -206,6 +206,6 @@ For local development, you can use `localhost` or `127.0.0.1` as the host (defau
 For production environments:
 - Run `nat mcp serve` behind a trusted network or an authenticating reverse proxy with HTTPS (OAuth2, JWT, or mTLS)
 - Do not expose the server directly to the public Internet
-- Do not bind to non-localhost addresses (such as `0.0.0.0` or public IPs) without authentication
+- Do not bind to non-localhost addresses (such as `0.0.0.0` or public IP addresses) without authentication
 
 If you bind the MCP server to a non-localhost address without configuring authentication, the server will log a warning. This configuration exposes your server to unauthorized access.


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated security and deployment guidance for the server workflow.
  * Added subsections on authentication limitations, local development defaults, and production deployment recommendations.
  * Consolidated transport-specific guidance into a general warning about binding to non-localhost addresses without proper authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->