### PR TITLE
fix(azure-openai): ensure api_version is specified

### DIFF
--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/llm.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/llm.py
@@ -51,6 +51,8 @@ async def azure_openai_adk(config: AzureOpenAIModelConfig, _builder: Builder):
     if config.azure_endpoint:
         config_dict["api_base"] = config.azure_endpoint
 
+    config_dict["api_version"] = config.api_version
+
     yield LiteLlm(f"azure/{config.azure_deployment}", **config_dict)
 
 

--- a/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
+++ b/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
@@ -98,7 +98,7 @@ async def azure_openai_crewai(llm_config: AzureOpenAIModelConfig, _builder: Buil
 
     client = LLM(
         **llm_config.model_dump(
-            exclude={"type", "api_key", "azure_endpoint", "azure_deployment", "thinking", "api_type"},
+            exclude={"type", "api_key", "azure_endpoint", "azure_deployment", "thinking", "api_type", "api_version"},
             by_alias=True,
             exclude_none=True,
             exclude_unset=True,

--- a/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
+++ b/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
@@ -104,6 +104,7 @@ async def azure_openai_crewai(llm_config: AzureOpenAIModelConfig, _builder: Buil
             exclude_unset=True,
         ),
         model=model,
+        api_version=llm_config.api_version,
     )
 
     yield _patch_llm_based_on_config(client, llm_config)

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
@@ -29,7 +29,9 @@ async def azure_openai_langchain(embedder_config: AzureOpenAIEmbedderModelConfig
     from langchain_openai import AzureOpenAIEmbeddings
 
     client = AzureOpenAIEmbeddings(
-        **embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True, exclude_unset=True))
+        **embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True, exclude_unset=True),
+        api_version=embedder_config.api_version,
+    )
 
     if isinstance(embedder_config, RetryMixin):
         client = patch_with_retry(client,

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
@@ -29,7 +29,10 @@ async def azure_openai_langchain(embedder_config: AzureOpenAIEmbedderModelConfig
     from langchain_openai import AzureOpenAIEmbeddings
 
     client = AzureOpenAIEmbeddings(
-        **embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True, exclude_unset=True),
+        **embedder_config.model_dump(exclude={"type", "api_version"},
+                                     by_alias=True,
+                                     exclude_none=True,
+                                     exclude_unset=True),
         api_version=embedder_config.api_version,
     )
 

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -136,7 +136,7 @@ async def azure_openai_langchain(llm_config: AzureOpenAIModelConfig, _builder: B
     validate_no_responses_api(llm_config, LLMFrameworkEnum.LANGCHAIN)
 
     client = AzureChatOpenAI(
-        **llm_config.model_dump(exclude={"type", "thinking", "api_type"},
+        **llm_config.model_dump(exclude={"type", "thinking", "api_type", "api_version"},
                                 by_alias=True,
                                 exclude_none=True,
                                 exclude_unset=True),

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -135,8 +135,13 @@ async def azure_openai_langchain(llm_config: AzureOpenAIModelConfig, _builder: B
 
     validate_no_responses_api(llm_config, LLMFrameworkEnum.LANGCHAIN)
 
-    client = AzureChatOpenAI(**llm_config.model_dump(
-        exclude={"type", "thinking", "api_type"}, by_alias=True, exclude_none=True, exclude_unset=True))
+    client = AzureChatOpenAI(
+        **llm_config.model_dump(exclude={"type", "thinking", "api_type"},
+                                by_alias=True,
+                                exclude_none=True,
+                                exclude_unset=True),
+        api_version=llm_config.api_version,
+    )
 
     yield _patch_llm_based_on_config(client, llm_config)
 

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
@@ -29,7 +29,9 @@ async def azure_openai_llama_index(embedder_config: AzureOpenAIEmbedderModelConf
     from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
 
     client = AzureOpenAIEmbedding(
-        **embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True, exclude_unset=True))
+        **embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True, exclude_unset=True),
+        api_version=embedder_config.api_version,
+    )
 
     if isinstance(embedder_config, RetryMixin):
         client = patch_with_retry(client,

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
@@ -29,7 +29,10 @@ async def azure_openai_llama_index(embedder_config: AzureOpenAIEmbedderModelConf
     from llama_index.embeddings.azure_openai import AzureOpenAIEmbedding
 
     client = AzureOpenAIEmbedding(
-        **embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True, exclude_unset=True),
+        **embedder_config.model_dump(exclude={"type", "api_version"},
+                                     by_alias=True,
+                                     exclude_none=True,
+                                     exclude_unset=True),
         api_version=embedder_config.api_version,
     )
 

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
@@ -101,7 +101,7 @@ async def azure_openai_llama_index(llm_config: AzureOpenAIModelConfig, _builder:
     validate_no_responses_api(llm_config, LLMFrameworkEnum.LLAMA_INDEX)
 
     llm = AzureOpenAI(
-        **llm_config.model_dump(exclude={"type", "thinking", "api_type"},
+        **llm_config.model_dump(exclude={"type", "thinking", "api_type", "api_version"},
                                 by_alias=True,
                                 exclude_none=True,
                                 exclude_unset=True),

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
@@ -100,8 +100,13 @@ async def azure_openai_llama_index(llm_config: AzureOpenAIModelConfig, _builder:
 
     validate_no_responses_api(llm_config, LLMFrameworkEnum.LLAMA_INDEX)
 
-    llm = AzureOpenAI(**llm_config.model_dump(
-        exclude={"type", "thinking", "api_type"}, by_alias=True, exclude_none=True, exclude_unset=True))
+    llm = AzureOpenAI(
+        **llm_config.model_dump(exclude={"type", "thinking", "api_type"},
+                                by_alias=True,
+                                exclude_none=True,
+                                exclude_unset=True),
+        api_version=llm_config.api_version,
+    )
 
     yield _patch_llm_based_on_config(llm, llm_config)
 

--- a/tests/nat/llm_providers/test_langchain_agents.py
+++ b/tests/nat/llm_providers/test_langchain_agents.py
@@ -103,7 +103,8 @@ async def test_aws_bedrock_langchain_agent():
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("azure_openai_keys")
-async def test_azure_openai_langchain_agent():
+@pytest.mark.parametrize("api_version", [None, '2025-04-01-preview'])
+async def test_azure_openai_langchain_agent(api_version: str | None):
     """
     Test Azure OpenAI LLM with LangChain/LangGraph agent.
     Requires AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT to be set.
@@ -112,7 +113,10 @@ async def test_azure_openai_langchain_agent():
     """
     prompt = ChatPromptTemplate.from_messages([("system", "You are a helpful AI assistant."), ("human", "{input}")])
 
-    llm_config = AzureOpenAIModelConfig(azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1"))
+    config_args = {"azure_deployment": os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1")}
+    if api_version is not None:
+        config_args["api_version"] = api_version
+    llm_config = AzureOpenAIModelConfig(**config_args)
 
     async with WorkflowBuilder() as builder:
         await builder.add_llm("azure_openai_llm", llm_config)

--- a/tests/nat/llm_providers/test_llama_index_agents.py
+++ b/tests/nat/llm_providers/test_llama_index_agents.py
@@ -110,16 +110,22 @@ async def test_aws_bedrock_minimal_agent():
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("azure_openai_keys")
-async def test_azure_openai_minimal_agent():
+@pytest.mark.parametrize("api_version", [None, '2025-04-01-preview'])
+async def test_azure_openai_minimal_agent(api_version: str | None):
     """
     Test Azure OpenAI LLM with minimal LlamaIndex agent.
     Requires AZURE_OPENAI_API_KEY and AZURE_OPENAI_ENDPOINT to be set.
     The model can be changed by setting AZURE_OPENAI_DEPLOYMENT.
     See https://learn.microsoft.com/en-us/azure/ai-foundry/openai/quickstart for more information.
     """
-    llm_config = AzureOpenAIModelConfig(azure_deployment=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1"),
-                                        azure_endpoint=os.environ.get("AZURE_OPENAI_ENDPOINT"),
-                                        api_key=os.environ.get("AZURE_OPENAI_API_KEY"))
+    config_args = {
+        "azure_deployment": os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1"),
+        "azure_endpoint": os.environ.get("AZURE_OPENAI_ENDPOINT"),
+        "api_key": os.environ.get("AZURE_OPENAI_API_KEY")
+    }
+    if api_version is not None:
+        config_args["api_version"] = api_version
+    llm_config = AzureOpenAIModelConfig(**config_args)
     agent = await create_minimal_agent("azure_openai_llm", llm_config)
 
     response = await agent.achat("What is 1+2?")


### PR DESCRIPTION
## Description
#1143 incorrectly restricted model_dump to exclude defaults.
We still need to emit defaults where appropriate.

Closes AIQ-2359


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Explicit API version support added across Azure OpenAI LLM and embedding integrations so configured api_version values are consistently forwarded to clients and preserved in model/state construction.
  * Reduces mismatches between configuration and runtime client behavior for different Azure deployments.

* **Tests**
  * Tests parameterized to validate behavior with multiple api_version values to ensure compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->