### PR TITLE
Fix `documentation_checks.sh` script to run on MacOS

### DIFF
--- a/ci/scripts/documentation_checks.sh
+++ b/ci/scripts/documentation_checks.sh
@@ -20,7 +20,7 @@ set +e
 DOC_FILES=$(git ls-files "*.md" "*.rst" | grep -v -E '(^|/)(CHANGELOG|LICENSE)\.md$')
 NOTEBOOK_FILES=$(git ls-files "*.ipynb")
 
-if [[ -v ${WORKSPACE_TMP} ]]; then
+if [[ -z "${WORKSPACE_TMP}" ]]; then
     MKTEMP_ARGS=""
 else
     MKTEMP_ARGS="--tmpdir=${WORKSPACE_TMP}"


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a condition in the documentation checks script to properly handle temporary directory configuration, preventing invalid empty arguments from being passed when the workspace variable is unset or empty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->