### PR TITLE
Add optional TTL configuration for Redis object store

### DIFF
--- a/packages/nvidia_nat_redis/src/nat/plugins/redis/object_store.py
+++ b/packages/nvidia_nat_redis/src/nat/plugins/redis/object_store.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from pydantic import Field
+from pydantic import field_validator
 
 from nat.builder.builder import Builder
 from nat.cli.register_workflow import register_object_store
@@ -23,7 +24,7 @@ from nat.data_models.object_store import ObjectStoreBaseConfig
 
 class RedisObjectStoreClientConfig(ObjectStoreBaseConfig, name="redis"):
     """
-    Object store that stores objects in a Redis database with optional TTL
+    Object store that stores objects in a Redis database with optional TTL.
     """
 
     host: str = Field(default="localhost", description="The host of the Redis server")
@@ -32,6 +33,13 @@ class RedisObjectStoreClientConfig(ObjectStoreBaseConfig, name="redis"):
     bucket_name: str = Field(description="The name of the bucket to use for the object store")
     password: OptionalSecretStr = Field(default=None, description="The password for the Redis server")
     ttl: int | None = Field(default=None, description="TTL in seconds for objects (None = no expiration)")
+
+    @field_validator("ttl")
+    @classmethod
+    def validate_ttl(cls, v: int | None) -> int | None:
+        if v is not None and v <= 0:
+            raise ValueError("TTL must be a positive integer greater than 0")
+        return v
 
 
 @register_object_store(config_type=RedisObjectStoreClientConfig)

--- a/packages/nvidia_nat_redis/src/nat/plugins/redis/redis_object_store.py
+++ b/packages/nvidia_nat_redis/src/nat/plugins/redis/redis_object_store.py
@@ -28,9 +28,10 @@ logger = logging.getLogger(__name__)
 
 class RedisObjectStore(ObjectStore):
     """
-    Implementation of ObjectStore that stores objects in Redis.
+    Implementation of ObjectStore that stores objects in Redis with optional TTL.
 
     Each object is stored as a single binary value at key "nat/object_store/{bucket_name}/{object_key}".
+    When TTL is configured, keys will automatically expire after the specified duration in seconds.
     """
 
     def __init__(


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This PR adds an optional TTL configuration (in seconds) for Redis object stores. Omitting `ttl` results in no expiration as before.

```
object_stores:
  my_object_store:
    _type: redis
    host: localhost
    port: 6379
    db: 0
    bucket_name: my-bucket
    ttl: 3600
```

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redis object store supports optional Time To Live (TTL) for objects, enabling automatic expiration after a specified number of seconds.

* **Behavior Change**
  * When TTL is configured, newly stored and upserted objects will expire automatically after the TTL; default remains no expiration.

* **Chores**
  * TTL values are validated to ensure they are positive when provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->