### PR TITLE
Make All CLI Commands Plugin-Discoverable

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -208,7 +208,7 @@ config-settings = { editable_mode = "compat" }
 # distribution (thus included in both nvidia-nat-all and nvidia-nat[all])
 #
 # Long-term solutions include better package isolation and testing, which is on the roadmap.
-# 
+#
 override-dependencies = [
   # Override tenacity version to resolve conflict between ragaai-catalyst ("tenacity==8.3.0")
   #   and strands-agents-tools ("tenacity>=9.1.2")
@@ -352,6 +352,22 @@ nat_front_ends = "nat.front_ends.register"
 
 [project.entry-points.'nat.registry_handlers']
 nat_registry_handlers = "nat.registry_handlers.register"
+
+
+[project.entry-points.'nat.cli']
+configure = "nat.cli.commands.configure.configure:configure_command"
+eval = "nat.cli.commands.evaluate:eval_command"
+finetune = "nat.cli.commands.finetune:finetune_command"
+info = "nat.cli.commands.info.info:info_command"
+object-store = "nat.cli.commands.object_store.object_store:object_store_command"
+optimize = "nat.cli.commands.optimize:optimizer_command"
+red-team = "nat.cli.commands.red_teaming.red_teaming:red_team_command"
+registry = "nat.cli.commands.registry.registry:registry_command"
+sizing = "nat.cli.commands.sizing.sizing:sizing"
+start = "nat.cli.commands.start:start_command"
+uninstall = "nat.cli.commands.uninstall:uninstall_command"
+validate = "nat.cli.commands.validate:validate_command"
+workflow = "nat.cli.commands.workflow.workflow:workflow_command"
 
 
 [project.scripts]

--- a/src/nat/cli/entrypoint.py
+++ b/src/nat/cli/entrypoint.py
@@ -33,19 +33,6 @@ from dotenv import load_dotenv
 
 from nat.utils.log_levels import LOG_LEVELS
 
-from .commands.configure.configure import configure_command
-from .commands.evaluate import eval_command
-from .commands.finetune import finetune_command
-from .commands.info.info import info_command
-from .commands.object_store.object_store import object_store_command
-from .commands.optimize import optimizer_command
-from .commands.red_teaming.red_teaming import red_team_command
-from .commands.registry.registry import registry_command
-from .commands.sizing.sizing import sizing
-from .commands.start import start_command
-from .commands.uninstall import uninstall_command
-from .commands.validate import validate_command
-from .commands.workflow.workflow import workflow_command
 from .plugin_loader import discover_and_load_cli_plugins
 
 # Load environment variables from .env file, if it exists
@@ -104,26 +91,14 @@ def cli(ctx: click.Context, log_level: str):
     ctx_dict["log_level"] = log_level
 
 
-cli.add_command(configure_command, name="configure")
-cli.add_command(eval_command, name="eval")
-cli.add_command(finetune_command, name="finetune")
-cli.add_command(info_command, name="info")
-cli.add_command(red_team_command, name="red-team")
-cli.add_command(registry_command, name="registry")
-cli.add_command(start_command, name="start")
-cli.add_command(uninstall_command, name="uninstall")
-cli.add_command(validate_command, name="validate")
-cli.add_command(workflow_command, name="workflow")
-cli.add_command(sizing, name="sizing")
-cli.add_command(optimizer_command, name="optimize")
-cli.add_command(object_store_command, name="object-store")
-
-# Discover and load CLI commands from plugin packages
+# Discover and load ALL CLI commands (core + plugins) via entry points
 discover_and_load_cli_plugins(cli)
 
-# Aliases
-cli.add_command(start_command.get_command(None, "console"), name="run")  # type: ignore
-cli.add_command(start_command.get_command(None, "fastapi"), name="serve")  # type: ignore
+# Aliases - need to get start_command from the loaded commands
+start_cmd = cli.commands.get("start")
+if start_cmd and hasattr(start_cmd, "get_command"):
+    cli.add_command(start_cmd.get_command(None, "console"), name="run")  # type: ignore
+    cli.add_command(start_cmd.get_command(None, "fastapi"), name="serve")  # type: ignore
 
 
 @cli.result_callback()

--- a/tests/nat/cli/test_plugin_loader.py
+++ b/tests/nat/cli/test_plugin_loader.py
@@ -234,4 +234,4 @@ class TestPluginLoaderIntegration:
 
         # Verify commands are Click command/group instances
         for name, cmd in cli_group.commands.items():
-            assert isinstance(cmd, (click.Command, click.Group)), f"Command '{name}' is not a valid Click command"
+            assert isinstance(cmd, click.Command | click.Group), f"Command '{name}' is not a valid Click command"

--- a/tests/nat/cli/test_plugin_loader.py
+++ b/tests/nat/cli/test_plugin_loader.py
@@ -234,3 +234,19 @@ class TestPluginLoaderIntegration:
         # Verify commands are Click command/group instances
         for name, cmd in cli_group.commands.items():
             assert isinstance(cmd, click.Command | click.Group), f"Command '{name}' is not a valid Click command"
+
+    def test_command_aliases_created(self):
+        """Test that 'run' and 'serve' aliases are created from 'start' command."""
+        # Import the actual CLI to test the full entrypoint logic
+        from nat.cli.entrypoint import cli
+
+        # Verify the start command exists (it's the base for aliases)
+        assert "start" in cli.commands, "start command should be discovered"
+
+        # Verify the aliases are created
+        assert "run" in cli.commands, "'run' alias should be created from start command"
+        assert "serve" in cli.commands, "'serve' alias should be created from start command"
+
+        # Verify they are valid Click commands
+        assert isinstance(cli.commands["run"], click.Command | click.Group)
+        assert isinstance(cli.commands["serve"], click.Command | click.Group)

--- a/tests/nat/cli/test_plugin_loader.py
+++ b/tests/nat/cli/test_plugin_loader.py
@@ -165,6 +165,37 @@ class TestPluginLoader:
 class TestPluginLoaderIntegration:
     """Integration tests for CLI plugin discovery with real plugins."""
 
+    def test_core_commands_discovered(self):
+        """Test that all core NAT commands are discovered via entry points."""
+        cli_group = click.Group()
+        discover_and_load_cli_plugins(cli_group)
+
+        # Core commands that should always be present
+        expected_core_commands = {
+            "configure",
+            "eval",
+            "finetune",
+            "info",
+            "object-store",
+            "optimize",
+            "red-team",
+            "registry",
+            "sizing",
+            "start",
+            "uninstall",
+            "validate",
+            "workflow",
+        }
+
+        discovered_commands = set(cli_group.commands.keys())
+        missing_commands = expected_core_commands - discovered_commands
+
+        assert not missing_commands, f"Missing core commands: {missing_commands}"
+
+        # Verify all expected commands are present
+        for cmd in expected_core_commands:
+            assert cmd in cli_group.commands, f"Core command '{cmd}' not discovered"
+
     def test_mcp_plugin_discovered(self):
         """Test that MCP plugin is discovered when nvidia-nat-mcp is installed."""
         try:
@@ -192,3 +223,15 @@ class TestPluginLoaderIntegration:
             assert "a2a" in cli_group.commands
         except ImportError:
             pytest.skip("nvidia-nat-a2a not installed")
+
+    def test_all_commands_together(self):
+        """Test that core and plugin commands can coexist."""
+        cli_group = click.Group()
+        discover_and_load_cli_plugins(cli_group)
+
+        # Should have at minimum all core commands
+        assert len(cli_group.commands) >= 13, "Should have at least 13 core commands"
+
+        # Verify commands are Click command/group instances
+        for name, cmd in cli_group.commands.items():
+            assert isinstance(cmd, (click.Command, click.Group)), f"Command '{name}' is not a valid Click command"

--- a/tests/nat/cli/test_plugin_loader.py
+++ b/tests/nat/cli/test_plugin_loader.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Tests for CLI plugin discovery system."""
 
+from typing import ClassVar
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -166,7 +167,7 @@ class TestPluginLoaderIntegration:
     """Integration tests for CLI plugin discovery with real plugins."""
 
     # Expected core commands that should always be present
-    EXPECTED_CORE_COMMANDS = {
+    EXPECTED_CORE_COMMANDS: ClassVar[set[str]] = {
         "configure",
         "eval",
         "finetune",

--- a/tests/nat/cli/test_plugin_loader.py
+++ b/tests/nat/cli/test_plugin_loader.py
@@ -165,36 +165,32 @@ class TestPluginLoader:
 class TestPluginLoaderIntegration:
     """Integration tests for CLI plugin discovery with real plugins."""
 
+    # Expected core commands that should always be present
+    EXPECTED_CORE_COMMANDS = {
+        "configure",
+        "eval",
+        "finetune",
+        "info",
+        "object-store",
+        "optimize",
+        "red-team",
+        "registry",
+        "sizing",
+        "start",
+        "uninstall",
+        "validate",
+        "workflow",
+    }
+
     def test_core_commands_discovered(self):
         """Test that all core NAT commands are discovered via entry points."""
         cli_group = click.Group()
         discover_and_load_cli_plugins(cli_group)
 
-        # Core commands that should always be present
-        expected_core_commands = {
-            "configure",
-            "eval",
-            "finetune",
-            "info",
-            "object-store",
-            "optimize",
-            "red-team",
-            "registry",
-            "sizing",
-            "start",
-            "uninstall",
-            "validate",
-            "workflow",
-        }
-
         discovered_commands = set(cli_group.commands.keys())
-        missing_commands = expected_core_commands - discovered_commands
+        missing_commands = self.EXPECTED_CORE_COMMANDS - discovered_commands
 
         assert not missing_commands, f"Missing core commands: {missing_commands}"
-
-        # Verify all expected commands are present
-        for cmd in expected_core_commands:
-            assert cmd in cli_group.commands, f"Core command '{cmd}' not discovered"
 
     def test_mcp_plugin_discovered(self):
         """Test that MCP plugin is discovered when nvidia-nat-mcp is installed."""
@@ -230,7 +226,9 @@ class TestPluginLoaderIntegration:
         discover_and_load_cli_plugins(cli_group)
 
         # Should have at minimum all core commands
-        assert len(cli_group.commands) >= 13, "Should have at least 13 core commands"
+        min_expected = len(self.EXPECTED_CORE_COMMANDS)
+        assert len(cli_group.commands) >= min_expected, \
+            f"Should have at least {min_expected} core commands"
 
         # Verify commands are Click command/group instances
         for name, cmd in cli_group.commands.items():

--- a/tests/nat/mcp/server/test_main.py
+++ b/tests/nat/mcp/server/test_main.py
@@ -13,14 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 def test_mcp_command_registration():
     """Test that MCP command is discoverable via entry points."""
     # Verify the MCP command can be imported
-    from nat.plugins.mcp.cli.commands import mcp_command
-
     # Verify it's a valid Click command
     import click
-    assert isinstance(mcp_command, (click.Command, click.Group)), \
+
+    from nat.plugins.mcp.cli.commands import mcp_command
+    assert isinstance(mcp_command, click.Command | click.Group), \
         "mcp_command should be a valid Click command or group"
 
     # Verify the CLI discovers and loads the MCP command

--- a/tests/nat/mcp/server/test_main.py
+++ b/tests/nat/mcp/server/test_main.py
@@ -13,30 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import sys
-from unittest.mock import MagicMock
-from unittest.mock import patch
+def test_mcp_command_registration():
+    """Test that MCP command is discoverable via entry points."""
+    # Verify the MCP command can be imported
+    from nat.plugins.mcp.cli.commands import mcp_command
 
+    # Verify it's a valid Click command
+    import click
+    assert isinstance(mcp_command, (click.Command, click.Group)), \
+        "mcp_command should be a valid Click command or group"
 
-@patch("nat.cli.entrypoint.cli.add_command")
-def test_mcp_command_registration(mock_add_command):
-    """Test the CLI command registration mechanism for MCP."""
-    from nat.cli.entrypoint import start_command
-
-    # Create a mock module to simulate main.py
-    mock_main_module = MagicMock()
-
-    # Create a mock command that would be returned by get_command
-    mock_command = MagicMock(name="mcp_command")
-
-    # Patch the get_command method to return our mock command
-    with patch.object(start_command, 'get_command', return_value=mock_command):
-        # Mock sys.modules to include our mock module
-        with patch.dict(sys.modules, {'nat.plugins.mcp.server.main': mock_main_module}):
-            # Import the module which would register the command
-            # Since we're mocking the module, we'll call the registration code directly
-            from nat.cli.entrypoint import cli
-            cli.add_command(mock_command, name="mcp")
-
-    # Verify that add_command was called with the correct arguments
-    mock_add_command.assert_called_with(mock_command, name="mcp")
+    # Verify the CLI discovers and loads the MCP command
+    from nat.cli.entrypoint import cli
+    assert "mcp" in cli.commands, "MCP command should be discovered and registered in CLI"


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
**Problem:**
#1341 moved MCP/A2A commands to plugin packages, the CLI still used mixed registration:
- Core commands: Explicitly imported and registered in entrypoint.py
- Plugin commands: Discovered via entry points

This inconsistency violated NAT's plugin architecture pattern where all components use entry point discovery.

**Solution:**
This PR addresses that inconsistency by extending the CLI plugin discovery system to include core commands, making the CLI architecture fully consistent with other NAT plugin systems (nat.components, nat.front_ends, etc.). 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * CLI now discovers and loads commands via a plugin system, with runtime-resolved aliases (e.g., run/serve).

* **Chores / Packaging**
  * Added CLI entry-point declarations to packaging metadata; duplicate entry-point block present.

* **Tests**
  * Added integration tests for CLI discovery, aliases, and command coexistence; simplified MCP registration test.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->