### PR TITLE
Remove `default_user_id` from `GeneralConfig` to prevent unsafe per-user workflow sharing

### DIFF
--- a/src/nat/cli/commands/evaluate.py
+++ b/src/nat/cli/commands/evaluate.py
@@ -195,16 +195,19 @@ def process_nat_eval(
                                "have a partially completed dataset.")
 
     # Create the configuration object
-    config = EvaluationRunConfig(
-        config_file=config_file,
-        dataset=str(dataset) if dataset else None,
-        result_json_path=result_json_path,
-        skip_workflow=skip_workflow,
-        skip_completed_entries=skip_completed_entries,
-        endpoint=endpoint,
-        endpoint_timeout=endpoint_timeout,
-        reps=reps,
-        override=override,
-        user_id=user_id,
-    )
+    # Only include user_id if explicitly provided via CLI, otherwise use the default
+    config_kwargs = {
+        "config_file": config_file,
+        "dataset": str(dataset) if dataset else None,
+        "result_json_path": result_json_path,
+        "skip_workflow": skip_workflow,
+        "skip_completed_entries": skip_completed_entries,
+        "endpoint": endpoint,
+        "endpoint_timeout": endpoint_timeout,
+        "reps": reps,
+        "override": override,
+    }
+    if user_id is not None:
+        config_kwargs["user_id"] = user_id
+    config = EvaluationRunConfig(**config_kwargs)
     asyncio.run(run_and_evaluate(config))

--- a/src/nat/data_models/config.py
+++ b/src/nat/data_models/config.py
@@ -215,12 +215,6 @@ class GeneralConfig(BaseModel):
 
     telemetry: TelemetryConfig = TelemetryConfig()
 
-    default_user_id: str = Field(
-        default="default_user_id",
-        description="Default user ID for per-user workflows when "
-        "no session is available (for example, when using 'nat run'). This value identifies "
-        "the workflow instances. For multi-user deployments with 'nat serve', the 'nat-session' "
-        "cookie overrides this value. Must be a non-empty string when used as a fallback user ID.")
     per_user_workflow_timeout: timedelta = Field(
         default=timedelta(minutes=30),
         description="Time after which inactive per-user workflows are cleaned up. "

--- a/src/nat/eval/config.py
+++ b/src/nat/eval/config.py
@@ -46,8 +46,8 @@ class EvaluationRunConfig(BaseModel):
     num_passes: int = 0
     # timeout for waiting for trace export tasks to complete
     export_timeout: float = 60.0
-    # User ID to use for workflow session
-    user_id: str | None = None
+    # User ID to use for workflow session. Defaults to 'nat_eval_user_id'.
+    user_id: str = "nat_eval_user_id"
 
 
 class EvaluationRunOutput(BaseModel):

--- a/src/nat/front_ends/console/console_front_end_config.py
+++ b/src/nat/front_ends/console/console_front_end_config.py
@@ -30,4 +30,6 @@ class ConsoleFrontEndConfig(FrontEndBaseConfig, name="console"):
                                           description="A single input to submit the the workflow.")
     input_file: Path | None = Field(default=None,
                                     description="Path to a json file of inputs to submit to the workflow.")
-    user_id: str | None = Field(default=None, description="User ID to use for the workflow session.")
+    user_id: str = Field(default="nat_run_user_id",
+                         description="User ID to use for the workflow session. "
+                         "Defaults to 'nat_run_user_id' for single-user CLI execution.")

--- a/src/nat/runtime/session.py
+++ b/src/nat/runtime/session.py
@@ -438,17 +438,12 @@ class SessionManager:
         builder_info: PerUserBuilderInfo | None = None
 
         if self._is_workflow_per_user:
-            # Resolve user_id: explicit param > context > default
+            # Resolve user_id: explicit param > context
             if user_id is None:
                 user_id = self._get_user_id_from_context()
             if user_id is None:
-                user_id = self._config.general.default_user_id
-                if user_id:
-                    logger.info(f"Using default_user_id='{user_id}' for per-user workflow")
-            if user_id is None:
                 raise ValueError("user_id is required for per-user workflow but could not be determined. "
-                                 "Ensure 'nat-session' cookie is set, pass user_id explicitly, or set "
-                                 "'general.default_user_id' in config.")
+                                 "Ensure 'nat-session' cookie is set or pass user_id explicitly.")
 
             # Get or create per-user builder
             logger.debug(f"Getting or creating per-user builder for user {user_id}")

--- a/tests/nat/runtime/test_session_manager.py
+++ b/tests/nat/runtime/test_session_manager.py
@@ -116,7 +116,6 @@ def create_mock_config(is_per_user: bool = False) -> Config:
     config.general = MagicMock(spec=GeneralConfig)
     config.general.per_user_workflow_timeout = timedelta(minutes=30)
     config.general.per_user_workflow_cleanup_interval = timedelta(minutes=5)
-    config.general.default_user_id = None
     config.workflow = MagicMock()
     return config
 
@@ -361,7 +360,7 @@ class TestSessionManagerSession:
                             entry_function=None,
                             shared_workflow=None)
 
-        with pytest.raises(ValueError, match="user_id is required for per-user workflow"):
+        with pytest.raises(ValueError, match="user_id is required for per-user workflow but could not be determined"):
             async with sm.session():
                 pass
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

The `default_user_id` field in `GeneralConfig` was designed to support single-user use cases like `nat run` and `nat eval` with per-user workflow lazy instantiation. However, when used with `nat serve`, this configuration is unsafe—if enabled without careful attention, all users would share the same `default_user_id`, causing requests from multiple users to unintentionally use the same workflow instance.

- For `nat run` and `nat eval`: Add a `user_id` field to their respective configs (`ConsoleFrontEndConfig` and `EvaluationRunConfig`) with explicit default values (`nat_run_user_id` and `nat_eval_user_id`), making it clear these are single-user contexts.
- For nat serve (per-user lazy init): Extract the `user_id` from the request context (via `nat-session` cookie). If no `user_id` can be determined, fail the per-user function/function group initialization and reject the request.

With this change, HTTP requests to per-user workflows via nat serve will be rejected if no `nat-session` cookie is set, since the `user_id` cannot be determined. This ensures multi-user deployments don't accidentally share workflow state.

This PR is breaking since it removes the `default_user_id` field from `GeneralConfig`. The impact should be small since the field was just added in recent [PR-1206](https://github.com/NVIDIA/NeMo-Agent-Toolkit/pull/1206).


Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Clearer error message when a workflow user ID cannot be determined.

* **Improvements**
  * User ID handling standardized: fields now have concrete defaults for CLI/evaluation runs, reducing ambiguous missing values and simplifying initialization.
  * Session resolution prefers explicit user_id and fails fast if still unset.

* **Chores**
  * Removed legacy fallback default user ID from configuration to streamline settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->