### PR TITLE
Add reference to NAT job_id in Weave evaluation attributes

### DIFF
--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -514,7 +514,7 @@ class EvaluationRun:
         # Run workflow and evaluate
         async with WorkflowEvalBuilder.from_config(config=config) as eval_workflow:
             # Initialize Weave integration
-            self.weave_eval.initialize_logger(workflow_alias, self.eval_input, config)
+            self.weave_eval.initialize_logger(workflow_alias, self.eval_input, config, job_id=job_id)
 
             with self.eval_trace_context.evaluation_context():
                 # Run workflow

--- a/src/nat/eval/utils/weave_eval.py
+++ b/src/nat/eval/utils/weave_eval.py
@@ -82,7 +82,7 @@ class WeaveEvaluationIntegration:
         """Get the full dataset for Weave."""
         return [item.full_dataset_entry for item in eval_input.eval_input_items]
 
-    def initialize_logger(self, workflow_alias: str, eval_input: EvalInput, config: Any):
+    def initialize_logger(self, workflow_alias: str, eval_input: EvalInput, config: Any, job_id: str | None = None):
         """Initialize the Weave evaluation logger."""
         if not self.client and not self.initialize_client():
             # lazy init the client
@@ -92,10 +92,16 @@ class WeaveEvaluationIntegration:
             weave_dataset = self._get_weave_dataset(eval_input)
             config_dict = config.model_dump(mode="json")
             config_dict["name"] = workflow_alias
+
+            # Include job_id in eval_attributes if provided
+            eval_attributes = {}
+            if job_id:
+                eval_attributes["job_id"] = job_id
+
             self.eval_logger = self.evaluation_logger_cls(model=config_dict,
                                                           dataset=weave_dataset,
                                                           name=workflow_alias,
-                                                          eval_attributes={})
+                                                          eval_attributes=eval_attributes)
             self.pred_loggers = {}
 
             # Capture the current evaluation call for context propagation


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

When using `append_job_id_to_output_dir` to preserve evaluation outputs across multiple runs, there was no way to see which job ID corresponded to each evaluation run in Weave. This made it challenging to match Weave traces with their associated local output directories. This PR exposes the job ID as an attribute in Weave evaluation runs.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional job identification parameter to evaluation logging. When provided, job identifiers are now included in evaluation context attributes, enabling improved correlation and tracking of evaluation runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->