### PR TITLE
Always perform wheel builds in nightly CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -149,7 +149,15 @@ package:wheel:
       # Match  the transitional wheels
       - .tmp/wheels/nat/*/*/*.whl
     expire_in: 1 week
-
+  rules:
+    - if: $CI_CRON_NIGHTLY == "1"
+      when: always
+    - if: $CI_PIPELINE_SOURCE == 'merge_request_event'
+    - if: $CI_COMMIT_TAG
+    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    - if: $CI_COMMIT_BRANCH == 'develop-test'
+    - if: $CI_COMMIT_BRANCH == 'main'
+    - if: $CI_COMMIT_BRANCH =~ /^release\/.*$/
 
 upload:artifactory:
   stage: upload


### PR DESCRIPTION
## Description
* Don't allow flaky integration tests to block nightly builds

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refined CI/CD pipeline rules to better control when package builds and artifact uploads occur, improving execution reliability across nightly builds, merge requests, tags, and branch deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->