### PR TITLE
Fix code concatenation issue with `code_execution_tool` when using a Piston server

### DIFF
--- a/src/nat/tool/code_execution/code_sandbox.py
+++ b/src/nat/tool/code_execution/code_sandbox.py
@@ -92,7 +92,9 @@ class Sandbox(abc.ABC):
             raise ValueError(f"Language {language} not supported")
 
         generated_code = generated_code.strip().strip("`")
-        code_to_execute = textwrap.dedent("""
+        # Use json.dumps to properly escape the generated_code instead of repr()
+        escaped_code = json.dumps(generated_code)
+        code_to_execute = textwrap.dedent(f"""
             import traceback
             import json
             import os
@@ -101,11 +103,6 @@ class Sandbox(abc.ABC):
             import io
             warnings.filterwarnings('ignore')
             os.environ['OPENBLAS_NUM_THREADS'] = '16'
-        """).strip()
-
-        # Use json.dumps to properly escape the generated_code instead of repr()
-        escaped_code = json.dumps(generated_code)
-        code_to_execute += textwrap.dedent(f"""
 
             generated_code = {escaped_code}
 


### PR DESCRIPTION
## Description
* As detailed in #1139 the string `strip` was causing the user submitted code to not begin on a new line.

Closes #1139

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code execution reliability by enhancing string handling and escape sequence processing to ensure safer execution of generated code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->