### PR TITLE
Ensure jq is installed prior to running integration tests

### DIFF
--- a/ci/scripts/gitlab/tests.sh
+++ b/ci/scripts/gitlab/tests.sh
@@ -31,6 +31,10 @@ PYTEST_ARGS=""
 REPORT_NAME="${CI_PROJECT_DIR}/pytest_junit_report.xml"
 COV_REPORT_NAME="${CI_PROJECT_DIR}/pytest_coverage_report.xml"
 if [ "${CI_CRON_NIGHTLY}" == "1" ]; then
+       rapids-logger "Installing jq (needed for notebook tests)"
+       apt update
+       apt install --no-install-recommends -y jq
+
        PYTEST_ARGS="--run_slow --run_integration"
 
        DATE_TAG=$(date +"%Y%m%d")


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI tooling configuration to ensure required dependencies are available during nightly test runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->