### PR TITLE
Update Cursor rules to use the new naming guidance

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -129,7 +129,7 @@ reviews:
           digit version (ex: `~=1.0`).
         - Not all packages contain Python code, if they do they should also contain their own set of tests, in a
           `tests/` directory at the same level as the `pyproject.toml` file.
-        - When adding a new package, that new package name (as defined in the `pyproject.toml` file) should 
+        - When adding a new package, that new package name (as defined in the `pyproject.toml` file) should
           be added as a dependency to the nvidia-nat-all package in `packages/nvidia_nat_all/pyproject.toml`
 
     - path: "tests/**/*.py"
@@ -142,6 +142,8 @@ reviews:
             @pytest.fixture(name="my_fixture")
             def fixture_my_fixture():
                 pass
+        - Do NOT add `@pytest.mark.asyncio` to any test. Async tests are automatically detected and run by the
+          async runner - the decorator is unnecessary clutter.
 
   auto_apply_labels: true
   suggested_labels: true

--- a/.cursor/rules/documentation/capitalization.mdc
+++ b/.cursor/rules/documentation/capitalization.mdc
@@ -1,5 +1,5 @@
 ---
-description: 
+description:
 globs: **/*.md
 alwaysApply: false
 ---
@@ -105,11 +105,14 @@ Don't capitalize:
 - **Commands**: Usually lowercase unless they're proper names
 
 ### Product Names
-- **Use official capitalization**: 
-  - NVIDIA NeMo Agent toolkit (first use)
-  - Agent toolkit (subsequent uses)
+- **Use official capitalization**:
+  - NVIDIA NeMo Agent toolkit (first use in body text)
+  - NVIDIA NeMo Agent Toolkit (first use in titles/headings where all words are capitalized)
+  - NeMo Agent toolkit or "the toolkit" (subsequent uses in body text)
+  - NeMo Agent Toolkit (subsequent uses in titles/headings)
   - CUDA, TensorRT, PyTorch
 - **Don't capitalize** generic terms: database, server, application (unless part of proper name)
+- **Never use** "NAT" or "nat" as an abbreviation for the toolkit in documentation
 
 ### Feature Names
 - **Capitalize** official feature names: Smart Search, Auto-Save, Real-time Analytics
@@ -136,7 +139,7 @@ Don't capitalize:
 - **Example**: "application programming interface" → "API"
 
 #### Version Numbers
-- **Follow product conventions**: 
+- **Follow product conventions**:
   - "version 2.1" (lowercase version)
   - "Python 3.9" (capitalize language name)
   - "CUDA 11.8" (follow product style)

--- a/.cursor/rules/documentation/general.mdc
+++ b/.cursor/rules/documentation/general.mdc
@@ -31,17 +31,23 @@ Follow these rules when working with any documentation in the NeMo Agent toolkit
 
 ### Terminology and Naming
 - Make sure to follow this naming convention for all the documentation. If there is any documentation not following this rule, you MUST update it.
-- **Full name on first use**: "NVIDIA NeMo Agent toolkit"
-- **Subsequent references**: "NeMo Agent toolkit"
-- **Abbreviations**: "NAT" or "nat"
-  - "nat" for the API namespace and CLI tool
-  - "nvidia-nat" for the package name
-  - "NAT" for environment variable prefixes, and informal usage in comments
-  - This should be used for all abbreviations in the comments in the code.
-  - This should NEVER be used in the documentation.
+- **Full name (first use)**: "NVIDIA NeMo Agent toolkit" — use for document titles, webpage headers, and any public descriptions
+- **Short name (subsequent references)**: "NeMo Agent toolkit" or "the toolkit"
+- **Capitalization rules**:
+  - In document titles, headings, or any context where all words are capitalized, use "Toolkit" (capital T): e.g., "NVIDIA NeMo Agent Toolkit" or "NeMo Agent Toolkit"
+  - In all other contexts (body text, descriptions), use "toolkit" (lowercase t): e.g., "NVIDIA NeMo Agent toolkit" or "NeMo Agent toolkit"
+- **Technical identifiers** (code, CLI, packages, URLs):
+  - `nat` for the API namespace and CLI tool
+  - `nvidia-nat` for the package name
+  - `NAT_` prefix for environment variables
+  - `NeMo-Agent-Toolkit` for URLs, directory names, and contexts where capitalization is preserved (no underscores or spaces)
+- **"NAT" abbreviation**:
+  - OK in code comments
+  - NEVER use "NAT" or "nat" to refer to the toolkit in documentation
 - Examples:
   - "In the NeMo Agent toolkit, you can…"
   - "Change directory to the NeMo Agent toolkit repo root…"
+  - Heading: "# Getting Started with NeMo Agent Toolkit"
 - Consistently use this terminology throughout all documentation
 - NeMo Agent toolkit was previously known as the Agent Intelligence toolkit, and AgentIQ. You should NEVER use the deprecated names, including Agent Intelligence toolkit, aiqtoolkit, AgentIQ, or AIQ/aiq. If you see any of these names in the documentation, you MUST update it based on the latest naming convention above, unless those names are intentionally used to refer to the deprecated names, or implementing a compatibility layer for the deprecated names.
 

--- a/.cursor/rules/documentation/punctuation.mdc
+++ b/.cursor/rules/documentation/punctuation.mdc
@@ -32,6 +32,10 @@ Use apostrophes for:
 - Possessive form of "it" → use `its`
 - Possessive pronouns → `yours`, `theirs`
 - Plural nouns → `devices` not `device's`
+- Inanimate objects (use alternative phrasing instead)
+  - **Incorrect**: "NeMo Agent Toolkit's evaluation system can be used..."
+  - **Correct**: "The NeMo Agent Toolkit evaluation system can be used..."
+  - **Also correct**: "The evaluation system included in NeMo Agent Toolkit can be used..."
 
 ### Brackets
 

--- a/.cursor/rules/documentation/punctuation.mdc
+++ b/.cursor/rules/documentation/punctuation.mdc
@@ -1,5 +1,5 @@
 ---
-description: 
+description:
 globs: **/*.md
 alwaysApply: false
 ---
