### PR TITLE
Add evaluator reasoning to Weave score logs

### DIFF
--- a/src/nat/eval/utils/weave_eval.py
+++ b/src/nat/eval/utils/weave_eval.py
@@ -136,9 +136,17 @@ class WeaveEvaluationIntegration:
         coros = []
         for eval_output_item in eval_output.eval_output_items:
             if eval_output_item.id in self.pred_loggers:
+                # Structure the score as a dict and include reasoning if available
+                score_value = {
+                    "score": eval_output_item.score,
+                }
+
+                if eval_output_item.reasoning is not None:
+                    score_value["reasoning"] = eval_output_item.reasoning
+
                 coros.append(self.pred_loggers[eval_output_item.id].alog_score(
                     scorer=evaluator_name,
-                    score=eval_output_item.score,
+                    score=score_value,
                 ))
 
         # Execute all coroutines concurrently


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR includes evaluator reasoning in Weave logs to supplement item score.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Score logging now includes optional reasoning information alongside numeric scores, enriching evaluation data with additional context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->