### PR TITLE
feat: Add claude-sonnet-4.5 support by model-gating `top_p`

### DIFF
--- a/docs/source/extend/adding-an-llm-provider.md
+++ b/docs/source/extend/adding-an-llm-provider.md
@@ -89,7 +89,7 @@ Some configuration parameters are only valid for certain models or may be depend
 - `ThinkingMixin`: adds a `thinking` field, with a default of `None` when supported by a model. If supported, the `thinking_system_prompt` property will return the system prompt to use for thinking.
 
 :::{note}
-The built-in mixins may reject certain fields for models that do not support them (for example, GPT-5 models currently reject `temperature` and `top_p`). If a gated field is explicitly set on an unsupported model, validation will fail.
+The built-in mixins may reject certain fields for models that do not support them (for example, GPT-5 models currently reject `temperature` and `top_p`). Claude Sonnet 4.5 models currently reject `top_p`. If a gated field is explicitly set on an unsupported model, validation will fail.
 :::
 
 #### TemperatureMixin

--- a/src/nat/data_models/top_p_mixin.py
+++ b/src/nat/data_models/top_p_mixin.py
@@ -28,10 +28,13 @@ class TopPMixin(
         field_name="top_p",
         default_if_supported=1.0,
         keys=("model_name", "model", "azure_deployment"),
-        unsupported=(re.compile(r"gpt-?5", re.IGNORECASE), ),
+        unsupported=(
+            re.compile(r"gpt-?5", re.IGNORECASE),
+            re.compile(r"claude.?sonnet.?4.5", re.IGNORECASE),
+        ),
 ):
     """
-    Mixin class for top-p configuration. Unsupported on models like gpt-5.
+    Mixin class for top-p configuration. Unsupported on models like gpt-5 and claude-sonnet-4.5.
 
     Attributes:
         top_p: Top-p for distribution sampling. Defaults to 1.0 when supported on the model.

--- a/tests/nat/data_models/test_top_p_mixin.py
+++ b/tests/nat/data_models/test_top_p_mixin.py
@@ -54,6 +54,12 @@ def test_top_p_rejected_when_unsupported_and_set():
     with pytest.raises(ValidationError, match=r"top_p is not supported for model_name: gpt-5o"):
         _ = TestConfig(model_name="gpt-5o", top_p=0.2)
 
+    with pytest.raises(ValidationError, match=r"top_p is not supported for model_name: claude-sonnet-4.5"):
+        _ = TestConfig(model_name="claude-sonnet-4.5", top_p=0.2)
+
+    with pytest.raises(ValidationError, match=r"top_p is not supported for model_name: claude-sonnet-4-5"):
+        _ = TestConfig(model_name="claude-sonnet-4-5", top_p=0.2)
+
 
 def test_top_p_none_when_unsupported_and_value_none():
 


### PR DESCRIPTION
## Description

Adds support for claude-sonnet-4.5

https://docs.claude.com/en/docs/about-claude/models/migrating-to-claude-4

By default, Anthropic only permits either `temperature` or `top_p` -- only surface temperature as an opinionated decision.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation support for Claude Sonnet 4.5 models regarding the top_p parameter.

* **Documentation**
  * Updated model validation examples to reference Claude Sonnet 4.5 alongside existing models.

* **Tests**
  * Added test coverage for Claude Sonnet 4.5 model validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->