### PR TITLE
Ensure that the `ADKProfilerHandler` patches are not applied more than once

### DIFF
--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/adk_callback_handler.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/adk_callback_handler.py
@@ -108,6 +108,7 @@ class ADKProfilerHandler(BaseProfilerCallback):
                 self._original_llm_call = None
 
             self._instrumented = False
+            self.last_call_ts = 0.0
             logger.debug("ADKProfilerHandler uninstrumented successfully.")
         except Exception as _e:
             logger.exception("Failed to uninstrument ADKProfilerHandler")

--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/adk_callback_handler.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/adk_callback_handler.py
@@ -43,8 +43,15 @@ class ADKProfilerHandler(BaseProfilerCallback):
     and store them in NeMo Agent Toolkit's usage_stats queue for subsequent analysis.
     """
 
-    def __init__(self) -> None:
-        super().__init__()
+    _instance: "ADKProfilerHandler | None" = None
+
+    def __new__(cls):
+        if cls._instance is None:
+            cls._instance = super(ADKProfilerHandler, cls).__new__(cls)
+
+        return cls._instance
+
+    def __init__(self):
         self._lock = threading.Lock()
         self.last_call_ts = 0.0
         self.step_manager = Context.get().intermediate_step_manager

--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/adk_callback_handler.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/adk_callback_handler.py
@@ -47,7 +47,7 @@ class ADKProfilerHandler(BaseProfilerCallback):
 
     def __new__(cls):
         if cls._instance is None:
-            cls._instance = super(ADKProfilerHandler, cls).__new__(cls)
+            cls._instance = super().__new__(cls)
 
         return cls._instance
 

--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/adk_callback_handler.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/adk_callback_handler.py
@@ -61,7 +61,7 @@ class ADKProfilerHandler(BaseProfilerCallback):
         """
         import litellm
 
-        if getattr(self, "_instrumented", False):
+        if self._instrumented:
             logger.debug("ADKProfilerHandler already instrumented; skipping.")
             return
         try:
@@ -95,9 +95,15 @@ class ADKProfilerHandler(BaseProfilerCallback):
                 FunctionTool.run_async = self._original_tool_call
             if self._original_llm_call:
                 litellm.acompletion = self._original_llm_call
+
+            self._instrumented = False
             logger.debug("ADKProfilerHandler uninstrumented successfully.")
         except Exception as _e:
             logger.exception("Failed to uninstrument ADKProfilerHandler")
+
+    def __del__(self):
+        """ Ensure uninstrumentation on deletion. """
+        self.uninstrument()
 
     def _tool_use_monkey_patch(self) -> Callable[..., Any]:
         """

--- a/packages/nvidia_nat_adk/tests/test_adk_callback_handler.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_callback_handler.py
@@ -80,11 +80,14 @@ def test_uninstrument_restores_originals():
     import litellm
     from google.adk.tools.function_tool import FunctionTool
 
+    original_acompletion = litellm.acompletion
+    original_function_tool_run_async = FunctionTool.run_async
+
     handler = ADKProfilerHandler()
     handler.instrument()
     assert handler._instrumented
-    assert handler._original_llm_call is litellm.acompletion
-    assert handler._original_tool_call is FunctionTool.run_async
+    assert handler._original_llm_call is original_acompletion
+    assert handler._original_tool_call is original_function_tool_run_async
 
     handler.uninstrument()
     assert not handler._instrumented

--- a/packages/nvidia_nat_adk/tests/test_adk_callback_handler.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_callback_handler.py
@@ -25,9 +25,24 @@ from nat.data_models.intermediate_step import IntermediateStepType
 from nat.data_models.intermediate_step import LLMFrameworkEnum
 from nat.plugins.adk.adk_callback_handler import ADKProfilerHandler
 
+
 # ----------------------------
 # Test Fixtures and Helpers
 # ----------------------------
+@pytest.fixture(autouse=True)
+def reset_patches():
+    import litellm
+    from google.adk.tools.function_tool import FunctionTool
+
+    # Store original references
+    original_acompletion = litellm.acompletion
+    original_function_tool_run_async = FunctionTool.run_async
+
+    yield
+
+    # Restore original references
+    litellm.acompletion = original_acompletion
+    FunctionTool.run_async = original_function_tool_run_async
 
 
 @pytest.fixture

--- a/packages/nvidia_nat_adk/tests/test_adk_callback_handler.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_callback_handler.py
@@ -34,13 +34,13 @@ def reset_patches():
     import litellm
     from google.adk.tools.function_tool import FunctionTool
 
-    # Store original references
+    # Store original functions
     original_acompletion = litellm.acompletion
     original_function_tool_run_async = FunctionTool.run_async
 
     yield
 
-    # Restore original references
+    # Restore original functions
     litellm.acompletion = original_acompletion
     FunctionTool.run_async = original_function_tool_run_async
 


### PR DESCRIPTION
## Description
* Fix the logic in `ADKProfilerHandler` preventing the patch from being applied more than once.
* Since the patches set attributes directly on the `ADKProfilerHandler` instance, concurrent `ADKProfilerHandler` instances are not possible, thus `ADKProfilerHandler` is now a singleton.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced profiler handler reliability with improved instance lifecycle management and automatic recovery
  * Added thread-safe initialization for concurrent operations
  * Strengthened instrumentation state tracking with improved restoration capabilities

* **Tests**
  * Added comprehensive test coverage for profiler independence and instrumentation cleanup verification

<!-- end of auto-generated comment: release notes by coderabbit.ai -->