@@ -33,9 +33,9 @@ Use apostrophes for:
 - Possessive pronouns → `yours`, `theirs`
 - Plural nouns → `devices` not `device's`
 - Inanimate objects (use alternative phrasing instead)
-  - **Incorrect**: "NeMo Agent Toolkit's evaluation system can be used..."
-  - **Correct**: "The NeMo Agent Toolkit evaluation system can be used..."
-  - **Also correct**: "The evaluation system included in NeMo Agent Toolkit can be used..."
+  - **Incorrect**: "NeMo Agent toolkit's evaluation system can be used..."
+  - **Correct**: "The NeMo Agent toolkit evaluation system can be used..."
+  - **Also correct**: "The evaluation system included in NeMo Agent toolkit can be used..."
 
 ### Brackets
 
@@ -125,7 +125,7 @@ Use apostrophes for:
   - `History is stained with blood spilled in the name of "civilization."`
 - **Colons and semicolons**: Always outside quotation marks
   - `Three elements of her "Olympic journey": family, commitment, coaching`
-- **Question marks and exclamation points**: 
+- **Question marks and exclamation points**:
   - Inside if they apply to the quotation
   - Outside if they apply to the whole sentence
 

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -13,18 +13,23 @@ These are the overarching standards that every **source, test, documentation and
 ## Terminology and Naming
 
 - Make sure to follow this naming convention for all the documentation. If there is any documentation not following this rule, you MUST update it.
-- **Full name on first use**: "NVIDIA NeMo Agent toolkit"
-- **Subsequent references**: "NeMo Agent toolkit"
-  - If the name is part of a heading, use "NeMo Agent Toolkit" in the heading. Capitalize the "T" in "Toolkit".
-- **Abbreviations**: "NAT" or "nat"
-  - "nat" for the API namespace and CLI tool
-  - "nvidia-nat" for the package name
-  - "NAT" for environment variable prefixes, and informal usage in comments
-  - This should be used for all abbreviations in the comments in the code.
-  - This should NEVER be used in the documentation.
+- **Full name (first use)**: "NVIDIA NeMo Agent toolkit" — use for document titles, webpage headers, and any public descriptions
+- **Short name (subsequent references)**: "NeMo Agent toolkit" or "the toolkit"
+- **Capitalization rules**:
+  - In document titles, headings, or any context where all words are capitalized, use "Toolkit" (capital T): e.g., "NVIDIA NeMo Agent Toolkit" or "NeMo Agent Toolkit"
+  - In all other contexts (body text, descriptions), use "toolkit" (lowercase t): e.g., "NVIDIA NeMo Agent toolkit" or "NeMo Agent toolkit"
+- **Technical identifiers** (code, CLI, packages, URLs):
+  - `nat` for the API namespace and CLI tool
+  - `nvidia-nat` for the package name
+  - `NAT_` prefix for environment variables
+  - `NeMo-Agent-Toolkit` for URLs, directory names, and contexts where capitalization is preserved (no underscores or spaces)
+- **"NAT" abbreviation**:
+  - OK in code comments
+  - NEVER use "NAT" or "nat" to refer to the toolkit in documentation
 - Examples:
   - "In the NeMo Agent toolkit, you can…"
   - "Change directory to the NeMo Agent toolkit repo root…"
