### PR TITLE
Fix: Add ca-certificates to simple_calculator Dockerfile

### DIFF
--- a/examples/getting_started/simple_calculator/Dockerfile
+++ b/examples/getting_started/simple_calculator/Dockerfile
@@ -30,7 +30,12 @@ ENV PYTHONDONTWRITEBYTECODE=1
 
 # Install compiler [g++, gcc] (currently only needed for thinc indirect dependency)
 RUN apt-get update && \
-    apt-get install -y g++ gcc
+    apt-get install -y g++ gcc ca-certificates && \
+    update-ca-certificates
+
+# Set SSL environment variables
+ENV REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
+ENV SSL_CERT_FILE=/etc/ssl/certs/ca-certificates.crt
 
 # Set working directory
 WORKDIR /workspace


### PR DESCRIPTION
This PR adds the installation of ca-certificates and sets the SSL certificate environment variables in the simple_calculator Dockerfile. This fixes the SSLCertVerificationError encountered when running the container, as the base image was missing the necessary certificates to verify the SSL connection to integrate.api.nvidia.com.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image configuration in the simple calculator example to improve SSL certificate handling and ensure proper certificate validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->