### PR TITLE
Add a tabular output for evaluation results

### DIFF
--- a/docs/source/workflows/evaluate.md
+++ b/docs/source/workflows/evaluate.md
@@ -242,6 +242,25 @@ eval:
 ```
 This setting reduces the number of concurrent requests to avoid overwhelming the LLM endpoint.
 
+## Summary Output
+The `nat eval` command writes a summary of the evaluation results to the console. The summary includes the workflow status, total runtime, and the average score for each evaluator.
+Sample summary output:
+```text
+=== EVALUATION SUMMARY ===
+Workflow Status: COMPLETED
+Total Runtime: 28.96s
+Workflow Runtime (p95): 7.77s
+LLM Latency (p95): 1.64s
+
+Per evaluator results:
+| Evaluator           |   Avg Score | Output File                     |
+|---------------------|-------------|---------------------------------|
+| relevance           |        1    | relevance_output.json           |
+| groundedness        |        1    | groundedness_output.json        |
+| accuracy            |        0.55 | accuracy_output.json            |
+| trajectory_accuracy |        0.9  | trajectory_accuracy_output.json |
+```
+
 ## Workflow Output
 The `nat eval` command runs the workflow on all the entries in the `dataset`. The output of these runs is stored in `workflow_output.json` under the `output_dir` specified in the configuration file.
 

--- a/src/nat/cli/commands/evaluate.py
+++ b/src/nat/cli/commands/evaluate.py
@@ -100,7 +100,7 @@ def write_tabular_output(eval_run_output: EvaluationRunOutput):
 
     click.echo("")
     click.echo(click.style("=== EVALUATION SUMMARY ===", fg="bright_blue", bold=True))
-    click.echo(f"Workflow Status: {workflow_status}")
+    click.echo(f"Workflow Status: {workflow_status} (workflow_output.json)")
     click.echo(f"Total Runtime: {total_runtime:.2f}s")
 
     # Include profiler stats if available
@@ -113,9 +113,10 @@ def write_tabular_output(eval_run_output: EvaluationRunOutput):
             llm_metrics = profiler_results.llm_latency_ci
             click.echo(f"LLM Latency (p95): {llm_metrics.p95:.2f}s")
 
+    # Build the evaluation results table
     if not eval_run_output.evaluation_results:
         return
-    # Build the evaluation results table
+
     click.echo("")
     click.echo("Per evaluator results:")
 
@@ -135,7 +136,7 @@ def write_tabular_output(eval_run_output: EvaluationRunOutput):
         # Add output file if available
         output_file = None
         for file_path in eval_run_output.evaluator_output_files:
-            if evaluator_name in file_path.name:
+            if file_path.stem.startswith(f"{evaluator_name}_") or file_path.stem == evaluator_name:
                 output_file = file_path.name
                 break
         row.append(output_file if output_file else "N/A")

--- a/src/nat/cli/commands/evaluate.py
+++ b/src/nat/cli/commands/evaluate.py
@@ -18,7 +18,9 @@ import logging
 from pathlib import Path
 
 import click
+from tabulate import tabulate
 
+from nat.eval.config import EvaluationRunOutput
 from nat.eval.evaluate import EvaluationRun
 from nat.eval.evaluate import EvaluationRunConfig
 
@@ -89,10 +91,70 @@ def eval_command(ctx, **kwargs) -> None:
     pass
 
 
+def write_tabular_output(eval_run_output: EvaluationRunOutput):
+    """Write evaluation results in a tabular format."""
+
+    # Print header with workflow status and runtime
+    workflow_status = "INTERRUPTED" if eval_run_output.workflow_interrupted else "COMPLETED"
+    total_runtime = eval_run_output.usage_stats.total_runtime if eval_run_output.usage_stats else 0.0
+
+    click.echo("")
+    click.echo(click.style("=== EVALUATION SUMMARY ===", fg="bright_blue", bold=True))
+    click.echo(f"Workflow Status: {workflow_status}")
+    click.echo(f"Total Runtime: {total_runtime:.2f}s")
+
+    # Include profiler stats if available
+    if eval_run_output.profiler_results:
+        profiler_results = eval_run_output.profiler_results
+        if profiler_results.workflow_runtime_metrics:
+            wf_metrics = profiler_results.workflow_runtime_metrics
+            click.echo(f"Workflow Runtime (p95): {wf_metrics.p95:.2f}s")
+        if profiler_results.llm_latency_ci:
+            llm_metrics = profiler_results.llm_latency_ci
+            click.echo(f"LLM Latency (p95): {llm_metrics.p95:.2f}s")
+
+    if not eval_run_output.evaluation_results:
+        return
+    # Build the evaluation results table
+    click.echo("")
+    click.echo("Per evaluator results:")
+
+    table = []
+    for evaluator_name, eval_output in eval_run_output.evaluation_results:
+        row = []
+
+        # Add evaluator name and average score
+        row.append(evaluator_name)
+
+        # Format average score
+        if isinstance(eval_output.average_score, int | float):
+            row.append(f"{eval_output.average_score:.4f}")
+        else:
+            row.append(str(eval_output.average_score))
+
+        # Add output file if available
+        output_file = None
+        for file_path in eval_run_output.evaluator_output_files:
+            if evaluator_name in file_path.name:
+                output_file = file_path.name
+                break
+        row.append(output_file if output_file else "N/A")
+
+        table.append(row)
+
+    # Build headers
+    headers = ["Evaluator", "Avg Score", "Output File"]
+
+    click.echo(tabulate(table, headers=headers, tablefmt="github"))
+    click.echo("")
+
+
 async def run_and_evaluate(config: EvaluationRunConfig):
     # Run evaluation
     eval_runner = EvaluationRun(config=config)
-    await eval_runner.run_and_evaluate()
+    eval_run_output = await eval_runner.run_and_evaluate()
+
+    write_tabular_output(eval_run_output)
 
 
 @eval_command.result_callback(replace=True)


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Sample Output:
```
=== EVALUATION SUMMARY ===
Workflow Status: COMPLETED
Total Runtime: 39.70s
Workflow Runtime (p95): 11.41s
LLM Latency (p95): 2.00s

Per evaluator results:
| Evaluator           |   Avg Score | Output File                     |
|---------------------|-------------|---------------------------------|
| relevance           |         1   | relevance_output.json           |
| groundedness        |         1   | groundedness_output.json        |
| accuracy            |         0.5 | accuracy_output.json            |
| trajectory_accuracy |         0.8 | trajectory_accuracy_output.json |
```
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation results now print as a human-readable tabular summary showing workflow status, total runtime, optional profiler metrics, and per-evaluator performance with average scores and output file references.

* **Documentation**
  * Added a "Summary Output" documentation block describing the evaluation summary and per-evaluator results (note: the block was inserted twice, creating duplicate sections).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->