### PR TITLE
Fix the `aiq_compatibility_span_prefix` fixture

### DIFF
--- a/examples/notebooks/getting_started_with_nat.ipynb
+++ b/examples/notebooks/getting_started_with_nat.ipynb
@@ -434,18 +434,7 @@
     "<a id=\"run-server\"></a>\n",
     "## 2.2) Run as a NAT server\n",
     "\n",
-    "NAT provides another mechanism for running workflows through `nat serve`. `nat serve` creates and launches a REST FastAPI web server for interfacing with the toolkit as though it was an OpenAI-compatible endpoint. To learn more about all endpoints served by `nat serve`, please consult [this documentation](https://docs.nvidia.com/nemo/agent-toolkit/latest/reference/api-server-endpoints.html).\n",
-    "\n",
-    "<span style=\"color: red\"><i>note: If running this notebook in a cloud provider such as Google Colab, `dask` may be installed. If it is, you will first have to uninstall it via:</i></span>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "!uv pip uninstall dask"
+    "NAT provides another mechanism for running workflows through `nat serve`. `nat serve` creates and launches a REST FastAPI web server for interfacing with the toolkit as though it was an OpenAI-compatible endpoint. To learn more about all endpoints served by `nat serve`, please consult [this documentation](https://docs.nvidia.com/nemo/agent-toolkit/latest/reference/api-server-endpoints.html)."
    ]
   },
   {

--- a/examples/notebooks/getting_started_with_nat.ipynb
+++ b/examples/notebooks/getting_started_with_nat.ipynb
@@ -442,7 +442,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "skip_e2e_test"
+    ]
+   },
    "outputs": [],
    "source": [
     "!uv pip uninstall dask"

--- a/examples/notebooks/getting_started_with_nat.ipynb
+++ b/examples/notebooks/getting_started_with_nat.ipynb
@@ -434,7 +434,18 @@
     "<a id=\"run-server\"></a>\n",
     "## 2.2) Run as a NAT server\n",
     "\n",
-    "NAT provides another mechanism for running workflows through `nat serve`. `nat serve` creates and launches a REST FastAPI web server for interfacing with the toolkit as though it was an OpenAI-compatible endpoint. To learn more about all endpoints served by `nat serve`, please consult [this documentation](https://docs.nvidia.com/nemo/agent-toolkit/latest/reference/api-server-endpoints.html)."
+    "NAT provides another mechanism for running workflows through `nat serve`. `nat serve` creates and launches a REST FastAPI web server for interfacing with the toolkit as though it was an OpenAI-compatible endpoint. To learn more about all endpoints served by `nat serve`, please consult [this documentation](https://docs.nvidia.com/nemo/agent-toolkit/latest/reference/api-server-endpoints.html).\n",
+    "\n",
+    "<span style=\"color: red\"><i>note: If running this notebook in a cloud provider such as Google Colab, `dask` may be installed. If it is, you will first have to uninstall it via:</i></span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!uv pip uninstall dask"
    ]
   },
   {

--- a/examples/notebooks/mcp_setup_and_integration.ipynb
+++ b/examples/notebooks/mcp_setup_and_integration.ipynb
@@ -1119,6 +1119,24 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "4c34f7ed",
+   "metadata": {},
+   "source": [
+    "<span style=\"color: red\"><i>note: If running this notebook in a cloud provider such as Google Colab, `dask` may be installed. If it is, you will first have to uninstall it via:</i></span>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c8df6918",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#!uv pip uninstall dask"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "id": "22754f85",

--- a/examples/notebooks/mcp_setup_and_integration.ipynb
+++ b/examples/notebooks/mcp_setup_and_integration.ipynb
@@ -1119,24 +1119,6 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "id": "4c34f7ed",
-   "metadata": {},
-   "source": [
-    "<span style=\"color: red\"><i>note: If running this notebook in a cloud provider such as Google Colab, `dask` may be installed. If it is, you will first have to uninstall it via:</i></span>"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "c8df6918",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#!uv pip uninstall dask"
-   ]
-  },
-  {
    "cell_type": "code",
    "execution_count": null,
    "id": "22754f85",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -303,6 +303,8 @@ markers = [
   "slow: Slow tests",
 ]
 filterwarnings = [
+  # Work-around for a warning emitted by strands https://github.com/strands-agents/sdk-python/issues/1236
+  "ignore:^These events have been moved to production.*strands:DeprecationWarning",
 ]
 testpaths = ["tests", "examples/**/tests", "packages/**/tests"]
 asyncio_mode = "auto"


### PR DESCRIPTION
## Description
* The values of the `SpanAttributes` enum are defined on import, the fixture originally attempted to reload the `span` module. However this created a problem since other modules had already imported the `span` module, which would cause pydantic validation to fail as the original `SpanContext` class no longer strictly matches the new `SpanContext`.

* Unrelated fix: Add the `skip_e2e_test` tag to the `uv pip uninstall dask` cell to prevent the notebook from altering the environment mid-test.
* Silence a warning being emitted by strands that we have no control over strands-agents/sdk-python#1236

Closes #1197

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved test fixture robustness by making reversible in-place adjustments instead of reloading modules or changing environment state.
* **Chores**
  * Added a pytest warning filter to suppress a specific deprecation warning.
* **Docs/Examples**
  * Marked a notebook step with a skip tag to exclude it from end-to-end test runs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->