### PR TITLE
Use secret value for client_secret in OAuth client

### DIFF
--- a/src/nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py
+++ b/src/nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py
@@ -65,7 +65,7 @@ class WebSocketAuthenticationFlowHandler(FlowHandlerBase):
     def create_oauth_client(self, config: OAuth2AuthCodeFlowProviderConfig) -> AsyncOAuth2Client:
         try:
             return AsyncOAuth2Client(client_id=config.client_id,
-                                     client_secret=config.client_secret,
+                                     client_secret=config.client_secret.get_secret_value(),
                                      redirect_uri=config.redirect_uri,
                                      scope=" ".join(config.scopes) if config.scopes else None,
                                      token_endpoint=config.token_url,


### PR DESCRIPTION
secret field in OAuth2AuthCodeFlowProviderConfig type was changed to SerializableSecretStr. In case we don't update authentication handler it failed with error 
```
2025-11-21 13:18:01 - ERROR    - talk_to_data.check_user_permissions_function:194 - Authentication error: Authentication callback failed: Authentication failed: cannot convert 'SecretStr' object to bytes
Traceback (most recent call last):
  File "/Users/dzmitryv/work/nemo-agent-toolkit/src/nat/authentication/oauth2/oauth2_auth_code_flow_provider.py", line 118, in authenticate
    authenticated_context = await auth_callback(self.config, AuthFlowType.OAUTH2_AUTHORIZATION_CODE)
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dzmitryv/work/nemo-agent-toolkit/src/nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py", line 61, in authenticate
    return await self._handle_oauth2_auth_code_flow(config)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dzmitryv/work/nemo-agent-toolkit/src/nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py", line 132, in _handle_oauth2_auth_code_flow
    token = await asyncio.wait_for(flow_state.future, timeout=300)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/tasks.py", line 520, in wait_for
    return await fut
           ^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/futures.py", line 289, in __await__
    yield self  # This tells Task to wait for completion.
    ^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/tasks.py", line 385, in __wakeup
    future.result()
  File "/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/futures.py", line 202, in result
    raise self._exception.with_traceback(self._exception_tb)
RuntimeError: Authentication failed: cannot convert 'SecretStr' object to bytes

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "/Users/dzmitryv/work/nemo-agent-toolkit/examples/dmo-talk-to-data/src/talk_to_data/check_user_permissions_function.py", line 182, in _inner
    auth_result = await auth_provider.authenticate()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/dzmitryv/work/nemo-agent-toolkit/src/nat/authentication/oauth2/oauth2_auth_code_flow_provider.py", line 120, in authenticate
    raise RuntimeError(f"Authentication callback failed: {e}") from e
RuntimeError: Authentication callback failed: Authentication failed: cannot convert 'SecretStr' object to bytes
{"timestamp": "2025-11-21T13:18:01.674832", "level": "ERROR", "logger": "ta                                             lk_to_data.check_user_permissions_function", "message": "Authentication err                                             or: Authentication callback failed: Authentication failed: cannot convert '                                             SecretStr' object to bytes", "module": "check_user_permissions_function", "                                       function": "_inner", "line": 194, "thread": 8438401024, "thread_name": "Mai            nThread", "conversation_id": "b3265b5d-8a2e-4e9e-800c-717a11c16fab", "user_                                             message_id": "54a0ebea-d237-4660-ba37-288827fae1b0", "active_function": "us                                             er_authentication", "function_id": "ce84d305-ebd8-4b54-89fc-574f71935009",                                              "exception": "Traceback (most recent call last):\n  File \"/Users/dzmitryv/                                             work/nemo-agent-toolkit/src/nat/authentication/oauth2/oauth2_auth_code_flow                        _provider.py\", line 118, in authenticate\n    authenticated_context = awai                                             t auth_callback(self.config, AuthFlowType.OAUTH2_AUTHORIZATION_CODE)\n                                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^                                             ^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/dzmitryv/work/nemo-agent-toolkit/src/                                             nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py\", line                                     61, in authenticate\n    return await self._handle_oauth2_auth_code_flow(c         onfig)\n           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File                                              \"/Users/dzmitryv/work/nemo-agent-toolkit/src/nat/front_ends/fastapi/auth_                                             flow_handlers/websocket_flow_handler.py\", line 132, in _handle_oauth2_auth                                             _code_flow\n    token = await asyncio.wait_for(flow_state.future, timeout=3                                             00)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n                       File \"/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/                                             Versions/3.12/lib/python3.12/asyncio/tasks.py\", line 520, in wait_for\n                                                 return await fut\n           ^^^^^^^^^\n  File \"/opt/homebrew/Cellar/pyth                                             on@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asy                                             ncio/futures.py\", line 289, in __await__\n    yield self  # This tells Tas                                 k to wait for completion.\n    ^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/py      thon@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/a                                             syncio/tasks.py\", line 385, in __wakeup\n    future.result()\n  File \"/op                                             t/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3                                             .12/lib/python3.12/asyncio/futures.py\", line 202, in result\n    raise sel                                             f._exception.with_traceback(self._exception_tb)\nRuntimeError: Authenticati                  on failed: cannot convert 'SecretStr' object to bytes\n\nThe above exceptio                                             n was the direct cause of the following exception:\n\nTraceback (most recen                                             t call last):\n  File \"/Users/dzmitryv/work/nemo-agent-toolkit/examples/dm                                             o-talk-to-data/src/talk_to_data/check_user_permissions_function.py\", line                                              182, in _inner\n    auth_result = await auth_provider.authenticate()\n                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/dzmitryv/w   ork/nemo-agent-toolkit/src/nat/authentication/oauth2/oauth2_auth_code_flow_                                             flow_handlers/websocket_flow_handler.py\", line 132, in _handle_oauth2_auth                                             _code_flow\n    token = await asyncio.wait_for(flow_state.future, timeout=3                                             00)\n            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n                                            File \"/opt/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/               Versions/3.12/lib/python3.12/asyncio/tasks.py\", line 520, in wait_for\n                                                 return await fut\n           ^^^^^^^^^\n  File \"/opt/homebrew/Cellar/pyth                                             on@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asy                                             ncio/futures.py\", line 289, in __await__\n    yield self  # This tells Tas                                             k to wait for completion.\n    ^^^^^^^^^^\n  File \"/opt/homebrew/Cellar/py                           thon@3.12/3.12.9/Frameworks/Python.framework/Versions/3.12/lib/python3.12/asyncio/tasks.py\", line 385, in __wakeup\n    future.result()\n  File \"/op                                             t/homebrew/Cellar/python@3.12/3.12.9/Frameworks/Python.framework/Versions/3                                             .12/lib/python3.12/asyncio/futures.py\", line 202, in result\n    raise sel                                             f._exception.with_traceback(self._exception_tb)\nRuntimeError: Authenticati                                       on failed: cannot convert 'SecretStr' object to bytes\n\nThe above exceptio            n was the direct cause of the following exception:\n\nTraceback (most recen                                             t call last):\n  File \"/Users/dzmitryv/work/nemo-agent-toolkit/examples/dm                                             o-talk-to-data/src/talk_to_data/check_user_permissions_function.py\", line                                              182, in _inner\n    auth_result = await auth_provider.authenticate()\n                                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n  File \"/Users/dzmitryv/w                        ork/nemo-agent-toolkit/src/nat/authentication/oauth2/oauth2_auth_code_flow_                                             provider.py\", line 120, in authenticate\n    raise RuntimeError(f\"Authent
(.venv) dzmitryv@dzmitryv-mlt nemo-agent-toolkit %  cd /Users/dzmitryv/work/nemo-agent-toolkit ; /usr/bin/env /Users/dzm
itryv/work/nemo-agent-toolkit/.venv/bin/python /Users/dzmitryv/.cursor/extensions/ms-python.debugpy-2025.14.1-darwin-arm
64/bundled/libs/debugpy/adapter/../../debugpy/launcher 59201 -- /Users/dzmitryv/work/nemo-agent-toolkit/.venv/bin/nat se
rve --config_file=/Users/dzmitryv/work/nemo-agent-toolkit/examples/dmo-talk-to-data/configs/config.yml --port 8000 
2025-11-21 13:23:50 - INFO     - nat.cli.commands.start:192 - Starting NAT from config file: '/Users/dzmitryv/work/nemo-agent-toolkit/examples/dmo-talk-to-data/configs/config.yml'
2025-11-21 13:23:50 - WARNING  - nat.front_ends.fastapi.fastapi_front_end_plugin:137 - Dask is not installed, async execution and evaluation will not be available.```

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth2 client credential handling to properly extract and supply secret values during authentication flow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->