### PR TITLE
 Enable observability for individual function calls in MCP server

### DIFF
--- a/src/nat/front_ends/mcp/mcp_front_end_plugin_worker.py
+++ b/src/nat/front_ends/mcp/mcp_front_end_plugin_worker.py
@@ -34,6 +34,7 @@ from nat.builder.workflow_builder import WorkflowBuilder
 from nat.data_models.config import Config
 from nat.front_ends.mcp.mcp_front_end_config import MCPFrontEndConfig
 from nat.front_ends.mcp.memory_profiler import MemoryProfiler
+from nat.runtime.session import SessionManager
 
 logger = logging.getLogger(__name__)
 
@@ -141,7 +142,7 @@ class MCPFrontEndPluginWorkerBase(ABC):
         # Set up the health endpoint
         self._setup_health_endpoint(mcp)
 
-        # Build the workflow and register all functions with MCP
+        # Build the default workflow
         workflow = await builder.build()
 
         # Get all functions from the workflow
@@ -162,16 +163,33 @@ class MCPFrontEndPluginWorkerBase(ABC):
                     logger.debug("Skipping function %s as it's not in tool_names", function_name)
             functions = filtered_functions
 
-        # Register each function with MCP, passing workflow context for observability
+        # Create SessionManagers for each function
+        # For regular functions, wrap them in a mini-workflow with that function as entry point
+        # For workflows, use them directly
+        session_managers: dict[str, SessionManager] = {}
         for function_name, function in functions.items():
-            register_function_with_mcp(mcp, function_name, function, workflow, self.memory_profiler)
+            if isinstance(function, Workflow):
+                # Already a workflow, use it directly
+                logger.info("Function %s is a Workflow, using directly", function_name)
+                session_managers[function_name] = SessionManager(function)
+            else:
+                # Regular function - build a workflow with this function as entry point
+                logger.info("Function %s is a regular function, building entry workflow", function_name)
+                entry_workflow = await builder.build(entry_function=function_name)
+                session_managers[function_name] = SessionManager(entry_workflow)
+
+        # Register each function with MCP, passing SessionManager for observability
+        for function_name, session_manager in session_managers.items():
+            register_function_with_mcp(mcp, function_name, session_manager, self.memory_profiler)
 
         # Add a simple fallback function if no functions were found
-        if not functions:
+        if not session_managers:
             raise RuntimeError("No functions found in workflow. Please check your configuration.")
 
         # After registration, expose debug endpoints for tool/schema inspection
