### PR TITLE
Add E2E tests for Simple RAG Example

### DIFF
--- a/examples/RAG/simple_rag/tests/test_simple_rag_e2e.py
+++ b/examples/RAG/simple_rag/tests/test_simple_rag_e2e.py
@@ -22,6 +22,10 @@ async def _run_simple_rag_workflow(milvus_uri: str,
                                    config_file: Path,
                                    question="How do I install CUDA?",
                                    expected_answer="CUDA") -> str:
+    """
+    The tests/running of the workflow is the same for all the different configurations.
+    However the API keys required are different.
+    """
     from pydantic import HttpUrl
 
     from nat.runtime.loader import load_config
@@ -44,7 +48,31 @@ async def test_full_workflow(milvus_uri: str, examples_dir: Path):
 
 @pytest.mark.slow
 @pytest.mark.integration
+@pytest.mark.usefixtures("nvidia_api_key", "populate_milvus")
+async def test_full_workflow_ttc(milvus_uri: str, examples_dir: Path):
+    config_file = examples_dir / "RAG" / "simple_rag" / "configs" / "milvus_rag_config_ttc.yml"
+    await _run_simple_rag_workflow(milvus_uri=milvus_uri, config_file=config_file)
+
+
+@pytest.mark.slow
+@pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key", "mem0_api_key", "populate_milvus")
 async def test_full_workflow_memory(milvus_uri: str, examples_dir: Path):
     config_file = examples_dir / "RAG" / "simple_rag" / "configs" / "milvus_memory_rag_config.yml"
+    await _run_simple_rag_workflow(milvus_uri=milvus_uri, config_file=config_file)
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@pytest.mark.usefixtures("nvidia_api_key", "tavily_api_key", "populate_milvus")
+async def test_full_workflow_tools(milvus_uri: str, examples_dir: Path):
+    config_file = examples_dir / "RAG" / "simple_rag" / "configs" / "milvus_rag_tools_config.yml"
+    await _run_simple_rag_workflow(milvus_uri=milvus_uri, config_file=config_file)
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@pytest.mark.usefixtures("nvidia_api_key", "mem0_api_key", "tavily_api_key", "populate_milvus")
+async def test_full_workflow_memory_tools(milvus_uri: str, examples_dir: Path):
+    config_file = examples_dir / "RAG" / "simple_rag" / "configs" / "milvus_memory_rag_tools_config.yml"
     await _run_simple_rag_workflow(milvus_uri=milvus_uri, config_file=config_file)


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end testing suite for RAG workflows with Milvus integration, covering multiple configurations including memory support, tool integration, and specialized TTC modes to ensure system reliability across different deployment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->