### PR TITLE
Remove `pytest-pretty`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -252,7 +252,6 @@ dev = [
   "pytest_httpserver==1.1.*",
   "pytest-asyncio==0.24.*",
   "pytest-cov~=6.1",
-  "pytest-pretty~=1.2.0",
   "pytest~=8.3",
   "python-docx~=1.1.0",
   "ruff~=0.12",

--- a/uv.lock
+++ b/uv.lock
@@ -6058,7 +6058,6 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-httpserver" },
-    { name = "pytest-pretty" },
     { name = "python-docx" },
     { name = "ruff" },
     { name = "setuptools" },
@@ -6191,7 +6190,6 @@ dev = [
     { name = "pytest-asyncio", specifier = "==0.24.*" },
     { name = "pytest-cov", specifier = "~=6.1" },
     { name = "pytest-httpserver", specifier = "==1.1.*" },
-    { name = "pytest-pretty", specifier = "~=1.2.0" },
     { name = "python-docx", specifier = "~=1.1.0" },
     { name = "ruff", specifier = "~=0.12" },
     { name = "setuptools", specifier = ">=64" },
@@ -8412,19 +8410,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/d8/def15ba33bd696dd72dd4562a5287c0cba4d18a591eeb82e0b08ab385afc/pytest_httpserver-1.1.3.tar.gz", hash = "sha256:af819d6b533f84b4680b9416a5b3f67f1df3701f1da54924afd4d6e4ba5917ec", size = 68870, upload-time = "2025-04-10T08:17:15.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/d2/dfc2f25f3905921c2743c300a48d9494d29032f1389fc142e718d6978fb2/pytest_httpserver-1.1.3-py3-none-any.whl", hash = "sha256:5f84757810233e19e2bb5287f3826a71c97a3740abe3a363af9155c0f82fdbb9", size = 21000, upload-time = "2025-04-10T08:17:13.906Z" },
-]
-
-[[package]]
-name = "pytest-pretty"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pytest" },
-    { name = "rich" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/a5/18/30ad0408295f3157f7a4913f0eaa51a0a377ebad0ffa51ff239e833c6c72/pytest_pretty-1.2.0.tar.gz", hash = "sha256:105a355f128e392860ad2c478ae173ff96d2f03044692f9818ff3d49205d3a60", size = 6542, upload-time = "2023-04-05T17:11:50.917Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/fe/d44d391312c1b8abee2af58ee70fabb1c00b6577ac4e0bdf25b70c1caffb/pytest_pretty-1.2.0-py3-none-any.whl", hash = "sha256:6f79122bf53864ae2951b6c9e94d7a06a87ef753476acd4588aeac018f062036", size = 6180, upload-time = "2023-04-05T17:11:49.801Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description
* While `pytest-pretty` provides a nice easy to read table summary, often the test names are truncated making it difficult to determine which test is failing.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->