### PR TITLE
Add default Phoenix session tracking support

### DIFF
--- a/src/nat/observability/exporter/span_exporter.py
+++ b/src/nat/observability/exporter/span_exporter.py
@@ -196,7 +196,7 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
         span_kind = event_type_to_span_kind(event.event_type)
         sub_span.set_attribute(f"{self._span_prefix}.span.kind", span_kind.value)
 
-        # Enable Phoenix session grouping by setting session.id from conversation_id
+        # Enable session grouping by setting session.id from conversation_id
         try:
             conversation_id = self._context_state.conversation_id.get()
             if conversation_id:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Adds `session.id` attribute to spans to enable Phoenix session grouping.

All traces from a conversation are now grouped together in Phoenix's Sessions view. This enables better visibility into multi-turn interactions.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-level grouping has been added to observability traces: a distinct session identifier is now attached to related spans, improving the ability to correlate and navigate session-related operations within trace data for clearer end-to-end visibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->