### PR TITLE
fix(rewoo): replace placeholder IFF type is `str`

### DIFF
--- a/src/nat/agent/rewoo_agent/agent.py
+++ b/src/nat/agent/rewoo_agent/agent.py
@@ -217,7 +217,7 @@ class ReWOOAgentGraph(BaseAgent):
                 if value is not None:
                     if value == placeholder:
                         tool_input[key] = tool_output
-                    elif placeholder in value:
+                    elif isinstance(value, str) and placeholder in value:
                         # If the placeholder is part of the value, replace it with the stringified output
                         tool_input[key] = value.replace(placeholder, str(tool_output))
 


### PR DESCRIPTION
## Description

We did not guard the string substitution of a placeholder.
This could cause a runtime error.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a type-handling issue in placeholder replacement that could cause errors when processing non-string values, improving system stability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->