### PR TITLE
Fix: add parent-child lineage to trace/span exporter attributes

### DIFF
--- a/examples/observability/simple_calculator_observability/README.md
+++ b/examples/observability/simple_calculator_observability/README.md
@@ -77,6 +77,33 @@ Phoenix provides local tracing capabilities perfect for development and testing.
 
 4. Open your browser to `http://localhost:6006` to explore traces in the Phoenix UI.
 
+### Phoenix Tracing with Nested Tool Calls
+
+This configuration demonstrates **parent-child span tracking** for nested tool calls. The `power_of_two` tool internally calls `calculator.multiply`, creating a hierarchy that you can filter in Phoenix.
+
+1. Run the workflow with nested tool tracing:
+
+    ```bash
+    nat run --config_file examples/observability/simple_calculator_observability/configs/config-phoenix-nested.yml --input "What is 5 squared?"
+    ```
+
+2. In Phoenix UI (`http://localhost:6006`), you can filter spans by their parent:
+
+    | Span Attribute | Value | Description |
+    |----------------|-------|-------------|
+    | `nat.function.parent_name` | `react_agent` | Shows only agent-selected tools |
+    | `nat.function.parent_name` | `power_of_two` | Shows nested tool calls |
+
+3. Expected span hierarchy:
+
+    ```
+    react_agent (root)
+    └── power_of_two (parent: react_agent)
+        └── calculator.multiply (parent: power_of_two)
+    ```
+
+This is useful for filtering out internal tool calls when analyzing agent behavior, allowing you to focus on only the tools the agent directly selected.
+
 ### File-Based Tracing
 
 For simple local development and debugging, you can export traces directly to a local file without requiring any external services.
@@ -305,6 +332,7 @@ The example includes multiple configuration files for different observability pl
 | Configuration File | Platform | Best For |
 |-------------------|----------|----------|
 | `config-phoenix.yml` | Phoenix | Tracing with Phoenix |
+| `config-phoenix-nested.yml` | Phoenix | Testing parent-child span tracking with nested tool calls |
 | `config-otel-file.yml` | File Export | Local file-based tracing for development and debugging |
 | `config-langfuse.yml` | Langfuse | Langfuse monitoring and analytics |
 | `config-langsmith.yml` | LangSmith | LangChain/LangGraph ecosystem integration |

--- a/examples/observability/simple_calculator_observability/README.md
+++ b/examples/observability/simple_calculator_observability/README.md
@@ -96,7 +96,7 @@ This configuration demonstrates **parent-child span tracking** for nested tool c
 
 3. Expected span hierarchy:
 
-    ```
+    ```text
     react_agent (root)
     └── power_of_two (parent: react_agent)
         └── calculator.multiply (parent: power_of_two)

--- a/examples/observability/simple_calculator_observability/configs/config-phoenix-nested.yml
+++ b/examples/observability/simple_calculator_observability/configs/config-phoenix-nested.yml
@@ -1,0 +1,72 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This config demonstrates NESTED TOOL CALLS for testing parent-child span tracking.
+#
+# The power_of_two tool internally calls calculator.multiply, creating a hierarchy:
+#   react_agent -> power_of_two -> calculator.multiply
+#
+# In Phoenix, you can filter spans by parent:
+#   - nat.function.parent_name = "react_agent" -> shows power_of_two (agent-selected tool)
+#   - nat.function.parent_name = "power_of_two" -> shows calculator.multiply (nested call)
+
+general:
+  telemetry:
+    logging:
+      console:
+        _type: console
+        level: WARN
+      file:
+        _type: file
+        path: ./.tmp/nat_simple_calculator_nested.log
+        level: DEBUG
+    tracing:
+      phoenix:
+        _type: phoenix
+        endpoint: http://localhost:6006/v1/traces
+        project: simple_calculator
+
+  front_end:
+    _type: fastapi
+    cors:
+      allow_origins: ['*']
+
+# The calculator function group provides the underlying multiply function
+function_groups:
+  calculator:
+    _type: calculator
+
+# The power_of_two function wraps calculator.multiply to create nested calls
+functions:
+  power_of_two:
+    _type: power_of_two
+    multiply_fn: calculator.multiply
+
+llms:
+  nim_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
+    temperature: 0.0
+    max_tokens: 1024
+
+workflow:
+  _type: react_agent
+  # Only expose power_of_two to the agent (not the raw calculator tools)
+  # This forces the agent to use power_of_two, which internally calls multiply
+  tool_names: [power_of_two]
+  llm_name: nim_llm
+  verbose: true
+  parse_agent_response_max_retries: 3
+

