### PR TITLE
Improve Multi-User Testing Instructions in Math Assistant A2A Example 

### DIFF
--- a/examples/A2A/math_assistant_a2a/README.md
+++ b/examples/A2A/math_assistant_a2a/README.md
@@ -128,19 +128,31 @@ The example uses `per_user_react_agent`, which is the per-user version of the Re
 ### Multi-User Testing
 When using `nat serve`, different users are identified by the `nat-session` cookie:
 
+Before testing multi-user support, ensure the Calculator A2A server is running:
 ```bash
-# Start the math assistant as a server on terminal 1
+# Terminal 1: Start the A2A calculator server (if not already running)
+nat a2a serve --config_file examples/getting_started/simple_calculator/configs/config.yml --port 10000
+```
+
+Verify the server is running:
+```bash
+# Terminal 2: Check discover card
+nat a2a client discover --url http://localhost:10000
+```
+
+```bash
+# Start the math assistant as a FastAPI server on terminal 2
 nat serve --config_file examples/A2A/math_assistant_a2a/configs/config.yml
 ```
 
 ```bash
-# User "Alice" makes a request on terminal 2
+# User "Alice" makes a request on terminal 3
 curl -X POST http://localhost:8000/generate \
   -H "Content-Type: application/json" \
   -H "Cookie: nat-session=Alice" \
   -d '{"messages": [{"role": "user", "content": "Is the sum of 5 and 3 greater than the current hour of the day?"}]}' | jq
 
-# User "Hatter" makes a request on terminal 2 (isolated from Alice)
+# User "Hatter" makes a request on terminal 3 (isolated from Alice)
 curl -X POST http://localhost:8000/generate \
   -H "Content-Type: application/json" \
   -H "Cookie: nat-session=Hatter" \


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes: nvbug-5762296

Added clearer instructions for multi-user testing to prevent users from forgetting to start the required Calculator A2A server before testing.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced setup instructions with explicit multi-user configuration steps for the math assistant example
  * Added verification commands to confirm proper server initialization
  * Updated user interaction examples demonstrating isolated per-user sessions with independent state

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->