### PR TITLE
docs: clarify that function groups can be used as part of `tool_name` list

### DIFF
--- a/.cursor/rules/nat-agents/general.mdc
+++ b/.cursor/rules/nat-agents/general.mdc
@@ -18,7 +18,7 @@ These rules standardise how the four built-in NeMo Agent Toolkit agents are conf
 
 1. **ReAct Agent**
    - Use `_type: react_agent` in either the top-level `workflow:` or inside `functions:`.
-   - Always provide `tool_names` (list of YAML-defined functions) and `llm_name`.
+   - Always provide `tool_names` (list of YAML-defined functions or function groups) and `llm_name`.
    - Optional but recommended parameters: `verbose`, `max_tool_calls`, `parse_agent_response_max_retries`, `pass_tool_call_errors_to_agent`.
    - When overriding the prompt, keep `{tools}` and `{tool_names}` placeholders and ensure the LLM outputs in ReAct format.
 

--- a/docs/source/workflows/about/react-agent.md
+++ b/docs/source/workflows/about/react-agent.md
@@ -84,7 +84,7 @@ functions:
 
 * `workflow_alias`: Defaults to `None`. The alias of the workflow. Useful when the ReAct agent is configured as a workflow and need to expose a customized name as a tool.
 
-* `tool_names`: A list of tools that the agent can call. The tools must be functions configured in the YAML file.
+* `tool_names`: A list of tools that the agent can call. The tools must be functions or function groups configured in the YAML file.
 
 * `llm_name`: The LLM the agent should use. The LLM must be configured in the YAML file.
 

--- a/docs/source/workflows/about/rewoo-agent.md
+++ b/docs/source/workflows/about/rewoo-agent.md
@@ -92,7 +92,7 @@ functions:
 
 * `workflow_alias`: Defaults to `None`. The alias of the workflow. Useful when the ReWOO agent is configured as a workflow and need to expose a customized name as a tool.
 
-* `tool_names`: A list of tools that the agent can call. The tools must be functions configured in the YAML file
+* `tool_names`: A list of tools that the agent can call. The tools must be functions or function groups configured in the YAML file
 
 * `llm_name`: The LLM the agent should use. The LLM must be configured in the YAML file
 

--- a/docs/source/workflows/about/tool-calling-agent.md
+++ b/docs/source/workflows/about/tool-calling-agent.md
@@ -84,7 +84,7 @@ functions:
 
 * `workflow_alias`: Defaults to `None`. The alias of the workflow. Useful when the Tool Calling agent is configured as a workflow and need to expose a customized name as a tool.
 
-* `tool_names`: A list of tools that the agent can call. The tools must be functions configured in the YAML file
+* `tool_names`: A list of tools that the agent can call. The tools must be functions or function groups configured in the YAML file
 
 * `llm_name`: The LLM the agent should use. The LLM must be configured in the YAML file
 

--- a/examples/advanced_agents/alert_triage_agent/README.md
+++ b/examples/advanced_agents/alert_triage_agent/README.md
@@ -221,7 +221,7 @@ workflow:
 ```
 
 * `_type`: The name of the agent (matching the agent's name in `register.py`).
-* `tool_names`: List of tools (from the `functions` section) used in the triage process.
+* `tool_names`: List of tools (from the `functions` or `function_groups` section) used in the triage process.
 * `llm_name`: Main LLM used by the agent for reasoning, tool-calling, and report generation.
 * `offline_mode`: Enables offline execution using predefined input/output instead of real systems.
 * `offline_data_path`: CSV file containing offline test alerts and their corresponding mocked tool responses.

--- a/examples/agents/rewoo/README.md
+++ b/examples/agents/rewoo/README.md
@@ -87,7 +87,7 @@ The ReWOO agent is configured through the `config.yml` file. The following confi
 
 ### Configurable Options
 
-* `tool_names`: A list of tools that the agent can call. The tools must be functions configured in the YAML file
+* `tool_names`: A list of tools that the agent can call. The tools must be functions or function groups configured in the YAML file
 
 * `llm_name`: The LLM the agent should use. The LLM must be configured in the YAML file
 


### PR DESCRIPTION
## Description

Before, this was only mentioned in the function groups documentation.
Surface this to agent documentation and cursor rules.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * tool_names parameter now accepts function groups in addition to individual functions configured in YAML.
  * Added benign_fallback_data_path configuration option for enhanced offline-mode data handling.

* **Documentation**
  * Updated agent workflow guidance to reflect expanded tool_names capabilities across ReAct, ReWOO, and Tool-Calling agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->