### PR TITLE
Add missing `tzdata` package to Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -55,4 +55,4 @@ RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \
 ENV PATH="/workspace/.venv/bin:$PATH"
 
 # Define the entry point to start the nat CLI tool
-# ENTRYPOINT ["nat"]
+ENTRYPOINT ["nat"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -33,7 +33,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
     export TZ=Etc/UTC && \
     apt-get update && \
     apt upgrade -y && \
-    apt-get install --no-install-recommends  -y ca-certificates && \
+    apt-get install --no-install-recommends  -y ca-certificates tzdata && \
     apt clean && \
     update-ca-certificates
 
@@ -55,4 +55,4 @@ RUN --mount=type=cache,id=uv_cache,target=/root/.cache/uv,sharing=locked \
 ENV PATH="/workspace/.venv/bin:$PATH"
 
 # Define the entry point to start the nat CLI tool
-ENTRYPOINT ["nat"]
+# ENTRYPOINT ["nat"]

--- a/docker/build_container.sh
+++ b/docker/build_container.sh
@@ -26,7 +26,6 @@ DOCKER_TARGET_ARCH=${DOCKER_TARGET_ARCH:-${HOST_ARCH}}
 
 if [ ${DOCKER_TARGET_ARCH} != ${HOST_ARCH} ]; then
     echo -n "Performing cross-build for ${DOCKER_TARGET_ARCH} on ${HOST_ARCH}, please ensure qemu is installed, "
-    echo "details in ${REPO_ROOT}/docs/source/advanced/running-ci-locally.md"
 fi
 
 NAT_VERSION=${NAT_VERSION:-$(git describe --tags --abbrev=0 2>/dev/null || echo "no-tag")}


### PR DESCRIPTION
## Description
* `tzdata` is needed for the `current_datetime` tool
* Remove echo statement which directed users to non-existent documentation 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build to include timezone data support.
  * Simplified build notification messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->