### PR TITLE
bug: fix non json serializable objects in config

### DIFF
--- a/src/nat/profiler/parameter_optimization/parameter_optimizer.py
+++ b/src/nat/profiler/parameter_optimization/parameter_optimizer.py
@@ -117,7 +117,7 @@ def optimize_parameters(
 
     # Save final results (out_dir already created and defined above)
     with (out_dir / "optimized_config.yml").open("w") as fh:
-        yaml.dump(tuned_cfg.model_dump(), fh)
+        yaml.dump(tuned_cfg.model_dump(mode='json'), fh)
     with (out_dir / "trials_dataframe_params.csv").open("w") as fh:
         # Export full trials DataFrame (values, params, timings, etc.).
         df = study.trials_dataframe()


### PR DESCRIPTION
## Description
This PR addresses a small bug in the serialization of optimal configurations determined by nat optimize, where serialized python objects were present in the saved config: (ex:   llm_name: !!python/object/new:nat.data_models.component_ref.LLMRef). By using model_dump(mode="json") we prevent these objects from being saved to the optimized_config.yml, and allow for the config to be re-loaded by downstream evals. 
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved configuration serialization in parameter optimization to ensure proper formatting and compatibility of optimized settings files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->