### PR TITLE
Work-around slow import issue for google-adk

### DIFF
--- a/packages/nvidia_nat_test/src/nat/test/plugin.py
+++ b/packages/nvidia_nat_test/src/nat/test/plugin.py
@@ -30,6 +30,7 @@ if typing.TYPE_CHECKING:
     import galileo.log_streams
     import galileo.projects
     import langsmith.client
+
     from docker.client import DockerClient
 
 
@@ -829,8 +830,6 @@ def import_adk_early():
     Since ADK is an optional dependency, we will ignore any import errors.
     """
     try:
-        import google.adk
+        import google.adk  # noqa: F401
     except ImportError:
         pass
-
-    return

--- a/packages/nvidia_nat_test/src/nat/test/plugin.py
+++ b/packages/nvidia_nat_test/src/nat/test/plugin.py
@@ -30,7 +30,6 @@ if typing.TYPE_CHECKING:
     import galileo.log_streams
     import galileo.projects
     import langsmith.client
-
     from docker.client import DockerClient
 
 
@@ -818,3 +817,20 @@ def piston_url_fixture(fail_missing: bool) -> str:
         if fail_missing:
             raise RuntimeError(reason)
         pytest.skip(reason)
+
+
+@pytest.fixture(autouse=True, scope="session")
+def import_adk_early():
+    """
+    Import ADK early to work-around slow import issue (https://github.com/google/adk-python/issues/2433),
+    when ADK is imported early it takes about 8 seconds, however if we wait until the `packages/nvidia_nat_adk/tests`
+    run the same import will take about 70 seconds.
+
+    Since ADK is an optional dependency, we will ignore any import errors.
+    """
+    try:
+        import google.adk.tools.function_tool
+    except ImportError:
+        pass
+
+    return

--- a/packages/nvidia_nat_test/src/nat/test/plugin.py
+++ b/packages/nvidia_nat_test/src/nat/test/plugin.py
@@ -829,7 +829,7 @@ def import_adk_early():
     Since ADK is an optional dependency, we will ignore any import errors.
     """
     try:
-        import google.adk.tools.function_tool
+        import google.adk
     except ImportError:
         pass
 


### PR DESCRIPTION
## Description
* Reduce test runtime by 60s by importing google-adk early.

Explanation:
`google-adk` has a known slow import issue (google/adk-python#2433), where the library takes ~8 seconds to import. However since we run the tests in the `packages` dir last (after `tests` and `examples`), the ADK related tests run close to last. For some reason when ADK is imported late, it takes 60-70s.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a session-scoped, automatically applied test fixture that attempts an early ADK import during test collection/run and silently ignores ImportError when ADK is not present, improving test initialization stability and reliability without affecting outcomes if ADK is absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->