### PR TITLE
Add early exit mechanisms for Sequential Executor

### DIFF
--- a/docs/source/components/agents/sequential-executor/sequential-executor.md
+++ b/docs/source/components/agents/sequential-executor/sequential-executor.md
@@ -39,6 +39,7 @@ workflow:
   _type: sequential_executor
   tool_list: [text_processor, data_analyzer, report_generator]
   raise_type_incompatibility: false
+  return_error_on_exception: false
 ```
 ### Example 2: Sequential Executor as a Function to Configure `config.yml`
 To use the sequential executor as a function, configure the YAML file as follows:
@@ -55,6 +56,7 @@ functions:
     tool_list: [text_processor, data_analyzer, report_generator]
     description: 'A pipeline that processes text through multiple stages'
     raise_type_incompatibility: false
+    return_error_on_exception: false
 ```
 
 ### Example 3: Configure with Tool Execution Settings
@@ -79,6 +81,7 @@ workflow:
     report_generator:
       use_streaming: true
   raise_type_incompatibility: false
+  return_error_on_exception: false
 ```
 
 ### Configurable Options
@@ -87,10 +90,14 @@ workflow:
 
 * `raise_type_incompatibility`: Defaults to `False`. Whether to raise an exception if the type compatibility check fails. The type compatibility check runs before executing the tool list, based on the type annotations of the functions. When set to `True`, any incompatibility immediately raises an exception. When set to `False`, incompatibilities generate warning messages and the sequential executor continues execution. Set this to `False` when functions in the tool list include custom type converters, as the type compatibility check may fail even though the sequential executor can still execute the tool list.
 
+* `return_error_on_exception`: Defaults to `False`. Whether to return an error message instead of raising an exception when a tool fails during execution. When set to `True`, the sequential executor exits early and returns an error message as the workflow output instead of raising the exception. When set to `False`, exceptions are re-raised. Set this to `True` when you want the workflow to gracefully handle uncaught tool failures and immediately return error information to the user.
+
 * `tool_execution_config`: Optional configuration for each tool in the sequential execution tool list. Keys must match the tool names from the `tool_list`.
   - `use_streaming`: Defaults to `False`. Whether to use streaming output for the tool.
 
+### Exceptions
 
+* **{py:class}`~nat.control_flow.sequential_executor.SequentialExecutorExit`**: Raised by a tool to exit the chain early and return a custom message as the workflow output. Unlike `return_error_on_exception` which handles unexpected errors, this exception is for intentional early termination.
 
 ## The Sequential Executor Workflow
 

--- a/examples/control_flow/sequential_executor/README.md
+++ b/examples/control_flow/sequential_executor/README.md
@@ -28,6 +28,7 @@ The NeMo Agent toolkit provides a [`sequential_executor`](../../../src/nat/contr
 - [Configuration](#configuration)
   - [Required Configuration Options](#required-configuration-options)
   - [Optional Configuration Options](#optional-configuration-options)
+  - [Exceptions](#exceptions)
   - [Example Configuration](#example-configuration)
 - [Installation and Setup](#installation-and-setup)
   - [Install this Workflow](#install-this-workflow)
@@ -64,12 +65,17 @@ The following options are required for the sequential executor:
 
 - **`_type`**: Set to `sequential_executor` to use the sequential executor tool
 - **`tool_list`**: List of functions to execute in order (such as `[text_processor, data_analyzer, report_generator]`)
-- **`raise_type_incompatibility`**: Whether to raise an exception if the type compatibility check fails (default: `false`).The type compatibility check runs before executing the tool list, based on the type annotations of the functions. When set to `true`, any incompatibility immediately raises an exception. When set to `false`, incompatibilities generate warning messages and the sequential executor continues execution. Set this to `false` when functions in the tool list include custom type converters, as the type compatibility check may fail even though the sequential executor can still execute the tool list.
+- **`raise_type_incompatibility`**: Whether to raise an exception if the type compatibility check fails (default: `false`). The type compatibility check runs before executing the tool list, based on the type annotations of the functions. When set to `true`, any incompatibility immediately raises an exception. When set to `false`, incompatibilities generate warning messages and the sequential executor continues execution. Set this to `false` when functions in the tool list include custom type converters, as the type compatibility check may fail even though the sequential executor can still execute the tool list.
+- **`return_error_on_exception`**: Whether to return an error message instead of raising an exception when a tool fails during execution (default: `false`). When set to `true`, the sequential executor exits early and returns an error message as the workflow output instead of raising the exception. When set to `false`, exceptions are re-raised. Set this to `true` when you want the workflow to gracefully handle uncaught tool failures and immediately return error information to the user.
 
 ### Optional Configuration Options
 
 - **`tool_execution_config`**: Configuration for each tool in the sequential execution tool list. Keys must match the tool names from the `tool_list`
   - **`use_streaming`**: Whether to use streaming output for the tool (default: `false`)
+
+### Exceptions
+
+- **`SequentialExecutorExit`**: Raised by a tool to exit the chain early and return a custom message as the workflow output. Unlike `return_error_on_exception` which handles unexpected errors, this exception is for intentional early termination. Import from `nat.control_flow.sequential_executor`.
 
 ### Example Configuration
 
@@ -89,6 +95,7 @@ workflow:
   _type: sequential_executor
   tool_list: [text_processor, data_analyzer, report_generator]
   raise_type_incompatibility: false
+  return_error_on_exception: false
 ```
 
 #### Configuration with Tool Execution Settings
