### PR TITLE
Improve haystack_deep_research_agent example

### DIFF
--- a/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/configs/config.yml
+++ b/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/configs/config.yml
@@ -16,12 +16,15 @@
 llms:
   rag_llm:
     _type: nim
-    model: nvidia/llama-3.3-nemotron-super-49b-v1
-    temperature: 0.0
+    model: nvidia/llama-3.3-nemotron-super-49b-v1.5
   agent_llm:
     _type: nim
-    model: nvidia/llama-3.3-nemotron-super-49b-v1
-    temperature: 0.0
+    model: nvidia/llama-3.3-nemotron-super-49b-v1.5
+
+embedders:
+  nv-embed:
+    _type: nim
+    model: nvidia/nv-embedqa-e5-v5
 
 workflow:
   _type: haystack_deep_research_agent
@@ -31,3 +34,5 @@ workflow:
   opensearch_url: http://localhost:9200
   index_on_startup: true
   data_dir: /data
+  embedder_name: nv-embed
+  embedding_dim: 1024

--- a/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/pipelines/indexing.py
+++ b/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/pipelines/indexing.py
@@ -22,6 +22,7 @@ from haystack.components.preprocessors import DocumentSplitter
 from haystack.components.writers import DocumentWriter
 from haystack.core.pipeline import Pipeline
 from haystack.document_stores.types import DuplicatePolicy
+from haystack_integrations.components.embedders.nvidia import NvidiaDocumentEmbedder
 
 
 def _gather_sources(base_dir: Path) -> tuple[list[Path], list[Path]]:
@@ -30,12 +31,16 @@ def _gather_sources(base_dir: Path) -> tuple[list[Path], list[Path]]:
     return pdfs, texts
 
 
-def _build_indexing_pipeline(document_store) -> Pipeline:
+def _build_indexing_pipeline(document_store, embedder_model: str) -> Pipeline:
     p = Pipeline()
     p.add_component("cleaner", DocumentCleaner())
     p.add_component(
         "splitter",
         DocumentSplitter(split_by="sentence", split_length=10, split_overlap=2),
+    )
+    p.add_component(
+        "embedder",
+        NvidiaDocumentEmbedder(model=embedder_model),
     )
     p.add_component(
         "writer",
@@ -44,8 +49,16 @@ def _build_indexing_pipeline(document_store) -> Pipeline:
     return p
 
 
-def run_startup_indexing(document_store, data_dir: str, logger) -> None:
+def run_startup_indexing(
+    document_store,
+    data_dir: str,
+    logger,
+    *,
+    embedder_model: str,
+) -> None:
     try:
+        if not embedder_model:
+            raise ValueError("An embedder model name must be provided for indexing.")
         data_dir_path = Path(data_dir).expanduser()
         if not data_dir_path.is_absolute():
             data_dir_path = (Path.cwd() / data_dir_path).resolve()
@@ -76,14 +89,15 @@ def run_startup_indexing(document_store, data_dir: str, logger) -> None:
                 len(text_sources),
             )
 
-            indexing_pipeline = _build_indexing_pipeline(document_store)
+            indexing_pipeline = _build_indexing_pipeline(document_store, embedder_model)
             indexing_pipeline.add_component("pdf_converter", PyPDFToDocument())
             indexing_pipeline.add_component("text_converter", TextFileToDocument(encoding="utf-8"))
 
             indexing_pipeline.connect("pdf_converter.documents", "cleaner.documents")
             indexing_pipeline.connect("text_converter.documents", "cleaner.documents")
             indexing_pipeline.connect("cleaner.documents", "splitter.documents")
-            indexing_pipeline.connect("splitter.documents", "writer.documents")
+            indexing_pipeline.connect("splitter.documents", "embedder.documents")
+            indexing_pipeline.connect("embedder.documents", "writer.documents")
 
             indexing_pipeline.warm_up()
 

--- a/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/pipelines/rag.py
+++ b/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/pipelines/rag.py
@@ -18,8 +18,9 @@ from haystack.core.pipeline import Pipeline
 from haystack.core.super_component import SuperComponent
 from haystack.dataclasses import ChatMessage
 from haystack.tools import ComponentTool
+from haystack_integrations.components.embedders.nvidia import NvidiaTextEmbedder
 from haystack_integrations.components.generators.nvidia import NvidiaChatGenerator
