### PR TITLE
fix ADK demo multi-user session

### DIFF
--- a/examples/frameworks/adk_demo/src/nat_adk_demo/agent.py
+++ b/examples/frameworks/adk_demo/src/nat_adk_demo/agent.py
@@ -18,12 +18,12 @@ import logging
 from pydantic import Field
 
 from nat.builder.builder import Builder
+from nat.builder.context import Context
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
 from nat.data_models.component_ref import LLMRef
 from nat.data_models.function import FunctionBaseConfig
-from nat.builder.context import Context
 
 logger = logging.getLogger(__name__)
 
@@ -74,9 +74,10 @@ async def adk_agent(config: ADKFunctionConfig, builder: Builder):
     # Initialize the Runner with the agent and services
     session_service = InMemorySessionService()
     artifact_service = InMemoryArtifactService()
-    runner = Runner(
-        app_name=config.name, agent=agent, artifact_service=artifact_service, session_service=session_service
-    )
+    runner = Runner(app_name=config.name,
+                    agent=agent,
+                    artifact_service=artifact_service,
+                    session_service=session_service)
 
     sessions_cache: dict[str, tuple] = {}
 

--- a/examples/frameworks/adk_demo/src/nat_adk_demo/weather_update_tool.py
+++ b/examples/frameworks/adk_demo/src/nat_adk_demo/weather_update_tool.py
@@ -29,6 +29,7 @@ class WeatherToolConfig(FunctionBaseConfig, name="weather_update"):
 
 @register_function(config_type=WeatherToolConfig, framework_wrappers=[LLMFrameworkEnum.ADK])
 async def weather_update(_config: WeatherToolConfig, _builder: Builder) -> AsyncIterator[FunctionInfo]:
+
     async def _weather_update(city: str) -> str:
         """
         Get the current weather for a specified city.


### PR DESCRIPTION
## Description

- Fixes multi-user session in ADK demo agent
- Uses `conversation_id` from NAT context instead of hardcoded user ID for session management
- Implements per-conversation session caching to prevent context mixing across different chat sessions
- Ensures each "New Chat" in NAT UI gets its own isolated ADK session
- Maintains backward compatibility by falling back to `config.user_id` when `conversation_id` is unavailable

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized session management with improved caching and lifecycle handling.
  * Enhanced user identification through context-based resolution.

* **Style**
  * Updated string formatting in utility functions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->