-        self._setup_debug_endpoints(mcp, functions)
+        # Extract the entry functions from session managers for debug endpoints
+        debug_functions = {name: sm.workflow for name, sm in session_managers.items()}
+        self._setup_debug_endpoints(mcp, debug_functions)
 
     async def _get_all_functions(self, workflow: Workflow) -> dict[str, Function]:
         """Get all functions from the workflow.

--- a/src/nat/front_ends/mcp/tool_converter.py
+++ b/src/nat/front_ends/mcp/tool_converter.py
@@ -25,13 +25,12 @@ from pydantic import BaseModel
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
-from nat.builder.context import ContextState
 from nat.builder.function import Function
 from nat.builder.function_base import FunctionBase
 
 if TYPE_CHECKING:
-    from nat.builder.workflow import Workflow
     from nat.front_ends.mcp.memory_profiler import MemoryProfiler
+    from nat.runtime.session import SessionManager
 
 logger = logging.getLogger(__name__)
 
@@ -73,20 +72,19 @@ def is_field_optional(field: FieldInfo) -> tuple[bool, Any]:
 
 def create_function_wrapper(
     function_name: str,
-    function: FunctionBase,
+    session_manager: 'SessionManager',
     schema: type[BaseModel],
-    is_workflow: bool = False,
-    workflow: 'Workflow | None' = None,
     memory_profiler: 'MemoryProfiler | None' = None,
 ):
-    """Create a wrapper function that exposes the actual parameters of a NAT Function as an MCP tool.
+    """Create a wrapper function that exposes a NAT Function as an MCP tool using SessionManager.
+
+    Here SessionManager.run() which is used to create a Runner that
+    automatically handles observability (emits intermediate step events, starts exporters, etc).
 
     Args:
         function_name (str): The name of the function/tool
-        function (FunctionBase): The NAT Function object
+        session_manager (SessionManager): SessionManager wrapping the function/workflow
         schema (type[BaseModel]): The input schema of the function
-        is_workflow (bool): Whether the function is a Workflow
-        workflow (Workflow | None): The parent workflow for observability context
         memory_profiler: Optional memory profiler to track requests
 
     Returns:
@@ -137,7 +135,10 @@ def create_function_wrapper(
     def create_wrapper():
 
         async def wrapper_with_ctx(**kwargs):
-            """Internal wrapper that will be called by MCP."""
+            """Internal wrapper that will be called by MCP.
+
+            Uses SessionManager.run() which creates a Runner that automatically handles observability.
+            """
             # MCP will add a ctx parameter, extract it
             ctx = kwargs.get("ctx")
 
@@ -151,56 +152,27 @@ def create_function_wrapper(
                 await ctx.report_progress(0, 100)
 
             try:
-                # Helper function to wrap function calls with observability
-                async def call_with_observability(func_call):
-                    # Use workflow's observability context (workflow should always be available)
-                    if not workflow:
-                        logger.error("Missing workflow context for function %s - observability will not be available",
-                                     function_name)
-                        raise RuntimeError("Workflow context is required for observability")
-
-                    logger.debug("Starting observability context for function %s", function_name)
-                    context_state = ContextState.get()
-                    async with workflow.exporter_manager.start(context_state=context_state):
-                        return await func_call()
-
-                # Special handling for ChatRequest
+                # Prepare input payload
                 if is_chat_request:
                     from nat.data_models.api_server import ChatRequest
-
                     # Create a chat request from the query string
                     query = kwargs.get("query", "")
-                    chat_request = ChatRequest.from_string(query)
-
-                    # Special handling for Workflow objects
-                    if is_workflow:
-                        # Workflows have a run method that is an async context manager
-                        # that returns a Runner
-                        async with function.run(chat_request) as runner:
-                            # Get the result from the runner
-                            result = await runner.result(to_type=str)
-                    else:
-                        # Regular functions use ainvoke
-                        result = await call_with_observability(lambda: function.ainvoke(chat_request, to_type=str))
+                    payload = ChatRequest.from_string(query)
                 else:
-                    # Regular handling
                     # Strip sentinel values so Pydantic can apply defaults/factories
                     cleaned_kwargs = {k: v for k, v in kwargs.items() if v is not _USE_PYDANTIC_DEFAULT}
-
                     # Always validate with the declared schema
-                    # This handles defaults, factories, nested models, validators, etc.
-                    model_input = schema.model_validate(cleaned_kwargs)
+                    payload = schema.model_validate(cleaned_kwargs)
 
-                    # Call the NAT function with the parameters - special handling for Workflow
-                    if is_workflow:
-                        # Workflows expect the model instance directly
-                        async with function.run(model_input) as runner:
-                            # Get the result from the runner
-                            result = await runner.result(to_type=str)
-                    else:
-                        # Regular function call - unpack the validated model
-                        result = await call_with_observability(lambda: function.acall_invoke(**model_input.model_dump())
-                                                               )
+                # Use SessionManager.run() pattern - this automatically handles all observability
+                # The Runner created by session_manager.run() will:
+                # 1. Start the exporter manager
+                # 2. Emit WORKFLOW_START/FUNCTION_START events
+                # 3. Execute the function/workflow
+                # 4. Emit WORKFLOW_END/FUNCTION_END events
+                # 5. Stop the exporter manager
+                async with session_manager.run(payload) as runner:
+                    result = await runner.result(to_type=str)
 
                 # Report completion
                 if ctx:
@@ -284,38 +256,31 @@ def get_function_description(function: FunctionBase) -> str:
 
 def register_function_with_mcp(mcp: FastMCP,
                                function_name: str,
-                               function: FunctionBase,
-                               workflow: 'Workflow | None' = None,
+                               session_manager: 'SessionManager',
                                memory_profiler: 'MemoryProfiler | None' = None) -> None:
-    """Register a NAT Function as an MCP tool.
+    """Register a NAT Function as an MCP tool using SessionManager.
+
+    Each function is wrapped in a SessionManager
+    so that all calls go through Runner that automatically handles observability.
 
     Args:
         mcp: The FastMCP instance
         function_name: The name to register the function under
-        function: The NAT Function to register
-        workflow: The parent workflow for observability context (if available)
+        session_manager: SessionManager wrapping the function/workflow
         memory_profiler: Optional memory profiler to track requests
     """
     logger.info("Registering function %s with MCP", function_name)
 
