### PR TITLE
Mark wheels with a beta tag as `ready`

### DIFF
--- a/ci/scripts/gitlab/common.sh
+++ b/ci/scripts/gitlab/common.sh
@@ -58,7 +58,7 @@ function is_current_commit_release_tagged() {
         local is_pre_release=0
 
         # Ensure we don't have a dev or alpha tag
-        if [[ ! (${GIT_TAG} =~ "-dev" || ${GIT_TAG} =~ "a") ]]; then
+        if [[ ${GIT_TAG} =~ "-beta" || (! (${GIT_TAG} =~ "-dev" || ${GIT_TAG} =~ "a")) ]]; then
             is_tagged=1
         fi
     fi


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release tagging logic to properly recognize and process beta releases in the build pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->