@@ -112,6 +119,7 @@ workflow:
     report_generator:
       use_streaming: false
   raise_type_incompatibility: false
+  return_error_on_exception: false
 ```
 
 ## Installation and Setup

--- a/examples/control_flow/sequential_executor/src/nat_sequential_executor/register.py
+++ b/examples/control_flow/sequential_executor/src/nat_sequential_executor/register.py
@@ -157,7 +157,7 @@ async def data_analyzer_function(config: DataAnalyzerFunctionConfig, builder: Bu
 
         except json.JSONDecodeError:
             # Handle invalid JSON input - exit chain early
-            raise SequentialExecutorExit("Invalid input format - cannot proceed")
+            raise SequentialExecutorExit("Invalid input format - cannot proceed") from None
 
     yield FunctionInfo.from_fn(
         analyze_data, description="Analyze processed text data and generate insights about complexity and content")

--- a/examples/control_flow/sequential_executor/src/nat_sequential_executor/register.py
+++ b/examples/control_flow/sequential_executor/src/nat_sequential_executor/register.py
@@ -21,6 +21,7 @@ from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
 from nat.cli.register_workflow import register_function
+from nat.control_flow.sequential_executor import SequentialExecutorExit
 from nat.data_models.function import FunctionBaseConfig
 
 logger = logging.getLogger(__name__)
@@ -155,9 +156,8 @@ async def data_analyzer_function(config: DataAnalyzerFunctionConfig, builder: Bu
             return json.dumps(analysis_results)
 
         except json.JSONDecodeError:
-            # Handle invalid JSON input
-            error_result = {"error": "Invalid input format", "analysis_status": "failed"}
-            return json.dumps(error_result)
+            # Handle invalid JSON input - exit chain early
+            raise SequentialExecutorExit("Invalid input format - cannot proceed")
 
     yield FunctionInfo.from_fn(
         analyze_data, description="Analyze processed text data and generate insights about complexity and content")

--- a/src/nat/control_flow/sequential_executor.py
+++ b/src/nat/control_flow/sequential_executor.py
@@ -32,6 +32,14 @@ from nat.utils.type_utils import DecomposedType
 logger = logging.getLogger(__name__)
 
 
+class SequentialExecutorExit(Exception):
+    """Raised when a tool wants to exit the sequential executor chain early with a custom message."""
+
+    def __init__(self, message: str):
+        self.message = message
+        super().__init__(message)
+
+
 class ToolExecutionConfig(BaseModel):
     """Configuration for individual tool execution within sequential execution."""
 
@@ -153,6 +161,10 @@ async def sequential_execution(config: SequentialExecutorConfig, builder: Builde
                         tool_response = await tool.ainvoke(tool_input)
                 else:
                     tool_response = await tool.ainvoke(tool_input)
+            except SequentialExecutorExit as e:
+                # Tool explicitly requested early exit - always return the message
+                logger.info(f"Tool {tool_name} requested early exit: {e.message}")
+                return e.message
             except Exception as e:
                 logger.error(f"Error with tool {tool_name}: {e}")
                 if config.return_error_on_exception:

--- a/src/nat/control_flow/sequential_executor.py
+++ b/src/nat/control_flow/sequential_executor.py
@@ -54,6 +54,11 @@ class SequentialExecutorConfig(FunctionBaseConfig, name="sequential_executor"):
         "which means the output type of the previous function is compatible with the input type of the next function."
         "If set to True, any incompatibility will raise an exception. If set to false, the incompatibility will only"
         "generate a warning message and the sequential execution will continue.")
+    return_error_on_exception: bool = Field(
+        default=False,
+        description="If set to True, when an uncaught exception occurs during tool execution, the sequential executor "
+        "will exit early and return an error message as the workflow output instead of raising the exception. "
+        "If set to False (default), exceptions are re-raised.")
 
 
 def _get_function_output_type(function: Function, tool_execution_config: dict[str, ToolExecutionConfig]) -> type:
@@ -150,6 +155,10 @@ async def sequential_execution(config: SequentialExecutorConfig, builder: Builde
                     tool_response = await tool.ainvoke(tool_input)
             except Exception as e:
                 logger.error(f"Error with tool {tool_name}: {e}")
+                if config.return_error_on_exception:
+                    # Return error message as workflow output instead of raising exception
+                    error_message = f"Error in {tool_name}: {type(e).__name__}: {str(e)}"
+                    return error_message
                 raise
 
             # The input of the next tool is the response of the previous tool

--- a/src/nat/control_flow/sequential_executor.py
+++ b/src/nat/control_flow/sequential_executor.py
@@ -166,11 +166,12 @@ async def sequential_execution(config: SequentialExecutorConfig, builder: Builde
                 logger.info(f"Tool {tool_name} requested early exit: {e.message}")
                 return e.message
             except Exception as e:
-                logger.error(f"Error with tool {tool_name}: {e}")
                 if config.return_error_on_exception:
                     # Return error message as workflow output instead of raising exception
+                    logger.exception(f"Error with tool {tool_name}, returning error message")
                     error_message = f"Error in {tool_name}: {type(e).__name__}: {str(e)}"
                     return error_message
+                logger.error(f"Error with tool {tool_name}: {e}")
                 raise
 
             # The input of the next tool is the response of the previous tool

--- a/tests/nat/control_flow/test_sequential_executor.py
+++ b/tests/nat/control_flow/test_sequential_executor.py
@@ -528,6 +528,10 @@ class TestSequentialExecution:
                 result = await actual_function("initial_input")  # type: ignore
                 assert result == "Custom exit message"
 
+                # Verify tool3 was never invoked after early exit
+                tool3 = mock_builder.get_tools.return_value[2]
+                assert tool3.__dict__['_call_count'] == 0
+
     @pytest.mark.asyncio
     async def test_empty_tool_list(self, mock_builder):
         """Test handling of empty tool list."""

--- a/tests/nat/control_flow/test_sequential_executor.py
+++ b/tests/nat/control_flow/test_sequential_executor.py
@@ -27,6 +27,7 @@ from nat.builder.builder import Builder
 from nat.builder.function import Function
 from nat.builder.function_info import FunctionInfo
 from nat.control_flow.sequential_executor import SequentialExecutorConfig
+from nat.control_flow.sequential_executor import SequentialExecutorExit
 from nat.control_flow.sequential_executor import ToolExecutionConfig
 from nat.control_flow.sequential_executor import _validate_function_type_compatibility
 from nat.control_flow.sequential_executor import _validate_tool_list_type_compatibility
@@ -141,6 +142,25 @@ class ErrorMockTool(BaseTool):
         raise RuntimeError(self.__dict__['_error_message'])
 
 
+class EarlyExitMockTool(BaseTool):
+    """Mock tool that raises SequentialExecutorExit for testing early exit."""
+
+    name: str = "early_exit_mock_tool"
+    description: str = "A mock tool that exits early"
+
+    def __init__(self, name: str = "early_exit_mock_tool", exit_message: str = "Early exit", **kwargs):
+        super().__init__(**kwargs)
+        self.name = name
+        # Store exit_message in a way that doesn't conflict with Pydantic
+        self.__dict__['_exit_message'] = exit_message
+
+    async def _arun(self, query: typing.Any = None, **kwargs) -> str:
+        raise SequentialExecutorExit(self.__dict__['_exit_message'])
+
+    def _run(self, query: typing.Any = None, **kwargs) -> str:
+        raise SequentialExecutorExit(self.__dict__['_exit_message'])
+
+
 class TestSequentialExecutionToolConfig:
     """Test cases for SequentialExecutionToolConfig."""
 
@@ -151,6 +171,7 @@ class TestSequentialExecutionToolConfig:
         assert config.tool_list == []
         assert config.tool_execution_config == {}
         assert not config.raise_type_incompatibility
+        assert not config.return_error_on_exception
 
     def test_config_with_values(self):
         """Test configuration with custom values."""
@@ -162,11 +183,13 @@ class TestSequentialExecutionToolConfig:
 
         config = SequentialExecutorConfig(tool_list=tool_list,
                                           tool_execution_config=tool_config,
-                                          raise_type_incompatibility=True)
+                                          raise_type_incompatibility=True,
+                                          return_error_on_exception=True)
 
         assert config.tool_list == tool_list
         assert config.tool_execution_config == tool_config
         assert config.raise_type_incompatibility
+        assert config.return_error_on_exception
 
 
 class TestToolExecutionConfig:
@@ -434,6 +457,76 @@ class TestSequentialExecution:
 
                 # Check that warning was logged
                 assert "The sequential executor tool list has incompatible types" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_return_error_on_exception_enabled(self, mock_builder):
+        """Test that errors are returned as messages when return_error_on_exception is True."""
+        # Replace middle tool with error tool
+        error_tool = ErrorMockTool(name="tool2", error_message="Test error")
+        mock_builder.get_tools.return_value = [
+            MockTool(name="tool1", return_value="result1"),
+            error_tool,
+            MockTool(name="tool3", return_value="final_result")
+        ]
+
+        config = SequentialExecutorConfig(tool_list=[FunctionRef("tool1"), FunctionRef("tool2"), FunctionRef("tool3")],
+                                          return_error_on_exception=True)
+
+        with patch('nat.control_flow.sequential_executor._validate_tool_list_type_compatibility',
+                   return_value=(str, str)):
+            async with sequential_execution(config, mock_builder) as function_info:
+                actual_function = function_info.single_fn  # type: ignore
+
+                # Test that the function returns error message instead of raising
+                result = await actual_function("initial_input")  # type: ignore
+                assert "Error in tool2" in result
+                assert "RuntimeError" in result
+                assert "Test error" in result
+
+    @pytest.mark.asyncio
+    async def test_return_error_on_exception_disabled(self, mock_builder):
+        """Test that errors are raised when return_error_on_exception is False (default)."""
+        # Replace middle tool with error tool
+        error_tool = ErrorMockTool(name="tool2", error_message="Test error")
+        mock_builder.get_tools.return_value = [
+            MockTool(name="tool1", return_value="result1"),
+            error_tool,
+            MockTool(name="tool3", return_value="final_result")
+        ]
+
+        config = SequentialExecutorConfig(tool_list=[FunctionRef("tool1"), FunctionRef("tool2"), FunctionRef("tool3")],
+                                          return_error_on_exception=False)
+
+        with patch('nat.control_flow.sequential_executor._validate_tool_list_type_compatibility',
+                   return_value=(str, str)):
+            async with sequential_execution(config, mock_builder) as function_info:
+                actual_function = function_info.single_fn  # type: ignore
+
+                # Test that the function raises the error
+                with pytest.raises(RuntimeError, match="Test error"):
+                    await actual_function("initial_input")  # type: ignore
+
+    @pytest.mark.asyncio
+    async def test_sequential_executor_exit(self, mock_builder):
+        """Test that SequentialExecutorExit causes early exit with custom message."""
+        # Replace middle tool with early exit tool
+        early_exit_tool = EarlyExitMockTool(name="tool2", exit_message="Custom exit message")
+        mock_builder.get_tools.return_value = [
+            MockTool(name="tool1", return_value="result1"),
+            early_exit_tool,
+            MockTool(name="tool3", return_value="final_result")
+        ]
+
+        config = SequentialExecutorConfig(tool_list=[FunctionRef("tool1"), FunctionRef("tool2"), FunctionRef("tool3")])
+
+        with patch('nat.control_flow.sequential_executor._validate_tool_list_type_compatibility',
+                   return_value=(str, str)):
+            async with sequential_execution(config, mock_builder) as function_info:
+                actual_function = function_info.single_fn  # type: ignore
+
+                # Test that the function returns the exit message
+                result = await actual_function("initial_input")  # type: ignore
+                assert result == "Custom exit message"
 
     @pytest.mark.asyncio
     async def test_empty_tool_list(self, mock_builder):

--- a/tests/nat/control_flow/test_sequential_executor.py
+++ b/tests/nat/control_flow/test_sequential_executor.py
@@ -22,6 +22,7 @@ from unittest.mock import patch
 import pytest
 from langchain_core.tools.base import BaseTool
 from pydantic import BaseModel
+from pydantic import PrivateAttr
 
 from nat.builder.builder import Builder
 from nat.builder.function import Function
@@ -128,18 +129,18 @@ class ErrorMockTool(BaseTool):
 
     name: str = "error_mock_tool"
     description: str = "A mock tool that raises errors"
+    _error_message: str = PrivateAttr(default="Mock error")
 
     def __init__(self, name: str = "error_mock_tool", error_message: str = "Mock error", **kwargs):
         super().__init__(**kwargs)
         self.name = name
-        # Store error_message in a way that doesn't conflict with Pydantic
-        self.__dict__['_error_message'] = error_message
+        self._error_message = error_message
 
     async def _arun(self, query: typing.Any = None, **kwargs) -> str:
-        raise RuntimeError(self.__dict__['_error_message'])
+        raise RuntimeError(self._error_message)
 
     def _run(self, query: typing.Any = None, **kwargs) -> str:
-        raise RuntimeError(self.__dict__['_error_message'])
+        raise RuntimeError(self._error_message)
 
 
 class EarlyExitMockTool(BaseTool):
@@ -147,18 +148,18 @@ class EarlyExitMockTool(BaseTool):
 
     name: str = "early_exit_mock_tool"
     description: str = "A mock tool that exits early"
+    _exit_message: str = PrivateAttr(default="Early exit")
 
     def __init__(self, name: str = "early_exit_mock_tool", exit_message: str = "Early exit", **kwargs):
         super().__init__(**kwargs)
         self.name = name
-        # Store exit_message in a way that doesn't conflict with Pydantic
-        self.__dict__['_exit_message'] = exit_message
+        self._exit_message = exit_message
 
     async def _arun(self, query: typing.Any = None, **kwargs) -> str:
-        raise SequentialExecutorExit(self.__dict__['_exit_message'])
+        raise SequentialExecutorExit(self._exit_message)
 
     def _run(self, query: typing.Any = None, **kwargs) -> str:
-        raise SequentialExecutorExit(self.__dict__['_exit_message'])
+        raise SequentialExecutorExit(self._exit_message)
 
 
 class TestSequentialExecutionToolConfig:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR adds two error handling mechanisms to the sequential executor:
1. **return_error_on_exception config option** - When enabled, catches exceptions and returns the error message as the workflow output instead of re-raising, allowing the error to be displayed in the UI.
1. **SequentialExecutorExit exception** - A special exception that tools can raise to explicitly exit the chain early with a custom message. This is always handled regardless of the `return_error_on_exception` setting.

Closes #1288 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added return_error_on_exception configuration to control whether tool errors return an error message or raise an exception.
  * Added SequentialExecutorExit to allow tools to trigger intentional early termination with a custom message.

* **Documentation**
  * Updated docs and examples to include the new option, defaults, usage guidance, and an Exceptions section describing early-exit semantics.

* **Tests**
  * Added tests covering error-return behavior and early-exit flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->