### PR TITLE
Fix ReAct agent TypeError with LiteLLM and Anthropic models

### DIFF
--- a/src/nat/agent/react_agent/agent.py
+++ b/src/nat/agent/react_agent/agent.py
@@ -122,7 +122,7 @@ class ReActAgentGraph(DualNodeAgent):
         """
         # models that don't need (or don't support)a stop sequence
         smart_models = re.compile(r"gpt-?5", re.IGNORECASE)
-        if any(smart_models.search(getattr(self.llm, model, "")) for model in ["model", "model_name"]):
+        if smart_models.search(str(getattr(self.llm, "model", ""))):
             # no need to bind any additional parameters to the LLM
             return self.llm
         # add a stop sequence to the LLM


### PR DESCRIPTION
## Description
Fixes the ReAct agent initialization failure when using LiteLLM provider with Anthropic models. The agent was throwing `TypeError: expected string or bytes-like object, got 'NoneType'` during model binding.

## Changes
- Modified `_maybe_bind_llm_and_yield()` method in `src/nemo_agent/react_agent/agent.py` (line 125)
- Removed redundant check for `model_name` attribute (always `None` in `ChatLiteLLM`)
- Check only the `model` attribute and add defensive `str()` conversion
- Works across all LiteLLM providers (OpenAI, Azure, Anthropic, Bedrock, Cohere, Groq)

## Root Cause
When using `ChatLiteLLM` (LangChain's wrapper for LiteLLM), the `model_name` attribute is always `None`. The code attempted to regex search on both `model` and `model_name`, causing a TypeError when `model_name` was `None`.

## Testing
- Verified `model_name` is always `None` across multiple providers
- Confirmed `model` attribute contains the model string for all providers  
- Tested that regex correctly identifies GPT-5 models
- Patch allows ReAct agent to initialize with Anthropic models without errors
- MCP tools load and agent makes tool calls successfully

Closes #1250

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved LLM model detection logic for more reliable configuration handling across different model types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->