### PR TITLE
feat: relax temperature bounds to be model-specific

### DIFF
--- a/src/nat/llm/aws_bedrock_llm.py
+++ b/src/nat/llm/aws_bedrock_llm.py
@@ -53,11 +53,11 @@ class AWSBedrockModelConfig(LLMBaseConfig, RetryMixin, OptimizableMixin, Thinkin
         default=None, description="Bedrock endpoint to use. Needed if you don't want to default to us-east-1 endpoint.")
     credentials_profile_name: str | None = Field(
         default=None, description="The name of the profile in the ~/.aws/credentials or ~/.aws/config files.")
-    temperature: float | None = OptimizableField(default=None,
-                                                 ge=0.0,
-                                                 le=1.0,
-                                                 description="Sampling temperature in [0, 1].",
-                                                 space=SearchSpace(high=0.9, low=0.1, step=0.2))
+    temperature: float | None = OptimizableField(
+        default=None,
+        ge=0.0,
+        description="Sampling temperature to control randomness in the output.",
+        space=SearchSpace(high=0.9, low=0.1, step=0.2))
     top_p: float | None = OptimizableField(default=None,
                                            ge=0.0,
                                            le=1.0,

--- a/src/nat/llm/azure_openai_llm.py
+++ b/src/nat/llm/azure_openai_llm.py
@@ -48,11 +48,11 @@ class AzureOpenAIModelConfig(
                                   serialization_alias="azure_deployment",
                                   description="The Azure OpenAI hosted model/deployment name.")
     seed: int | None = Field(default=None, description="Random seed to set for generation.")
-    temperature: float | None = OptimizableField(default=None,
-                                                 ge=0.0,
-                                                 le=1.0,
-                                                 description="Sampling temperature in [0, 1].",
-                                                 space=SearchSpace(high=0.9, low=0.1, step=0.2))
+    temperature: float | None = OptimizableField(
+        default=None,
+        ge=0.0,
+        description="Sampling temperature to control randomness in the output.",
+        space=SearchSpace(high=0.9, low=0.1, step=0.2))
     top_p: float | None = OptimizableField(default=None,
                                            ge=0.0,
                                            le=1.0,

--- a/src/nat/llm/litellm_llm.py
+++ b/src/nat/llm/litellm_llm.py
@@ -51,11 +51,11 @@ class LiteLlmModelConfig(
                                        serialization_alias="model",
                                        description="The LiteLlm hosted model name.")
     seed: int | None = Field(default=None, description="Random seed to set for generation.")
-    temperature: float | None = OptimizableField(default=None,
-                                                 ge=0.0,
-                                                 le=1.0,
-                                                 description="Sampling temperature in [0, 1].",
-                                                 space=SearchSpace(high=0.9, low=0.1, step=0.2))
+    temperature: float | None = OptimizableField(
+        default=None,
+        ge=0.0,
+        description="Sampling temperature to control randomness in the output.",
+        space=SearchSpace(high=0.9, low=0.1, step=0.2))
     top_p: float | None = OptimizableField(default=None,
                                            ge=0.0,
                                            le=1.0,

--- a/src/nat/llm/nim_llm.py
+++ b/src/nat/llm/nim_llm.py
@@ -43,11 +43,11 @@ class NIMModelConfig(LLMBaseConfig, RetryMixin, OptimizableMixin, ThinkingMixin,
     max_tokens: PositiveInt = OptimizableField(default=300,
                                                description="Maximum number of tokens to generate.",
                                                space=SearchSpace(high=2176, low=128, step=512))
-    temperature: float | None = OptimizableField(default=None,
-                                                 ge=0.0,
-                                                 le=1.0,
-                                                 description="Sampling temperature in [0, 1].",
-                                                 space=SearchSpace(high=0.9, low=0.1, step=0.2))
+    temperature: float | None = OptimizableField(
+        default=None,
+        ge=0.0,
+        description="Sampling temperature to control randomness in the output.",
+        space=SearchSpace(high=0.9, low=0.1, step=0.2))
     top_p: float | None = OptimizableField(default=None,
                                            ge=0.0,
                                            le=1.0,

--- a/src/nat/llm/openai_llm.py
+++ b/src/nat/llm/openai_llm.py
@@ -41,11 +41,11 @@ class OpenAIModelConfig(LLMBaseConfig, RetryMixin, OptimizableMixin, ThinkingMix
                                        description="The OpenAI hosted model name.")
     seed: int | None = Field(default=None, description="Random seed to set for generation.")
     max_retries: int = Field(default=10, description="The max number of retries for the request.")
-    temperature: float | None = OptimizableField(default=None,
-                                                 ge=0.0,
-                                                 le=1.0,
-                                                 description="Sampling temperature in [0, 1].",
-                                                 space=SearchSpace(high=0.9, low=0.1, step=0.2))
+    temperature: float | None = OptimizableField(
+        default=None,
+        ge=0.0,
+        description="Sampling temperature to control randomness in the output.",
+        space=SearchSpace(high=0.9, low=0.1, step=0.2))
     top_p: float | None = OptimizableField(default=None,
                                            ge=0.0,
                                            le=1.0,


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Extended valid temperature range for LLM model configurations across multiple providers (AWS Bedrock, Azure OpenAI, LiteLLM, NIM, and OpenAI), allowing higher values for greater output randomness control.
  - Updated temperature parameter descriptions for clarity across all affected configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->