### PR TITLE
Add Configuration Preservation to Evaluation Output

### DIFF
--- a/docs/source/improve-workflows/evaluate.md
+++ b/docs/source/improve-workflows/evaluate.md
@@ -84,10 +84,22 @@ eval:
 The dataset section specifies the dataset to use for running the workflow. The dataset can be of type `json`, `jsonl`, `csv`, `xls`, or `parquet`. The dataset file path is specified using the `file_path` key.
 
 ## Evaluation outputs (what you will get)
-Running `nat eval` produces a set of artifacts in the configured output directory. These files fall into three groups: workflow outputs, evaluator outputs, and profiler observability outputs.
+Running `nat eval` produces a set of artifacts in the configured output directory. These files fall into four groups: workflow outputs, configuration outputs, evaluator outputs, and profiler observability outputs.
 
 ### Workflow outputs (always available)
 - `workflow_output.json`: Per-sample execution results including question, expected `answer`, `generated_answer`, and `intermediate_steps`. Use this to inspect or debug individual runs.
+
+### Configuration outputs (always available)
+For reproducibility and debugging, the evaluation system saves the configuration used for each run:
+- `config_original.yml`: The original configuration file as provided, before any modifications
+- `config_effective.yml`: The final configuration with all command-line overrides applied (the actual configuration used to run the evaluation)
+- `config_metadata.json`: Metadata about the evaluation run, including all command-line arguments such as `--override` flags, `--dataset`, `--reps`, `--endpoint`, and a timestamp
+
+These files allow you to reproduce the exact evaluation conditions or compare configurations between different runs.
+
+:::{note}
+When evaluating remote workflows using the `--endpoint` flag, the saved configuration captures the evaluation settings (dataset, evaluators, endpoint URL) but does not reflect the workflow configuration running on the remote server. To fully reproduce a remote evaluation, you need both the saved evaluation configuration and access to the same workflow configuration on the remote endpoint.
+:::
 
 ### Evaluator outputs (only when configured)
 

--- a/src/nat/eval/config.py
+++ b/src/nat/eval/config.py
@@ -62,3 +62,8 @@ class EvaluationRunOutput(BaseModel):
     evaluation_results: list[tuple[str, EvalOutput]]
     usage_stats: UsageStats | None = None
     profiler_results: ProfilerResults
+
+    # Configuration files written to output directory
+    config_original_file: Path | None = None
+    config_effective_file: Path | None = None
+    config_metadata_file: Path | None = None

--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -14,13 +14,16 @@
 # limitations under the License.
 
 import asyncio
+import json
 import logging
 import shutil
 import warnings
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
+import yaml
 from pydantic import BaseModel
 from tqdm import tqdm
 
@@ -62,6 +65,7 @@ class EvaluationRun:
         # Run-specific configuration
         self.config: EvaluationRunConfig = config
         self.eval_config: EvalConfig | None = None
+        self.effective_config: Any = None  # Stores the complete config after applying overrides
 
         # Helpers
         self.intermediate_step_adapter: IntermediateStepAdapter = IntermediateStepAdapter()
@@ -96,6 +100,11 @@ class EvaluationRun:
 
         # evaluation output files
         self.evaluator_output_files: list[Path] = []
+
+        # configuration output files
+        self.config_original_file: Path | None = None
+        self.config_effective_file: Path | None = None
+        self.config_metadata_file: Path | None = None
 
     def _compute_usage_stats(self, item: EvalInputItem):
         """Compute usage stats for a single item using the intermediate steps"""
@@ -332,9 +341,103 @@ class EvaluationRun:
             except Exception as e:
                 logger.exception("Failed to delete old job directory: %s: %s", dir_to_delete, e)
 
