### PR TITLE
Add a Kaggle MCP usage example

### DIFF
--- a/ci/markdown-link-check-config.json
+++ b/ci/markdown-link-check-config.json
@@ -17,6 +17,9 @@
         },
         {
             "pattern": "^https://arize\\.com"
+        },
+        {
+            "pattern": "^https://milvus\\.io"
         }
     ]
 }

--- a/ci/vale/styles/config/vocabularies/nat/accept.txt
+++ b/ci/vale/styles/config/vocabularies/nat/accept.txt
@@ -78,6 +78,7 @@ isort
 Jama
 Jira
 jsonlines
+[Kk]aggle
 Langfuse
 LangChain
 LangGraph

--- a/docs/source/_static/nat-maas-jira-ssa.png
+++ b/docs/source/_static/nat-maas-jira-ssa.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:45b6edf9825bf022b925e64c4e25fb54c22304d58fe11f5c2062063f1cc52ac5
+size 75159

--- a/docs/source/_static/nat-maas-jira.png
+++ b/docs/source/_static/nat-maas-jira.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:96b4024f5de3f951b7be1fabc20757fc1983ebefa957f984045f1eb089a3978f
+size 110101

--- a/docs/source/tutorials/create-a-new-workflow.md
+++ b/docs/source/tutorials/create-a-new-workflow.md
@@ -115,7 +115,7 @@ Examining the `webquery_tool` function (`examples/getting_started/simple_web_que
     docs = [document async for document in loader.alazy_load()]
 ```
 
-For the new tool, instead of the `WebBaseLoader` class, use the [`langchain_community.document_loaders.DirectoryLoader`](https://api.python.langchain.com/en/latest/document_loaders/langchain_community.document_loaders.directory.DirectoryLoader.html) and [`langchain_community.document_loaders.TextLoader`](https://api.python.langchain.com/en/latest/document_loaders/langchain_community.document_loaders.text.TextLoader.html) classes.
+For the new tool, instead of the `WebBaseLoader` class, use the `langchain_community.document_loaders.DirectoryLoader` and `langchain_community.document_loaders.TextLoader` classes.
 
 ```python
     (ingest_dir, ingest_glob) = os.path.split(config.ingest_glob)

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -49,7 +49,7 @@ authentication:
   kaggle:
     _type: api_key
     raw_key: ${KAGGLE_BEARER_TOKEN}
-    auth_scheme: BEARER
+    auth_scheme: Bearer
 ```
 
 ### Environment Variables
@@ -94,16 +94,18 @@ The configuration connects to Kaggle's MCP server using:
 - **Authentication**: Bearer token via `api_key` provider
 
 ## CLI Commands
+
 You can use the following CLI commands to interact with the Kaggle MCP server. This is useful for prototyping and debugging.
 
-### Tool Discovery
+### Discover Tools (No Authentication Required)
 
 To list available tools from the Kaggle MCP server:
 
 ```bash
 nat mcp client tool list --url https://www.kaggle.com/mcp
 ```
-### Tool schema validation
+
+### Get Tool Schema (No Authentication Required)
 
 To validate the tool schema:
 
@@ -111,13 +113,32 @@ To validate the tool schema:
 nat mcp client tool list --url https://www.kaggle.com/mcp --tool list_dataset_files
 ```
 
-### Tool call
+### Authenticated Tool Calls
 
-To call a tool:
+**Important**: The Kaggle MCP server requires bearer token authentication for tool calls. The NAT CLI `mcp client tool call` command currently supports OAuth2 authentication but not bearer token authentication directly via command-line flags.
+
+For authenticated tool calls with bearer token, use the workflow configuration:
 
 ```bash
-nat mcp client tool call list_dataset_files --url https://www.kaggle.com/mcp --json-args '{"dataset_name": "titanic"}'
+# Set your Kaggle bearer token
+export KAGGLE_BEARER_TOKEN="your_kaggle_api_key_here"
+
+# Use the workflow which includes authentication configuration
+nat run --config_file examples/MCP/kaggle_mcp/configs/config.yml \
+  --input "List files in the kaggle/titanic dataset"
 ```
+
+The workflow automatically handles bearer token authentication as configured in `config.yml`:
+
+```yaml
+authentication:
+  kaggle:
+    _type: api_key
+    raw_key: ${KAGGLE_BEARER_TOKEN}
+    auth_scheme: Bearer
+```
+
+**Note**: Kaggle's MCP tools use a nested `request` object structure. Tool parameters must be wrapped in a `{"request": {...}}` object. The workflow handles this automatically based on the tool schema.
 
 ## References
 

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -30,7 +30,7 @@ The Kaggle MCP server uses bearer token authentication. Obtain your Kaggle beare
 
 ## Configuration
 
-The `config.yml` file uses NAT's built-in `api_key` authentication provider with Bearer token scheme:
+The `config.yml` file uses the built-in `api_key` authentication provider with Bearer token scheme:
 
 ```yaml
 authentication:
@@ -63,21 +63,12 @@ Example queries:
 
 ## Configuration Details
 
-### Authentication Provider
-
-This example uses NAT's `api_key` authentication provider, which supports:
-- **BEARER** scheme (default) - Adds `Authorization: Bearer <token>` header
-- **X_API_KEY** scheme - Adds `X-Api-Key: <token>` header
-- **CUSTOM** scheme - Custom header name and prefix
-
-For Kaggle, we use the BEARER scheme as shown in the Kaggle MCP documentation.
-
 ### MCP Client Setup
 
 The configuration connects to Kaggle's MCP server using:
 - **Transport**: `streamable-http` (recommended for HTTP-based MCP servers)
 - **URL**: `https://www.kaggle.com/mcp`
-- **Authentication**: Bearer token via `api_key` provider
+- **Authentication**: Bearer token via the built-in `api_key` authentication provider
 
 ## CLI Commands
 

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -66,7 +66,7 @@ Run the workflow with a query:
 
 ```bash
 nat run --config_file examples/MCP/kaggle_mcp/configs/config.yml \
-  --input "Search for datasets about machine learning"
+  --input ""List files in the kaggle/titanic dataset"
 ```
 
 Example queries:
@@ -110,14 +110,41 @@ nat mcp client tool list --url https://www.kaggle.com/mcp
 To validate the tool schema:
 
 ```bash
-nat mcp client tool list --url https://www.kaggle.com/mcp --tool list_dataset_files
+nat mcp client tool list --url https://www.kaggle.com/mcp --tool search_datasets
 ```
 
 ### Authenticated Tool Calls
 
-**Important**: The Kaggle MCP server requires bearer token authentication for tool calls. The NAT CLI `mcp client tool call` command currently supports OAuth2 authentication but not bearer token authentication directly via command-line flags.
+The Kaggle MCP server requires bearer token authentication for tool calls.
 
-For authenticated tool calls with bearer token, use the workflow configuration:
+#### Using Environment Variable (Recommended)
+
+```bash
+# Set your Kaggle bearer token
+export KAGGLE_BEARER_TOKEN="your_kaggle_api_key_here"
+
+# Call a tool with bearer token authentication
+nat mcp client tool call search_datasets \
+  --url https://www.kaggle.com/mcp \
+  --bearer-token-env KAGGLE_BEARER_TOKEN \
+  --json-args '{"request": {"search": "climate"}}'
+```
+
+#### Using Direct Token
+
+```bash
+# Call a tool with direct token (less secure)
+nat mcp client tool call search_datasets \
+  --url https://www.kaggle.com/mcp \
+  --bearer-token "your_kaggle_api_key_here" \
+  --json-args '{"request": {"search": "climate"}}'
+```
+
+**Note**: The `--bearer-token-env` approach is more secure because it doesn't expose the token in command history or process lists.
+
+#### Using Workflow Configuration
+
+For more complex scenarios or integration with agents, use the workflow configuration:
 
 ```bash
 # Set your Kaggle bearer token
@@ -138,7 +165,7 @@ authentication:
     auth_scheme: Bearer
 ```
 
-**Note**: Kaggle's MCP tools use a nested `request` object structure. Tool parameters must be wrapped in a `{"request": {...}}` object. The workflow handles this automatically based on the tool schema.
+**Important**: Kaggle's MCP tools use a nested `request` object structure. Tool parameters must be wrapped in a `{"request": {...}}` object.
 
 ## References
 

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -17,7 +17,7 @@ limitations under the License.
 
 # Kaggle MCP Example
 
-This example demonstrates how to use the Kaggle MCP server with NeMo Agent Toolkit to interact with Kaggle's datasets, notebooks, models, and competitions.
+This example demonstrates how to use the Kaggle MCP server with NVIDIA NeMo Agent Toolkit to interact with Kaggle's datasets, notebooks, models, and competitions.
 
 ## Prerequisites
 

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -123,21 +123,21 @@ The Kaggle MCP server requires bearer token authentication for tool calls.
 # Set your Kaggle bearer token
 export KAGGLE_BEARER_TOKEN="your_kaggle_api_key_here"
 
-# Call a tool with bearer token authentication
+# Search for Titanic datasets
 nat mcp client tool call search_datasets \
   --url https://www.kaggle.com/mcp \
   --bearer-token-env KAGGLE_BEARER_TOKEN \
-  --json-args '{"request": {"search": "climate"}}'
+  --json-args '{"request": {"search": "titanic"}}'
 ```
 
 #### Using Direct Token
 
 ```bash
-# Call a tool with direct token (less secure)
+# Search for Titanic datasets with direct token (less secure)
 nat mcp client tool call search_datasets \
   --url https://www.kaggle.com/mcp \
   --bearer-token "your_kaggle_api_key_here" \
-  --json-args '{"request": {"search": "climate"}}'
+  --json-args '{"request": {"search": "titanic"}}'
 ```
 
 **Note**: The `--bearer-token-env` approach is more secure because it doesn't expose the token in command history or process lists.
@@ -152,7 +152,7 @@ export KAGGLE_BEARER_TOKEN="your_kaggle_api_key_here"
 
 # Use the workflow which includes authentication configuration
 nat run --config_file examples/MCP/kaggle_mcp/configs/config.yml \
-  --input "List files in the kaggle/titanic dataset"
+  --input "Search for Titanic datasets on Kaggle"
 ```
 
 The workflow automatically handles bearer token authentication as configured in `config.yml`:

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -54,7 +54,7 @@ Run the workflow with a query:
 
 ```bash
 nat run --config_file examples/MCP/kaggle_mcp/configs/config.yml \
-  --input ""List files in the kaggle/titanic dataset"
+  --input "List files in the kaggle/titanic dataset"
 ```
 
 Example queries:

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -17,28 +17,16 @@ limitations under the License.
 
 # Kaggle MCP Example
 
-This example demonstrates how to use the Kaggle MCP server with NeMo Agent Toolkit (NAT) to interact with Kaggle's datasets, notebooks, models, and competitions.
+This example demonstrates how to use the Kaggle MCP server with NeMo Agent Toolkit to interact with Kaggle's datasets, notebooks, models, and competitions.
 
 ## Prerequisites
 
-- NAT installed with MCP support (`nvidia-nat-mcp` package)
+- NeMo Agent Toolkit installed with MCP support (`nvidia-nat-mcp` package)
 - A Kaggle account and API token
 
-## Getting Your Kaggle Bearer Token
+### Getting Your Kaggle Bearer Token
 
-The Kaggle MCP server uses bearer token authentication. To obtain your token:
-
-1. Go to your [Kaggle Account Settings](https://www.kaggle.com/settings)
-2. Scroll down to the **API** section
-3. Click **Create New Token**
-4. This will download a `kaggle.json` file containing your credentials:
-   ```json
-   {
-     "username": "your_username",
-     "key": "your_api_key"
-   }
-   ```
-5. Your bearer token is the `key` value from this file
+The Kaggle MCP server uses bearer token authentication. Obtain your Kaggle bearer token from https://www.kaggle.com/settings/account.
 
 ## Configuration
 
@@ -71,9 +59,7 @@ nat run --config_file examples/MCP/kaggle_mcp/configs/config.yml \
 
 Example queries:
 - "Find the most popular datasets about natural language processing"
-- "Search for notebooks related to computer vision"
 - "What competitions are currently active?"
-- "List the files in the titanic dataset"
 
 ## Configuration Details
 
@@ -115,7 +101,7 @@ nat mcp client tool list --url https://www.kaggle.com/mcp --tool search_datasets
 
 ### Authenticated Tool Calls
 
-The Kaggle MCP server requires bearer token authentication for tool calls.
+The Kaggle MCP server requires bearer token authentication for some tool calls.
 
 #### Using Environment Variable (Recommended)
 
@@ -142,30 +128,53 @@ nat mcp client tool call search_datasets \
 
 **Note**: The `--bearer-token-env` approach is more secure because it doesn't expose the token in command history or process lists.
 
-#### Using Workflow Configuration
+## Troubleshooting
 
-For more complex scenarios or integration with agents, use the workflow configuration:
+### Agent Uses Wrong Parameter Names
+
+**Problem**: The agent generates tool calls with incorrect parameter names, such as using `query` instead of `search` for `search_datasets`.
+
+**Cause**: The default tool descriptions from Kaggle MCP are generic and don't specify parameter names, causing the LLM to infer incorrect names.
+
+**Solution**: Check the tool schema and add tool overrides in your `config.yml` to provide explicit parameter guidance:
 
 ```bash
-# Set your Kaggle bearer token
-export KAGGLE_BEARER_TOKEN="your_kaggle_api_key_here"
-
-# Use the workflow which includes authentication configuration
-nat run --config_file examples/MCP/kaggle_mcp/configs/config.yml \
-  --input "Search for Titanic datasets on Kaggle"
+nat mcp client tool list --url https://www.kaggle.com/mcp --tool search_datasets
 ```
 
-The workflow automatically handles bearer token authentication as configured in `config.yml`:
+After getting the tool schema, add the following tool overrides to your `config.yml`:
 
 ```yaml
-authentication:
-  kaggle:
-    _type: api_key
-    raw_key: ${KAGGLE_BEARER_TOKEN}
-    auth_scheme: Bearer
+function_groups:
+  kaggle_mcp_tools:
+    tool_overrides:
+      search_datasets:
+        description: >
+          Search for datasets on Kaggle. Use the 'search' parameter (not 'query')
+          to search by keywords. Example: {"request": {"search": "titanic"}}
 ```
 
-**Important**: Kaggle's MCP tools use a nested `request` object structure. Tool parameters must be wrapped in a `{"request": {...}}` object.
+### Permission Denied Errors
+
+**Problem**: Tool calls fail with "Permission 'datasets.get' was denied" or similar errors.
+
+**Cause**: Your Kaggle API token lacks the required permissions for certain operations.
+
+**Solution**:
+- Ensure you're using a valid Kaggle API key from https://www.kaggle.com/settings/account
+- Some operations require dataset ownership or special permissions
+- Use `search_datasets` for browsing (requires minimal permissions)
+- Use `list_dataset_files` only for datasets you own or have access to
+
+### CLI Tool Calls Work but Workflow Fails
+
+**Problem**: `nat mcp client tool call` succeeds but `nat run` with a workflow fails with the same tool.
+
+**Possible causes**:
+1. **Parameter validation**: CLI bypasses some validation that workflows enforce
+2. **Agent parameter inference**: Agent might use wrong parameter names (see "Agent Uses Wrong Parameter Names" above)
+
+**Solution**: Use `--direct` mode to test the raw MCP server behavior, then add tool overrides to guide the agent.
 
 ## References
 

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -170,5 +170,4 @@ function_groups:
 ## References
 
 - [Kaggle MCP Documentation](https://www.kaggle.com/docs/mcp)
-- [NAT MCP Documentation](https://docs.nvidia.com/nemo-agent-toolkit/mcp/)
-- [NAT Authentication Guide](https://docs.nvidia.com/nemo-agent-toolkit/authentication/)
+- [NeMo Agent Toolkit MCP Documentation](../../../docs/source/workflows/mcp/index.md)

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -1,0 +1,126 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Kaggle MCP Example
+
+This example demonstrates how to use the Kaggle MCP server with NeMo Agent Toolkit (NAT) to interact with Kaggle's datasets, notebooks, models, and competitions.
+
+## Prerequisites
+
+- NAT installed with MCP support (`nvidia-nat-mcp` package)
+- A Kaggle account and API token
+
+## Getting Your Kaggle Bearer Token
+
+The Kaggle MCP server uses bearer token authentication. To obtain your token:
+
+1. Go to your [Kaggle Account Settings](https://www.kaggle.com/settings)
+2. Scroll down to the **API** section
+3. Click **Create New Token**
+4. This will download a `kaggle.json` file containing your credentials:
+   ```json
+   {
+     "username": "your_username",
+     "key": "your_api_key"
+   }
+   ```
+5. Your bearer token is the `key` value from this file
+
+## Configuration
+
+The `config.yml` file uses NAT's built-in `api_key` authentication provider with Bearer token scheme:
+
+```yaml
+authentication:
+  kaggle:
+    _type: api_key
+    raw_key: ${KAGGLE_BEARER_TOKEN}
+    auth_scheme: BEARER
+```
+
+### Environment Variables
+
+Set the following environment variable:
+
+```bash
+export KAGGLE_BEARER_TOKEN="your_kaggle_api_key_here"
+```
+
+## Usage
+
+Run the workflow with a query:
+
+```bash
+nat run --config_file examples/MCP/kaggle_mcp/configs/config.yml \
+  --input "Search for datasets about machine learning"
+```
+
+Example queries:
+- "Find the most popular datasets about natural language processing"
+- "Search for notebooks related to computer vision"
+- "What competitions are currently active?"
+- "List the files in the titanic dataset"
+
+## Configuration Details
+
+### Authentication Provider
+
+This example uses NAT's `api_key` authentication provider, which supports:
+- **BEARER** scheme (default) - Adds `Authorization: Bearer <token>` header
+- **X_API_KEY** scheme - Adds `X-Api-Key: <token>` header
+- **CUSTOM** scheme - Custom header name and prefix
+
+For Kaggle, we use the BEARER scheme as shown in the Kaggle MCP documentation.
+
+### MCP Client Setup
+
+The configuration connects to Kaggle's MCP server using:
+- **Transport**: `streamable-http` (recommended for HTTP-based MCP servers)
+- **URL**: `https://www.kaggle.com/mcp`
+- **Authentication**: Bearer token via `api_key` provider
+
+## CLI Commands
+You can use the following CLI commands to interact with the Kaggle MCP server. This is useful for prototyping and debugging.
+
+### Tool Discovery
+
+To list available tools from the Kaggle MCP server:
+
+```bash
+nat mcp client tool list --url https://www.kaggle.com/mcp
+```
+### Tool schema validation
+
+To validate the tool schema:
+
+```bash
+nat mcp client tool list --url https://www.kaggle.com/mcp --tool list_dataset_files
+```
+
+### Tool call
+
+To call a tool:
+
+```bash
+nat mcp client tool call list_dataset_files --url https://www.kaggle.com/mcp --json-args '{"dataset_name": "titanic"}'
+```
+
+## References
+
+- [Kaggle MCP Documentation](https://www.kaggle.com/docs/mcp)
+- [NAT MCP Documentation](https://docs.nvidia.com/nemo-agent-toolkit/mcp/)
+- [NAT Authentication Guide](https://docs.nvidia.com/nemo-agent-toolkit/authentication/)

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -54,11 +54,11 @@ Run the workflow with a query:
 
 ```bash
 nat run --config_file examples/MCP/kaggle_mcp/configs/config.yml \
-  --input "List files in the kaggle/titanic dataset"
+  --input "Find the most popular datasets about natural language processing"
 ```
 
 Example queries:
-- "Find the most popular datasets about natural language processing"
+- "What is the titanic dataset about?"
 - "What competitions are currently active?"
 
 ## Configuration Details

--- a/examples/MCP/kaggle_mcp/README.md
+++ b/examples/MCP/kaggle_mcp/README.md
@@ -26,7 +26,7 @@ This example demonstrates how to use the Kaggle MCP server with NeMo Agent Toolk
 
 ### Getting Your Kaggle Bearer Token
 
-The Kaggle MCP server uses bearer token authentication. Obtain your Kaggle bearer token from https://www.kaggle.com/settings/account.
+The Kaggle MCP server uses bearer token authentication. Obtain your Kaggle bearer token from [Kaggle Account Settings](https://www.kaggle.com/settings/account).
 
 ## Configuration
 

--- a/examples/MCP/kaggle_mcp/configs/config.yml
+++ b/examples/MCP/kaggle_mcp/configs/config.yml
@@ -29,8 +29,8 @@ function_groups:
     tool_overrides:
       search_datasets:
         description: >
-          Search for datasets on Kaggle. Use the 'search' parameter (not 'query')
-          to search by keywords. Returns a list of datasets with metadata including
+          Search for datasets on Kaggle. Use the 'search' parameter to search by keywords.
+          Returns a list of datasets with metadata including
           title, owner, download count, and URL. Example: {"request": {"search": "titanic"}}
 
 authentication:

--- a/examples/MCP/kaggle_mcp/configs/config.yml
+++ b/examples/MCP/kaggle_mcp/configs/config.yml
@@ -31,7 +31,7 @@ authentication:
   kaggle:
     _type: api_key
     raw_key: ${KAGGLE_BEARER_TOKEN}
-    auth_scheme: BEARER
+    auth_scheme: Bearer
 
 workflow:
    # Use an agent that 'reasons' and 'acts'

--- a/examples/MCP/kaggle_mcp/configs/config.yml
+++ b/examples/MCP/kaggle_mcp/configs/config.yml
@@ -42,7 +42,7 @@ authentication:
 workflow:
    # Use an agent that 'reasons' and 'acts'
    _type: react_agent
-   # Give it access to our wikipedia search tool
+   # Give it access to our kaggle MCP tools
    tool_names: [kaggle_mcp_tools]
    # Tell it which LLM to use
    llm_name: nim_llm

--- a/examples/MCP/kaggle_mcp/configs/config.yml
+++ b/examples/MCP/kaggle_mcp/configs/config.yml
@@ -26,6 +26,12 @@ function_groups:
       transport: streamable-http
       url: https://www.kaggle.com/mcp
       auth_provider: kaggle
+    tool_overrides:
+      search_datasets:
+        description: >
+          Search for datasets on Kaggle. Use the 'search' parameter (not 'query')
+          to search by keywords. Returns a list of datasets with metadata including
+          title, owner, download count, and URL. Example: {"request": {"search": "titanic"}}
 
 authentication:
   kaggle:

--- a/examples/MCP/kaggle_mcp/configs/config.yml
+++ b/examples/MCP/kaggle_mcp/configs/config.yml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+llms:
+   # Tell NeMo Agent Toolkit which LLM to use for the agent
+   nim_llm:
+      _type: nim
+      model_name: meta/llama-3.1-70b-instruct
+      temperature: 0.0
+function_groups:
+  kaggle_mcp_tools:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      url: https://www.kaggle.com/mcp
+      auth_provider: kaggle
+
+authentication:
+  kaggle:
+    _type: api_key
+    raw_key: ${KAGGLE_BEARER_TOKEN}
+    auth_scheme: BEARER
+
+workflow:
+   # Use an agent that 'reasons' and 'acts'
+   _type: react_agent
+   # Give it access to our wikipedia search tool
+   tool_names: [kaggle_mcp_tools]
+   # Tell it which LLM to use
+   llm_name: nim_llm
+   # Make it verbose
+   verbose: true
+   # Retry up to 3 times
+   parse_agent_response_max_retries: 3

--- a/examples/MCP/kaggle_mcp/pyproject.toml
+++ b/examples/MCP/kaggle_mcp/pyproject.toml
@@ -1,0 +1,24 @@
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools >= 64", "setuptools-scm>=8"]
+
+[tool.setuptools]
+packages = []
+
+[tool.setuptools_scm]
+git_describe_command = "git describe --long --first-parent"
+root = "../../.."
+
+[project]
+name = "nat_kaggle_mcp"
+dynamic = ["version"]
+dependencies = [
+    "nvidia-nat[mcp]~=1.4",
+]
+requires-python = ">=3.11,<3.14"
+description = "Kaggle MCP integration example with bearer token authentication"
+keywords = ["ai", "mcp", "protocol", "agents", "kaggle", "datasets"]
+classifiers = ["Programming Language :: Python"]
+
+[tool.uv.sources]
+nvidia-nat = { path = "../../..", editable = true }

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider.py
@@ -34,6 +34,7 @@ from nat.authentication.interfaces import AuthFlowType
 from nat.authentication.interfaces import AuthProviderBase
 from nat.authentication.oauth2.oauth2_auth_code_flow_provider_config import OAuth2AuthCodeFlowProviderConfig
 from nat.data_models.authentication import AuthResult
+from nat.data_models.common import get_secret_value
 from nat.plugins.mcp.auth.auth_flow_handler import MCPAuthenticationFlowHandler
 from nat.plugins.mcp.auth.auth_provider_config import MCPOAuth2ProviderConfig
 
@@ -371,7 +372,7 @@ class MCPOAuth2Provider(AuthProviderBase[MCPOAuth2ProviderConfig]):
                 # Manual registration mode
                 self._cached_credentials = OAuth2Credentials(
                     client_id=self.config.client_id,
-                    client_secret=self.config.client_secret.get_secret_value() if self.config.client_secret else None,
+                    client_secret=get_secret_value(self.config.client_secret),
                 )
                 logger.info("Using manual client_id: %s", self._cached_credentials.client_id)
             else:

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider.py
@@ -371,7 +371,7 @@ class MCPOAuth2Provider(AuthProviderBase[MCPOAuth2ProviderConfig]):
                 # Manual registration mode
                 self._cached_credentials = OAuth2Credentials(
                     client_id=self.config.client_id,
-                    client_secret=self.config.client_secret,
+                    client_secret=self.config.client_secret.get_secret_value() if self.config.client_secret else None,
                 )
                 logger.info("Using manual client_id: %s", self._cached_credentials.client_id)
             else:

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client_impl.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client_impl.py
@@ -450,11 +450,19 @@ def mcp_session_tool_function(tool, function_group: MCPFunctionGroup):
 
             # Preserve original calling convention
             if tool_input:
-                args = tool_input.model_dump()
+                args = tool_input.model_dump(exclude_none=True, mode='json')
                 return await session_tool.acall(args)
 
-            _ = session_tool.input_schema.model_validate(kwargs)
-            return await session_tool.acall(kwargs)
+            # kwargs arrives with all optional fields set to None because NAT's framework
+            # converts the input dict to a Pydantic model (filling in all Field(default=None)),
+            # then dumps it back to a dict. We need to strip out these None values because
+            # many MCP servers (e.g., Kaggle) reject requests with excessive null fields.
+            # We re-validate here (yes, redundant) to leverage Pydantic's exclude_none with
+            # mode='json' for recursive None removal in nested models.
+            # Reference: function_info.py:_convert_input_pydantic
+            validated_input = session_tool.input_schema.model_validate(kwargs)
+            args = validated_input.model_dump(exclude_none=True, mode='json')
+            return await session_tool.acall(args)
         except Exception as e:
             logger.warning("Error calling tool %s", tool.name, exc_info=True)
             return str(e)

--- a/src/nat/authentication/api_key/api_key_auth_provider_config.py
+++ b/src/nat/authentication/api_key/api_key_auth_provider_config.py
@@ -19,6 +19,7 @@ import string
 
 from pydantic import Field
 from pydantic import field_validator
+from pydantic import model_validator
 
 from nat.authentication.exceptions.api_key_exceptions import APIKeyFieldError
 from nat.authentication.exceptions.api_key_exceptions import HeaderNameFieldError
@@ -78,9 +79,10 @@ class APIKeyAuthProviderConfig(AuthProviderBaseConfig, name="api_key"):
 
     @field_validator('custom_header_name')
     @classmethod
-    def validate_custom_header_name(cls, value: str) -> str:
-        if not value:
-            raise HeaderNameFieldError('value_missing', 'custom_header_name is required.')
+    def validate_custom_header_name(cls, value: str | None) -> str | None:
+        # Only validate format if value is provided (required check is in model_validator)
+        if value is None:
+            return value
 
         if value != value.strip():
             raise HeaderNameFieldError('whitespace_found',
@@ -99,9 +101,10 @@ class APIKeyAuthProviderConfig(AuthProviderBaseConfig, name="api_key"):
 
     @field_validator('custom_header_prefix')
     @classmethod
-    def validate_custom_header_prefix(cls, value: str) -> str:
-        if not value:
-            raise HeaderPrefixFieldError('value_missing', 'custom_header_prefix is required.')
+    def validate_custom_header_prefix(cls, value: str | None) -> str | None:
+        # Only validate format if value is provided (required check is in model_validator)
+        if value is None:
+            return value
 
         if value != value.strip():
             raise HeaderPrefixFieldError(
@@ -125,3 +128,15 @@ class APIKeyAuthProviderConfig(AuthProviderBaseConfig, name="api_key"):
                                    'required after construction.')
 
         return value
+
+    @model_validator(mode='after')
+    def validate_custom_scheme_requirements(self) -> 'APIKeyAuthProviderConfig':
+        """Validate that custom_header_name and custom_header_prefix are provided when using CUSTOM scheme."""
+        if self.auth_scheme == HeaderAuthScheme.CUSTOM:
+            if not self.custom_header_name:
+                raise HeaderNameFieldError('value_missing',
+                                           'custom_header_name is required when auth_scheme is CUSTOM.')
+            if not self.custom_header_prefix:
+                raise HeaderPrefixFieldError('value_missing',
+                                             'custom_header_prefix is required when auth_scheme is CUSTOM.')
+        return self

--- a/src/nat/cli/commands/mcp/mcp.py
+++ b/src/nat/cli/commands/mcp/mcp.py
@@ -217,6 +217,39 @@ async def _create_mcp_client_config(
     return MCPClientConfig(server=server_cfg)
 
 
+async def _create_bearer_token_auth_config(
+    builder,
+    server_cfg,
+    bearer_token: str | None,
+    bearer_token_env: str | None,
+):
+    """Create bearer token auth configuration for CLI usage."""
+    from nat.authentication.api_key.api_key_auth_provider_config import APIKeyAuthProviderConfig
+    from nat.data_models.authentication import HeaderAuthScheme
+    from pydantic import SecretStr
+    import os
+
+    # Get token from env var or direct input
+    if bearer_token_env:
+        token_value = os.getenv(bearer_token_env)
+        if not token_value:
+            raise ValueError(f"Environment variable '{bearer_token_env}' not found or empty")
+    elif bearer_token:
+        token_value = bearer_token
+    else:
+        raise ValueError("No bearer token provided")
+
+    # Create API key auth config with Bearer scheme
+    auth_config = APIKeyAuthProviderConfig(
+        raw_key=SecretStr(token_value),
+        auth_scheme=HeaderAuthScheme.BEARER,
+    )
+
+    auth_provider_name = "bearer_token_cli"
+    await builder.add_auth_provider(auth_provider_name, auth_config)
+    server_cfg.auth_provider = auth_provider_name
+
+
 async def list_tools_via_function_group(
     command: str | None,
     url: str | None,
@@ -795,7 +828,9 @@ async def call_tool_and_print(command: str | None,
                               direct: bool,
                               auth_redirect_uri: str | None = None,
                               auth_user_id: str | None = None,
-                              auth_scopes: list[str] | None = None) -> str:
+                              auth_scopes: list[str] | None = None,
+                              bearer_token: str | None = None,
+                              bearer_token_env: str | None = None) -> str:
     """Call an MCP tool either directly or via the function group and return output.
 
     When ``direct`` is True, uses the raw MCP protocol client (bypassing the
@@ -842,11 +877,18 @@ async def call_tool_and_print(command: str | None,
         env=env if transport == 'stdio' else None,
     )
 
-    group_cfg = MCPClientConfig(server=server_cfg)
-
     async with WorkflowBuilder() as builder:  # type: ignore
-        # Add auth provider if url is provided and auth_redirect_uri is given (only for streamable-http)
-        if url and transport == 'streamable-http' and auth_redirect_uri:
+        # Configure authentication if provided
+        if bearer_token or bearer_token_env:
+            # Use bearer token auth
+            try:
+                await _create_bearer_token_auth_config(builder, server_cfg, bearer_token, bearer_token_env)
+                group_cfg = MCPClientConfig(server=server_cfg)
+            except Exception as e:
+                click.echo(f"[ERROR] Failed to configure bearer token authentication: {e}", err=True)
+                return ""
+        elif url and transport == 'streamable-http' and auth_redirect_uri:
+            # Use OAuth2 auth
             try:
                 group_cfg = await _create_mcp_client_config(builder,
                                                             server_cfg,
@@ -857,6 +899,10 @@ async def call_tool_and_print(command: str | None,
                                                             auth_scopes)
             except ImportError:
                 click.echo("[WARNING] MCP OAuth2 authentication requires nvidia-nat-mcp package.", err=True)
+                group_cfg = MCPClientConfig(server=server_cfg)
+        else:
+            # No auth
+            group_cfg = MCPClientConfig(server=server_cfg)
 
         group = await builder.add_function_group("mcp_client", group_cfg)
         fns = await group.get_accessible_functions()
@@ -894,6 +940,10 @@ async def call_tool_and_print(command: str | None,
               help='OAuth2 redirect URI for authentication (streamable-http only, not with --direct)')
 @click.option('--auth-user-id', help='User ID for authentication (streamable-http only, not with --direct)')
 @click.option('--auth-scopes', help='OAuth2 scopes (comma-separated, streamable-http only, not with --direct)')
+@click.option('--bearer-token',
+              help='Bearer token for authentication (streamable-http only, not with --direct)')
+@click.option('--bearer-token-env',
+              help='Environment variable name containing bearer token (e.g., KAGGLE_BEARER_TOKEN)')
 def mcp_client_tool_call(tool_name: str,
                          direct: bool,
                          url: str | None,
@@ -905,7 +955,9 @@ def mcp_client_tool_call(tool_name: str,
                          auth: bool,
                          auth_redirect_uri: str | None,
                          auth_user_id: str | None,
-                         auth_scopes: str | None) -> None:
+                         auth_scopes: str | None,
+                         bearer_token: str | None,
+                         bearer_token_env: str | None) -> None:
     """Call an MCP tool by name with optional JSON arguments.
 
     Validates transport parameters, parses ``--json-args`` into a dictionary,
@@ -950,6 +1002,16 @@ def mcp_client_tool_call(tool_name: str,
         auth, url, auth_redirect_uri, auth_user_id, auth_scopes
     )
 
+    # Validate: only one auth method at a time
+    if (auth or auth_redirect_uri) and (bearer_token or bearer_token_env):
+        click.echo("[ERROR] Cannot use both OAuth2 (--auth) and bearer token authentication", err=True)
+        return
+
+    # Bearer token not supported with --direct
+    if direct and (bearer_token or bearer_token_env):
+        click.echo("[ERROR] --bearer-token and --bearer-token-env are not supported with --direct mode", err=True)
+        return
+
     # Parse tool args
     arg_obj: dict[str, Any] = {}
     if json_args:
@@ -977,6 +1039,8 @@ def mcp_client_tool_call(tool_name: str,
                 auth_redirect_uri=auth_redirect_uri,
                 auth_user_id=auth_user_id,
                 auth_scopes=auth_scopes_list,
+                bearer_token=bearer_token,
+                bearer_token_env=bearer_token_env,
             ))
         if output:
             click.echo(output)

--- a/src/nat/cli/commands/mcp/mcp.py
+++ b/src/nat/cli/commands/mcp/mcp.py
@@ -224,10 +224,12 @@ async def _create_bearer_token_auth_config(
     bearer_token_env: str | None,
 ):
     """Create bearer token auth configuration for CLI usage."""
+    import os
+
+    from pydantic import SecretStr
+
     from nat.authentication.api_key.api_key_auth_provider_config import APIKeyAuthProviderConfig
     from nat.data_models.authentication import HeaderAuthScheme
-    from pydantic import SecretStr
-    import os
 
     # Get token from env var or direct input
     if bearer_token_env:
@@ -940,8 +942,7 @@ async def call_tool_and_print(command: str | None,
               help='OAuth2 redirect URI for authentication (streamable-http only, not with --direct)')
 @click.option('--auth-user-id', help='User ID for authentication (streamable-http only, not with --direct)')
 @click.option('--auth-scopes', help='OAuth2 scopes (comma-separated, streamable-http only, not with --direct)')
-@click.option('--bearer-token',
-              help='Bearer token for authentication (streamable-http only, not with --direct)')
+@click.option('--bearer-token', help='Bearer token for authentication (streamable-http only, not with --direct)')
 @click.option('--bearer-token-env',
               help='Environment variable name containing bearer token (e.g., KAGGLE_BEARER_TOKEN)')
 def mcp_client_tool_call(tool_name: str,

--- a/tests/nat/cli/commands/mcp/test_mcp_cli.py
+++ b/tests/nat/cli/commands/mcp/test_mcp_cli.py
@@ -762,3 +762,69 @@ def test_call_tool_and_print_group_tool_not_found(monkeypatch):
     except RuntimeError as exc:  # noqa: BLE001
         err = str(exc)
     assert err is not None and "Tool 'echo' not found" in err
+
+
+@patch("nat.cli.commands.mcp.mcp.call_tool_and_print", new_callable=AsyncMock)
+def test_mcp_client_tool_call_bearer_token_direct(mock_call, cli_runner):
+    """Test that bearer token flags are passed correctly"""
+    mock_call.return_value = "OK"
+    result = cli_runner.invoke(mcp_client_tool_call, [
+        "my_tool",
+        "--bearer-token",
+        "test_token_123",
+        "--json-args",
+        "{}",
+    ])
+    assert result.exit_code == 0
+    assert mock_call.await_args is not None
+    _, kwargs = mock_call.await_args
+    assert kwargs.get("bearer_token") == "test_token_123"
+    assert kwargs.get("bearer_token_env") is None
+
+
+@patch("nat.cli.commands.mcp.mcp.call_tool_and_print", new_callable=AsyncMock)
+def test_mcp_client_tool_call_bearer_token_env(mock_call, cli_runner):
+    """Test that bearer token env flag is passed correctly"""
+    mock_call.return_value = "OK"
+    result = cli_runner.invoke(mcp_client_tool_call, [
+        "my_tool",
+        "--bearer-token-env",
+        "MY_TOKEN_VAR",
+        "--json-args",
+        "{}",
+    ])
+    assert result.exit_code == 0
+    assert mock_call.await_args is not None
+    _, kwargs = mock_call.await_args
+    assert kwargs.get("bearer_token") is None
+    assert kwargs.get("bearer_token_env") == "MY_TOKEN_VAR"
+
+
+def test_mcp_client_tool_call_bearer_token_both_flags_error(cli_runner):
+    """Test that using both bearer token flags fails"""
+    result = cli_runner.invoke(mcp_client_tool_call,
+                               [
+                                   "my_tool",
+                                   "--bearer-token",
+                                   "token123",
+                                   "--bearer-token-env",
+                                   "MY_VAR",
+                                   "--json-args",
+                                   "{}",
+                               ])
+    assert result.exit_code == 0
+    assert "Cannot use both --bearer-token and --bearer-token-env" in result.output
+
+
+def test_mcp_client_tool_call_bearer_token_with_direct_error(cli_runner):
+    """Test that bearer token with --direct fails"""
+    result = cli_runner.invoke(mcp_client_tool_call, [
+        "my_tool",
+        "--direct",
+        "--bearer-token",
+        "token123",
+        "--json-args",
+        "{}",
+    ])
+    assert result.exit_code == 0
+    assert "Bearer token authentication is not supported with --direct" in result.output

--- a/tests/nat/cli/commands/mcp/test_mcp_cli.py
+++ b/tests/nat/cli/commands/mcp/test_mcp_cli.py
@@ -800,20 +800,18 @@ def test_mcp_client_tool_call_bearer_token_env(mock_call, cli_runner):
     assert kwargs.get("bearer_token_env") == "MY_TOKEN_VAR"
 
 
-def test_mcp_client_tool_call_bearer_token_both_flags_error(cli_runner):
-    """Test that using both bearer token flags fails"""
-    result = cli_runner.invoke(mcp_client_tool_call,
-                               [
-                                   "my_tool",
-                                   "--bearer-token",
-                                   "token123",
-                                   "--bearer-token-env",
-                                   "MY_VAR",
-                                   "--json-args",
-                                   "{}",
-                               ])
+def test_mcp_client_tool_call_bearer_token_with_oauth_error(cli_runner):
+    """Test that bearer token cannot be used with OAuth"""
+    result = cli_runner.invoke(mcp_client_tool_call, [
+        "my_tool",
+        "--bearer-token",
+        "token123",
+        "--auth",
+        "--json-args",
+        "{}",
+    ])
     assert result.exit_code == 0
-    assert "Cannot use both --bearer-token and --bearer-token-env" in result.output
+    assert "Cannot use both OAuth2 (--auth) and bearer token authentication" in result.output
 
 
 def test_mcp_client_tool_call_bearer_token_with_direct_error(cli_runner):
@@ -827,4 +825,4 @@ def test_mcp_client_tool_call_bearer_token_with_direct_error(cli_runner):
         "{}",
     ])
     assert result.exit_code == 0
-    assert "Bearer token authentication is not supported with --direct" in result.output
+    assert "--bearer-token and --bearer-token-env are not supported with --direct mode" in result.output

--- a/tests/nat/mcp/test_mcp_auth_provider.py
+++ b/tests/nat/mcp/test_mcp_auth_provider.py
@@ -626,7 +626,7 @@ class TestMCPOAuth2Provider:
     async def test_discover_and_register_with_manual_credentials(self, mock_config):
         """Test discover and register with manual credentials."""
         config = mock_config.model_copy(update={
-            'client_id': 'manual_client_id', 'client_secret': 'manual_client_secret'
+            'client_id': 'manual_client_id', 'client_secret': SecretStr('manual_client_secret')
         })
         provider = MCPOAuth2Provider(config)
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Kaggle protected MCP server has additional auth requirements that are addressed in this PR. Changes include:
1. A Kaggle MCP example to show usage with an api_key authentication provider
2. Fix to not pass None fields in the tool_args. This change is limited to MCP functions only (although it may work universally). The fix is optional but without it tool calls to the Kaggle MCP server fail.
3. Fix pydantic secret_str handling in the mcp client implementation.
4. Fix validations done in APIKeyAuthProviderConfig, custom header config is only required if auth_scheme is `HeaderAuthScheme.CUSTOM`

Note:
The tool descriptions on the kaggle MCP server are not very verbose which makes it challenging for agents to call the tool with the right format. To workaround you can either supply the tool schema to the agent or update tool description via mcp_client function group tool overrides. See `search_dataset` override in the sample config file:
<img width="582" height="734" alt="image" src="https://github.com/user-attachments/assets/e1920d75-55f9-4b03-8bc7-a97da388b390" />

Closes #1207 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI: add bearer-token auth via flag or environment variable.
  * Example: add Kaggle MCP example with README, workflow config, and packaging.

* **Bug Fixes / Improvements**
  * Client calls validate inputs and omit null fields before sending.
  * Secret values are unwrapped where required.
  * Validation enforces custom-scheme requirements and prevents conflicting auth/direct usage.

* **Tests**
  * Add tests covering bearer-token flows and error cases.

* **Documentation**
  * Update tutorial text and add Kaggle README with usage and troubleshooting.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->