-from haystack_integrations.components.retrievers.opensearch import OpenSearchBM25Retriever
+from haystack_integrations.components.retrievers.opensearch import OpenSearchEmbeddingRetriever
 
 
 def create_rag_tool(
@@ -27,6 +28,7 @@ def create_rag_tool(
     *,
     top_k: int = 15,
     generator: NvidiaChatGenerator | None = None,
+    embedder_model: str,
 ) -> tuple[ComponentTool, Pipeline]:
     """
     Build a RAG tool composed of OpenSearch retriever and NvidiaChatGenerator.
@@ -35,6 +37,7 @@ def create_rag_tool(
         document_store: OpenSearch document store instance.
         top_k: Number of documents to retrieve for RAG.
         generator: Pre-configured NvidiaChatGenerator created from builder LLM config.
+        embedder_model: The name of the embedding model to use for query encoding.
 
     Returns:
         (ComponentTool, Pipeline): The tool and underlying pipeline.
@@ -42,7 +45,11 @@ def create_rag_tool(
     Raises:
         ValueError: If a generator is not provided.
     """
-    retriever = OpenSearchBM25Retriever(document_store=document_store, top_k=top_k)
+    if not embedder_model:
+        raise ValueError("An embedder model name must be provided for the RAG tool.")
+
+    retriever = OpenSearchEmbeddingRetriever(document_store=document_store, top_k=top_k)
+    query_embedder = NvidiaTextEmbedder(model=embedder_model)
     if generator is None:
         raise ValueError("NvidiaChatGenerator instance must be provided via builder-configured LLM.")
 
@@ -58,16 +65,21 @@ def create_rag_tool(
     prompt_builder = ChatPromptBuilder(template=[ChatMessage.from_user(template)], required_variables="*")
 
     rag_pipeline = Pipeline()
+    rag_pipeline.add_component("query_embedder", query_embedder)
     rag_pipeline.add_component("retriever", retriever)
     rag_pipeline.add_component("prompt_builder", prompt_builder)
     rag_pipeline.add_component("llm", generator)
 
+    rag_pipeline.connect("query_embedder.embedding", "retriever.query_embedding")
     rag_pipeline.connect("retriever", "prompt_builder.documents")
     rag_pipeline.connect("prompt_builder", "llm")
 
     rag_component = SuperComponent(
         pipeline=rag_pipeline,
-        input_mapping={"query": ["retriever.query", "prompt_builder.query"]},
+        input_mapping={"query": [
+            "query_embedder.text",
+            "prompt_builder.query",
+        ]},
         output_mapping={"llm.replies": "rag_result"},
     )
 

--- a/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
+++ b/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
@@ -74,5 +74,7 @@ def test_config_yaml_loads_and_has_keys() -> None:
             "opensearch_url:",
             "index_on_startup:",
             "data_dir:",
+            "embedding_model:",
+            "embedding_dim:",
     ]:
         assert key in text, f"Missing key: {key}"

--- a/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
+++ b/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
@@ -74,7 +74,6 @@ def test_config_yaml_loads_and_has_keys() -> None:
             "opensearch_url:",
             "index_on_startup:",
             "data_dir:",
-            "embedding_model:",
             "embedding_dim:",
     ]:
         assert key in text, f"Missing key: {key}"


### PR DESCRIPTION
This improves the Haystack Deep Research Agent example:

- Updates the RAG / Agent LLM model to `nvidia/llama-3.3-nemotron-super-49b-v1.5`
- Use embedding-based retrieval and document indexing replacing `OpenSearchBM25Retriever` with `OpenSearchEmbeddingRetriever` and `NvidiaDocumentEmbedder` Haystack components, improving search relevance and enabling actual semantic search. The main changes include switching to embedding models for both document indexing and retrieval Haystack pipelines, updating configuration to support embedding parameters, and refactoring pipelines to integrate embedding components.

(retry of https://github.com/NVIDIA/NeMo-Agent-Toolkit/pull/1161)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated NVIDIA embedders for document indexing and query embedding; retrieval now uses embedding-based matching.

* **Updates**
  * Language model identifiers updated to v1.5.
  * Configuration now requires an embedder model name and embedding_dim (1024 by default).
  * Startup indexing and retrieval flows updated to require and propagate the embedder selection.

* **Tests**
  * Config validation updated to assert presence of embedding_dim.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->