### PR TITLE
Fix notebook E2E tests

### DIFF
--- a/packages/nvidia_nat_semantic_kernel/pyproject.toml
+++ b/packages/nvidia_nat_semantic_kernel/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   # Keep sorted!!!
   "nvidia-nat~=1.4",
   "semantic-kernel~=1.35",
-  "ruamel-yaml==0.19.0" # Avoids dependency conflicts introduced with version 0.19.1
+  "ruamel-yaml-clibz==0.3.5" # Avoids an install error `No such file or directory: 'zig'` introduced with version 0.3.6
 ]
 requires-python = ">=3.11,<3.14"
 description = "Subpackage for Semantic-Kernel integration in NeMo Agent toolkit"

--- a/packages/nvidia_nat_semantic_kernel/pyproject.toml
+++ b/packages/nvidia_nat_semantic_kernel/pyproject.toml
@@ -21,8 +21,10 @@ dependencies = [
   # version when adding a new package. If unsure, default to using `~=` instead of `==`. Does not apply to nvidia-nat packages.
   # Keep sorted!!!
   "nvidia-nat~=1.4",
-  "semantic-kernel~=1.35",
-  "ruamel-yaml-clibz==0.3.5" # Avoids an install error `No such file or directory: 'zig'` introduced with version 0.3.6
+  # Avoids an install error `No such file or directory: 'zig'` introduced with version 0.3.6, this is a transitive
+  # dependency, remove the dependency when the issue is resolved in a future release.
+  "ruamel-yaml-clibz==0.3.5", 
+  "semantic-kernel~=1.35"
 ]
 requires-python = ">=3.11,<3.14"
 description = "Subpackage for Semantic-Kernel integration in NeMo Agent toolkit"

--- a/packages/nvidia_nat_semantic_kernel/pyproject.toml
+++ b/packages/nvidia_nat_semantic_kernel/pyproject.toml
@@ -22,6 +22,7 @@ dependencies = [
   # Keep sorted!!!
   "nvidia-nat~=1.4",
   "semantic-kernel~=1.35",
+  "ruamel-yaml==0.19.0" # Avoids dependency conflicts introduced with version 0.19.1
 ]
 requires-python = ">=3.11,<3.14"
 description = "Subpackage for Semantic-Kernel integration in NeMo Agent toolkit"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -55,7 +55,6 @@ SRC_DIR = os.path.join(PROJECT_DIR, "src")
 EXAMPLES_DIR = os.path.join(PROJECT_DIR, "examples")
 sys.path.append(SRC_DIR)
 
-os.environ["PYTHONPATH"] = (f"{SRC_DIR}:{os.environ['PYTHONPATH']}" if "PYTHONPATH" in os.environ else SRC_DIR)
 os.environ.setdefault("DASK_DISTRIBUTED__WORKER__PYTHON", sys.executable)
 
 if typing.TYPE_CHECKING:

--- a/uv.lock
+++ b/uv.lock
@@ -6538,12 +6538,14 @@ name = "nvidia-nat-semantic-kernel"
 source = { editable = "packages/nvidia_nat_semantic_kernel" }
 dependencies = [
     { name = "nvidia-nat" },
+    { name = "ruamel-yaml-clibz" },
     { name = "semantic-kernel" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "nvidia-nat", editable = "." },
+    { name = "ruamel-yaml-clibz", specifier = "==0.3.5" },
     { name = "semantic-kernel", specifier = "~=1.35" },
 ]
 
@@ -9132,9 +9134,9 @@ wheels = [
 
 [[package]]
 name = "ruamel-yaml-clibz"
-version = "0.3.7"
+version = "0.3.5"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cb/73/2a9857a017f8ee260c683d8155634f0e3ca57964da2c3055b02822d582cd/ruamel_yaml_clibz-0.3.7.tar.gz", hash = "sha256:2be85214793cfc787eb12380fa3226e10cd7727b24551c3067c173d66c9bedd9", size = 231233, upload-time = "2026-01-02T14:52:41.734Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/5d/c589ccf1b86632d21c0cc89a442294c7cebd46aa0e03cfc604dc534ea678/ruamel_yaml_clibz-0.3.5.tar.gz", hash = "sha256:fdffa4b92ed86d00d59324b15f358f1b807e6b8b0464be53ffecf6bc10153b87", size = 231097, upload-time = "2026-01-02T08:13:40.577Z" }
 
 [[package]]
 name = "ruff"


### PR DESCRIPTION
## Description
* Removes the setting of the `PYTHONPATH` environment variable when running tests (introduced in PR #1221).
* Unrelated fix: pin the `ruamel-yaml-clibz` package to v0.3.5, avoids an install error introduced with version 0.3.6. This is a transitive dependency for semantic-kernel.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Tests**
  * Test environment no longer augments the Python import path during test runs; tests rely on the existing environment configuration.

* **Chores**
  * Added a specific YAML C-extension dependency (ruamel-yaml-clibz==0.3.5) to address a recent installation issue and ensure reliable package installation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->