### PR TITLE
Update the `test_lifetime_task_timeout` test to not take 60s

### DIFF
--- a/tests/nat/mcp/test_mcp_session_management.py
+++ b/tests/nat/mcp/test_mcp_session_management.py
@@ -610,7 +610,7 @@ class TestMCPSessionManagement:
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
         with patch('nat.plugins.mcp.client_base.MCPStreamableHTTPClient', return_value=mock_client):
-            with pytest.raises(RuntimeError, match="Session client initialization timed out after 2.0s"):
+            with pytest.raises(RuntimeError, match=r"Session client initialization timed out after 2\.0s"):
                 await fg._create_session_client(session_id)
 
     async def test_lifetime_task_cleanup_on_stop_event(self, function_group):

--- a/tests/nat/mcp/test_mcp_session_management.py
+++ b/tests/nat/mcp/test_mcp_session_management.py
@@ -590,6 +590,7 @@ class TestMCPSessionManagement:
             with pytest.raises(RuntimeError, match="Failed to initialize session client: Connection failed"):
                 await function_group._create_session_client(session_id)
 
+    @pytest.mark.slow
     async def test_lifetime_task_timeout(self, function_group):
         """Test that lifetime task times out if initialization hangs."""
         session_id = "test-session-timeout"


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a session-management test to accept injected mocks and use a locally constructed instance instead of a shared fixture.
  * Adjusted timeout expectation in the test to 2.0s and updated assertions accordingly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->