--- a/examples/observability/simple_calculator_observability/pyproject.toml
+++ b/examples/observability/simple_calculator_observability/pyproject.toml
@@ -3,7 +3,10 @@ build-backend = "setuptools.build_meta"
 requires = ["setuptools >= 64", "setuptools-scm>=8"]
 
 [tool.setuptools]
-packages = []
+package-dir = {"" = "src"}
+
+[tool.setuptools.packages.find]
+where = ["src"]
 
 [tool.setuptools_scm]
 git_describe_command = "git describe --long --first-parent"
@@ -20,6 +23,9 @@ requires-python = ">=3.11,<3.14"
 description = "Simple Calculator Observability - demonstrates NeMo Agent toolkit observability and tracing capabilities"
 keywords = ["ai", "observability", "tracing", "agents"]
 classifiers = ["Programming Language :: Python"]
+
+[project.entry-points."nat.components"]
+nat_simple_calculator_observability = "nat_simple_calculator_observability.register"
 
 [tool.uv.sources]
 nvidia-nat = { path = "../../..", editable = true }

--- a/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/__init__.py
+++ b/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/__init__.py
@@ -12,4 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-

--- a/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/__init__.py
+++ b/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/__init__.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+

--- a/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/register.py
+++ b/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/register.py
@@ -20,6 +20,7 @@ multiply function, creating a nested tool call scenario for testing span lineage
 """
 
 import logging
+from typing import AsyncGenerator
 
 from pydantic import Field
 

--- a/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/register.py
+++ b/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/register.py
@@ -1,0 +1,92 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""
+Nested tool example for testing parent-child span tracking.
+
+This module defines a `power_of_two` tool that internally calls the calculator's
+multiply function, creating a nested tool call scenario for testing span lineage.
+"""
+
+import logging
+
+from pydantic import Field
+
+from nat.builder.builder import Builder
+from nat.builder.function import Function
+from nat.builder.function_info import FunctionInfo
+from nat.cli.register_workflow import register_function
+from nat.data_models.component_ref import FunctionRef
+from nat.data_models.function import FunctionBaseConfig
+
+logger = logging.getLogger(__name__)
+
+
+class PowerOfTwoConfig(FunctionBaseConfig, name="power_of_two"):
+    """Configuration for the power_of_two function that wraps calculator.multiply."""
+
+    multiply_fn: FunctionRef = Field(
+        default=FunctionRef("calculator.multiply"),
+        description="Reference to the multiply function to use internally.",
+    )
+
+
+@register_function(config_type=PowerOfTwoConfig)
+async def power_of_two_function(config: PowerOfTwoConfig, builder: Builder):
+    """
+    Create a power_of_two function that internally calls calculator.multiply.
+
+    This creates a nested tool call scenario:
+    - react_agent calls power_of_two (parent_name = "react_agent")
+    - power_of_two calls calculator.multiply (parent_name = "power_of_two")
+
+    This allows testing of the parent_id and parent_name span attributes.
+    """
+
+    # Get the multiply function from the calculator function group
+    multiply_fn: Function = await builder.get_function(config.multiply_fn)
+
+    async def _power_of_two(number: float) -> str:
+        """
+        Calculate a number raised to the power of 2 by calling multiply internally.
+
+        This is a wrapper tool that demonstrates nested tool calls.
+        It internally calls the calculator's multiply function.
+
+        Args:
+            number: The number to square (raise to power of 2).
+
+        Returns:
+            A string describing the result of number^2.
+        """
+        logger.info("power_of_two called with number=%s, calling multiply internally", number)
+
+        # Call multiply internally - this creates a nested tool call
+        # The multiply function expects a list of numbers via .ainvoke()
+        # Function objects are not directly callable - use .ainvoke() method
+        result = await multiply_fn.ainvoke({"numbers": [number, number]})
+
+        logger.info("multiply returned result=%s", result)
+
+        return f"The power of 2 of {number} is {result} (computed via nested multiply call)"
+
+    yield FunctionInfo.from_fn(
+        _power_of_two,
+        description=(
+            "Calculate a number raised to the power of 2. "
+            "This tool internally calls the multiply function, creating a nested tool call."
+        ),
+    )
+

--- a/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/register.py
+++ b/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/register.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 Nested tool example for testing parent-child span tracking.
 
@@ -84,9 +83,6 @@ async def power_of_two_function(config: PowerOfTwoConfig, builder: Builder):
 
     yield FunctionInfo.from_fn(
         _power_of_two,
-        description=(
-            "Calculate a number raised to the power of 2. "
-            "This tool internally calls the multiply function, creating a nested tool call."
-        ),
+        description=("Calculate a number raised to the power of 2. "
+                     "This tool internally calls the multiply function, creating a nested tool call."),
     )
-