+    def write_configuration(self):
+        """Save the configuration used for this evaluation run to the output directory.
+
+        This saves three files:
+        1. config_original.yml - The original configuration file
+        2. config_effective.yml - The configuration with all overrides applied
+        3. config_metadata.json - Metadata about the evaluation run and overrides
+        """
+        output_dir = self.eval_config.general.output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+
+        try:
+            # 1. Save original configuration
+            config_original_file = output_dir / "config_original.yml"
+            if isinstance(self.config.config_file, Path):
+                # Copy original file if it exists
+                if self.config.config_file.exists():
+                    shutil.copy2(self.config.config_file, config_original_file)
+                    self.config_original_file = config_original_file
+                    logger.info("Original config file copied to %s", config_original_file)
+                else:
+                    logger.warning("Original config file not found at %s", self.config.config_file)
+            elif isinstance(self.config.config_file, BaseModel):
+                # Serialize programmatic config, using mode='json' to handle special types like timedelta
+                config_dict = self.config.config_file.model_dump(mode='json')
+                with open(config_original_file, "w", encoding="utf-8") as f:
+                    yaml.safe_dump(config_dict, f, default_flow_style=False, sort_keys=False)
+                self.config_original_file = config_original_file
+                logger.info("Programmatic config saved to %s", config_original_file)
+
+            # 2. Save effective configuration (with overrides applied)
+            config_effective_file = output_dir / "config_effective.yml"
+            if self.effective_config is not None:
+                # Convert to dict if it's a BaseModel, using mode='json' to handle special types like timedelta
+                if isinstance(self.effective_config, BaseModel):
+                    effective_config_dict = self.effective_config.model_dump(mode='json')
+                else:
+                    effective_config_dict = self.effective_config
+
+                with open(config_effective_file, "w", encoding="utf-8") as f:
+                    yaml.safe_dump(effective_config_dict, f, default_flow_style=False, sort_keys=False)
+                self.config_effective_file = config_effective_file
+                logger.info("Effective config (with overrides) saved to %s", config_effective_file)
+            else:
+                logger.warning("Effective config not available, skipping config_effective.yml")
+
+            # 3. Save metadata about the run
+            config_metadata_file = output_dir / "config_metadata.json"
+            metadata = {
+                "config_file":
+                    str(self.config.config_file),
+                "config_file_type":
+                    "Path" if isinstance(self.config.config_file, Path) else "BaseModel",
+                "overrides": [{
+                    "path": path, "value": value
+                } for path, value in self.config.override] if self.config.override else [],
+                "dataset":
+                    self.config.dataset,
+                "result_json_path":
+                    self.config.result_json_path,
+                "skip_workflow":
+                    self.config.skip_workflow,
+                "skip_completed_entries":
+                    self.config.skip_completed_entries,
+                "reps":
+                    self.config.reps,
+                "endpoint":
+                    self.config.endpoint,
+                "endpoint_timeout":
+                    self.config.endpoint_timeout,
+                "adjust_dataset_size":
+                    self.config.adjust_dataset_size,
+                "num_passes":
+                    self.config.num_passes,
+                "export_timeout":
+                    self.config.export_timeout,
+                "user_id":
+                    self.config.user_id,
+                "timestamp":
+                    datetime.now().isoformat(),
+            }
+
+            with open(config_metadata_file, "w", encoding="utf-8") as f:
+                json.dump(metadata, f, indent=2)
+            self.config_metadata_file = config_metadata_file
+            logger.info("Configuration metadata saved to %s", config_metadata_file)
+
+        except Exception as e:
+            logger.exception("Failed to write configuration files: %s", e)
+            # Don't raise - this is not critical enough to fail the entire evaluation
+
     def write_output(self, dataset_handler: DatasetHandler, profiler_results: ProfilerResults):
         workflow_output_file = self.eval_config.general.output_dir / "workflow_output.json"
         workflow_output_file.parent.mkdir(parents=True, exist_ok=True)
+
+        # Write the configuration files (original, effective, and metadata)
+        self.write_configuration()
 
         # Write the workflow output to a file (this can be used for re-running the evaluation)
 
@@ -470,6 +573,8 @@ class EvaluationRun:
         else:
             config = load_config(self.config.config_file)
 
+        # Store the effective configuration for later saving to output directory
+        self.effective_config = config
         self.eval_config = config.eval
         workflow_alias = self._get_workflow_alias(config.workflow.type)
         logger.debug("Loaded %s evaluation configuration: %s", workflow_alias, self.eval_config)
@@ -501,7 +606,10 @@ class EvaluationRun:
                                        eval_input=EvalInput(eval_input_items=[]),
                                        evaluation_results=[],
                                        usage_stats=UsageStats(),
-                                       profiler_results=ProfilerResults())
+                                       profiler_results=ProfilerResults(),
+                                       config_original_file=self.config_original_file,
+                                       config_effective_file=self.config_effective_file,
+                                       config_metadata_file=self.config_metadata_file)
 
         custom_pre_eval_process_function = self.eval_config.general.output.custom_pre_eval_process_function \
             if self.eval_config.general.output else None
