### PR TITLE
Fix base64 image support in ChatRequest to match OpenAI API specification

### DIFF
--- a/src/nat/data_models/api_server.py
+++ b/src/nat/data_models/api_server.py
@@ -24,7 +24,6 @@ from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Discriminator
 from pydantic import Field
-from pydantic import HttpUrl
 from pydantic import conlist
 from pydantic import field_serializer
 from pydantic import field_validator
@@ -90,7 +89,8 @@ class AudioContent(BaseModel):
 
 
 class ImageUrl(BaseModel):
-    url: HttpUrl = HttpUrl(url="http://default.com")
+    url: str = Field(default="http://default.com",
+                     description="Either a URL of the image or the base64 encoded image data.")
 
 
 class ImageContent(BaseModel):


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

This PR fixes NAT's OpenAI Chat Completions API implementation to properly support base64-encoded images in the `data:image/*;base64,...` format. The root issue was that `ImageUrl.url` was typed as Pydantic's `HttpUrl`, which only accepts http/https schemes and rejects data URIs. This has been changed to plain `str` to match OpenAI's official implementation, which accepts both regular URLs and base64-encoded data URIs. The fix enables full compatibility with OpenAI's vision API and allows the NAT UI's base64 image encoding to work end-to-end. All changes are backward compatible - HTTP/HTTPS URLs continue to work as before.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified image URL field structure to improve handling and default value management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->