+  - Heading: "# Getting Started with NeMo Agent Toolkit"
 - Consistently use this terminology throughout all documentation
 - NeMo Agent toolkit was previously known as the Agent Intelligence toolkit, and AgentIQ. You should NEVER use the deprecated names, including Agent Intelligence toolkit, aiqtoolkit, AgentIQ, or AIQ/aiq. If you see any of these names in the documentation, you should update it based on the latest naming convention above, unless those names are intentionally used to refer to the deprecated names, or implementing a compatibility layer for the deprecated names.
 - DO NOT change the content of `CHANGELOG.md`

--- a/.cursor/rules/nat-tests/general.mdc
+++ b/.cursor/rules/nat-tests/general.mdc
@@ -26,6 +26,7 @@ All tests in NeMo Agent toolkit use pytest. See the general coding guidelines fo
 - Use `@pytest.fixture(name="fixture_name")` decorator pattern
 - Mock external services with `pytest_httpserver` or `unittest.mock`
 - Maintain ≥ 80% code coverage
+- Do NOT add `@pytest.mark.asyncio` to any test - async tests are automatically detected and run by the async runner
 
 ### Integration Tests
 

--- a/.cursor/rules/nat-tests/integration-tests.mdc
+++ b/.cursor/rules/nat-tests/integration-tests.mdc
@@ -175,6 +175,7 @@ Key practices:
 - Import third-party service libraries at module level in fixtures
 - Use function scope for service fixtures (use session scope)
 - Fail tests when services are unavailable (skip them instead)
+- Add `@pytest.mark.asyncio` decorator - async tests are automatically detected and run by the async runner
 
 ## Running Integration Tests
 

--- a/docs/source/get-started/tutorials/build-a-demo-agent-workflow-using-cursor-rules.md
+++ b/docs/source/get-started/tutorials/build-a-demo-agent-workflow-using-cursor-rules.md
@@ -28,10 +28,6 @@ Cursor rules in NeMo Agent toolkit act as an intelligent development that offers
 
 ## Common Prompts
 
-:::{note}
-For optimal Cursor rules experience, avoid using the `Auto` mode for LLM model selection. Instead, manually choose a model from the selection menu, such as `claude-4.5-opus-high`.
-:::
-
 The following are frequently used prompts to begin development:
 
 **Installing NeMo Agent Toolkit:**

--- a/docs/source/get-started/tutorials/build-a-demo-agent-workflow-using-cursor-rules.md
+++ b/docs/source/get-started/tutorials/build-a-demo-agent-workflow-using-cursor-rules.md
@@ -29,7 +29,7 @@ Cursor rules in NeMo Agent toolkit act as an intelligent development that offers
 ## Common Prompts
 
 :::{note}
-For optimal Cursor rules experience, avoid using the `Auto` mode for LLM model selection. Instead, manually choose a model from the selection menu, such as `claude-4-sonnet`.
+For optimal Cursor rules experience, avoid using the `Auto` mode for LLM model selection. Instead, manually choose a model from the selection menu, such as `claude-4.5-opus-high`.
 :::
 
 The following are frequently used prompts to begin development:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Updates the terminology sections in Cursor rules to reflect the new naming guidance of NVIDIA NeMo Agent toolkit.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded and clarified naming/capitalization guidance for NeMo Agent Toolkit (first‑use vs subsequent references, headings vs body)
  * Prohibited "NAT"/"nat" as a documentation abbreviation; clarified allowed technical identifiers in code contexts
  * Added punctuation guidance and examples (avoid possessive apostrophes for inanimate objects)
  * Removed an outdated LLM model‑selection note from a tutorial
  * Reinforced designated blueprint name and changelog handling guidance

* **Tests**
  * Added guideline: do not add pytest.mark.asyncio; async tests are auto-detected

* **Chores**
  * Minor formatting adjustments in config/documentation files

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->