### PR TITLE
Unify the `user_id` adding logic to `context_state` for multiple CLI commands

### DIFF
--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -24,7 +24,6 @@ from uuid import uuid4
 from pydantic import BaseModel
 from tqdm import tqdm
 
-from nat.builder.context import ContextState
 from nat.data_models.evaluate import EvalConfig
 from nat.data_models.evaluate import JobEvictionPolicy
 from nat.data_models.runtime_enum import RuntimeTypeEnum
@@ -170,14 +169,9 @@ class EvaluationRun:
             if stop_event.is_set():
                 return "", []
 
-            # Set user_id in context if provided
-            user_id_token = None
-            if self.config.user_id:
-                user_id_token = ContextState().user_id.set(self.config.user_id)
-
-            try:
-                async with session_manager.run(item.input_obj, runtime_type=RuntimeTypeEnum.EVALUATE) as runner:
-                    if not session_manager.workflow.has_single_output:
+            async with session_manager.session(user_id=self.config.user_id) as session:
+                async with session.run(item.input_obj, runtime_type=RuntimeTypeEnum.EVALUATE) as runner:
+                    if not session.workflow.has_single_output:
                         # raise an error if the workflow has multiple outputs
                         raise NotImplementedError("Multiple outputs are not supported")
 
@@ -234,10 +228,6 @@ class EvaluationRun:
 
                     self.weave_eval.log_prediction(item, output)
                     await self.weave_eval.log_usage_stats(item, usage_stats_item)
-            finally:
-                # Reset user_id context if it was set
-                if user_id_token is not None:
-                    ContextState().user_id.reset(user_id_token)
 
         async def wrapped_run(item: EvalInputItem) -> None:
             await run_one(item)

--- a/src/nat/runtime/session.py
+++ b/src/nat/runtime/session.py
@@ -459,6 +459,11 @@ class SessionManager:
             # Use shared semaphore for concurrency control
             semaphore = self._semaphore
 
+        # Set user_id in context for unified behavior across nat run/serve/eval
+        token_user_id = None
+        if user_id is not None:
+            token_user_id = self._context_state.user_id.set(user_id)
+
         try:
             session = Session(session_manager=self, user_id=user_id, workflow=workflow, semaphore=semaphore)
 
@@ -470,6 +475,8 @@ class SessionManager:
                     builder_info.ref_count -= 1
                     builder_info.last_activity = datetime.now()
 
+            if token_user_id is not None:
+                self._context_state.user_id.reset(token_user_id)
             if token_user_manager is not None:
                 self._context_state.user_manager.reset(token_user_manager)
             if token_user_input is not None:

--- a/src/nat/runtime/session.py
+++ b/src/nat/runtime/session.py
@@ -445,6 +445,9 @@ class SessionManager:
                 raise ValueError("user_id is required for per-user workflow but could not be determined. "
                                  "Ensure 'nat-session' cookie is set or pass user_id explicitly.")
 
+            # To ensure the user_id is set in the context before the per-user builder is created
+            self._context_state.user_id.set(user_id)
+
             # Get or create per-user builder
             logger.debug(f"Getting or creating per-user builder for user {user_id}")
             _, workflow = await self._get_or_create_per_user_builder(user_id)
@@ -459,7 +462,8 @@ class SessionManager:
             # Use shared semaphore for concurrency control
             semaphore = self._semaphore
 
-        # Set user_id in context for unified behavior across nat run/serve/eval
+        # TODO: this logic needs to be cleaned up since it is a duplicated setting of the user_id
+        # But we need to keep it for now to maintain the token_user_id
         token_user_id = None
         if user_id is not None:
             token_user_id = self._context_state.user_id.set(user_id)

--- a/tests/nat/eval/test_evaluate.py
+++ b/tests/nat/eval/test_evaluate.py
@@ -197,7 +197,18 @@ def session_manager(generated_answer, mock_pull_intermediate):
         """Mock async context manager for runner."""
         yield mock_runner
 
-    session_manager.run = mock_run
+    # Create a mock session with run method
+    mock_session = MagicMock()
+    mock_session.run = mock_run
+    mock_session.workflow = mock_workflow
+
+    # Define an async context manager for session
+    @asynccontextmanager
+    async def mock_session_cm(user_id=None):
+        """Mock async context manager for session."""
+        yield mock_session
+
+    session_manager.session = mock_session_cm
     return session_manager
 
 
@@ -288,7 +299,15 @@ async def test_run_workflow_local_workflow_interrupted(evaluation_run, eval_inpu
         """Mock async context manager for runner."""
         yield mock_error_runner
 
-    session_manager.run = mock_error_run
+    # Get the mock session from session_manager.session and update its run method
+    @asynccontextmanager
+    async def mock_error_session(user_id=None):
+        mock_session = MagicMock()
+        mock_session.run = mock_error_run
+        mock_session.workflow = session_manager.workflow
+        yield mock_session
+
+    session_manager.session = mock_error_session
     # Run the actual function
     # Check if workflow_interrupted is set to True
     await evaluation_run.run_workflow_local(session_manager)


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This PR ensures the `user_id` is always set to the builder's context for `nat run`, `nat eval` and `nat serve` by adding the logic to `SessionManager.session()`. 

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Streamlined internal session management and user context handling in workflow execution.
  * Enhanced session initialization to ensure proper context setup during per-user workflow operations.

* **Tests**
  * Updated session mocking infrastructure to align with improved session handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->