@@ -520,7 +628,10 @@ class EvaluationRun:
                                        eval_input=self.eval_input,
                                        evaluation_results=self.evaluation_results,
                                        usage_stats=self.usage_stats,
-                                       profiler_results=ProfilerResults())
+                                       profiler_results=ProfilerResults(),
+                                       config_original_file=self.config_original_file,
+                                       config_effective_file=self.config_effective_file,
+                                       config_metadata_file=self.config_metadata_file)
 
         # Run workflow and evaluate
         async with WorkflowEvalBuilder.from_config(config=config) as eval_workflow:
@@ -582,4 +693,7 @@ class EvaluationRun:
                                    eval_input=self.eval_input,
                                    evaluation_results=self.evaluation_results,
                                    usage_stats=self.usage_stats,
-                                   profiler_results=profiler_results)
+                                   profiler_results=profiler_results,
+                                   config_original_file=self.config_original_file,
+                                   config_effective_file=self.config_effective_file,
+                                   config_metadata_file=self.config_metadata_file)

--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -27,6 +27,7 @@ import yaml
 from pydantic import BaseModel
 from tqdm import tqdm
 
+from nat.data_models.config import Config
 from nat.data_models.evaluate import EvalConfig
 from nat.data_models.evaluate import JobEvictionPolicy
 from nat.data_models.runtime_enum import RuntimeTypeEnum
@@ -65,7 +66,7 @@ class EvaluationRun:
         # Run-specific configuration
         self.config: EvaluationRunConfig = config
         self.eval_config: EvalConfig | None = None
-        self.effective_config: Any = None  # Stores the complete config after applying overrides
+        self.effective_config: Config | None = None  # Stores the complete config after applying overrides
 
         # Helpers
         self.intermediate_step_adapter: IntermediateStepAdapter = IntermediateStepAdapter()
@@ -341,7 +342,7 @@ class EvaluationRun:
             except Exception as e:
                 logger.exception("Failed to delete old job directory: %s: %s", dir_to_delete, e)
 
