### PR TITLE
dynamo unit test patch and cleanup

### DIFF
--- a/examples/dynamo_integration/data/raw/banking/tools.json
+++ b/examples/dynamo_integration/data/raw/banking/tools.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0146cdfbb72b6f1b51f5836fb613fd16aed965454cfbe7a8f321e242b6febbbb
+size 47306

--- a/examples/dynamo_integration/react_benchmark_agent/tests/test_self_evaluation.py
+++ b/examples/dynamo_integration/react_benchmark_agent/tests/test_self_evaluation.py
@@ -325,7 +325,6 @@ Please try again, addressing the issues identified above.
         assert "Tips: Test tip" in feedback
 
 
-@pytest.mark.slow
 @pytest.mark.integration
 class TestSelfEvaluatingAgentWithNIM:
     """

--- a/examples/dynamo_integration/react_benchmark_agent/tests/test_self_evaluation.py
+++ b/examples/dynamo_integration/react_benchmark_agent/tests/test_self_evaluation.py
@@ -371,7 +371,6 @@ class TestSelfEvaluatingAgentWithNIM:
 
         return temp_config
 
-    @pytest.mark.asyncio
     async def test_self_evaluation_workflow_loads_with_nim(self, nim_self_eval_config):
         """Test that the self-evaluation workflow can be loaded with NIM backend."""
         from nat.builder.workflow_builder import WorkflowBuilder
@@ -383,7 +382,6 @@ class TestSelfEvaluatingAgentWithNIM:
             workflow = builder.get_workflow()
             assert workflow is not None
 
-    @pytest.mark.asyncio
     async def test_self_evaluation_rethinking_with_nim(self, nim_self_eval_config):
         """
         Test the self-evaluation re-thinking mechanism with NIM.
@@ -410,7 +408,6 @@ class TestSelfEvaluatingAgentWithNIM:
             assert result is not None
             assert len(result) > 0, "Expected non-empty response from self-evaluating agent"
 
-    @pytest.mark.asyncio
     async def test_self_evaluation_complex_question_with_nim(self, nim_self_eval_config):
         """
         Test self-evaluation with a more complex multi-step question.

--- a/examples/dynamo_integration/react_benchmark_agent/tests/test_tool_intent_buffer.py
+++ b/examples/dynamo_integration/react_benchmark_agent/tests/test_tool_intent_buffer.py
@@ -287,7 +287,6 @@ class TestPermissiveToolInput:
 class TestCreateToolStubFunction:
     """Test create_tool_stub_function."""
 
-    @pytest.mark.asyncio
     async def test_stub_records_intent(self):
         """Test that tool stub records intent to buffer."""
         from react_benchmark_agent.tool_intent_stubs import create_tool_stub_function
@@ -315,7 +314,6 @@ class TestCreateToolStubFunction:
         # Check response
         assert result == "Test response"
 
-    @pytest.mark.asyncio
     async def test_stub_filters_none_values(self):
         """Test that tool stub filters out None parameter values."""
         from react_benchmark_agent.tool_intent_stubs import create_tool_stub_function
@@ -331,7 +329,6 @@ class TestCreateToolStubFunction:
         assert "none_param" not in intents[0]["parameters"]
         assert intents[0]["parameters"] == {"valid": "value", "another": "data"}
 
-    @pytest.mark.asyncio
     async def test_stub_handles_nested_params(self):
         """Test that tool stub handles nested 'params' dict from LangChain."""
         from react_benchmark_agent.tool_intent_stubs import create_tool_stub_function


### PR DESCRIPTION
## Description
Fix unit test failure for dynamo example by adding the tools.json file so workflow can be instantiated. Remove overlapping run_slow and run_integration where run_slow not needed. Remove pytest asyncio decorators that were not needed.
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added new banking tools data file to the repository infrastructure.

* **Tests**
  * Updated test configuration by removing deprecated pytest markers from test suite.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->