-    # Get the input schema from the function
-    input_schema = function.input_schema
+    # Get the workflow from the session manager
+    workflow = session_manager.workflow
+
+    # Get the input schema from the workflow
+    input_schema = workflow.input_schema
     logger.info("Function %s has input schema: %s", function_name, input_schema)
 
-    # Check if we're dealing with a Workflow
-    from nat.builder.workflow import Workflow
-    is_workflow = isinstance(function, Workflow)
-    if is_workflow:
-        logger.info("Function %s is a Workflow", function_name)
-
     # Get function description
-    function_description = get_function_description(function)
+    function_description = get_function_description(workflow)
 
     # Create and register the wrapper function with MCP
-    wrapper_func = create_function_wrapper(function_name,
-                                           function,
-                                           input_schema,
-                                           is_workflow,
-                                           workflow,
-                                           memory_profiler)
+    wrapper_func = create_function_wrapper(function_name, session_manager, input_schema, memory_profiler)
     mcp.tool(name=function_name, description=function_description)(wrapper_func)

--- a/tests/nat/front_ends/mcp/test_tool_converter.py
+++ b/tests/nat/front_ends/mcp/test_tool_converter.py
@@ -29,6 +29,7 @@ from nat.front_ends.mcp.tool_converter import create_function_wrapper
 from nat.front_ends.mcp.tool_converter import get_function_description
 from nat.front_ends.mcp.tool_converter import is_field_optional
 from nat.front_ends.mcp.tool_converter import register_function_with_mcp
+from nat.runtime.session import SessionManager
 
 
 # Test schemas
@@ -88,6 +89,32 @@ def create_mock_workflow_with_observability():
     mock_workflow.exporter_manager.start.return_value = async_context_manager
 
     return mock_workflow
+
+
+def create_mock_session_manager(workflow=None, result_value="result"):
+    """Create a mock SessionManager for testing.
+
+    Args:
+        workflow: Optional workflow to attach to the session manager
+        result_value: The value to return from runner.result()
+    """
+    mock_session_manager = MagicMock(spec=SessionManager)
+
+    if workflow is None:
+        workflow = create_mock_workflow_with_observability()
+
+    mock_session_manager.workflow = workflow
+
+    # Create mock runner with async context manager
+    mock_runner = MagicMock()
+    mock_runner.__aenter__ = AsyncMock(return_value=mock_runner)
+    mock_runner.__aexit__ = AsyncMock(return_value=None)
+    mock_runner.result = AsyncMock(return_value=result_value)
+
+    # Make session_manager.run() return the runner
+    mock_session_manager.run = MagicMock(return_value=mock_runner)
+
+    return mock_session_manager
 
 
 class TestIsFieldOptional:
@@ -210,12 +237,12 @@ class TestCreateFunctionWrapper:
     def test_create_wrapper_for_chat_request_function(self):
         """Test creating wrapper for function with ChatRequest schema."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
+        mock_session_manager = create_mock_session_manager()
         function_name = "test_function"
         schema = MockChatRequest
 
         # Act
-        wrapper = create_function_wrapper(function_name, mock_function, schema, False, None)
+        wrapper = create_function_wrapper(function_name, mock_session_manager, schema)
 
         # Assert
         assert callable(wrapper)
@@ -227,12 +254,12 @@ class TestCreateFunctionWrapper:
     def test_create_wrapper_for_regular_function(self):
         """Test creating wrapper for function with regular schema."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
+        mock_session_manager = create_mock_session_manager()
         function_name = "regular_function"
         schema = MockRegularSchema
 
         # Act
-        wrapper = create_function_wrapper(function_name, mock_function, schema, False, None)
+        wrapper = create_function_wrapper(function_name, mock_session_manager, schema)
 
         # Assert
         assert callable(wrapper)
@@ -245,49 +272,48 @@ class TestCreateFunctionWrapper:
     def test_create_wrapper_for_workflow(self):
         """Test creating wrapper for workflow function."""
         # Arrange
