### PR TITLE
Add `model_name` as a computed field to `AzureOpenAIModelConfig`

### DIFF
--- a/src/nat/llm/azure_openai_llm.py
+++ b/src/nat/llm/azure_openai_llm.py
@@ -68,6 +68,7 @@ class AzureOpenAIModelConfig(
         """
         return self.azure_deployment
 
+
 @register_llm_provider(config_type=AzureOpenAIModelConfig)
 async def azure_openai_llm(config: AzureOpenAIModelConfig, _builder: Builder):
 

--- a/src/nat/llm/azure_openai_llm.py
+++ b/src/nat/llm/azure_openai_llm.py
@@ -16,6 +16,7 @@
 from pydantic import AliasChoices
 from pydantic import ConfigDict
 from pydantic import Field
+from pydantic import computed_field
 
 from nat.builder.builder import Builder
 from nat.builder.llm import LLMProviderInfo
@@ -59,6 +60,13 @@ class AzureOpenAIModelConfig(
                                            description="Top-p for distribution sampling.",
                                            space=SearchSpace(high=1.0, low=0.5, step=0.1))
 
+    @computed_field
+    @property
+    def model_name(self) -> str:
+        """
+        Returns the model name for compatibility with other parts of the code base which expect a model_name attribute.
+        """
+        return self.azure_deployment
 
 @register_llm_provider(config_type=AzureOpenAIModelConfig)
 async def azure_openai_llm(config: AzureOpenAIModelConfig, _builder: Builder):

--- a/tests/nat/llm_providers/test_langchain_agents.py
+++ b/tests/nat/llm_providers/test_langchain_agents.py
@@ -129,3 +129,12 @@ async def test_azure_openai_langchain_agent(api_version: str | None):
         assert response.content is not None
         assert isinstance(response.content, str)
         assert "3" in response.content.lower()
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("azure_openai_keys")
+async def test_azure_openai_react_e2e(test_data_dir: str):
+    from nat.test.utils import run_workflow
+
+    config_file = os.path.join(test_data_dir, "azure_openai_e2e.yaml")
+    await run_workflow(config_file=config_file, question="What is 1+2?", expected_answer="3")

--- a/tests/test_data/azure_openai_e2e.yaml
+++ b/tests/test_data/azure_openai_e2e.yaml
@@ -1,0 +1,27 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+llms:
+  agent_llm:
+    _type: azure_openai
+    azure_deployment: gpt-35-turbo
+    azure_endpoint: $AZURE_OPENAI_ENDPOINT
+    api_version: 2025-04-01-preview
+
+workflow:
+  _type: react_agent
+  llm_name: agent_llm
+  verbose: true
+  tool_names: []

--- a/tests/test_data/azure_openai_e2e.yaml
+++ b/tests/test_data/azure_openai_e2e.yaml
@@ -13,6 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+functions:
+  current_datetime:
+    _type: current_datetime
+
 llms:
   agent_llm:
     _type: azure_openai
@@ -24,4 +28,4 @@ workflow:
   _type: react_agent
   llm_name: agent_llm
   verbose: true
-  tool_names: []
+  tool_names: [current_datetime]


### PR DESCRIPTION
## Description
* Fixes a problem where parts of the code which expect a `model_name` attribute.
* Although `model_name` was a validation alias, this only allowed users to specify `model_name` rather than `azure_deployment`, however it didn't make `model_name` available as an attribute.

Closes #1210

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced Azure OpenAI model configuration with improved name accessibility and external system compatibility.

* **Tests**
  * Added end-to-end integration test suite validating Azure OpenAI React-style agent workflows with tool support.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->