### PR TITLE
fix: strip rc package from notebook

### DIFF
--- a/examples/notebooks/2_bringing_your_own_agent.ipynb
+++ b/examples/notebooks/2_bringing_your_own_agent.ipynb
@@ -149,7 +149,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!uv pip install --pre \"nvidia-nat[langchain]==1.3.0rc5\""
+    "!uv pip install \"nvidia-nat[langchain]\""
    ]
   },
   {


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation instructions in example notebooks to use the latest available version instead of a pinned pre-release version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->