-        mock_workflow = MagicMock(spec=Workflow)
+        mock_workflow = create_mock_workflow_with_observability()
+        mock_session_manager = create_mock_session_manager(workflow=mock_workflow)
         function_name = "test_workflow"
         schema = MockChatRequest
 
         # Act
-        wrapper = create_function_wrapper(function_name, mock_workflow, schema, True, mock_workflow)
+        wrapper = create_function_wrapper(function_name, mock_session_manager, schema)
 
         # Assert
         assert callable(wrapper)
         assert wrapper.__name__ == function_name
 
-    @patch('nat.front_ends.mcp.tool_converter.ContextState')
-    async def test_wrapper_execution_with_observability(self, mock_context_state_class):
-        """Test wrapper execution with observability context."""
+    async def test_wrapper_execution_with_observability(self):
+        """Test wrapper execution with SessionManager pattern."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
-        mock_function.acall_invoke = AsyncMock(return_value="result")
+        mock_session_manager = create_mock_session_manager(result_value="result")
 
-        mock_workflow = create_mock_workflow_with_observability()
-
-        # Mock ContextState.get()
-        mock_context_state = MagicMock()
-        mock_context_state_class.get.return_value = mock_context_state
-
-        wrapper = create_function_wrapper("test_func", mock_function, MockRegularSchema, False, mock_workflow)
+        wrapper = create_function_wrapper("test_func", mock_session_manager, MockRegularSchema)
 
         # Act
         result = await wrapper(name="test", age=30)
 
         # Assert
         assert result == "result"
-        mock_workflow.exporter_manager.start.assert_called_once_with(context_state=mock_context_state)
-        mock_context_state_class.get.assert_called_once()
+        # Verify session_manager.run() was called with the validated input
+        mock_session_manager.run.assert_called_once()
+        # Verify runner.result() was called
+        call_args = mock_session_manager.run.call_args
+        assert call_args is not None
 
-    async def test_wrapper_execution_without_workflow_fails(self):
-        """Test wrapper execution fails without workflow context."""
+    async def test_wrapper_execution_via_session_manager(self):
+        """Test wrapper execution uses SessionManager.run() pattern."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
-        wrapper = create_function_wrapper("test_func", mock_function, MockChatRequest, False, None)
+        mock_session_manager = create_mock_session_manager(result_value="chat response")
+        wrapper = create_function_wrapper("test_func", mock_session_manager, MockChatRequest)
 
-        # Act & Assert
-        with pytest.raises(RuntimeError, match="Workflow context is required for observability"):
-            await wrapper(query="test")
+        # Act
+        result = await wrapper(query="test")
+
+        # Assert
+        assert result == "chat response"
+        mock_session_manager.run.assert_called_once()
 
 
 class TestGetFunctionDescription:
@@ -352,11 +378,12 @@ class TestRegisterFunctionWithMcp:
     @patch('nat.front_ends.mcp.tool_converter.get_function_description')
     @patch('nat.front_ends.mcp.tool_converter.logger')
     def test_register_function_with_mcp(self, mock_logger, mock_get_desc, mock_create_wrapper):
-        """Test registering a regular function with MCP."""
+        """Test registering a function with MCP using SessionManager."""
         # Arrange
         mock_mcp = MagicMock()
-        mock_function = MagicMock(spec=Function)
         mock_workflow = MagicMock(spec=Workflow)
+        mock_session_manager = MagicMock(spec=SessionManager)
+        mock_session_manager.workflow = mock_workflow
         function_name = "test_function"
 
         mock_get_desc.return_value = "Test description"
@@ -364,16 +391,14 @@ class TestRegisterFunctionWithMcp:
         mock_create_wrapper.return_value = mock_wrapper
 
         # Act
-        register_function_with_mcp(mock_mcp, function_name, mock_function, mock_workflow)
+        register_function_with_mcp(mock_mcp, function_name, mock_session_manager)
 
-        # Assert - Check that logging happened (actual message order may vary)
+        # Assert - Check that logging happened
         assert mock_logger.info.call_count >= 1
