### PR TITLE
Minor documentation for LangSmith tracing

### DIFF
--- a/examples/observability/simple_calculator_observability/README.md
+++ b/examples/observability/simple_calculator_observability/README.md
@@ -152,7 +152,7 @@ For simple local development and debugging, you can export traces directly to a 
     nat run --config_file examples/observability/simple_calculator_observability/configs/config-langsmith.yml --input "Is 100 > 50?"
     ```
 
-    This workflow is set to use the `default` LangSmith project. If you want to use a different project you can either edit the config file or by adding the following flag to the above command: `--override general.telemetry.tracing.langsmith.project <your_project_name>`
+    This workflow is set to use the `default` LangSmith project. If you want to use a different project, you can either edit the config file or add the following flag to the above command: `--override general.telemetry.tracing.langsmith.project <your_project_name>`
 
     > **Note**: This workflow happens to use LangChain, since that library has built-in support for LangSmith, if you run the above workflow with the `LANGSMITH_TRACING=true` environment variable set, will result in duplicate traces being sent to LangSmith.
 


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified that the workflow uses the default LangSmith project ("default") with an optional override via configuration or command-line.
  * Removed the separate project setup step for simpler onboarding.
  * Added a warning that enabling tracing alongside LangChain may produce duplicate traces.
  * Made minor formatting and spacing improvements across the guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->