### PR TITLE
fix(examples-hitl): `RetryReactAgent` must work with function groups

### DIFF
--- a/examples/HITL/simple_calculator_hitl/src/nat_simple_calculator_hitl/retry_react_agent.py
+++ b/examples/HITL/simple_calculator_hitl/src/nat_simple_calculator_hitl/retry_react_agent.py
@@ -108,8 +108,14 @@ async def retry_react_agent(config: RetryReactAgentConfig, builder: Builder):
             # Add any tools needed by the react agent
             # This ensures the temporary agent has access to all the same tools
             for tool_name in original_config.tool_names:
-                tool_config = builder.get_function_config(tool_name)
-                await temp_builder.add_function(tool_name, tool_config)
+                # Check if it's a function group first
+                try:
+                    function_group_config = builder.get_function_group_config(tool_name)
+                    await temp_builder.add_function_group(tool_name, function_group_config)
+                except Exception:
+                    # If not a function group, treat it as a regular function
+                    tool_config = builder.get_function_config(tool_name)
+                    await temp_builder.add_function(tool_name, tool_config)
 
             # Create the retry agent with the original configuration
             temp_retry_agent = await temp_builder.add_function("retry_agent", retry_config)


### PR DESCRIPTION
## Description

Since ReAct Agent accepts tool_names in the form of functions or function groups, ensure that the Retry ReAct Agent (part of the HITL example) can, too.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Agent now supports both function groups and regular functions for tool configuration, with automatic fallback handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->