-        mock_get_desc.assert_called_once_with(mock_function)
+        mock_get_desc.assert_called_once_with(mock_workflow)
         mock_create_wrapper.assert_called_once_with(function_name,
-                                                    mock_function,
-                                                    mock_function.input_schema,
-                                                    False,
-                                                    mock_workflow,
+                                                    mock_session_manager,
+                                                    mock_workflow.input_schema,
                                                     None)  # memory_profiler defaults to None
         mock_mcp.tool.assert_called_once_with(name=function_name, description="Test description")
 
@@ -381,10 +406,12 @@ class TestRegisterFunctionWithMcp:
     @patch('nat.front_ends.mcp.tool_converter.get_function_description')
     @patch('nat.front_ends.mcp.tool_converter.logger')
     def test_register_workflow_with_mcp(self, mock_logger, mock_get_desc, mock_create_wrapper):
-        """Test registering a workflow with MCP."""
+        """Test registering a workflow with MCP using SessionManager."""
         # Arrange
         mock_mcp = MagicMock()
         mock_workflow = MagicMock(spec=Workflow)
+        mock_session_manager = MagicMock(spec=SessionManager)
+        mock_session_manager.workflow = mock_workflow
         function_name = "test_workflow"
 
         mock_get_desc.return_value = "Workflow description"
@@ -392,16 +419,14 @@ class TestRegisterFunctionWithMcp:
         mock_create_wrapper.return_value = mock_wrapper
 
         # Act
-        register_function_with_mcp(mock_mcp, function_name, mock_workflow, mock_workflow)
+        register_function_with_mcp(mock_mcp, function_name, mock_session_manager)
 
-        # Assert - Check that logging happened (actual message order may vary)
-        assert mock_logger.info.call_count >= 2  # Should log at least twice for workflow
+        # Assert - Check that logging happened
+        assert mock_logger.info.call_count >= 1
         mock_get_desc.assert_called_once_with(mock_workflow)
         mock_create_wrapper.assert_called_once_with(function_name,
-                                                    mock_workflow,
+                                                    mock_session_manager,
                                                     mock_workflow.input_schema,
-                                                    True,
-                                                    mock_workflow,
                                                     None)  # memory_profiler defaults to None
         mock_mcp.tool.assert_called_once_with(name=function_name, description="Workflow description")
 
@@ -412,11 +437,11 @@ class TestParameterSchemaValidation:
     def test_all_required_parameters(self):
         """Test schema with all required parameters."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
+        mock_session_manager = create_mock_session_manager()
         function_name = "all_required_func"
 
         # Act
-        wrapper = create_function_wrapper(function_name, mock_function, MockAllRequiredSchema, False, None)
+        wrapper = create_function_wrapper(function_name, mock_session_manager, MockAllRequiredSchema)
 
         # Assert
         sig = getattr(wrapper, '__signature__', None)
@@ -433,11 +458,11 @@ class TestParameterSchemaValidation:
     def test_all_optional_parameters(self):
         """Test schema with all optional parameters."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
+        mock_session_manager = create_mock_session_manager()
         function_name = "all_optional_func"
 
         # Act
-        wrapper = create_function_wrapper(function_name, mock_function, MockAllOptionalSchema, False, None)
+        wrapper = create_function_wrapper(function_name, mock_session_manager, MockAllOptionalSchema)
 
         # Assert
         sig = getattr(wrapper, '__signature__', None)
@@ -463,11 +488,11 @@ class TestParameterSchemaValidation:
     def test_mixed_required_and_optional_parameters(self):
         """Test schema with mix of required and optional parameters."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
+        mock_session_manager = create_mock_session_manager()
         function_name = "mixed_func"
 
         # Act
-        wrapper = create_function_wrapper(function_name, mock_function, MockMixedRequiredOptionalSchema, False, None)
+        wrapper = create_function_wrapper(function_name, mock_session_manager, MockMixedRequiredOptionalSchema)
 
         # Assert
         sig = getattr(wrapper, '__signature__', None)
@@ -492,11 +517,11 @@ class TestParameterSchemaValidation:
     def test_optional_with_none_type(self):
         """Test optional parameters with None type (Union types)."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
+        mock_session_manager = create_mock_session_manager()
         function_name = "optional_none_func"
 
         # Act
-        wrapper = create_function_wrapper(function_name, mock_function, MockOptionalTypesSchema, False, None)
+        wrapper = create_function_wrapper(function_name, mock_session_manager, MockOptionalTypesSchema)
 
         # Assert
         sig = getattr(wrapper, '__signature__', None)
