### PR TITLE
Truncate long error messages

### DIFF
--- a/ci/scripts/gitlab/report_test_results.py
+++ b/ci/scripts/gitlab/report_test_results.py
@@ -98,7 +98,7 @@ def text_to_block(text: str) -> dict:
 def add_text(text: str, blocks: list[dict], plain_text: list[str]) -> None:
     if len(text) > MAX_TEXT_LENGTH:
         text = text[:(MAX_TEXT_LENGTH - 3)] + "..."
-    assert len(text) <= MAX_TEXT_LENGTH
+
     blocks.append(text_to_block(text))
     plain_text.append(text)
 

--- a/ci/scripts/gitlab/report_test_results.py
+++ b/ci/scripts/gitlab/report_test_results.py
@@ -23,6 +23,8 @@ from datetime import date
 
 from slack_sdk import WebClient
 
+MAX_TEXT_LENGTH = 3000  # Slack message text limit
+
 
 class ReportMessages(typing.NamedTuple):
     plain_text: list[str]
@@ -94,6 +96,9 @@ def text_to_block(text: str) -> dict:
 
 
 def add_text(text: str, blocks: list[dict], plain_text: list[str]) -> None:
+    if len(text) > MAX_TEXT_LENGTH:
+        text = text[:(MAX_TEXT_LENGTH - 3)] + "..."
+    assert len(text) <= MAX_TEXT_LENGTH
     blocks.append(text_to_block(text))
     plain_text.append(text)
 


### PR DESCRIPTION
## Description
* Fixes an issue where test error messages can exceed the maximum length for slack messages.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed text truncation in Slack test report notifications so oversized messages are shortened (with "..." appended) and kept within the allowed length to prevent broken/oversized blocks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->