--- a/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/register.py
+++ b/examples/observability/simple_calculator_observability/src/nat_simple_calculator_observability/register.py
@@ -20,7 +20,6 @@ multiply function, creating a nested tool call scenario for testing span lineage
 """
 
 import logging
-from typing import AsyncGenerator
 
 from pydantic import Field
 

--- a/examples/observability/simple_calculator_observability/tests/test_simple_calc_observability.py
+++ b/examples/observability/simple_calculator_observability/tests/test_simple_calc_observability.py
@@ -290,12 +290,13 @@ async def test_nested_span_parent_child_lineage(tmp_path: Path, config_dir: Path
 
     # Replace phoenix tracing with file-based tracing for testability
     config.general.telemetry.tracing = {
-        "otel_file": FileTelemetryExporterConfig(
-            output_path=str(otel_file.absolute()),
-            project="nested_test",
-            mode="append",
-            enable_rolling=False,
-        )
+        "otel_file":
+            FileTelemetryExporterConfig(
+                output_path=str(otel_file.absolute()),
+                project="nested_test",
+                mode="append",
+                enable_rolling=False,
+            )
     }
 
     # Ask a question that requires using power_of_two (which internally calls multiply)
@@ -325,8 +326,7 @@ async def test_nested_span_parent_child_lineage(tmp_path: Path, config_dir: Path
 
     # Verify power_of_two span exists and has correct lineage
     assert "power_of_two" in spans_by_function, (
-        f"power_of_two span not found. Available functions: {list(spans_by_function.keys())}"
-    )
+        f"power_of_two span not found. Available functions: {list(spans_by_function.keys())}")
     power_of_two_span = spans_by_function["power_of_two"]
     power_of_two_ancestry = power_of_two_span.get("function_ancestry", {})
 
@@ -336,15 +336,13 @@ async def test_nested_span_parent_child_lineage(tmp_path: Path, config_dir: Path
 
     # Verify calculator.multiply span exists and has power_of_two as parent
     assert "calculator.multiply" in spans_by_function, (
-        f"calculator.multiply span not found. Available functions: {list(spans_by_function.keys())}"
-    )
+        f"calculator.multiply span not found. Available functions: {list(spans_by_function.keys())}")
     multiply_span = spans_by_function["calculator.multiply"]
     multiply_ancestry = multiply_span.get("function_ancestry", {})
 
     multiply_parent_name = multiply_ancestry.get("parent_name")
     assert multiply_parent_name == "power_of_two", (
-        f"calculator.multiply parent_name should be 'power_of_two', got '{multiply_parent_name}'"
-    )
+        f"calculator.multiply parent_name should be 'power_of_two', got '{multiply_parent_name}'")
 
     # Additionally verify the parent_id linkage is consistent
     power_of_two_id = power_of_two_ancestry.get("function_id")

--- a/examples/observability/simple_calculator_observability/tests/test_simple_calc_observability.py
+++ b/examples/observability/simple_calculator_observability/tests/test_simple_calc_observability.py
@@ -24,6 +24,7 @@ from pathlib import Path
 
 import pytest
 
+from nat.observability.register import FileTelemetryExporterConfig
 from nat.runtime.loader import load_config
 from nat.test.utils import run_workflow
 
@@ -269,3 +270,86 @@ async def test_catalyst_full_workflow(config_dir: Path,
             await asyncio.sleep(0.5)
 
     assert dataset_found
+
+
+@pytest.mark.integration
+async def test_nested_span_parent_child_lineage(tmp_path: Path, config_dir: Path):
+    """
+    Test that nested tool calls correctly track parent-child span lineage.
+
+    This test verifies that when power_of_two internally calls calculator.multiply,
+    the span exports correctly reflect the parent-child relationship:
+    - power_of_two should have parent_name pointing to the react_agent
+    - calculator.multiply should have parent_name = "power_of_two"
+    """
+    otel_file = tmp_path / "otel-nested-trace.jsonl"
+
+    # Load the nested config that has power_of_two -> calculator.multiply
+    config_file = config_dir / "config-phoenix-nested.yml"
+    config = load_config(config_file)
+
+    # Replace phoenix tracing with file-based tracing for testability
+    config.general.telemetry.tracing = {
+        "otel_file": FileTelemetryExporterConfig(
+            output_path=str(otel_file.absolute()),
+            project="nested_test",
+            mode="append",
+            enable_rolling=False,
+        )
+    }
+
+    # Ask a question that requires using power_of_two (which internally calls multiply)
+    nested_question = "What is 5 to the power of 2?"
+    expected_answer = "25"
+
+    await run_workflow(config=config, question=nested_question, expected_answer=expected_answer)
+
+    assert otel_file.exists(), "OTEL trace file was not created"
+
+    # Parse all spans from the trace file
+    spans = []
+    with open(otel_file, encoding="utf-8") as fh:
+        for line in fh:
+            span = json.loads(line)
+            spans.append(span)
+
+    assert len(spans) > 0, "No spans were exported"
+
+    # Build a lookup of spans by function name
+    spans_by_function = {}
+    for span in spans:
+        func_ancestry = span.get("function_ancestry", {})
+        func_name = func_ancestry.get("function_name")
+        if func_name:
+            spans_by_function[func_name] = span
+
+    # Verify power_of_two span exists and has correct lineage
+    assert "power_of_two" in spans_by_function, (
+        f"power_of_two span not found. Available functions: {list(spans_by_function.keys())}"
+    )
+    power_of_two_span = spans_by_function["power_of_two"]
+    power_of_two_ancestry = power_of_two_span.get("function_ancestry", {})
+
+    # power_of_two's parent should be the react_agent (or workflow)
+    power_of_two_parent = power_of_two_ancestry.get("parent_name")
+    assert power_of_two_parent is not None, "power_of_two should have a parent_name"
+
+    # Verify calculator.multiply span exists and has power_of_two as parent
+    assert "calculator.multiply" in spans_by_function, (
+        f"calculator.multiply span not found. Available functions: {list(spans_by_function.keys())}"
+    )
+    multiply_span = spans_by_function["calculator.multiply"]
+    multiply_ancestry = multiply_span.get("function_ancestry", {})
+
+    multiply_parent_name = multiply_ancestry.get("parent_name")
+    assert multiply_parent_name == "power_of_two", (
+        f"calculator.multiply parent_name should be 'power_of_two', got '{multiply_parent_name}'"
+    )
+
+    # Additionally verify the parent_id linkage is consistent
+    power_of_two_id = power_of_two_ancestry.get("function_id")
+    multiply_parent_id = multiply_ancestry.get("parent_id")
+    assert multiply_parent_id == power_of_two_id, (
+        f"calculator.multiply parent_id ({multiply_parent_id}) should match "
+        f"power_of_two function_id ({power_of_two_id})"
+    )

--- a/src/nat/observability/exporter/span_exporter.py
+++ b/src/nat/observability/exporter/span_exporter.py
@@ -174,6 +174,10 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
                 event.function_ancestry.function_id if event.function_ancestry else "unknown",
             f"{self._span_prefix}.function.name":
                 event.function_ancestry.function_name if event.function_ancestry else "unknown",
+            f"{self._span_prefix}.function.parent_id":
+                event.function_ancestry.parent_id if event.function_ancestry and event.function_ancestry.parent_id else "unknown",
+            f"{self._span_prefix}.function.parent_name":
+                event.function_ancestry.parent_name if event.function_ancestry and event.function_ancestry.parent_name else "unknown",
             f"{self._span_prefix}.subspan.name":
                 event.payload.name or "",
             f"{self._span_prefix}.event_timestamp":

--- a/src/nat/observability/exporter/span_exporter.py
+++ b/src/nat/observability/exporter/span_exporter.py
@@ -175,9 +175,11 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
             f"{self._span_prefix}.function.name":
                 event.function_ancestry.function_name if event.function_ancestry else "unknown",
             f"{self._span_prefix}.function.parent_id":
-                event.function_ancestry.parent_id if event.function_ancestry and event.function_ancestry.parent_id else "unknown",
+                event.function_ancestry.parent_id
+                if event.function_ancestry and event.function_ancestry.parent_id else "unknown",
             f"{self._span_prefix}.function.parent_name":
-                event.function_ancestry.parent_name if event.function_ancestry and event.function_ancestry.parent_name else "unknown",
+                event.function_ancestry.parent_name
+                if event.function_ancestry and event.function_ancestry.parent_name else "unknown",
             f"{self._span_prefix}.subspan.name":
                 event.payload.name or "",
             f"{self._span_prefix}.event_timestamp":


### PR DESCRIPTION
## Description
This PR adds in a parent-child lineage to trace/span exporting from `IntermediateStep`. It enables us to attribute parent/caller tool hierarchy when we have nested tool-calls to improve the granularity of filtering in phoenix. Example and docs added as needed.

Closes #1225 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Observability now records parent-child span attributes for nested tool calls to improve trace hierarchy and filtering.

* **Documentation**
  * Added a Phoenix tracing guide demonstrating workflow setup, UI filtering, and expected span hierarchies for nested nested tool calls.

* **Chores**
  * Converted example packaging to src layout and registered the example as a discoverable component.

* **Tests**
  * Added an integration test that validates nested span parent-child lineage in emitted traces.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->