### PR TITLE
Remove work-around for qdrant/qdrant-client#983

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -374,22 +374,6 @@ def mock_tool():
     return _create_mock_tool
 
 
-@pytest.fixture(scope="function", autouse=True)
-def patched_async_memory_client(monkeypatch):
-    # Suppress Pydantic's class-based Config deprecation only during mem0 import
-    with warnings.catch_warnings():
-        warnings.filterwarnings(
-            "ignore",
-            category=PydanticDeprecatedSince20,
-            module=r"^pydantic\._internal\._config$",
-        )
-        from mem0.client.main import MemoryClient
-
-    mock_method = mock.MagicMock(return_value=None)
-    monkeypatch.setattr(MemoryClient, "_validate_api_key", mock_method)
-    return MemoryClient
-
-
 @pytest.fixture(name="rag_user_inputs")
 def rag_user_inputs_fixture() -> list[str]:
     """Fixture providing multiple user inputs."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,7 +29,6 @@ import os
 import sys
 import typing
 import uuid
-import warnings
 from collections.abc import AsyncGenerator
 from collections.abc import Callable
 from collections.abc import Sequence
@@ -49,7 +48,6 @@ from langchain_core.outputs import ChatGeneration
 from langchain_core.outputs import ChatResult
 from langchain_core.tools import BaseTool
 from pydantic import BaseModel
-from pydantic.warnings import PydanticDeprecatedSince20
 
 TESTS_DIR = os.path.dirname(__file__)
 PROJECT_DIR = os.path.dirname(TESTS_DIR)

--- a/tests/nat/middleware/test_cache_middleware.py
+++ b/tests/nat/middleware/test_cache_middleware.py
@@ -29,13 +29,13 @@ from nat.middleware.cache_middleware import CacheMiddleware
 from nat.middleware.middleware import FunctionMiddlewareContext
 
 
-class TestInput(BaseModel):
+class _TestInput(BaseModel):
     """Test input model."""
     value: str
     number: int
 
 
-class TestOutput(BaseModel):
+class _TestOutput(BaseModel):
     """Test output model."""
     result: str
 
@@ -46,8 +46,8 @@ def middleware_context():
     return FunctionMiddlewareContext(name="test_function",
                                      config=MagicMock(),
                                      description="Test function",
-                                     input_schema=TestInput,
-                                     single_output_schema=TestOutput,
+                                     input_schema=_TestInput,
+                                     single_output_schema=_TestOutput,
                                      stream_output_schema=None)
 
 
@@ -83,7 +83,7 @@ class TestCacheMiddlewareCaching:
         async def mock_next_call(_val):
             nonlocal call_count
             call_count += 1
-            return TestOutput(result=f"Result for {_val['value']}")
+            return _TestOutput(result=f"Result for {_val['value']}")
 
         # First call - should call the function
         input1 = {"value": "test", "number": 42}
@@ -111,7 +111,7 @@ class TestCacheMiddlewareCaching:
         async def mock_next_call(_val):
             nonlocal call_count
             call_count += 1
-            return TestOutput(result=f"Result {call_count}")
+            return _TestOutput(result=f"Result {call_count}")
 
         # First call
         input1 = {"value": "hello world", "number": 42}
@@ -140,7 +140,7 @@ class TestCacheMiddlewareCaching:
         async def mock_next_call(_val):
             nonlocal call_count
             call_count += 1
-            return TestOutput(result=f"Result {call_count}")
+            return _TestOutput(result=f"Result {call_count}")
 
         # Mock ContextState to control is_evaluating
         mock_ctx_cls = 'nat.middleware.cache_middleware.ContextState'
@@ -179,7 +179,7 @@ class TestCacheMiddlewareCaching:
         async def mock_next_call(_val):
             nonlocal call_count
             call_count += 1
-            return TestOutput(result="Result")
+            return _TestOutput(result="Result")
 
         # Create an object that can't be serialized
         class UnserializableObject:
@@ -241,7 +241,7 @@ class TestCacheMiddlewareEdgeCases:
         async def mock_next_call(_val):
             nonlocal call_count
             call_count += 1
-            return TestOutput(result="Result")
+            return _TestOutput(result="Result")
 
         # Mock ContextState.get to raise an exception
         mock_ctx_cls = 'nat.middleware.cache_middleware.ContextState.get'
@@ -281,11 +281,11 @@ class TestCacheMiddlewareEdgeCases:
             {
                 "value": "test input 2", "number": 42
             })
-        middleware._cache[key1] = TestOutput(result="Result 1")  # noqa
-        middleware._cache[key2] = TestOutput(result="Result 2")  # noqa
+        middleware._cache[key1] = _TestOutput(result="Result 1")  # noqa
+        middleware._cache[key2] = _TestOutput(result="Result 2")  # noqa
 
         async def mock_next_call(_val):
-            return TestOutput(result="New Result")
+            return _TestOutput(result="New Result")
 
         # Query with something similar to all
         input_str = {"value": "test input X", "number": 42}

--- a/tests/nat/middleware/test_middleware_components.py
+++ b/tests/nat/middleware/test_middleware_components.py
@@ -30,14 +30,14 @@ from nat.data_models.middleware import MiddlewareBaseConfig
 from nat.middleware.function_middleware import FunctionMiddleware
 
 
-class TestMiddlewareConfig(MiddlewareBaseConfig, name="test_component_middleware"):
+class _TestMiddlewareConfig(MiddlewareBaseConfig, name="test_component_middleware"):
     """Test middleware configuration."""
 
     test_param: str = Field(default="default_value")
     call_order: list[str] = Field(default_factory=list)
 
 
-class TestMiddleware(FunctionMiddleware):
+class _TestMiddleware(FunctionMiddleware):
     """Test middleware that records calls."""
 
     def __init__(self, *, test_param: str, call_order: list[str]):
@@ -56,9 +56,9 @@ class TestMiddleware(FunctionMiddleware):
 def register_test_middleware():
     """Register test middleware."""
 
-    @register_middleware(config_type=TestMiddlewareConfig)
-    async def test_middleware(config: TestMiddlewareConfig, builder: Builder):
-        yield TestMiddleware(test_param=config.test_param, call_order=config.call_order)
+    @register_middleware(config_type=_TestMiddlewareConfig)
+    async def test_middleware(config: _TestMiddlewareConfig, builder: Builder):
+        yield _TestMiddleware(test_param=config.test_param, call_order=config.call_order)
 
 
 class TestMiddlewareRegistration:
@@ -70,17 +70,17 @@ class TestMiddlewareRegistration:
         registered = registry.get_registered_middleware()
 
         # Find our test middleware
-        test_middlewares = [r for r in registered if r.config_type == TestMiddlewareConfig]
+        test_middlewares = [r for r in registered if r.config_type == _TestMiddlewareConfig]
         assert len(test_middlewares) == 1
-        assert test_middlewares[0].full_type == TestMiddlewareConfig.full_type
+        assert test_middlewares[0].full_type == _TestMiddlewareConfig.full_type
 
     def test_can_retrieve_middleware_registration(self):
         """Test that we can retrieve middleware registration info."""
         registry = GlobalTypeRegistry.get()
-        registration = registry.get_middleware(TestMiddlewareConfig)
+        registration = registry.get_middleware(_TestMiddlewareConfig)
 
-        assert registration.config_type == TestMiddlewareConfig
-        assert registration.full_type == TestMiddlewareConfig.full_type
+        assert registration.config_type == _TestMiddlewareConfig
+        assert registration.full_type == _TestMiddlewareConfig.full_type
         assert registration.build_fn is not None
 
 
@@ -89,40 +89,40 @@ class TestBuilderMethods:
 
     async def test_add_middleware(self):
         """Test adding a function middleware to the builder."""
-        config = TestMiddlewareConfig(test_param="builder_test", call_order=[])
+        config = _TestMiddlewareConfig(test_param="builder_test", call_order=[])
 
         async with WorkflowBuilder() as builder:
             middleware = await builder.add_middleware("test_middleware_1", config)
 
-            assert isinstance(middleware, TestMiddleware)
+            assert isinstance(middleware, _TestMiddleware)
             assert middleware.test_param == "builder_test"
 
     async def test_get_middleware(self):
         """Test retrieving a function middleware from the builder."""
-        config = TestMiddlewareConfig(test_param="get_test", call_order=[])
+        config = _TestMiddlewareConfig(test_param="get_test", call_order=[])
 
         async with WorkflowBuilder() as builder:
             await builder.add_middleware("test_middleware_2", config)
             retrieved = await builder.get_middleware("test_middleware_2")
 
-            assert isinstance(retrieved, TestMiddleware)
+            assert isinstance(retrieved, _TestMiddleware)
             assert retrieved.test_param == "get_test"
 
     async def test_get_middleware_config(self):
         """Test retrieving middleware config from the builder."""
-        config = TestMiddlewareConfig(test_param="config_test", call_order=[])
+        config = _TestMiddlewareConfig(test_param="config_test", call_order=[])
 
         async with WorkflowBuilder() as builder:
             await builder.add_middleware("test_middleware_3", config)
             retrieved_config = builder.get_middleware_config("test_middleware_3")
 
-            assert isinstance(retrieved_config, TestMiddlewareConfig)
+            assert isinstance(retrieved_config, _TestMiddlewareConfig)
             assert retrieved_config.test_param == "config_test"
 
     async def test_get_middlewares_batch(self):
         """Test retrieving multiple middlewares at once."""
-        config1 = TestMiddlewareConfig(test_param="batch1", call_order=[])
-        config2 = TestMiddlewareConfig(test_param="batch2", call_order=[])
+        config1 = _TestMiddlewareConfig(test_param="batch1", call_order=[])
+        config2 = _TestMiddlewareConfig(test_param="batch2", call_order=[])
 
         async with WorkflowBuilder() as builder:
             await builder.add_middleware("batch_1", config1)
@@ -131,13 +131,13 @@ class TestBuilderMethods:
             middlewares = await builder.get_middleware_list(["batch_1", "batch_2"])
 
             assert len(middlewares) == 2
-            assert all(isinstance(i, TestMiddleware) for i in middlewares)
+            assert all(isinstance(i, _TestMiddleware) for i in middlewares)
             params = {i.test_param for i in middlewares}
             assert params == {"batch1", "batch2"}
 
     async def test_duplicate_middleware_raises_error(self):
         """Test that adding duplicate middleware raises error."""
-        config = TestMiddlewareConfig(test_param="duplicate", call_order=[])
+        config = _TestMiddlewareConfig(test_param="duplicate", call_order=[])
 
         async with WorkflowBuilder() as builder:
             await builder.add_middleware("duplicate_test", config)
@@ -180,7 +180,7 @@ class TestYAMLIntegration:
 
             # Verify middleware was built
             middleware = await builder.get_middleware("yaml_middleware")
-            assert isinstance(middleware, TestMiddleware)
+            assert isinstance(middleware, _TestMiddleware)
             assert middleware.test_param == "from_yaml"
 
 
@@ -448,7 +448,7 @@ class TestFunctionGroupMiddlewares:
         call_order = []
 
         # Create test middleware
-        middleware = TestMiddleware(test_param="dynamic", call_order=call_order)
+        middleware = _TestMiddleware(test_param="dynamic", call_order=call_order)
 
         # Create function group with middlewares
         config = FunctionGroupBaseConfig()
@@ -496,8 +496,8 @@ class TestFunctionGroupMiddlewares:
         assert len(call_order1) == 0  # No middlewares called
 
         # Now configure middlewares
-        middleware1 = TestMiddleware(test_param="after1", call_order=call_order1)
-        middleware2 = TestMiddleware(test_param="after2", call_order=call_order2)
+        middleware1 = _TestMiddleware(test_param="after1", call_order=call_order1)
+        middleware2 = _TestMiddleware(test_param="after2", call_order=call_order2)
         group.configure_middleware([middleware1, middleware2])
 
         # Test functions with middlewares


### PR DESCRIPTION
## Description
* qdrant/qdrant-client#983 has been fixed, this PR remove our work-around (added in PR #305) for that issue.
* Rename test utility classes which are not test-suites, avoids a warning from pytest about not being able to collect tests.
* Assert that the aiq compatibility alias emits a deprecation warning, which also removes these from the warnings summary.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified test infrastructure by removing deprecated fixtures and streamlining test configuration.
  * Refactored test utilities and improved internal test structure for better maintainability across testing modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->