### PR TITLE
Add rules to try and catch a bug where `default=''` is used for a `SecretStr` field

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -73,6 +73,14 @@ reviews:
           and should contain an Apache License 2.0 header comment at the top of each file.
         - Confirm that copyright years are up-to date whenever a file is changed.
 
+        # Common Bugs to Look For
+        - Pydantic models using one of the `SecretStr`, `SerializableSecretStr`, or `OptionalSecretStr` with a default
+          defined as `default=""`, creates a bug where the field will be initialized as `str` and not as an instance of
+          `SecretStr`. Instead, use `default=None` for optional secret fields such as `OptionalSecretStr` or with a
+          `default_factory=lambda: SerializableSecretStr("")` for non-optional secret fields such as `SerializableSecretStr`.
+          The `default_factory` approach is preferred for non-optional secret fields to ensure that the field is always
+          returns a unique instance.
+
     - path: "docs/source/**/*"
       instructions: >-
         This directory contains the source code for the documentation. All documentation should be written in Markdown

--- a/.cursor/rules/general.mdc
+++ b/.cursor/rules/general.mdc
@@ -85,6 +85,13 @@ These are the overarching standards that every **source, test, documentation and
 - When re-raising exceptions: use bare `raise` statements to maintain the original stack trace, and use `logger.error()` for logging (not `logger.exception()`) to avoid duplicate stack trace output.
 - When catching and logging exceptions without re-raising: always use `logger.exception()` (equivalent to `logger.error(exc_info=True)`) to capture the full stack trace information.
 
+
+## Common Bugs to Avoid
+
+- **Pydantic SecretStr defaults**: Pydantic models using `SecretStr`, `SerializableSecretStr`, or `OptionalSecretStr` with `default=""` creates a bug where the field is initialized as `str` instead of a `SecretStr` instance. Instead:
+  - For optional secret fields (e.g., `OptionalSecretStr`): use `default=None`
+  - For non-optional secret fields (e.g., `SerializableSecretStr`): use `default_factory=lambda: SerializableSecretStr("")` to ensure each instance gets a unique `SecretStr` object
+
 ## Documentation
 
 - Provide Google-style docstrings for every public module, class, function and CLI command.


### PR DESCRIPTION
## Description:
* Add coderabbit & cursor rules to try and catch a bug where `default=''` is used for a `SecretStr` field

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new "Common Bugs to Look For" section with guidance on handling secret/optional fields and recommended default patterns to avoid common pitfalls.
  * Fixed and duplicated placement of that guidance (one accidental repeat).
  * Expanded documentation quality and style requirements (concise summaries, code formatting, sync expectations, and automated checks).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->