@@ -517,11 +542,11 @@ class TestParameterSchemaValidation:
     def test_parameter_annotations_preserved(self):
         """Test that parameter type annotations are preserved."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
+        mock_session_manager = create_mock_session_manager()
         function_name = "annotated_func"
 
         # Act
-        wrapper = create_function_wrapper(function_name, mock_function, MockMixedRequiredOptionalSchema, False, None)
+        wrapper = create_function_wrapper(function_name, mock_session_manager, MockMixedRequiredOptionalSchema)
 
         # Assert
         sig = getattr(wrapper, '__signature__', None)
@@ -536,11 +561,11 @@ class TestParameterSchemaValidation:
     def test_parameter_order_preserved(self):
         """Test that parameter order is preserved in wrapper."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
+        mock_session_manager = create_mock_session_manager()
         function_name = "ordered_func"
 
         # Act
-        wrapper = create_function_wrapper(function_name, mock_function, MockMixedRequiredOptionalSchema, False, None)
+        wrapper = create_function_wrapper(function_name, mock_session_manager, MockMixedRequiredOptionalSchema)
 
         # Assert
         sig = getattr(wrapper, '__signature__', None)
@@ -558,97 +583,64 @@ class TestParameterSchemaValidation:
 class TestIntegrationScenarios:
     """Integration test scenarios combining multiple components."""
 
-    @patch('nat.front_ends.mcp.tool_converter.ContextState')
-    async def test_observability_context_propagation(self, mock_context_state_class):
-        """Test that observability context is properly propagated."""
+    async def test_observability_context_propagation(self):
+        """Test that SessionManager.run() handles observability."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
-        mock_function.acall_invoke = AsyncMock(return_value="result")
-
-        mock_workflow = create_mock_workflow_with_observability()
-
-        # Mock ContextState.get()
-        mock_context_state = MagicMock()
-        mock_context_state_class.get.return_value = mock_context_state
+        mock_session_manager = create_mock_session_manager(result_value="result")
 
         # Create wrapper
-        wrapper = create_function_wrapper("test_func", mock_function, MockRegularSchema, False, mock_workflow)
+        wrapper = create_function_wrapper("test_func", mock_session_manager, MockRegularSchema)
 
         # Act - Execute wrapper
         await wrapper(name="test", age=25)
 
-        # Assert - Check that observability was started with correct context
-        mock_workflow.exporter_manager.start.assert_called_once_with(context_state=mock_context_state)
-        mock_context_state_class.get.assert_called_once()
+        # Assert - Check that session_manager.run() was called
+        mock_session_manager.run.assert_called_once()
 
-    @patch('nat.front_ends.mcp.tool_converter.ContextState')
-    async def test_error_handling_in_wrapper_execution(self, mock_context_state_class):
+    async def test_error_handling_in_wrapper_execution(self):
         """Test error handling during wrapper execution."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
-        mock_function.acall_invoke.side_effect = Exception("Test error")
-
         mock_workflow = create_mock_workflow_with_observability()
+        mock_session_manager = MagicMock(spec=SessionManager)
+        mock_session_manager.workflow = mock_workflow
 
-        # Mock ContextState.get()
-        mock_context_state = MagicMock()
-        mock_context_state_class.get.return_value = mock_context_state
+        # Create mock runner that raises an error
+        mock_runner = MagicMock()
+        mock_runner.__aenter__ = AsyncMock(return_value=mock_runner)
+        mock_runner.__aexit__ = AsyncMock(return_value=None)
+        mock_runner.result = AsyncMock(side_effect=Exception("Test error"))
+        mock_session_manager.run = MagicMock(return_value=mock_runner)
 
-        wrapper = create_function_wrapper("test_func", mock_function, MockRegularSchema, False, mock_workflow)
+        wrapper = create_function_wrapper("test_func", mock_session_manager, MockRegularSchema)
 
         # Act & Assert
         with pytest.raises(Exception, match="Test error"):
             await wrapper(name="test", age=25)
 
-        # Observability context should still have been started
-        mock_workflow.exporter_manager.start.assert_called_once_with(context_state=mock_context_state)
-        mock_context_state_class.get.assert_called_once()
+        # Verify session_manager.run() was called even though it raised an error
+        mock_session_manager.run.assert_called_once()
 
