### PR TITLE
Fix documentation version switcher

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,11 +30,14 @@ uv sync --all-groups --all-extras
 ```bash
 make -C docs
 
-# verify
-firefox docs/build/html/index.html
+# preview with local server (open http://localhost:8000 in your browser)
+python -m http.server --directory docs/build/html 8000
+
 ```
 <!-- path-check-skip-next-line -->
 Outputs to `docs/build/docs/html`
+
+**Note**: When viewing documentation locally, the version switcher in the navigation bar will redirect to the production documentation site (`https://docs.nvidia.com/nemo/agent-toolkit/`) when selecting a different version. This is expected behavior, as the version switcher uses absolute URLs to ensure proper page path preservation in production.
 
 ## Contributing
 Refer to the [Contributing to NeMo Agent toolkit](./source/resources/contributing.md) guide.

--- a/docs/source/versions1.json
+++ b/docs/source/versions1.json
@@ -2,18 +2,18 @@
     {
         "version": "1.3",
         "preferred": true,
-        "url": "../1.3/"
+        "url": "https://docs.nvidia.com/nemo/agent-toolkit/1.3/"
     },
     {
         "version": "1.2",
-        "url": "../1.2/"
+        "url": "https://docs.nvidia.com/nemo/agent-toolkit/1.2/"
     },
     {
         "version": "1.1",
-        "url": "../1.1/"
+        "url": "https://docs.nvidia.com/nemo/agent-toolkit/1.1/"
     },
     {
         "version": "1.0",
-        "url": "../1.0/"
+        "url": "https://docs.nvidia.com/nemo/agent-toolkit/1.0/"
     }
 ]


### PR DESCRIPTION
This PR replaces relative URLs with absolute paths in Sphinx version switcher configuration to correctly preserve page path when switching versions while on nested documentation pages

In addition, documentation build README is updated to recommend using a local web server to view the documentation rather than opening the HTML files directly with `file://` URLs. Opening files directly causes a CORS error that prevent the version switcher from loading at all.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local documentation preview instructions to use a static server for improved accessibility.
  * Added clarification on version switcher behavior when accessing documentation locally.
  * Updated documentation version URLs to absolute NVIDIA documentation links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->