### PR TITLE
fix: strip remaining occurrences of `.` for function groups

### DIFF
--- a/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/evaluators/tsq_evaluator.py
+++ b/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/evaluators/tsq_evaluator.py
@@ -28,6 +28,7 @@ from pydantic import Field
 
 from nat.builder.builder import EvalBuilder
 from nat.builder.evaluator import EvaluatorInfo
+from nat.builder.function import FunctionGroup
 from nat.cli.register_workflow import register_evaluator
 from nat.data_models.component_ref import LLMRef
 from nat.data_models.evaluator import EvaluatorBaseConfig
@@ -161,8 +162,8 @@ async def tsq_evaluator_function(config: TSQEvaluatorConfig, builder: EvalBuilde
             return ""
 
         # Strip module prefix (e.g., "banking_tools.report_lost_stolen_card" -> "report_lost_stolen_card")
-        if "." in tool_name:
-            tool_name = tool_name.rsplit(".", 1)[-1]
+        if FunctionGroup.SEPARATOR in tool_name:
+            _, tool_name = FunctionGroup.decompose(tool_name)
 
         return tool_name.lower().strip().replace("_", "").replace("-", "")
 

--- a/examples/dynamo_integration/react_benchmark_agent/tests/test_tsq_formula.py
+++ b/examples/dynamo_integration/react_benchmark_agent/tests/test_tsq_formula.py
@@ -28,8 +28,8 @@ def normalize_tool_name(tool_name: str) -> str:
         return ""
 
     # Strip module prefix (e.g., "banking_tools.report_lost_stolen_card" -> "report_lost_stolen_card")
-    if "." in tool_name:
-        tool_name = tool_name.rsplit(".", 1)[-1]
+    if "__" in tool_name:
+        _, tool_name = tool_name.split("__", maxsplit=1)
 
     return tool_name.lower().strip().replace("_", "").replace("-", "")
 

--- a/examples/dynamo_integration/react_benchmark_agent/tests/test_tsq_formula.py
+++ b/examples/dynamo_integration/react_benchmark_agent/tests/test_tsq_formula.py
@@ -226,12 +226,12 @@ class TestNormalization:
 
     def test_module_prefix_stripping(self):
         """Verify module prefixes are stripped (e.g., banking_tools.report_lost_stolen_card)."""
-        assert normalize_tool_name("banking_tools.report_lost_stolen_card") == "reportloststolencard"
-        assert normalize_tool_name("module.submodule.tool_name") == "toolname"
+        assert normalize_tool_name("banking_tools__report_lost_stolen_card") == "reportloststolencard"
+        assert normalize_tool_name("module__submodule__tool_name") == "submoduletoolname"
 
     def test_module_prefix_matching(self):
         """Verify tools match even with module prefixes."""
-        actual = [{"tool": "banking_tools.report_lost_stolen_card"}]
+        actual = [{"tool": "banking_tools__report_lost_stolen_card"}]
         expected = [{"tool": "report_lost_stolen_card"}]
 
         accuracy = calculate_tool_accuracy(actual, expected)

--- a/src/nat/builder/eval_builder.py
+++ b/src/nat/builder/eval_builder.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from nat.builder.builder import EvalBuilder
 from nat.builder.evaluator import EvaluatorInfo
 from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.builder.function import FunctionGroup
 from nat.builder.workflow_builder import WorkflowBuilder
 from nat.builder.workflow_builder import _log_build_failure
 from nat.cli.type_registry import TypeRegistry
@@ -97,13 +98,13 @@ class WorkflowEvalBuilder(WorkflowBuilder, EvalBuilder):
 
         async def get_tool(fn_name: str):
             # Maintain backwards compatibility with the old function group name format
-            compat_name = fn_name.replace(".", "__")
-            if (fn_name not in self._functions) and (compat_name in self._functions):
+            new_fn_name = fn_name.replace(FunctionGroup.LEGACY_SEPARATOR, FunctionGroup.SEPARATOR)
+            if (fn_name not in self._functions) and (new_fn_name in self._functions):
                 logger.warning(
                     f"Function `{fn_name}` is deprecated and will be removed in a future release." + \
-                        f"Use `{compat_name}` instead."
+                        f"Use `{new_fn_name}` instead."
                 )
-                fn_name = compat_name
+                fn_name = new_fn_name
             # end of backwards compatibility check
 
             fn = await self.get_function(fn_name)

--- a/src/nat/builder/function.py
+++ b/src/nat/builder/function.py
@@ -394,6 +394,32 @@ class FunctionGroup:
     A group of functions that can be used together, sharing the same configuration, context, and resources.
     """
 
+    SEPARATOR: str = "__"
+    """The separator between the function group name and the function name."""
+
+    LEGACY_SEPARATOR: str = "."
+    """The legacy separator between the function group name and the function name."""
+
+    @staticmethod
+    def decompose(name: str, legacy_compat: bool = False) -> tuple[str, str]:
+        """
+        Decompose a function name into the function group name and the function name.
+
+        Parameters
+        ----------
+        name : str
+            The function name to decompose.
+        legacy_compat : bool, optional
+            Whether to use the legacy separator (period) instead of the new separator (double underscore).
+
+        Returns
+        -------
+        tuple[str, str]
+            The function group name and the function name.
+        """
+        g, f = name.split(FunctionGroup.LEGACY_SEPARATOR if legacy_compat else FunctionGroup.SEPARATOR, maxsplit=1)
+        return g, f
+
     def __init__(self,
                  *,
                  config: FunctionGroupBaseConfig,
@@ -492,9 +518,9 @@ class FunctionGroup:
         The function name of a function in a function group is the function name concatenated with
         the function group instance name separated with a separator string.
 
-        The separator is a double underscore (``__``), but was a period (``.``) in prior versions.
+        The separator is a double underscore (``__``).
         """
-        return f"{self._instance_name}__{name}"
+        return f"{self._instance_name}{FunctionGroup.SEPARATOR}{name}"
 
     async def _fn_should_be_included(self, name: str) -> bool:
         if name not in self._per_function_filter_fn:
@@ -761,12 +787,10 @@ class FunctionGroup:
         instance_name : str
             The instance name to set for the function group.
         """
+        old_name = self._instance_name
         self._instance_name = instance_name
         for func in self._functions.values():
-            current_instance_name = func.instance_name
-            suffix = current_instance_name.split('.')[-1]
-            new_instance_name = f"{instance_name}.{suffix}"
-            func.instance_name = new_instance_name
+            func.instance_name = func.instance_name.replace(old_name, instance_name, 1)
 
     @property
     def instance_name(self) -> str:

--- a/src/nat/builder/per_user_workflow_builder.py
+++ b/src/nat/builder/per_user_workflow_builder.py
@@ -212,8 +212,8 @@ class PerUserWorkflowBuilder(Builder, AbstractAsyncContextManager):
            (name in self._shared_builder._functions) or \
            (name in self._shared_builder._function_groups):
             raise ValueError(f"Function `{name}` already exists in the list of functions or function groups")
-        if any(name.startswith(k + "__") for k in self._per_user_function_groups.keys()) or \
-            any(name.startswith(k + "__") for k in self._shared_builder._function_groups.keys()):
+        if any(name.startswith(k + FunctionGroup.SEPARATOR) for k in self._per_user_function_groups.keys()) or \
+            any(name.startswith(k + FunctionGroup.SEPARATOR) for k in self._shared_builder._function_groups.keys()):
             raise ValueError(f"A Function name starts with a Function Group name: `{name}`")
 
         registration = self._registry.get_function(type(config))
@@ -228,12 +228,11 @@ class PerUserWorkflowBuilder(Builder, AbstractAsyncContextManager):
     def _check_backwards_compatibility_function_name(self, name: str) -> str:
         if name in self._per_user_functions:
             return name
-        compat_name = name.replace(".", "__")
-        if compat_name in self._per_user_functions:
+        new_name = name.replace(FunctionGroup.LEGACY_SEPARATOR, FunctionGroup.SEPARATOR)
+        if new_name in self._per_user_functions:
             logger.warning(
-                f"Function `{name}` is deprecated and will be removed in a future release. Use `{compat_name}` instead."
-            )
-            return compat_name
+                f"Function `{name}` is deprecated and will be removed in a future release. Use `{new_name}` instead.")
+            return new_name
         return name
 
     @override
@@ -276,8 +275,8 @@ class PerUserWorkflowBuilder(Builder, AbstractAsyncContextManager):
             (name in self._shared_builder._function_groups) or \
             (name in self._shared_builder._functions):
             raise ValueError(f"Function group `{name}` already exists in the list of function groups or functions")
-        if any(k.startswith(name + "__") for k in self._per_user_functions.keys()) or \
-           any(k.startswith(name + "__") for k in self._shared_builder._functions.keys()):
+        if any(k.startswith(name + FunctionGroup.SEPARATOR) for k in self._per_user_functions.keys()) or \
+           any(k.startswith(name + FunctionGroup.SEPARATOR) for k in self._shared_builder._functions.keys()):
             raise ValueError(f"A Function name starts with a Function Group name: `{name}`")
 
         registration = self._registry.get_function_group(type(config))

--- a/src/nat/builder/workflow_builder.py
+++ b/src/nat/builder/workflow_builder.py
@@ -656,7 +656,7 @@ class WorkflowBuilder(Builder, AbstractAsyncContextManager):
 
         if (name in self._functions or name in self._function_groups):
             raise ValueError(f"Function `{name}` already exists in the list of functions or function groups")
-        if any(name.startswith(k + "__") for k in self._function_groups.keys()):
+        if any(name.startswith(k + FunctionGroup.SEPARATOR) for k in self._function_groups.keys()):
             raise ValueError(f"A Function name starts with a Function Group name: `{name}`")
 
         build_result = await self._build_function(name=name, config=config)
@@ -672,7 +672,7 @@ class WorkflowBuilder(Builder, AbstractAsyncContextManager):
 
         if (name in self._function_groups or name in self._functions):
             raise ValueError(f"Function group `{name}` already exists in the list of function groups or functions")
-        if any(k.startswith(name + "__") for k in self._functions.keys()):
+        if any(k.startswith(name + FunctionGroup.SEPARATOR) for k in self._functions.keys()):
             raise ValueError(f"A Function name starts with a Function Group name: `{name}`")
 
         # Build the function group
@@ -696,12 +696,11 @@ class WorkflowBuilder(Builder, AbstractAsyncContextManager):
     def _check_backwards_compatibility_function_name(self, name: str) -> str:
         if name in self._functions:
             return name
-        compat_name = name.replace(".", "__")
-        if compat_name in self._functions:
+        new_name = name.replace(FunctionGroup.LEGACY_SEPARATOR, FunctionGroup.SEPARATOR)
+        if new_name in self._functions:
             logger.warning(
-                f"Function `{name}` is deprecated and will be removed in a future release. Use `{compat_name}` instead."
-            )
-            return compat_name
+                f"Function `{name}` is deprecated and will be removed in a future release. Use `{new_name}` instead.")
+            return new_name
         return name
 
     @override


### PR DESCRIPTION
## Description

In addition to fixing `FunctionGroup.set_instance_name`, also:

- add `FunctionGroup.decompose(name: str) -> tuple[str, str]`
- add `FunctionGroup.SEPARATOR` and `FunctionGroup.LEGACY_SEPARATOR`
- update logic to use the separators where appropriate

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized tool/function name separator and introduced a consistent decomposition method for naming across the system.
  * Updated backwards-compatibility handling to map legacy names to the new convention and adjusted related warnings.
* **Tests**
  * Updated normalization and matching tests to reflect the new naming and prefix-stripping behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->