### PR TITLE
Ensure that the compatibility loader is removed after each test

### DIFF
--- a/tests/nat/compat/test_compatibility_aliases.py
+++ b/tests/nat/compat/test_compatibility_aliases.py
@@ -13,13 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import copy
 import importlib
 import subprocess
 
 import pytest
 
-# Prevent isort from removing the pylint disable comments
-# isort:skip_file
+
+@pytest.fixture(autouse=True)
+def remove_aiq_compat_finder():
+    import sys
+    # Restore the original sys.meta_path this ensures that the AIQ compatibility finder is removed after each test
+    original_meta_path = copy.copy(sys.meta_path)
+    yield
+    sys.meta_path = original_meta_path
+
+    # Remove aiq from sys.modules so that the compatibility finder will be added on the next import of aiq
+    sys.modules.pop('aiq', None)
 
 
 def test_aiq_subclass_is_nat_subclass():

--- a/tests/nat/compat/test_compatibility_aliases.py
+++ b/tests/nat/compat/test_compatibility_aliases.py
@@ -16,13 +16,13 @@
 import copy
 import importlib
 import subprocess
+import sys
 
 import pytest
 
 
 @pytest.fixture(autouse=True)
 def remove_aiq_compat_finder():
-    import sys
     # Restore the original sys.meta_path this ensures that the AIQ compatibility finder is removed after each test
     original_meta_path = copy.copy(sys.meta_path)
     yield


### PR DESCRIPTION
## Description
* Ensures that the 1.0 compatibility loader is removed after performing the compatibility tests. Since the rest of the tests should not depend on it, we should ensure that it is removed so that we don't have other tests silently depending on it.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced test suite to automatically restore import-related state and remove compatibility helpers between runs, improving isolation and preventing cross-test interference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->