### PR TITLE
Added a note in the MCP doc for directly referencing a MCP tool within a client

### DIFF
--- a/docs/source/workflows/mcp/mcp-client.md
+++ b/docs/source/workflows/mcp/mcp-client.md
@@ -72,7 +72,7 @@ A tool within a function group can also be referenced by its name using the foll
 :::{note}
 This requires that the tool name is explicitly listed under the optional `include` list of the function group configuration.
 
-See [Function Group Accessiblity](../function-groups.md#understanding-function-accessibility) for more details.
+See [function group accessibility](../function-groups.md#understanding-function-accessibility) for more details.
 :::
 Example:
 ```yaml


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added guidance on referencing a tool inside a function group via dot-notation (function_group.tool_name), noting the tool must be listed in the group’s optional include list.
  * Linked to function accessibility details and added a YAML example demonstrating usage for building custom sub-tools that leverage an MCP server tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->