### PR TITLE
Migrate the a2a client implementation to per-user mode

### DIFF
--- a/docs/source/build-workflows/a2a-client.md
+++ b/docs/source/build-workflows/a2a-client.md
@@ -68,7 +68,7 @@ workflow:
 
 The `a2a_client` function group connects to a remote A2A agent, discovers its skills through the [Agent Card](https://a2a-protocol.org/latest/topics/agent-discovery/), and provides a function interface for invoking those skills.
 
-**Note**: Since A2A clients are per-user, the workflow must also be per-user. The example above uses `per_user_react_agent`, which is the per-user version of the builtin [ReAct agent](../build-workflows/react-agent.md). See the [examples](#examples) section for complete implementations.
+**Note**: Since A2A clients are per-user, the workflow must also be per-user. The example above uses `per_user_react_agent`, which is the per-user version of the builtin [ReAct agent](../components/agents/react-agent/react-agent.md). See the [examples](#examples) section for complete implementations.
 
 ### Configuration Options
 

--- a/docs/source/build-workflows/a2a-client.md
+++ b/docs/source/build-workflows/a2a-client.md
@@ -23,6 +23,17 @@ You can create a workflow that connects to remote A2A agents and provides a func
 
 This guide covers how to use NeMo Agent toolkit as an A2A client. For information on publishing workflows as A2A servers, refer to [A2A Server](../run-workflows/a2a-server.md).
 
+:::important
+**Per-User A2A Clients**
+
+A2A clients are per-user function groups, which means:
+- Each user gets their own isolated A2A client instance with separate connections, authentication, and session state
+- Workflows using A2A clients **must** be registered as per-user using `@register_per_user_function` or use one of the builtin per-user workflows (such as `per_user_react_agent`)
+- Shared workflows (such as `react_agent`) **cannot** use A2A client function groups directly
+
+For multi-user deployments, this provides automatic isolation between users. See [Writing Per-User Functions](../extend/custom-components/custom-functions/per-user-functions.md) for details on creating per-user workflows.
+:::
+
 ## Installation
 
 A2A client functionality requires the `nvidia-nat-a2a` package. Install it with:
@@ -49,13 +60,15 @@ function_groups:
     task_timeout: 60
 
 workflow:
-  _type: react_agent
+  _type: per_user_react_agent  # Per-user workflow required for A2A clients
   tool_names:
     - currency_agent
   llm_name: nim_llm
 ```
 
 The `a2a_client` function group connects to a remote A2A agent, discovers its skills through the [Agent Card](https://a2a-protocol.org/latest/topics/agent-discovery/), and provides a function interface for invoking those skills.
+
+**Note**: Since A2A clients are per-user, the workflow must also be per-user. The example above uses `per_user_react_agent`, which is the per-user version of the builtin [ReAct agent](../build-workflows/react-agent.md). See the [examples](#examples) section for complete implementations.
 
 ### Configuration Options
 
@@ -76,7 +89,7 @@ nat info components -t function_group -q a2a_client
 
 ### Multiple A2A Clients
 
-You can connect to multiple A2A agents in the same workflow:
+You can connect to multiple A2A agents in the same per-user workflow:
 
 ```yaml
 function_groups:
@@ -89,11 +102,13 @@ function_groups:
     url: http://localhost:11000
 
 workflow:
-  _type: react_agent
+  _type: per_user_react_agent  # Per-user workflow required for A2A clients
   tool_names:
     - calculator_agent
     - currency_agent
 ```
+
+**Note**: All A2A clients in a workflow will be per-user, providing isolated connections for each user.
 
 ## Three-Level API Architecture
 

--- a/examples/A2A/currency_agent_a2a/README.md
+++ b/examples/A2A/currency_agent_a2a/README.md
@@ -17,13 +17,15 @@ limitations under the License.
 
 # Currency Agent A2A Example
 
-This example demonstrates connecting to a third-party A2A service, the LangGraph-based currency agent, to perform currency conversions and financial queries with time-based context.
+This example demonstrates a per-user workflow connecting to a third-party A2A service, the LangGraph-based currency agent, to perform currency conversions and financial queries with time-based context.
 
 ## Key Features
 
+- **Per-User A2A Client**: Each user gets isolated A2A client connections to external services
 - **External A2A Integration**: Connects to a third-party LangGraph currency agent
 - **Hybrid Tool Architecture**: Combines A2A currency tools with MCP time services
 - **Simple Real-world Use Case**: Currency conversion with historical date context
+- **Multi-User Support**: Demonstrates user isolation with different session cookies
 
 ## Architecture Overview
 
@@ -118,17 +120,65 @@ nat run --config_file examples/A2A/currency_agent_a2a/configs/config.yml \
 
 For comprehensive examples, see [`data/sample_queries.json`](data/sample_queries.json).
 
+## Per-User Workflow Architecture
+
+This example uses a **per-user workflow** pattern because A2A clients are per-user function groups:
+
+**Why Per-User for External Services?**
+- Each user gets isolated connections to the external A2A service
+- Independent session state and request tracking per user
+- Protection against rate limits affecting other users
+- Supports per-user authentication if the external service requires it
+
+**Implementation**:
+The example uses `per_user_react_agent`, which is the per-user version of the ReAct agent:
+- Each user gets their own isolated ReAct agent instance
+- Gets per-user A2A client tools for the external currency service
+- Each user maintains separate connections to the third-party service
+- Built-in support for per-user function groups like A2A clients
+
+**Multi-User Testing**:
+When using `nat serve`, test with different session cookies:
+
+```bash
+# User "alice" queries currency rates
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -H "Cookie: nat-session=alice" \
+  -d '{"messages": [{"role": "user", "content": "What is the EUR to USD rate?"}]}'
+
+# User "hatter" queries independently (separate connection)
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -H "Cookie: nat-session=hatter" \
+  -d '{"messages": [{"role": "user", "content": "Convert 100 GBP to JPY"}]}'
+```
+
 ## Configuration Details
+
+### Workflow Configuration
+
+The workflow is configured to use the core per-user ReAct agent:
+
+```yaml
+workflow:
+  _type: per_user_react_agent  # Per-user ReAct agent
+  tool_names:
+    - mcp_date_time.get_current_time_mcp_tool
+    - currency_agent  # Per-user A2A client to external service
+  llm_name: nim_llm
+```
 
 ### Tool Composition
 
 The configuration demonstrates two types of tool integration:
 
-1. **A2A Client Tools** (`currency_agent`):
+1. **A2A Client Tools** (`currency_agent`) - **Per-User**:
    - Connects to external LangGraph currency agent
+   - Each user gets isolated connection to the external service
    - Provides currency conversion and exchange rate queries
 
-2. **MCP Client Tools** (`mcp_date_time`):
+2. **MCP Client Tools** (`mcp_date_time`) - **Shared**:
    - Local MCP server for time operations
    - Provides: `get_current_time_mcp_tool` function
 

--- a/examples/A2A/currency_agent_a2a/README.md
+++ b/examples/A2A/currency_agent_a2a/README.md
@@ -124,35 +124,8 @@ For comprehensive examples, see [`data/sample_queries.json`](data/sample_queries
 
 This example uses a **per-user workflow** pattern because A2A clients are per-user function groups:
 
-**Why Per-User for External Services?**
 - Each user gets isolated connections to the external A2A service
 - Independent session state and request tracking per user
-- Protection against rate limits affecting other users
-- Supports per-user authentication if the external service requires it
-
-**Implementation**:
-The example uses `per_user_react_agent`, which is the per-user version of the ReAct agent:
-- Each user gets their own isolated ReAct agent instance
-- Gets per-user A2A client tools for the external currency service
-- Each user maintains separate connections to the third-party service
-- Built-in support for per-user function groups like A2A clients
-
-**Multi-User Testing**:
-When using `nat serve`, test with different session cookies:
-
-```bash
-# User "alice" queries currency rates
-curl -X POST http://localhost:8000/generate \
-  -H "Content-Type: application/json" \
-  -H "Cookie: nat-session=alice" \
-  -d '{"messages": [{"role": "user", "content": "What is the EUR to USD rate?"}]}'
-
-# User "hatter" queries independently (separate connection)
-curl -X POST http://localhost:8000/generate \
-  -H "Content-Type: application/json" \
-  -H "Cookie: nat-session=hatter" \
-  -d '{"messages": [{"role": "user", "content": "Convert 100 GBP to JPY"}]}'
-```
 
 ## Configuration Details
 

--- a/examples/A2A/currency_agent_a2a/configs/config.yml
+++ b/examples/A2A/currency_agent_a2a/configs/config.yml
@@ -40,10 +40,10 @@ llms:
     max_tokens: 1024
 
 workflow:
-  _type: react_agent
+  _type: per_user_react_agent
   tool_names:
     - mcp_date_time.get_current_time_mcp_tool
-    - currency_agent
+    - currency_agent  # External A2A service (per-user)
   llm_name: nim_llm
   verbose: true
   retry_parsing_errors: true

--- a/examples/A2A/math_assistant_a2a/README.md
+++ b/examples/A2A/math_assistant_a2a/README.md
@@ -16,13 +16,15 @@ limitations under the License.
 
 # Math Assistant A2A Example
 
-This example demonstrates a math assistant that connects to a NAT-based calculator server while integrating with local tools, showcasing end-to-end NAT-to-NAT A2A communication with hybrid tool composition.
+This example demonstrates a per-user math assistant workflow that connects to a NAT-based calculator server while integrating with local tools, showcasing end-to-end NAT-to-NAT A2A communication with per-user isolation and hybrid tool composition.
 
 ## Key Features
 
+- **Per-User A2A Client**: Each user gets isolated A2A client connections with separate authentication and session state
 - **A2A Protocol Integration**: Connects to a remote NAT calculator workflow via A2A protocol
 - **Hybrid Tool Architecture**: Combines remote A2A tools with local MCP and custom functions
-- **OAuth2 Authentication**: Optional OAuth2-protected A2A server setup for secure agent-to-agent communication
+- **OAuth2 Authentication**: Optional OAuth2-protected A2A server setup for secure per-user agent-to-agent communication
+- **Multi-User Support**: Demonstrates user isolation with different session cookies
 
 ## Architecture Overview
 
@@ -105,6 +107,46 @@ nat run --config_file examples/A2A/math_assistant_a2a/configs/config.yml \
 
 For comprehensive examples demonstrating different capabilities (basic calculations, time-integrated math, multi-step problems), see [`data/sample_queries.json`](data/sample_queries.json).
 
+
+## Per-User Workflow Architecture
+
+This example uses a **per-user workflow** pattern because A2A clients are per-user function groups:
+
+**Why Per-User?**
+- Each user gets isolated A2A client connections
+- Separate authentication credentials per user (important for OAuth2)
+- Independent session state and task tracking
+- No interference between users
+
+**Implementation**:
+The example uses `per_user_react_agent`, which is the per-user version of the ReAct agent:
+- Each user gets their own isolated ReAct agent instance
+- Gets per-user A2A client tools via the builder
+- Provides the same interface as the shared `react_agent` but with per-user isolation
+- Built-in support for per-user function groups like A2A clients
+
+**Multi-User Testing**:
+When using `nat serve`, different users are identified by the `nat-session` cookie:
+
+```bash
+# Start the math assistant as a server on terminal 1
+nat serve --config_file examples/A2A/math_assistant_a2a/configs/config.yml
+```
+
+```bash
+# User "alice" makes a request on terminal 2
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -H "Cookie: nat-session=alice" \
+  -d '{"messages": [{"role": "user", "content": "Is the sum of 5 and 3 greater than the current hour of the day?"}]}' | jq
+
+# User "hatter" makes a request on terminal 2 (isolated from alice)
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -H "Cookie: nat-session=hatter" \
+  -d '{"messages": [{"role": "user", "content": "Is the product of 3 and 2 greater than the current hour of the day?"}]}' | jq
+```
+
 ## OAuth2 Protected Setup
 
 For production scenarios requiring authentication:
@@ -124,21 +166,37 @@ This setup uses the OAuth2-enabled configuration (`configs/config-client-oauth2.
 ### Available Configurations
 
 - **`config.yml`**: Basic setup with unprotected calculator server
-- **`config-client-oauth2.yml`**: OAuth2-protected setup (requires Keycloak - see [OAuth2 guide](oauth2-keycloak-setup.md))
+- **`config-client-oauth2.yml`**: OAuth2-protected setup with per-user authentication (requires Keycloak - see [OAuth2 guide](oauth2-keycloak-setup.md))
+
+### Workflow Configuration
+
+The workflow is configured to use the core per-user ReAct agent:
+
+```yaml
+workflow:
+  _type: per_user_react_agent  # Per-user ReAct agent
+  tool_names:
+    - calculator_a2a  # Per-user A2A client
+    - mcp_time.get_current_time_mcp
+    - logic_evaluator.if_then_else
+    - logic_evaluator.evaluate_condition
+  llm_name: nim_llm
+```
 
 ### Tool Composition
 
 The configuration demonstrates three types of tool integration:
 
-1. **A2A Client Tools** (`calculator_a2a`):
+1. **A2A Client Tools** (`calculator_a2a`) - **Per-User**:
    - Connects to remote calculator server
+   - Each user gets isolated connection and authentication
    - Provides: `add`, `subtract`, `multiply`, `divide`, `compare` functions
 
-2. **MCP Client Tools** (`mcp_time`):
+2. **MCP Client Tools** (`mcp_time`) - **Shared**:
    - Local MCP server for time operations
    - Provides: `get_current_time_mcp` function
 
-3. **Logic Evaluator** (`logic_evaluator`):
+3. **Logic Evaluator** (`logic_evaluator`) - **Shared**:
    - Simple local utility for logical operations
    - Provides: `if_then_else` and `evaluate_condition` functions
 

--- a/examples/A2A/math_assistant_a2a/README.md
+++ b/examples/A2A/math_assistant_a2a/README.md
@@ -112,20 +112,20 @@ For comprehensive examples demonstrating different capabilities (basic calculati
 
 This example uses a **per-user workflow** pattern because A2A clients are per-user function groups:
 
-**Why Per-User?**
+### Why Per-User?
 - Each user gets isolated A2A client connections
 - Separate authentication credentials per user (important for OAuth2)
 - Independent session state and task tracking
 - No interference between users
 
-**Implementation**:
+### Implementation
 The example uses `per_user_react_agent`, which is the per-user version of the ReAct agent:
 - Each user gets their own isolated ReAct agent instance
 - Gets per-user A2A client tools via the builder
 - Provides the same interface as the shared `react_agent` but with per-user isolation
 - Built-in support for per-user function groups like A2A clients
 
-**Multi-User Testing**:
+### Multi-User Testing
 When using `nat serve`, different users are identified by the `nat-session` cookie:
 
 ```bash
@@ -134,17 +134,38 @@ nat serve --config_file examples/A2A/math_assistant_a2a/configs/config.yml
 ```
 
 ```bash
-# User "alice" makes a request on terminal 2
+# User "Alice" makes a request on terminal 2
 curl -X POST http://localhost:8000/generate \
   -H "Content-Type: application/json" \
-  -H "Cookie: nat-session=alice" \
+  -H "Cookie: nat-session=Alice" \
   -d '{"messages": [{"role": "user", "content": "Is the sum of 5 and 3 greater than the current hour of the day?"}]}' | jq
 
-# User "hatter" makes a request on terminal 2 (isolated from alice)
+# User "Hatter" makes a requ est on terminal 2 (isolated from Alice)
 curl -X POST http://localhost:8000/generate \
   -H "Content-Type: application/json" \
-  -H "Cookie: nat-session=hatter" \
+  -H "Cookie: nat-session=Hatter" \
   -d '{"messages": [{"role": "user", "content": "Is the product of 3 and 2 greater than the current hour of the day?"}]}' | jq
+```
+#### Testing with the UI
+
+1. Start the UI by following the instructions in the [Launching the UI](../../../docs/source/run-workflows/launching-ui.md) documentation.
+
+2. Connect to the UI at `http://localhost:3000`
+
+3. Enable WebSocket mode in the UI by toggling the WebSocket button on the top right corner of the UI.
+
+:::important
+Per-user workflows are not supported in HTTP mode. You must use WebSocket mode to test multi-user support.
+:::
+
+4. Send a message to the agent by typing in the chat input:
+```text
+Is the sum of 5 and 3 greater than the current hour of the day?
+```
+
+5. The workflow will be instantiated for the user on the first message and agent will respond with the result.
+```text
+Yes, the sum of 5 and 3 is greater than the current hour of the day.
 ```
 
 ## OAuth2 Protected Setup

--- a/examples/A2A/math_assistant_a2a/README.md
+++ b/examples/A2A/math_assistant_a2a/README.md
@@ -140,7 +140,7 @@ curl -X POST http://localhost:8000/generate \
   -H "Cookie: nat-session=Alice" \
   -d '{"messages": [{"role": "user", "content": "Is the sum of 5 and 3 greater than the current hour of the day?"}]}' | jq
 
-# User "Hatter" makes a requ est on terminal 2 (isolated from Alice)
+# User "Hatter" makes a request on terminal 2 (isolated from Alice)
 curl -X POST http://localhost:8000/generate \
   -H "Content-Type: application/json" \
   -H "Cookie: nat-session=Hatter" \

--- a/examples/A2A/math_assistant_a2a/oauth2-keycloak-setup.md
+++ b/examples/A2A/math_assistant_a2a/oauth2-keycloak-setup.md
@@ -329,13 +329,13 @@ In separate terminals or browser tabs:
 curl -X POST http://localhost:8000/generate \
   -H "Content-Type: application/json" \
   -H "Cookie: nat-session=alice" \
-  -d '{"messages": [{"role": "user", "content": "Is the sum of 5 and 3 greater than the current hour of the day?"}]}'
+  -d '{"messages": [{"role": "user", "content": "Is the sum of 5 and 3 greater than the current hour of the day?"}]}' |jq
 
 # User "hatter" - will trigger separate OAuth2 flow for hatter
 curl -X POST http://localhost:8000/generate \
   -H "Content-Type: application/json" \
   -H "Cookie: nat-session=hatter" \
-  -d '{"messages": [{"role": "user", "content": "Is the product of 3 and 2 greater than the current hour of the day?"}]}'
+  -d '{"messages": [{"role": "user", "content": "Is the product of 3 and 2 greater than the current hour of the day?"}]}' |jq
 ```
 
 **Expected behavior:**

--- a/examples/A2A/math_assistant_a2a/oauth2-keycloak-setup.md
+++ b/examples/A2A/math_assistant_a2a/oauth2-keycloak-setup.md
@@ -23,9 +23,10 @@ For architectural overview and authentication concepts, see the [A2A Authenticat
 ## What You'll Build
 
 - **Protected A2A Server**: Calculator service that requires OAuth2 authentication
-- **A2A Client**: Math assistant that authenticates and calls the calculator
+- **Per-User A2A Client**: Math assistant with isolated OAuth2 credentials per user
 - **OAuth2 Flow**: Complete authorization code flow with JWT validation
 - **Custom Scopes**: Resource-specific permissions (for example, `calculator_a2a_execute`)
+- **Multi-User Support**: Each user gets their own OAuth2 flow and authentication tokens
 
 This example is designed for **development and testing**. See [Production Considerations](#production-considerations) for deployment guidance.
 
@@ -67,9 +68,10 @@ graph TB
 **Components Overview:**
 
 1. **NAT Math Assistant (Client)**
-   - NAT workflow that needs calculator operations
+   - Per-user NAT workflow using `per_user_react_agent`
+   - Each user gets isolated A2A client instance with separate OAuth2 credentials
    - Uses A2A client plugin to connect to calculator
-   - Handles user authentication flow via browser
+   - Handles user authentication flow through browser
 
 2. **NAT Calculator A2A Server (Resource Server)**
    - Protected A2A server requiring authentication
@@ -77,14 +79,19 @@ graph TB
    - Validates JWT tokens before processing requests
 
 3. **Keycloak (Authorization Server)**
-   - Test Keycloak OAuth2 server for testing OAuth2-protected A2A servers in NAT.
+   - Test OAuth2 server for testing OAuth2-protected A2A servers in NAT
    - Authenticates users and manages consent
    - Provides JWKS endpoint for token verification
+
+**Per-User Architecture:** Each user identified by `nat-session` cookie gets their own:
+- A2A client connection with isolated state
+- OAuth2 authentication flow and tokens
+- Independent calculator session
 
 
 ## A2A OAuth2 Flow
 
-This example demonstrates the A2A protocol with OAuth 2.1 Authorization Code Flow:
+This example demonstrates the A2A protocol with OAuth 2.1 Authorization Code Flow. This flow executes independently for each user session:
 
 ```mermaid
 sequenceDiagram
@@ -120,11 +127,13 @@ sequenceDiagram
     Resource-->>Client: Calculator result
 ```
 
-**Key Steps:**
+**Key Steps (Per User Session):**
 1. **Agent card discovery** - Client fetches public metadata to discover authentication requirements
 2. **Dynamic authentication** - Client initiates OAuth flow based on agent card security schemes
-3. **Token acquisition** - User authenticates via browser, client obtains JWT token
+3. **Token acquisition** - User authenticates through browser, client obtains JWT token
 4. **Authenticated communication** - Client includes token in A2A requests, server validates JWT
+
+**Per-User Isolation:** Each user identified by `nat-session` cookie goes through this flow independently. Tokens and authentication state are isolated per user, enabling secure multi-user deployments.
 
 ## Prerequisites
 
@@ -304,6 +313,39 @@ Workflow Result:
 --------------------------------------------------
 ```
 
+## Step 7: Test Multi-User OAuth2 (Optional)
+
+The per-user architecture allows each user to have their own OAuth2 authentication. Test this with `nat serve`:
+
+```bash
+# Terminal 2: Start the math assistant as a server
+nat serve --config_file examples/A2A/math_assistant_a2a/configs/config-client-oauth2.yml
+```
+
+In separate terminals or browser tabs:
+
+```bash
+# User "alice" - will trigger OAuth2 flow for alice
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -H "Cookie: nat-session=alice" \
+  -d '{"messages": [{"role": "user", "content": "Is the sum of 5 and 3 greater than the current hour of the day?"}]}'
+
+# User "hatter" - will trigger separate OAuth2 flow for hatter
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -H "Cookie: nat-session=hatter" \
+  -d '{"messages": [{"role": "user", "content": "Is the product of 3 and 2 greater than the current hour of the day?"}]}'
+```
+
+**Expected behavior:**
+- Each new user session triggers its own OAuth2 authorization flow
+- Different users authenticate independently with their own Keycloak credentials
+- Each user maintains separate JWT tokens and calculator sessions
+- User "alice" and "hatter" have completely isolated authentication state
+
+**Note:** The OAuth2 flow will open a browser window for each new user. If you are testing with `curl`, you will need to complete the OAuth2 flow manually in the browser for each user session.
+
 ## Cleanup
 
 To stop and remove Keycloak:
@@ -347,6 +389,23 @@ This setup is for **development and testing only**. For production:
    - Don't use the `master` realm for applications
    - Create dedicated realms per environment (dev, staging, prod)
    - Configure proper user management and authentication policies
+
+### Per-User OAuth2 Considerations
+
+1. **Session Management**
+   - Configure appropriate `per_user_workflow_timeout` for token lifetime
+   - Consider refresh token strategies for long-running user sessions
+   - Implement proper session cleanup to avoid memory leaks
+
+2. **Token Storage**
+   - Each user's OAuth2 tokens are stored in memory per session
+   - Tokens are automatically cleaned up when user sessions expire
+   - Consider persistent token storage for production deployments
+
+3. **Concurrent Users**
+   - Each user maintains independent OAuth2 credentials
+   - Monitor memory usage with many concurrent users
+   - Plan capacity based on expected concurrent user load
 
 ## References
 

--- a/examples/A2A/math_assistant_a2a/oauth2-keycloak-setup.md
+++ b/examples/A2A/math_assistant_a2a/oauth2-keycloak-setup.md
@@ -317,34 +317,40 @@ Workflow Result:
 
 The per-user architecture allows each user to have their own OAuth2 authentication. Test this with `nat serve`:
 
+1. Start the math assistant as a server
 ```bash
 # Terminal 2: Start the math assistant as a server
 nat serve --config_file examples/A2A/math_assistant_a2a/configs/config-client-oauth2.yml
 ```
 
-In separate terminals or browser tabs:
+2. Start the UI by following the instructions in the [Launching the UI](../../../docs/source/run-workflows/launching-ui.md) documentation.
 
-```bash
-# User "alice" - will trigger OAuth2 flow for alice
-curl -X POST http://localhost:8000/generate \
-  -H "Content-Type: application/json" \
-  -H "Cookie: nat-session=alice" \
-  -d '{"messages": [{"role": "user", "content": "Is the sum of 5 and 3 greater than the current hour of the day?"}]}' |jq
+3. Connect to the UI at `http://localhost:3000`
 
-# User "hatter" - will trigger separate OAuth2 flow for hatter
-curl -X POST http://localhost:8000/generate \
-  -H "Content-Type: application/json" \
-  -H "Cookie: nat-session=hatter" \
-  -d '{"messages": [{"role": "user", "content": "Is the product of 3 and 2 greater than the current hour of the day?"}]}' |jq
+4. Enable WebSocket mode in the UI by toggling the WebSocket button on the top right corner of the UI.
+
+:::important
+Per-user workflows are not supported in HTTP mode. You must use WebSocket mode to test multi-user support.
+:::
+
+5. Send a message to the agent by typing in the chat input:
+```text
+Is the sum of 5 and 3 greater than the current hour of the day?
+```
+
+6. The workflow will be instantiated for the user on the first message. The user will be authenticated and the workflow will be executed.
+
+```text
+Workflow Result:
+['Yes, the sum of 5 and 3 is greater than the current hour of the day.']
+--------------------------------------------------
 ```
 
 **Expected behavior:**
 - Each new user session triggers its own OAuth2 authorization flow
 - Different users authenticate independently with their own Keycloak credentials
-- Each user maintains separate JWT tokens and calculator sessions
-- User "alice" and "hatter" have completely isolated authentication state
+- Each user maintains separate JWT tokens and workflow instances
 
-**Note:** The OAuth2 flow will open a browser window for each new user. If you are testing with `curl`, you will need to complete the OAuth2 flow manually in the browser for each user session.
 
 ## Cleanup
 

--- a/examples/A2A/math_assistant_a2a/src/nat_math_assistant_a2a/configs/config-client-oauth2.yml
+++ b/examples/A2A/math_assistant_a2a/src/nat_math_assistant_a2a/configs/config-client-oauth2.yml
@@ -68,9 +68,9 @@ llms:
     max_tokens: 1024
 
 workflow:
-  _type: react_agent
+  _type: per_user_react_agent
   tool_names:
-    - calculator_a2a  # A2A calculator functions
+    - calculator_a2a  # A2A calculator functions (per-user with OAuth2)
     - mcp_time.get_current_time_mcp  # Local time function
     - logic_evaluator.if_then_else  # Conditional logic
     - logic_evaluator.evaluate_condition  # Comparison operations

--- a/examples/A2A/math_assistant_a2a/src/nat_math_assistant_a2a/configs/config.yml
+++ b/examples/A2A/math_assistant_a2a/src/nat_math_assistant_a2a/configs/config.yml
@@ -48,9 +48,9 @@ llms:
     max_tokens: 1024
 
 workflow:
-  _type: react_agent
+  _type: per_user_react_agent
   tool_names:
-    - calculator_a2a  # A2A calculator functions
+    - calculator_a2a  # A2A calculator functions (per-user)
     - mcp_time.get_current_time_mcp  # Local time function
     - logic_evaluator.if_then_else  # Conditional logic
     - logic_evaluator.evaluate_condition  # Comparison operations

--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/auth/credential_service.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/auth/credential_service.py
@@ -52,7 +52,7 @@ class A2ACredentialService(CredentialService):
 
     Args:
         auth_provider: NAT authentication provider instance
-        default_user_id: Default user identifier for authentication (defaults to agent URL)
+        default_user_id: User identifier for authentication (provided by per-user function group)
         agent_card: Agent card containing security scheme definitions
     """
 
@@ -124,7 +124,7 @@ class A2ACredentialService(CredentialService):
 
         Priority order:
         1. sessionId from context.state (for multi-user workflows via nat serve)
-        2. Configured default_user_id (for CLI via nat run, defaults to agent URL)
+        2. Configured default_user_id (provided by per-user function group from builder)
 
         Args:
             context: Client call context

--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/auth/credential_service.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/auth/credential_service.py
@@ -26,6 +26,7 @@ from a2a.types import OAuth2SecurityScheme
 from a2a.types import OpenIdConnectSecurityScheme
 from a2a.types import SecurityScheme
 from nat.authentication.interfaces import AuthProviderBase
+from nat.builder.context import Context
 from nat.data_models.authentication import AuthResult
 from nat.data_models.authentication import BasicAuthCred
 from nat.data_models.authentication import BearerTokenCred
@@ -52,18 +53,15 @@ class A2ACredentialService(CredentialService):
 
     Args:
         auth_provider: NAT authentication provider instance
-        default_user_id: User identifier for authentication (provided by per-user function group)
         agent_card: Agent card containing security scheme definitions
     """
 
     def __init__(
         self,
         auth_provider: AuthProviderBase,
-        default_user_id: str | None = None,
         agent_card: AgentCard | None = None,
     ):
         self._auth_provider = auth_provider
-        self._default_user_id = default_user_id
         self._agent_card = agent_card
         self._cached_auth_result: AuthResult | None = None
         self._auth_lock = asyncio.Lock()
@@ -80,7 +78,7 @@ class A2ACredentialService(CredentialService):
         Retrieve credentials for a security scheme.
 
         This method:
-        1. Extracts user_id from context or uses configured user_id
+        1. Gets user_id from NAT context
         2. Authenticates via NAT auth provider
         3. Handles token expiration and refresh
         4. Maps credentials to the requested security scheme
@@ -92,8 +90,8 @@ class A2ACredentialService(CredentialService):
         Returns:
             Credential string or None if not available
         """
-        # Extract user_id from context if available
-        user_id = self._resolve_user_id(context)
+        # Get user_id from NAT context
+        user_id = Context.get().user_id
 
         # Authenticate and get credentials from NAT provider
         auth_result = await self._authenticate(user_id)
@@ -117,24 +115,6 @@ class A2ACredentialService(CredentialService):
             )
 
         return credential
-
-    def _resolve_user_id(self, context: ClientCallContext | None) -> str | None:
-        """
-        Resolve user ID from context or configuration.
-
-        Priority order:
-        1. sessionId from context.state (for multi-user workflows via nat serve)
-        2. Configured default_user_id (provided by per-user function group from builder)
-
-        Args:
-            context: Client call context
-
-        Returns:
-            User ID string or None
-        """
-        if context and "sessionId" in context.state:
-            return context.state["sessionId"]
-        return self._default_user_id
 
     async def _authenticate(self, user_id: str | None) -> AuthResult | None:
         """

--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_base.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_base.py
@@ -51,7 +51,7 @@ class A2ABaseClient:
         task_timeout: Timeout for task operations (default: 300 seconds)
         streaming: Enable streaming responses (default: True)
         auth_provider: Optional NAT authentication provider for securing requests
-        user_id: Optional user identifier for authentication
+        default_user_id: User identifier for authentication (provided by per-user function group)
     """
 
     def __init__(

--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_base.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_base.py
@@ -51,7 +51,6 @@ class A2ABaseClient:
         task_timeout: Timeout for task operations (default: 300 seconds)
         streaming: Enable streaming responses (default: True)
         auth_provider: Optional NAT authentication provider for securing requests
-        default_user_id: User identifier for authentication (provided by per-user function group)
     """
 
     def __init__(
@@ -61,14 +60,12 @@ class A2ABaseClient:
         task_timeout: timedelta = timedelta(seconds=300),
         streaming: bool = True,
         auth_provider: AuthProviderBase | None = None,
-        default_user_id: str | None = None,
     ):
         self._base_url = base_url
         self._agent_card_path = agent_card_path
         self._task_timeout = task_timeout
         self._streaming = streaming
         self._auth_provider = auth_provider
-        self._default_user_id = default_user_id
 
         self._httpx_client: httpx.AsyncClient | None = None
         self._client: Client | None = None
@@ -103,11 +100,10 @@ class A2ABaseClient:
 
                 credential_service = A2ACredentialService(
                     auth_provider=self._auth_provider,
-                    default_user_id=self._default_user_id,
                     agent_card=self._agent_card,
                 )
                 interceptors.append(AuthInterceptor(credential_service))
-                logger.info("Authentication configured for A2A client (default_user_id: %s)", self._default_user_id)
+                logger.info("Authentication configured for A2A client")
             except ImportError as e:
                 logger.error("Failed to setup authentication: %s", e)
                 raise RuntimeError("Authentication requires a2a-sdk with AuthInterceptor support") from e

--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_config.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_config.py
@@ -17,7 +17,6 @@ from datetime import timedelta
 
 from pydantic import Field
 from pydantic import HttpUrl
-from pydantic import model_validator
 
 from nat.data_models.component_ref import AuthenticationRef
 from nat.data_models.function import FunctionGroupBaseConfig
@@ -36,7 +35,6 @@ class A2AClientConfig(FunctionGroupBaseConfig, name="a2a_client"):
         include_skills_in_description: Include skill details in high-level function description (default: True)
         streaming: Whether to enable streaming support for the A2A client (default: False)
         auth_provider: Optional reference to NAT auth provider for authentication
-        default_user_id: Default user identifier for authentication when no session context is available
     """
 
     url: HttpUrl = Field(
@@ -72,16 +70,3 @@ class A2AClientConfig(FunctionGroupBaseConfig, name="a2a_client"):
         description="Reference to NAT authentication provider for authenticating with the A2A agent. "
         "Supports OAuth2, API Key, HTTP Basic, and other NAT auth providers.",
     )
-
-    default_user_id: str | None = Field(
-        default=None,
-        description="Default user ID for authentication. Defaults to agent URL if not provided. "
-        "Used for CLI workflows and token storage cache key.",
-    )
-
-    @model_validator(mode="after")
-    def _set_default_user_id(self) -> "A2AClientConfig":
-        """Set default_user_id to agent URL if not provided."""
-        if not self.default_user_id:
-            self.default_user_id = str(self.url)
-        return self

--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_impl.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_impl.py
@@ -23,7 +23,7 @@ from pydantic import Field
 
 from nat.builder.function import FunctionGroup
 from nat.builder.workflow_builder import Builder
-from nat.cli.register_workflow import register_function_group
+from nat.cli.register_workflow import register_per_user_function_group
 from nat.plugins.a2a.client.client_base import A2ABaseClient
 from nat.plugins.a2a.client.client_config import A2AClientConfig
 
@@ -303,11 +303,12 @@ class A2AClientFunctionGroup(FunctionGroup):
             yield event
 
 
-@register_function_group(config_type=A2AClientConfig)
+@register_per_user_function_group(config_type=A2AClientConfig)
 async def a2a_client_function_group(config: A2AClientConfig, _builder: Builder):
     """
     Connect to an A2A agent, discover agent card and publish the primary
-    agent function and helper functions.
+    agent function and helper functions. This function group is per-user,
+    meaning each user gets their own isolated instance.
 
     This function group creates a three-level API:
     - High-level: Agent function named after the agent (e.g., dice_agent)

--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_impl.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_impl.py
@@ -73,6 +73,8 @@ class A2AClientFunctionGroup(FunctionGroup):
         # Get user_id from context (set by runtime for per-user function groups)
         from nat.builder.context import Context
         user_id = Context.get().user_id
+        if not user_id:
+            raise RuntimeError("User ID not found in context")
 
         # Resolve auth provider if configured
         auth_provider: AuthProviderBase | None = None
@@ -91,7 +93,6 @@ class A2AClientFunctionGroup(FunctionGroup):
             task_timeout=config.task_timeout,
             streaming=config.streaming,
             auth_provider=auth_provider,
-            default_user_id=user_id,
         )
         await self._client.__aenter__()
 

--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_impl.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/client/client_impl.py
@@ -70,6 +70,10 @@ class A2AClientFunctionGroup(FunctionGroup):
         config: A2AClientConfig = self._config  # type: ignore[assignment]
         base_url = str(config.url)
 
+        # Get user_id from context (set by runtime for per-user function groups)
+        from nat.builder.context import Context
+        user_id = Context.get().user_id
+
         # Resolve auth provider if configured
         auth_provider: AuthProviderBase | None = None
         if config.auth_provider:
@@ -87,14 +91,14 @@ class A2AClientFunctionGroup(FunctionGroup):
             task_timeout=config.task_timeout,
             streaming=config.streaming,
             auth_provider=auth_provider,
-            default_user_id=config.default_user_id,
+            default_user_id=user_id,
         )
         await self._client.__aenter__()
 
         if auth_provider:
-            logger.info("Connected to A2A agent at %s with authentication", base_url)
+            logger.info("Connected to A2A agent at %s with authentication (user_id: %s)", base_url, user_id)
         else:
-            logger.info("Connected to A2A agent at %s", base_url)
+            logger.info("Connected to A2A agent at %s (user_id: %s)", base_url, user_id)
 
         # Discover agent card and register functions
         self._register_functions()

--- a/tests/nat/a2a/auth/test_credential_service.py
+++ b/tests/nat/a2a/auth/test_credential_service.py
@@ -179,11 +179,19 @@ async def test_bearer_token_mapping(scheme_name,
     card = sample_agent_card({scheme_name: scheme})
     service = A2ACredentialService(
         auth_provider=provider,
-        default_user_id="test-user",
         agent_card=card,
     )
 
-    credential = await service.get_credentials(scheme_name, None)
+    # Mock the Context to return a user_id
+    from unittest.mock import patch
+
+    # Create a simple object with user_id attribute
+    class MockUserContext:
+        user_id = "test-user"
+
+    with patch('nat.builder.context.Context') as mock_context:
+        mock_context.get.return_value = MockUserContext()
+        credential = await service.get_credentials(scheme_name, None)
 
     assert credential == token_value
     assert provider.authenticate_called_with == ["test-user"]
@@ -197,7 +205,11 @@ async def test_header_credential_with_api_key_scheme(api_key_scheme, mock_auth_p
     card = sample_agent_card({"api_key": api_key_scheme})
     service = A2ACredentialService(auth_provider=provider, agent_card=card)
 
-    credential = await service.get_credentials("api_key", None)
+    # Mock the Context to return a user_id
+    from unittest.mock import patch
+    with patch('nat.builder.context.Context') as mock_context:
+        mock_context.get.return_value.user_id = "test-user"
+        credential = await service.get_credentials("api_key", None)
 
     assert credential == "test-api-key"
 
@@ -230,15 +242,19 @@ async def test_token_expiration_triggers_reauthentication(oauth2_scheme, mock_au
     card = sample_agent_card({"oauth": oauth2_scheme})
     service = A2ACredentialService(auth_provider=provider, agent_card=card)
 
-    # First call: gets and caches expired token (provider's responsibility to return valid tokens)
-    credential1 = await service.get_credentials("oauth", None)
-    assert credential1 == "expired-token"
-    assert call_count[0] == 1
+    # Mock the Context to return a user_id
+    from unittest.mock import patch
+    with patch('nat.builder.context.Context') as mock_context:
+        mock_context.get.return_value.user_id = "test-user"
+        # First call: gets and caches expired token (provider's responsibility to return valid tokens)
+        credential1 = await service.get_credentials("oauth", None)
+        assert credential1 == "expired-token"
+        assert call_count[0] == 1
 
-    # Second call: detects cache is expired, re-authenticates and gets fresh token
-    credential2 = await service.get_credentials("oauth", None)
-    assert credential2 == "fresh-token"
-    assert call_count[0] == 2
+        # Second call: detects cache is expired, re-authenticates and gets fresh token
+        credential2 = await service.get_credentials("oauth", None)
+        assert credential2 == "fresh-token"
+        assert call_count[0] == 2
 
 
 async def test_credential_caching(oauth2_scheme, mock_auth_provider, sample_agent_card):
@@ -252,8 +268,12 @@ async def test_credential_caching(oauth2_scheme, mock_auth_provider, sample_agen
     card = sample_agent_card({"oauth": oauth2_scheme})
     service = A2ACredentialService(auth_provider=provider, agent_card=card)
 
-    credential1 = await service.get_credentials("oauth", None)
-    credential2 = await service.get_credentials("oauth", None)
+    # Mock the Context to return a user_id
+    from unittest.mock import patch
+    with patch('nat.builder.context.Context') as mock_context:
+        mock_context.get.return_value.user_id = "test-user"
+        credential1 = await service.get_credentials("oauth", None)
+        credential2 = await service.get_credentials("oauth", None)
 
     assert credential1 == credential2 == "cached-token"
     assert len(provider.authenticate_called_with) == 1  # Only called once
@@ -265,19 +285,22 @@ async def test_credential_caching(oauth2_scheme, mock_auth_provider, sample_agen
 
 
 async def test_user_id_from_context(oauth2_scheme, mock_auth_provider, sample_agent_card):
-    """Test user_id is extracted from ClientCallContext."""
+    """Test user_id is extracted from NAT Context."""
     auth_result = AuthResult(credentials=[BearerTokenCred(token=SecretStr("test-token"))])
     provider = mock_auth_provider("MockOAuth2Provider", auth_result)
 
     card = sample_agent_card({"oauth": oauth2_scheme})
     service = A2ACredentialService(
         auth_provider=provider,
-        default_user_id="default-user",
         agent_card=card,
     )
 
-    context = ClientCallContext(state={"sessionId": "context-user"})
-    credential = await service.get_credentials("oauth", context)
+    # Mock the Context to return a user_id
+    from unittest.mock import patch
+    with patch('nat.builder.context.Context') as mock_context:
+        mock_context.get.return_value.user_id = "context-user"
+        context = ClientCallContext(state={"sessionId": "context-user"})
+        credential = await service.get_credentials("oauth", context)
 
     assert credential == "test-token"
     assert provider.authenticate_called_with == ["context-user"]
@@ -296,7 +319,11 @@ async def test_missing_security_scheme_returns_none(mock_auth_provider, sample_a
     card = sample_agent_card({})
     service = A2ACredentialService(auth_provider=provider, agent_card=card)
 
-    credential = await service.get_credentials("nonexistent", None)
+    # Mock the Context to return a user_id
+    from unittest.mock import patch
+    with patch('nat.builder.context.Context') as mock_context:
+        mock_context.get.return_value.user_id = "test-user"
+        credential = await service.get_credentials("nonexistent", None)
 
     assert credential is None
 
@@ -308,7 +335,11 @@ async def test_authentication_failure_returns_none(oauth2_scheme, mock_auth_prov
     card = sample_agent_card({"oauth": oauth2_scheme})
     service = A2ACredentialService(auth_provider=provider, agent_card=card)
 
-    credential = await service.get_credentials("oauth", None)
+    # Mock the Context to return a user_id
+    from unittest.mock import patch
+    with patch('nat.builder.context.Context') as mock_context:
+        mock_context.get.return_value.user_id = "test-user"
+        credential = await service.get_credentials("oauth", None)
 
     assert credential is None
 
@@ -349,7 +380,6 @@ def test_provider_validation(provider_name,
     if should_pass:
         service = A2ACredentialService(
             auth_provider=provider,
-            default_user_id="test-user",
             agent_card=card,
         )
         assert service is not None
@@ -357,7 +387,6 @@ def test_provider_validation(provider_name,
         with pytest.raises(ValueError, match="not compatible with agent's security requirements"):
             A2ACredentialService(
                 auth_provider=provider,
-                default_user_id="test-user",
                 agent_card=card,
             )
 
@@ -376,7 +405,6 @@ def test_validation_skipped_when_no_schemes(agent_card_config, mock_auth_provide
     card = sample_agent_card(agent_card_config) if agent_card_config is not None else None
     service = A2ACredentialService(
         auth_provider=provider,
-        default_user_id="test-user",
         agent_card=card,
     )
 

--- a/tests/nat/a2a/auth/test_credential_service.py
+++ b/tests/nat/a2a/auth/test_credential_service.py
@@ -189,7 +189,7 @@ async def test_bearer_token_mapping(scheme_name,
     class MockUserContext:
         user_id = "test-user"
 
-    with patch('nat.builder.context.Context') as mock_context:
+    with patch('nat.plugins.a2a.auth.credential_service.Context') as mock_context:
         mock_context.get.return_value = MockUserContext()
         credential = await service.get_credentials(scheme_name, None)
 
@@ -297,8 +297,13 @@ async def test_user_id_from_context(oauth2_scheme, mock_auth_provider, sample_ag
 
     # Mock the Context to return a user_id
     from unittest.mock import patch
-    with patch('nat.builder.context.Context') as mock_context:
-        mock_context.get.return_value.user_id = "context-user"
+
+    # Create a simple object with user_id attribute
+    class MockUserContext:
+        user_id = "context-user"
+
+    with patch('nat.plugins.a2a.auth.credential_service.Context') as mock_context:
+        mock_context.get.return_value = MockUserContext()
         context = ClientCallContext(state={"sessionId": "context-user"})
         credential = await service.get_credentials("oauth", context)
 

--- a/tests/nat/a2a/auth/test_credential_service.py
+++ b/tests/nat/a2a/auth/test_credential_service.py
@@ -18,6 +18,7 @@ from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
 from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 from a2a.client import ClientCallContext
@@ -165,12 +166,15 @@ def sample_agent_card():
                              ("oidc", "oidc_scheme", "test-id-token"),
                              ("http_bearer", "http_bearer_scheme", "test-bearer-token"),
                          ])
-async def test_bearer_token_mapping(scheme_name,
-                                    scheme_fixture,
-                                    token_value,
-                                    request,
-                                    mock_auth_provider,
-                                    sample_agent_card):
+async def test_bearer_token_mapping(
+    scheme_name,
+    scheme_fixture,
+    token_value,
+    request,
+    mock_auth_provider,
+    sample_agent_card,
+    mock_user_context,
+):
     """Test BearerTokenCred maps to various bearer-compatible schemes."""
     scheme = request.getfixturevalue(scheme_fixture)
     auth_result = AuthResult(credentials=[BearerTokenCred(token=SecretStr(token_value))])
@@ -183,14 +187,8 @@ async def test_bearer_token_mapping(scheme_name,
     )
 
     # Mock the Context to return a user_id
-    from unittest.mock import patch
-
-    # Create a simple object with user_id attribute
-    class MockUserContext:
-        user_id = "test-user"
-
     with patch('nat.plugins.a2a.auth.credential_service.Context') as mock_context:
-        mock_context.get.return_value = MockUserContext()
+        mock_context.get.return_value = mock_user_context
         credential = await service.get_credentials(scheme_name, None)
 
     assert credential == token_value
@@ -206,8 +204,7 @@ async def test_header_credential_with_api_key_scheme(api_key_scheme, mock_auth_p
     service = A2ACredentialService(auth_provider=provider, agent_card=card)
 
     # Mock the Context to return a user_id
-    from unittest.mock import patch
-    with patch('nat.builder.context.Context') as mock_context:
+    with patch('nat.plugins.a2a.auth.credential_service.Context') as mock_context:
         mock_context.get.return_value.user_id = "test-user"
         credential = await service.get_credentials("api_key", None)
 
@@ -243,8 +240,7 @@ async def test_token_expiration_triggers_reauthentication(oauth2_scheme, mock_au
     service = A2ACredentialService(auth_provider=provider, agent_card=card)
 
     # Mock the Context to return a user_id
-    from unittest.mock import patch
-    with patch('nat.builder.context.Context') as mock_context:
+    with patch('nat.plugins.a2a.auth.credential_service.Context') as mock_context:
         mock_context.get.return_value.user_id = "test-user"
         # First call: gets and caches expired token (provider's responsibility to return valid tokens)
         credential1 = await service.get_credentials("oauth", None)
@@ -269,8 +265,7 @@ async def test_credential_caching(oauth2_scheme, mock_auth_provider, sample_agen
     service = A2ACredentialService(auth_provider=provider, agent_card=card)
 
     # Mock the Context to return a user_id
-    from unittest.mock import patch
-    with patch('nat.builder.context.Context') as mock_context:
+    with patch('nat.plugins.a2a.auth.credential_service.Context') as mock_context:
         mock_context.get.return_value.user_id = "test-user"
         credential1 = await service.get_credentials("oauth", None)
         credential2 = await service.get_credentials("oauth", None)
@@ -284,7 +279,7 @@ async def test_credential_caching(oauth2_scheme, mock_auth_provider, sample_agen
 # ============================================================================
 
 
-async def test_user_id_from_context(oauth2_scheme, mock_auth_provider, sample_agent_card):
+async def test_user_id_from_context(oauth2_scheme, mock_auth_provider, sample_agent_card, mock_user_context):
     """Test user_id is extracted from NAT Context."""
     auth_result = AuthResult(credentials=[BearerTokenCred(token=SecretStr("test-token"))])
     provider = mock_auth_provider("MockOAuth2Provider", auth_result)
@@ -296,14 +291,12 @@ async def test_user_id_from_context(oauth2_scheme, mock_auth_provider, sample_ag
     )
 
     # Mock the Context to return a user_id
-    from unittest.mock import patch
-
-    # Create a simple object with user_id attribute
-    class MockUserContext:
-        user_id = "context-user"
+    # Override the user_id for this specific test
+    mock_user_context.user_id = "context-user"
 
     with patch('nat.plugins.a2a.auth.credential_service.Context') as mock_context:
-        mock_context.get.return_value = MockUserContext()
+        mock_context.get.return_value = mock_user_context
+        # Note: user_id is sourced from mocked Context.get().user_id, not from the context parameter
         context = ClientCallContext(state={"sessionId": "context-user"})
         credential = await service.get_credentials("oauth", context)
 
@@ -325,8 +318,7 @@ async def test_missing_security_scheme_returns_none(mock_auth_provider, sample_a
     service = A2ACredentialService(auth_provider=provider, agent_card=card)
 
     # Mock the Context to return a user_id
-    from unittest.mock import patch
-    with patch('nat.builder.context.Context') as mock_context:
+    with patch('nat.plugins.a2a.auth.credential_service.Context') as mock_context:
         mock_context.get.return_value.user_id = "test-user"
         credential = await service.get_credentials("nonexistent", None)
 
@@ -341,8 +333,7 @@ async def test_authentication_failure_returns_none(oauth2_scheme, mock_auth_prov
     service = A2ACredentialService(auth_provider=provider, agent_card=card)
 
     # Mock the Context to return a user_id
-    from unittest.mock import patch
-    with patch('nat.builder.context.Context') as mock_context:
+    with patch('nat.plugins.a2a.auth.credential_service.Context') as mock_context:
         mock_context.get.return_value.user_id = "test-user"
         credential = await service.get_credentials("oauth", None)
 

--- a/tests/nat/a2a/client/conftest.py
+++ b/tests/nat/a2a/client/conftest.py
@@ -107,8 +107,11 @@ def fixture_mock_a2a_client(sample_agent_card: AgentCard) -> AsyncMock:
 
 
 @pytest.fixture(name="a2a_function_group")
-async def fixture_a2a_function_group(mock_a2a_client: AsyncMock,
-                                     sample_agent_card: AgentCard) -> tuple[FunctionGroup, AsyncMock]:
+async def fixture_a2a_function_group(
+    mock_a2a_client: AsyncMock,
+    sample_agent_card: AgentCard,
+    mock_user_context,
+) -> tuple[FunctionGroup, AsyncMock]:
     """A2A client function group with mocked agent.
 
     This fixture provides a fully configured A2A client function group
@@ -117,6 +120,7 @@ async def fixture_a2a_function_group(mock_a2a_client: AsyncMock,
     Args:
         mock_a2a_client: Mock A2A client fixture
         sample_agent_card: Sample agent card fixture
+        mock_user_context: Mock user context fixture
 
     Yields:
         Tuple of (function_group, mock_client) for testing
@@ -134,12 +138,8 @@ async def fixture_a2a_function_group(mock_a2a_client: AsyncMock,
         )
 
         # Mock the Context to provide a user_id (required for per-user A2A clients)
-        # Create a simple object with user_id attribute
-        class MockUserContext:
-            user_id = "test-user"
-
         with patch('nat.builder.context.Context') as mock_context:
-            mock_context.get.return_value = MockUserContext()
+            mock_context.get.return_value = mock_user_context
 
             # Create workflow builder and add function group
             async with WorkflowBuilder() as builder:

--- a/tests/nat/a2a/client/conftest.py
+++ b/tests/nat/a2a/client/conftest.py
@@ -133,7 +133,15 @@ async def fixture_a2a_function_group(mock_a2a_client: AsyncMock,
             task_timeout=timedelta(seconds=30),
         )
 
-        # Create workflow builder and add function group
-        async with WorkflowBuilder() as builder:
-            group = await builder.add_function_group("test_agent", config)
-            yield group, mock_class.return_value
+        # Mock the Context to provide a user_id (required for per-user A2A clients)
+        # Create a simple object with user_id attribute
+        class MockUserContext:
+            user_id = "test-user"
+
+        with patch('nat.builder.context.Context') as mock_context:
+            mock_context.get.return_value = MockUserContext()
+
+            # Create workflow builder and add function group
+            async with WorkflowBuilder() as builder:
+                group = await builder.add_function_group("test_agent", config)
+                yield group, mock_class.return_value

--- a/tests/nat/a2a/client/test_client_functionality.py
+++ b/tests/nat/a2a/client/test_client_functionality.py
@@ -85,7 +85,7 @@ class TestA2AClientFunctionality:
         assert call_fn.description is not None
         assert "Test agent for unit tests" in call_fn.description
 
-    async def test_skills_embedded_when_enabled(self, sample_agent_card):
+    async def test_skills_embedded_when_enabled(self, sample_agent_card, mock_user_context):
         """Test skills are embedded in function description when enabled.
 
         Verifies that when include_skills_in_description is True,
@@ -102,12 +102,8 @@ class TestA2AClientFunctionality:
             )
 
             # Mock the Context to provide a user_id
-            # Create a simple object with user_id attribute
-            class MockUserContext:
-                user_id = "test-user"
-
             with patch('nat.builder.context.Context') as mock_context:
-                mock_context.get.return_value = MockUserContext()
+                mock_context.get.return_value = mock_user_context
 
                 async with WorkflowBuilder() as builder:
                     group = await builder.add_function_group("test_agent", config)
@@ -124,7 +120,7 @@ class TestA2AClientFunctionality:
                     assert "add" in description_lower or "multiply" in description_lower \
                         or "datetime" in description_lower
 
-    async def test_skills_not_embedded_when_disabled(self, sample_agent_card):
+    async def test_skills_not_embedded_when_disabled(self, sample_agent_card, mock_user_context):
         """Test skills are not embedded when disabled.
 
         Verifies that when include_skills_in_description is False,
@@ -141,12 +137,8 @@ class TestA2AClientFunctionality:
             )
 
             # Mock the Context to provide a user_id
-            # Create a simple object with user_id attribute
-            class MockUserContext:
-                user_id = "test-user"
-
             with patch('nat.builder.context.Context') as mock_context:
-                mock_context.get.return_value = MockUserContext()
+                mock_context.get.return_value = mock_user_context
 
                 async with WorkflowBuilder() as builder:
                     group = await builder.add_function_group("test_agent", config)
@@ -191,7 +183,7 @@ class TestA2AClientFunctionality:
         # Verify skill count
         assert result["num_skills"] == 3
 
-    async def test_client_connection_configuration(self, sample_agent_card):
+    async def test_client_connection_configuration(self, sample_agent_card, mock_user_context):
         """Test client connection configuration is properly set.
 
         Verifies that the client is initialized with the correct
@@ -205,12 +197,8 @@ class TestA2AClientFunctionality:
             config = A2AClientConfig(url="http://localhost:10000", task_timeout=60.0)
 
             # Mock the Context to provide a user_id
-            # Create a simple object with user_id attribute
-            class MockUserContext:
-                user_id = "test-user"
-
             with patch('nat.builder.context.Context') as mock_context:
-                mock_context.get.return_value = MockUserContext()
+                mock_context.get.return_value = mock_user_context
 
                 async with WorkflowBuilder() as builder:
                     group = await builder.add_function_group("test_agent", config)
@@ -224,12 +212,11 @@ class TestA2AClientFunctionality:
                 # URL gets normalized with trailing slash
                 assert call_kwargs['base_url'] == "http://localhost:10000/"
                 # Timeout is converted to timedelta
-                from datetime import timedelta
                 assert call_kwargs['task_timeout'] == timedelta(seconds=60)
                 # Default A2A agent card path
                 assert call_kwargs['agent_card_path'] == '/.well-known/agent-card.json'
 
-    async def test_client_timeout_configuration(self, sample_agent_card):
+    async def test_client_timeout_configuration(self, sample_agent_card, mock_user_context):
         """Test client timeout can be configured.
 
         Verifies that the task_timeout configuration is properly
@@ -249,12 +236,8 @@ class TestA2AClientFunctionality:
             assert config.task_timeout.total_seconds() == 60
 
             # Mock the Context to provide a user_id
-            # Create a simple object with user_id attribute
-            class MockUserContext:
-                user_id = "test-user"
-
             with patch('nat.builder.context.Context') as mock_context:
-                mock_context.get.return_value = MockUserContext()
+                mock_context.get.return_value = mock_user_context
 
                 async with WorkflowBuilder() as builder:
                     group = await builder.add_function_group("test_agent", config)

--- a/tests/nat/a2a/client/test_client_functionality.py
+++ b/tests/nat/a2a/client/test_client_functionality.py
@@ -121,7 +121,8 @@ class TestA2AClientFunctionality:
 
                     # Verify skill names or descriptions appear
                     description_lower = call_fn.description.lower()
-                    assert "add" in description_lower or "multiply" in description_lower or "datetime" in description_lower
+                    assert "add" in description_lower or "multiply" in description_lower \
+                        or "datetime" in description_lower
 
     async def test_skills_not_embedded_when_disabled(self, sample_agent_card):
         """Test skills are not embedded when disabled.

--- a/tests/nat/a2a/client/test_client_functionality.py
+++ b/tests/nat/a2a/client/test_client_functionality.py
@@ -101,19 +101,27 @@ class TestA2AClientFunctionality:
                 include_skills_in_description=True,
             )
 
-            async with WorkflowBuilder() as builder:
-                group = await builder.add_function_group("test_agent", config)
-                functions = await group.get_accessible_functions()
+            # Mock the Context to provide a user_id
+            # Create a simple object with user_id attribute
+            class MockUserContext:
+                user_id = "test-user"
 
-                call_fn = functions["test_agent.call"]
+            with patch('nat.builder.context.Context') as mock_context:
+                mock_context.get.return_value = MockUserContext()
 
-                # Verify skills are embedded in description
-                # The description should mention the skills/capabilities
-                assert "Capabilities" in call_fn.description or "Skills" in call_fn.description
+                async with WorkflowBuilder() as builder:
+                    group = await builder.add_function_group("test_agent", config)
+                    functions = await group.get_accessible_functions()
 
-                # Verify skill names or descriptions appear
-                description_lower = call_fn.description.lower()
-                assert "add" in description_lower or "multiply" in description_lower or "datetime" in description_lower
+                    call_fn = functions["test_agent.call"]
+
+                    # Verify skills are embedded in description
+                    # The description should mention the skills/capabilities
+                    assert "Capabilities" in call_fn.description or "Skills" in call_fn.description
+
+                    # Verify skill names or descriptions appear
+                    description_lower = call_fn.description.lower()
+                    assert "add" in description_lower or "multiply" in description_lower or "datetime" in description_lower
 
     async def test_skills_not_embedded_when_disabled(self, sample_agent_card):
         """Test skills are not embedded when disabled.
@@ -131,18 +139,26 @@ class TestA2AClientFunctionality:
                 include_skills_in_description=False,
             )
 
-            async with WorkflowBuilder() as builder:
-                group = await builder.add_function_group("test_agent", config)
-                functions = await group.get_accessible_functions()
+            # Mock the Context to provide a user_id
+            # Create a simple object with user_id attribute
+            class MockUserContext:
+                user_id = "test-user"
 
-                call_fn = functions["test_agent.call"]
+            with patch('nat.builder.context.Context') as mock_context:
+                mock_context.get.return_value = MockUserContext()
 
-                # Verify description is shorter when skills not embedded
-                # (it should still have a description, just without skill details)
-                assert len(call_fn.description) > 0
+                async with WorkflowBuilder() as builder:
+                    group = await builder.add_function_group("test_agent", config)
+                    functions = await group.get_accessible_functions()
 
-                # The description should be more generic
-                # (not checking for absence of specific terms as format may vary)
+                    call_fn = functions["test_agent.call"]
+
+                    # Verify description is shorter when skills not embedded
+                    # (it should still have a description, just without skill details)
+                    assert len(call_fn.description) > 0
+
+                    # The description should be more generic
+                    # (not checking for absence of specific terms as format may vary)
 
     async def test_get_info_returns_agent_metadata(self, a2a_function_group):
         """Test get_info returns correct agent metadata.
@@ -187,22 +203,30 @@ class TestA2AClientFunctionality:
 
             config = A2AClientConfig(url="http://localhost:10000", task_timeout=60.0)
 
-            async with WorkflowBuilder() as builder:
-                group = await builder.add_function_group("test_agent", config)
+            # Mock the Context to provide a user_id
+            # Create a simple object with user_id attribute
+            class MockUserContext:
+                user_id = "test-user"
 
-            # Verify function group was created
-            assert group is not None
+            with patch('nat.builder.context.Context') as mock_context:
+                mock_context.get.return_value = MockUserContext()
 
-            # Verify A2ABaseClient was instantiated with correct parameters
-            mock_class.assert_called_once()
-            call_kwargs = mock_class.call_args.kwargs
-            # URL gets normalized with trailing slash
-            assert call_kwargs['base_url'] == "http://localhost:10000/"
-            # Timeout is converted to timedelta
-            from datetime import timedelta
-            assert call_kwargs['task_timeout'] == timedelta(seconds=60)
-            # Default A2A agent card path
-            assert call_kwargs['agent_card_path'] == '/.well-known/agent-card.json'
+                async with WorkflowBuilder() as builder:
+                    group = await builder.add_function_group("test_agent", config)
+
+                # Verify function group was created
+                assert group is not None
+
+                # Verify A2ABaseClient was instantiated with correct parameters
+                mock_class.assert_called_once()
+                call_kwargs = mock_class.call_args.kwargs
+                # URL gets normalized with trailing slash
+                assert call_kwargs['base_url'] == "http://localhost:10000/"
+                # Timeout is converted to timedelta
+                from datetime import timedelta
+                assert call_kwargs['task_timeout'] == timedelta(seconds=60)
+                # Default A2A agent card path
+                assert call_kwargs['agent_card_path'] == '/.well-known/agent-card.json'
 
     async def test_client_timeout_configuration(self, sample_agent_card):
         """Test client timeout can be configured.
@@ -223,13 +247,21 @@ class TestA2AClientFunctionality:
             # Verify timeout is set correctly
             assert config.task_timeout.total_seconds() == 60
 
-            async with WorkflowBuilder() as builder:
-                group = await builder.add_function_group("test_agent", config)
+            # Mock the Context to provide a user_id
+            # Create a simple object with user_id attribute
+            class MockUserContext:
+                user_id = "test-user"
 
-                # Verify group was created successfully
-                assert group is not None
-                functions = await group.get_accessible_functions()
-                assert len(functions) == 7
+            with patch('nat.builder.context.Context') as mock_context:
+                mock_context.get.return_value = MockUserContext()
+
+                async with WorkflowBuilder() as builder:
+                    group = await builder.add_function_group("test_agent", config)
+
+                    # Verify group was created successfully
+                    assert group is not None
+                    functions = await group.get_accessible_functions()
+                    assert len(functions) == 7
 
     async def test_multiple_functions_accessible(self, a2a_function_group):
         """Test multiple functions are accessible from function group.

--- a/tests/nat/a2a/conftest.py
+++ b/tests/nat/a2a/conftest.py
@@ -1,0 +1,37 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared fixtures for A2A tests."""
+
+import pytest
+
+
+class MockUserContext:
+    """Mock user context for testing.
+
+    This simple mock provides a user_id attribute for testing
+    Context-dependent functionality without requiring full Context setup.
+    """
+
+    user_id: str = "test-user"
+
+
+@pytest.fixture(name="mock_user_context")
+def fixture_mock_user_context() -> MockUserContext:
+    """Fixture providing a mock user context.
+
+    Returns:
+        MockUserContext with default test user ID
+    """
+    return MockUserContext()


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enforced per-user A2A behavior: A2A clients and function groups are per-user, providing isolated connections, per-user authentication, and independent sessions for multi-user workflows.

* **Documentation**
  * Updated guides, examples, and READMEs to use per-user workflow types, per-user OAuth2/config snippets, and per-user vs. shared tool roles; added multi-user testing steps.

* **Configuration**
  * Removed default-user fallback: authentication now requires per-user runtime context for credentials.

* **Tests**
  * Test suites updated to mock and validate per-user context and multi-user scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->