-    def write_configuration(self):
+    def write_configuration(self) -> None:
         """Save the configuration used for this evaluation run to the output directory.
 
         This saves three files:
@@ -374,12 +375,7 @@ class EvaluationRun:
             # 2. Save effective configuration (with overrides applied)
             config_effective_file = output_dir / "config_effective.yml"
             if self.effective_config is not None:
-                # Convert to dict if it's a BaseModel, using mode='json' to handle special types like timedelta
-                if isinstance(self.effective_config, BaseModel):
-                    effective_config_dict = self.effective_config.model_dump(mode='json')
-                else:
-                    effective_config_dict = self.effective_config
-
+                effective_config_dict = self.effective_config.model_dump(mode='json') if self.effective_config else {}
                 with open(config_effective_file, "w", encoding="utf-8") as f:
                     yaml.safe_dump(effective_config_dict, f, default_flow_style=False, sort_keys=False)
                 self.config_effective_file = config_effective_file
@@ -420,7 +416,7 @@ class EvaluationRun:
                 "user_id":
                     self.config.user_id,
                 "timestamp":
-                    datetime.now().isoformat(),
+                    datetime.now(tz=datetime.UTC).isoformat(),
             }
 
             with open(config_metadata_file, "w", encoding="utf-8") as f:
@@ -428,8 +424,8 @@ class EvaluationRun:
             self.config_metadata_file = config_metadata_file
             logger.info("Configuration metadata saved to %s", config_metadata_file)
 
-        except Exception as e:
-            logger.exception("Failed to write configuration files: %s", e)
+        except Exception:
+            logger.exception("Failed to write configuration files")
             # Don't raise - this is not critical enough to fail the entire evaluation
 
     def write_output(self, dataset_handler: DatasetHandler, profiler_results: ProfilerResults):
@@ -565,7 +561,7 @@ class EvaluationRun:
         from nat.runtime.loader import load_config
 
         # Load and override the config
-        config = None
+        config: Config | None = None
         if isinstance(self.config.config_file, BaseModel):
             config = self.config.config_file
         elif self.config.override:

--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -18,6 +18,7 @@ import json
 import logging
 import shutil
 import warnings
+from datetime import UTC
 from datetime import datetime
 from pathlib import Path
 from typing import Any
@@ -416,7 +417,7 @@ class EvaluationRun:
                 "user_id":
                     self.config.user_id,
                 "timestamp":
-                    datetime.now(tz=datetime.UTC).isoformat(),
+                    datetime.now(tz=UTC).isoformat(),
             }
 
             with open(config_metadata_file, "w", encoding="utf-8") as f:

--- a/tests/nat/eval/test_evaluate.py
+++ b/tests/nat/eval/test_evaluate.py
@@ -491,6 +491,110 @@ def test_write_output_handles_none_output(evaluation_run, eval_input):
             pytest.fail("write_output should not access .output without a None check")
 
 
+def test_write_configuration_with_path_config(evaluation_run, default_eval_config, tmp_path):
+    """Test that write_configuration correctly saves config files when config_file is a Path."""
+    # Create a temporary config file
+    config_file = tmp_path / "test_config.yml"
+    config_file.write_text("workflow:\n  type: test\neval:\n  general:\n    max_concurrency: 1\n")
+
+    # Setup evaluation run
+    evaluation_run.config.config_file = config_file
+    evaluation_run.config.override = (("eval.general.max_concurrency", "5"),)
+    evaluation_run.eval_config = default_eval_config
+    evaluation_run.eval_config.general.output_dir = tmp_path / "output"
+
+    # Create a mock effective config
+    mock_effective_config = Config()
+    mock_effective_config.eval = default_eval_config
+    evaluation_run.effective_config = mock_effective_config
+
+    # Run the function
+    with patch("nat.eval.evaluate.logger.info") as mock_logger:
+        evaluation_run.write_configuration()
+
+    # Verify that all three files were created
+    config_original_file = evaluation_run.eval_config.general.output_dir / "config_original.yml"
+    config_effective_file = evaluation_run.eval_config.general.output_dir / "config_effective.yml"
+    config_metadata_file = evaluation_run.eval_config.general.output_dir / "config_metadata.json"
+
+    assert config_original_file.exists(), "config_original.yml should be created"
+    assert config_effective_file.exists(), "config_effective.yml should be created"
+    assert config_metadata_file.exists(), "config_metadata.json should be created"
+
+    # Verify metadata content
+    with open(config_metadata_file, "r", encoding="utf-8") as f:
+        metadata = json.load(f)
+    assert metadata["config_file"] == str(config_file)
+    assert metadata["config_file_type"] == "Path"
+    assert len(metadata["overrides"]) == 1
+    assert metadata["overrides"][0]["path"] == "eval.general.max_concurrency"
+    assert metadata["overrides"][0]["value"] == "5"
+
+    # Verify logging
+    assert mock_logger.call_count >= 3, "Should log for all three config files"
+
+
+def test_write_configuration_with_basemodel_config(evaluation_run, default_eval_config, tmp_path):
+    """Test that write_configuration correctly saves config files when config_file is a BaseModel."""
+    # Setup evaluation run with BaseModel config
+    mock_config = Config()
+    mock_config.eval = default_eval_config
+    evaluation_run.config.config_file = mock_config
+    evaluation_run.config.override = ()  # No overrides
+    evaluation_run.eval_config = default_eval_config
+    evaluation_run.eval_config.general.output_dir = tmp_path / "output"
+    evaluation_run.effective_config = mock_config
+
+    # Run the function
+    with patch("nat.eval.evaluate.logger.info"):
+        evaluation_run.write_configuration()
+
+    # Verify that all three files were created
+    config_original_file = evaluation_run.eval_config.general.output_dir / "config_original.yml"
+    config_effective_file = evaluation_run.eval_config.general.output_dir / "config_effective.yml"
+    config_metadata_file = evaluation_run.eval_config.general.output_dir / "config_metadata.json"
+
+    assert config_original_file.exists(), "config_original.yml should be created"
+    assert config_effective_file.exists(), "config_effective.yml should be created"
+    assert config_metadata_file.exists(), "config_metadata.json should be created"
+
+    # Verify metadata content
+    with open(config_metadata_file, "r", encoding="utf-8") as f:
+        metadata = json.load(f)
+    assert metadata["config_file_type"] == "BaseModel"
+    assert len(metadata["overrides"]) == 0, "Should have no overrides"
+
+
+def test_write_configuration_handles_missing_effective_config(evaluation_run, default_eval_config, tmp_path):
+    """Test that write_configuration handles gracefully when effective_config is None."""
+    # Create a temporary config file
+    config_file = tmp_path / "test_config.yml"
+    config_file.write_text("workflow:\n  type: test\n")
+
+    # Setup evaluation run with None effective_config
+    evaluation_run.config.config_file = config_file
+    evaluation_run.eval_config = default_eval_config
+    evaluation_run.eval_config.general.output_dir = tmp_path / "output"
+    evaluation_run.effective_config = None  # This is the key test condition
+
+    # Run the function - it should not crash
+    with patch("nat.eval.evaluate.logger.info"), \
+         patch("nat.eval.evaluate.logger.warning") as mock_warning:
+        evaluation_run.write_configuration()
+
+    # Verify warning was logged
+    mock_warning.assert_any_call("Effective config not available, skipping config_effective.yml")
+
+    # Verify that original and metadata files were created but not effective
+    config_original_file = evaluation_run.eval_config.general.output_dir / "config_original.yml"
+    config_effective_file = evaluation_run.eval_config.general.output_dir / "config_effective.yml"
+    config_metadata_file = evaluation_run.eval_config.general.output_dir / "config_metadata.json"
+
+    assert config_original_file.exists(), "config_original.yml should be created"
+    assert not config_effective_file.exists(), "config_effective.yml should NOT be created when effective_config is None"
+    assert config_metadata_file.exists(), "config_metadata.json should be created"
+
+
 @pytest.mark.parametrize("skip_workflow", [True, False])
 async def test_run_and_evaluate(evaluation_run, default_eval_config, session_manager, mock_evaluator, skip_workflow):
     """

