### PR TITLE
Add bind_tools and bind methods to LangChainTestLLM 

### DIFF
--- a/packages/nvidia_nat_test/src/nat/test/llm.py
+++ b/packages/nvidia_nat_test/src/nat/test/llm.py
@@ -96,6 +96,14 @@ async def test_llm_langchain(config: TestLLMConfig, builder: Builder):
             await chooser.async_sleep()
             yield chooser.next_response()
 
+        def bind_tools(self, tools: Any, **_kwargs: Any) -> "LangChainTestLLM":
+            """Bind tools to the LLM. Returns self to maintain fluent interface."""
+            return self
+
+        def bind(self, **_kwargs: Any) -> "LangChainTestLLM":
+            """Bind additional parameters to the LLM. Returns self to maintain fluent interface."""
+            return self
+
     yield LangChainTestLLM()
 
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes #1160
This PR adds missing `bind_tools()` and `bind()` methods to `LangChainTestLLM` to support testing workflows that use tool-calling and ReAct agents.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added fluent interface methods to test LLM for improved compatibility with LangChain workflows.

* **Tests**
  * Added tests to verify new binding methods work correctly and support method chaining.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->