### PR TITLE
Simplify ReAct system prompt to align with LangChain standard

### DIFF
--- a/src/nat/agent/react_agent/prompt.py
+++ b/src/nat/agent/react_agent/prompt.py
@@ -25,7 +25,7 @@ Use the following format:
 Question: the input question you must answer
 Thought: you should always think about what to do
 Action: the action to take, should be one of [{tool_names}]
-Action Input: the input to the action
+Action Input: the input to the action (if no input is required, use "None")
 Observation: the result of the action
 ... (this Thought/Action/Action Input/Observation can repeat N times)
 Thought: I now know the final answer

--- a/src/nat/agent/react_agent/prompt.py
+++ b/src/nat/agent/react_agent/prompt.py
@@ -16,22 +16,18 @@
 # flake8: noqa
 
 SYSTEM_PROMPT = """
-Answer the following questions as best you can. You may ask the human to use the following tools:
+Answer the following questions as best you can. You have access to the following tools:
 
 {tools}
 
-You may respond in one of two formats.
-Use the following format exactly to ask the human to use a tool:
+Use the following format:
 
 Question: the input question you must answer
 Thought: you should always think about what to do
 Action: the action to take, should be one of [{tool_names}]
-Action Input: the input to the action (if there is no required input, include "Action Input: None")
-Observation: wait for the human to respond with the result from the tool, do not assume the response
-
-... (this Thought/Action/Action Input/Observation can repeat N times. If you do not need to use a tool, or after asking the human to use any tools and waiting for the human to respond, you might know the final answer.)
-Use the following format once you have the final answer:
-
+Action Input: the input to the action
+Observation: the result of the action
+... (this Thought/Action/Action Input/Observation can repeat N times)
 Thought: I now know the final answer
 Final Answer: the final answer to the original input question
 """


### PR DESCRIPTION
## Description

The original prompt used non-standard "human intermediary" framing. The new prompt matches the LangChain MRKL format, which is the industry standard that modern LLMs are trained on.

Closes #1295

- Simplifies the ReAct agent system prompt to align with the standard LangChain ReAct format.
- What changed:
- Replaced "You may ask the human to use the following tools" → "You have access to the following tools"
- Replaced verbose observation instruction → "Observation: the result of the action"
- Removed unnecessary "Action Input: None" instruction
- Streamlined format instructions

I tested it and all ReAct agent unit tests pass 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified agent system instructions to state tool availability more directly.
  * Reduced and clarified prompt guidance, removing repetitive scaffolding while keeping the final answer flow.
  * Streamlined action/input/observation format for clearer, more consistent user-facing interactions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->