--- a/tests/nat/eval/test_evaluate.py
+++ b/tests/nat/eval/test_evaluate.py
@@ -499,7 +499,7 @@ def test_write_configuration_with_path_config(evaluation_run, default_eval_confi
 
     # Setup evaluation run
     evaluation_run.config.config_file = config_file
-    evaluation_run.config.override = (("eval.general.max_concurrency", "5"),)
+    evaluation_run.config.override = (("eval.general.max_concurrency", "5"), )
     evaluation_run.eval_config = default_eval_config
     evaluation_run.eval_config.general.output_dir = tmp_path / "output"
 
@@ -522,7 +522,7 @@ def test_write_configuration_with_path_config(evaluation_run, default_eval_confi
     assert config_metadata_file.exists(), "config_metadata.json should be created"
 
     # Verify metadata content
-    with open(config_metadata_file, "r", encoding="utf-8") as f:
+    with open(config_metadata_file, encoding="utf-8") as f:
         metadata = json.load(f)
     assert metadata["config_file"] == str(config_file)
     assert metadata["config_file_type"] == "Path"
@@ -559,7 +559,7 @@ def test_write_configuration_with_basemodel_config(evaluation_run, default_eval_
     assert config_metadata_file.exists(), "config_metadata.json should be created"
 
     # Verify metadata content
-    with open(config_metadata_file, "r", encoding="utf-8") as f:
+    with open(config_metadata_file, encoding="utf-8") as f:
         metadata = json.load(f)
     assert metadata["config_file_type"] == "BaseModel"
     assert len(metadata["overrides"]) == 0, "Should have no overrides"
@@ -591,7 +591,7 @@ def test_write_configuration_handles_missing_effective_config(evaluation_run, de
     config_metadata_file = evaluation_run.eval_config.general.output_dir / "config_metadata.json"
 
     assert config_original_file.exists(), "config_original.yml should be created"
-    assert not config_effective_file.exists(), "config_effective.yml should NOT be created when effective_config is None"
+    assert not config_effective_file.exists(), "config_effective.yml should NOT be created when there are no overrides"
     assert config_metadata_file.exists(), "config_metadata.json should be created"
 
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes #1297 

**Summary**
Saves the complete evaluation configuration (including command-line overrides) to the output directory for reproducibility and debugging purposes.

**What's New**
Running nat eval now automatically saves three configuration files to the output directory:
- config_original.yml - The original configuration file before any modifications
- config_effective.yml - The final configuration with all --override flags applied
- config_metadata.json - Metadata including all CLI arguments (--dataset, --reps, --endpoint, etc.) and timestamp

**Notes**

- Configuration files are saved automatically during evaluation (no action required)
- For remote workflow evaluation (--endpoint), configs capture evaluation settings but not the remote workflow configuration

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Evaluation runs now save three configuration outputs: original configuration, effective configuration, and a metadata file for improved reproducibility and post-run visibility.

* **Documentation**
  * Evaluation artifacts docs updated to list four output categories — workflow, configuration, evaluator, and profiler observability outputs — with notes on reproducibility and endpoint-specific considerations.

* **Tests**
  * Added tests verifying configuration files, metadata contents, and related logging across scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->