### PR TITLE
fix: reintroduce `--all-files` to pre-commit CI

### DIFF
--- a/ci/scripts/checks.sh
+++ b/ci/scripts/checks.sh
@@ -20,7 +20,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 source ${SCRIPT_DIR}/common.sh
 
 set +e
-pre-commit run --show-diff-on-failure
+pre-commit run --all-files --show-diff-on-failure
 PRE_COMMIT_RETVAL=$?
 
 echo "Checking copyright headers"


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced CI/CD validation by expanding pre-commit checks to run on all files in the codebase, strengthening overall code quality standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->