-    @patch('nat.front_ends.mcp.tool_converter.ContextState')
-    async def test_wrapper_with_optional_parameters_omitted(self, mock_context_state_class):
+    async def test_wrapper_with_optional_parameters_omitted(self):
         """Test wrapper execution when optional parameters are omitted."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
-        mock_function.acall_invoke = AsyncMock(return_value="result")
+        mock_session_manager = create_mock_session_manager(result_value="result")
 
-        mock_workflow = create_mock_workflow_with_observability()
-
-        # Mock ContextState.get()
-        mock_context_state = MagicMock()
-        mock_context_state_class.get.return_value = mock_context_state
-
-        wrapper = create_function_wrapper("test_func",
-                                          mock_function,
-                                          MockMixedRequiredOptionalSchema,
-                                          False,
-                                          mock_workflow)
+        wrapper = create_function_wrapper("test_func", mock_session_manager, MockMixedRequiredOptionalSchema)
 
         # Act - Call with only required parameters
         result = await wrapper(required_str="test", required_int=123)
 
         # Assert
         assert result == "result"
-        # Function should have been called with defaults for optional parameters
-        mock_function.acall_invoke.assert_called_once()
+        # SessionManager.run() should have been called
+        mock_session_manager.run.assert_called_once()
 
-    @patch('nat.front_ends.mcp.tool_converter.ContextState')
-    async def test_wrapper_with_optional_parameters_provided(self, mock_context_state_class):
+    async def test_wrapper_with_optional_parameters_provided(self):
         """Test wrapper execution when optional parameters are provided."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
-        mock_function.acall_invoke = AsyncMock(return_value="result")
+        mock_session_manager = create_mock_session_manager(result_value="result")
 
-        mock_workflow = create_mock_workflow_with_observability()
-
-        # Mock ContextState.get()
-        mock_context_state = MagicMock()
-        mock_context_state_class.get.return_value = mock_context_state
-
-        wrapper = create_function_wrapper("test_func",
-                                          mock_function,
-                                          MockMixedRequiredOptionalSchema,
-                                          False,
-                                          mock_workflow)
+        wrapper = create_function_wrapper("test_func", mock_session_manager, MockMixedRequiredOptionalSchema)
 
         # Act - Call with all parameters
         result = await wrapper(required_str="test",
@@ -659,26 +651,18 @@ class TestIntegrationScenarios:
 
         # Assert
         assert result == "result"
-        mock_function.acall_invoke.assert_called_once()
+        mock_session_manager.run.assert_called_once()
 
-    @patch('nat.front_ends.mcp.tool_converter.ContextState')
-    async def test_wrapper_with_none_values(self, mock_context_state_class):
+    async def test_wrapper_with_none_values(self):
         """Test wrapper execution with explicit None values for optional parameters."""
         # Arrange
-        mock_function = MagicMock(spec=Function)
-        mock_function.acall_invoke = AsyncMock(return_value="result")
+        mock_session_manager = create_mock_session_manager(result_value="result")
 
-        mock_workflow = create_mock_workflow_with_observability()
-
-        # Mock ContextState.get()
-        mock_context_state = MagicMock()
-        mock_context_state_class.get.return_value = mock_context_state
-
-        wrapper = create_function_wrapper("test_func", mock_function, MockOptionalTypesSchema, False, mock_workflow)
+        wrapper = create_function_wrapper("test_func", mock_session_manager, MockOptionalTypesSchema)
 
         # Act - Call with None for optional parameters
         result = await wrapper(required_field="test", optional_str_none=None, optional_int_none=None)
 
         # Assert
         assert result == "result"
-        mock_function.acall_invoke.assert_called_once()
+        mock_session_manager.run.assert_called_once()


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes https://github.com/NVIDIA/NeMo-Agent-Toolkit/issues/1233

This PR resolves an observability issue where traces were not exported when individual tools were called via MCP clients. Previously, traces were only exported when the MCP server's main workflow was invoked directly.

The fix wraps each registered function in a lightweight workflow and uses `SessionManager` to route all tool calls through the `Runner` execution path, which automatically handles observability event emission and exporter lifecycle management.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Optimized session and workflow management for MCP tool execution
  * Enhanced observability and error handling in tool registration
  * Streamlined integration of functions and workflows in MCP services

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->