### PR TITLE
Fix training cancellation 404 error

### DIFF
--- a/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
+++ b/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
@@ -407,38 +407,32 @@ class NeMoCustomizerTrainerAdapter(TrainerAdapter):
                 if status.status == TrainingStatusEnum.FAILED:
                     error_msg = status.message or "Training job failed"
                     logger.error(f"Training job {ref.run_id} FAILED: {error_msg}")
-                    raise RuntimeError(
-                        f"Training job {ref.run_id} failed: {error_msg}. "
-                        f"Model was not trained and cannot be deployed. "
-                        f"Please check the job logs for details and retry the training."
-                    )
-                
+                    raise RuntimeError(f"Training job {ref.run_id} failed: {error_msg}. "
+                                       f"Model was not trained and cannot be deployed. "
+                                       f"Please check the job logs for details and retry the training.")
+
                 if status.status == TrainingStatusEnum.CANCELED:
                     error_msg = status.message or "Training job was canceled"
                     logger.error(f"Training job {ref.run_id} CANCELED: {error_msg}")
-                    
+
                     # Format progress safely
                     progress_str = f"{status.progress:.1f}%" if status.progress is not None else "unknown progress"
-                    
+
                     # If deployment was expected, raise an error
                     if self.adapter_config.deploy_on_completion:
-                        raise RuntimeError(
-                            f"Training job {ref.run_id} was canceled at {progress_str}: {error_msg}. "
-                            f"Model was not trained and will NOT be deployed. "
-                            f"Evaluation will fail because the model does not exist. "
-                            f"\n\nACTION REQUIRED:"
-                            f"\n1. Check if the job was manually canceled or timed out"
-                            f"\n2. Review NeMo MS platform health and resource availability"
-                            f"\n3. Consider increasing deployment_timeout_seconds in config"
-                            f"\n4. Use a fresh namespace to avoid conflicts: namespace: nat-dpo-test-v2"
-                            f"\n5. Retry training: nat finetune --config_file=..."
-                        )
+                        raise RuntimeError(f"Training job {ref.run_id} was canceled at {progress_str}: {error_msg}. "
+                                           f"Model was not trained and will NOT be deployed. "
+                                           f"Evaluation will fail because the model does not exist. "
+                                           f"\n\nACTION REQUIRED:"
+                                           f"\n1. Check if the job was manually canceled or timed out"
+                                           f"\n2. Review NeMo MS platform health and resource availability"
+                                           f"\n3. Consider increasing deployment_timeout_seconds in config"
+                                           f"\n4. Use a fresh namespace to avoid conflicts: namespace: nat-dpo-test-v2"
+                                           f"\n5. Retry training: nat finetune --config_file=...")
                     else:
                         # Just log warning if deployment wasn't expected
-                        logger.warning(
-                            f"Training job {ref.run_id} was canceled at {progress_str}. "
-                            f"No deployment was configured (deploy_on_completion=False)."
-                        )
+                        logger.warning(f"Training job {ref.run_id} was canceled at {progress_str}. "
+                                       f"No deployment was configured (deploy_on_completion=False).")
                         return status
 
                 # Handle successful completion with deployment
@@ -448,10 +442,8 @@ class NeMoCustomizerTrainerAdapter(TrainerAdapter):
                         await self._deploy_model(ref)
                         logger.info(f"Model deployed successfully for job {ref.run_id}")
                     else:
-                        logger.info(
-                            f"Training job {ref.run_id} completed successfully. "
-                            f"Skipping deployment (deploy_on_completion=False)."
-                        )
+                        logger.info(f"Training job {ref.run_id} completed successfully. "
+                                    f"Skipping deployment (deploy_on_completion=False).")
 
                 return status
 

--- a/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
+++ b/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
@@ -400,12 +400,55 @@ class NeMoCustomizerTrainerAdapter(TrainerAdapter):
                     TrainingStatusEnum.FAILED,
                     TrainingStatusEnum.CANCELED,
             ):
-                # Handle deployment if configured
-                if (status.status == TrainingStatusEnum.COMPLETED and self.adapter_config.deploy_on_completion):
-                    await self._deploy_model(ref)
-
-                # Clean up active job tracking
+                # Clean up active job tracking first
                 self._active_jobs.pop(ref.run_id, None)
+
+                # Handle non-successful completions with clear error messages
+                if status.status == TrainingStatusEnum.FAILED:
+                    error_msg = status.message or "Training job failed"
+                    logger.error(f"Training job {ref.run_id} FAILED: {error_msg}")
+                    raise RuntimeError(
+                        f"Training job {ref.run_id} failed: {error_msg}. "
+                        f"Model was not trained and cannot be deployed. "
+                        f"Please check the job logs for details and retry the training."
+                    )
+                
+                if status.status == TrainingStatusEnum.CANCELED:
+                    error_msg = status.message or "Training job was canceled"
+                    logger.error(f"Training job {ref.run_id} CANCELED: {error_msg}")
+                    
+                    # If deployment was expected, raise an error
+                    if self.adapter_config.deploy_on_completion:
+                        raise RuntimeError(
+                            f"Training job {ref.run_id} was canceled at {status.progress:.1f}% progress: {error_msg}. "
+                            f"Model was not trained and will NOT be deployed. "
+                            f"Evaluation will fail because the model does not exist. "
+                            f"\n\nACTION REQUIRED:"
+                            f"\n1. Check if the job was manually canceled or timed out"
+                            f"\n2. Review NeMo MS platform health and resource availability"
+                            f"\n3. Consider increasing deployment_timeout_seconds in config"
+                            f"\n4. Use a fresh namespace to avoid conflicts: namespace: nat-dpo-test-v2"
+                            f"\n5. Retry training: nat finetune --config_file=..."
+                        )
+                    else:
+                        # Just log warning if deployment wasn't expected
+                        logger.warning(
+                            f"Training job {ref.run_id} was canceled at {status.progress:.1f}% progress. "
+                            f"No deployment was configured (deploy_on_completion=False)."
+                        )
+                        return status
+
+                # Handle successful completion with deployment
+                if status.status == TrainingStatusEnum.COMPLETED:
+                    if self.adapter_config.deploy_on_completion:
+                        logger.info(f"Training job {ref.run_id} completed successfully. Deploying model...")
+                        await self._deploy_model(ref)
+                        logger.info(f"Model deployed successfully for job {ref.run_id}")
+                    else:
+                        logger.info(
+                            f"Training job {ref.run_id} completed successfully. "
+                            f"Skipping deployment (deploy_on_completion=False)."
+                        )
 
                 return status
 

--- a/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
+++ b/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
@@ -417,10 +417,13 @@ class NeMoCustomizerTrainerAdapter(TrainerAdapter):
                     error_msg = status.message or "Training job was canceled"
                     logger.error(f"Training job {ref.run_id} CANCELED: {error_msg}")
                     
+                    # Format progress safely
+                    progress_str = f"{status.progress:.1f}%" if status.progress is not None else "unknown progress"
+                    
                     # If deployment was expected, raise an error
                     if self.adapter_config.deploy_on_completion:
                         raise RuntimeError(
-                            f"Training job {ref.run_id} was canceled at {status.progress:.1f}% progress: {error_msg}. "
+                            f"Training job {ref.run_id} was canceled at {progress_str}: {error_msg}. "
                             f"Model was not trained and will NOT be deployed. "
                             f"Evaluation will fail because the model does not exist. "
                             f"\n\nACTION REQUIRED:"
@@ -433,7 +436,7 @@ class NeMoCustomizerTrainerAdapter(TrainerAdapter):
                     else:
                         # Just log warning if deployment wasn't expected
                         logger.warning(
-                            f"Training job {ref.run_id} was canceled at {status.progress:.1f}% progress. "
+                            f"Training job {ref.run_id} was canceled at {progress_str}. "
                             f"No deployment was configured (deploy_on_completion=False)."
                         )
                         return status

--- a/src/nat/data_models/evaluate.py
+++ b/src/nat/data_models/evaluate.py
@@ -91,6 +91,11 @@ class EvalGeneralConfig(BaseModel):
     # Inference profiler
     profiler: ProfilerConfig | None = None
 
+    # When enabled, validates that all LLM endpoints are accessible before starting evaluation.
+    # This catches deployment issues early (e.g., 404 errors from canceled training jobs).
+    # Recommended for production workflows. Opt-in for now, may become default in future.
+    validate_llm_endpoints: bool = False
+
     # overwrite the output_dir with the output config if present
     @model_validator(mode="before")
     @classmethod

--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -643,7 +643,7 @@ class EvaluationRun:
                 raise
             except Exception as e:
                 # Non-critical errors (missing packages, config issues) - warn but continue
-                logger.warning("LLM endpoint validation incomplete: %s. Continuing with evaluation...", e)
+                logger.warning("LLM endpoint validation incomplete: %s. Continuing with evaluation...", e, exc_info=True)
 
         # Run workflow and evaluate
         async with WorkflowEvalBuilder.from_config(config=config) as eval_workflow:

--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -630,15 +630,20 @@ class EvaluationRun:
                                        config_effective_file=self.config_effective_file,
                                        config_metadata_file=self.config_metadata_file)
 
-        # Validate LLM endpoints before running evaluation
-        if not self.config.skip_workflow and not self.config.endpoint:
+        # Validate LLM endpoints before running evaluation (opt-in via config)
+        if (not self.config.skip_workflow and not self.config.endpoint
+                and config.eval.general.validate_llm_endpoints):
             try:
                 from nat.eval.llm_validator import validate_llm_endpoints
-                logger.info("Validating LLM endpoints before evaluation...")
+                logger.info("Validating LLM endpoints before evaluation (enabled via config)...")
                 await validate_llm_endpoints(config)
-            except Exception as e:
-                logger.error(f"LLM endpoint validation failed: {e}")
+            except RuntimeError as e:
+                # Critical validation errors (404, connection failures) - fail fast
+                logger.error("LLM endpoint validation failed: %s", e)
                 raise
+            except Exception as e:
+                # Non-critical errors (missing packages, config issues) - warn but continue
+                logger.warning("LLM endpoint validation incomplete: %s. Continuing with evaluation...", e)
 
         # Run workflow and evaluate
         async with WorkflowEvalBuilder.from_config(config=config) as eval_workflow:

--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -630,6 +630,16 @@ class EvaluationRun:
                                        config_effective_file=self.config_effective_file,
                                        config_metadata_file=self.config_metadata_file)
 
+        # Validate LLM endpoints before running evaluation
+        if not self.config.skip_workflow and not self.config.endpoint:
+            try:
+                from nat.eval.llm_validator import validate_llm_endpoints
+                logger.info("Validating LLM endpoints before evaluation...")
+                await validate_llm_endpoints(config)
+            except Exception as e:
+                logger.error(f"LLM endpoint validation failed: {e}")
+                raise
+
         # Run workflow and evaluate
         async with WorkflowEvalBuilder.from_config(config=config) as eval_workflow:
             # Initialize Weave integration

--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -38,6 +38,7 @@ from nat.eval.dataset_handler.dataset_handler import DatasetHandler
 from nat.eval.evaluator.evaluator_model import EvalInput
 from nat.eval.evaluator.evaluator_model import EvalInputItem
 from nat.eval.evaluator.evaluator_model import EvalOutput
+from nat.eval.llm_validator import validate_llm_endpoints
 from nat.eval.usage_stats import UsageStats
 from nat.eval.usage_stats import UsageStatsItem
 from nat.eval.usage_stats import UsageStatsLLM
@@ -634,7 +635,6 @@ class EvaluationRun:
         if (not self.config.skip_workflow and not self.config.endpoint
                 and config.eval.general.validate_llm_endpoints):
             try:
-                from nat.eval.llm_validator import validate_llm_endpoints
                 logger.info("Validating LLM endpoints before evaluation (enabled via config)...")
                 await validate_llm_endpoints(config)
             except RuntimeError as e:

--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -632,8 +632,7 @@ class EvaluationRun:
                                        config_metadata_file=self.config_metadata_file)
 
         # Validate LLM endpoints before running evaluation (opt-in via config)
-        if (not self.config.skip_workflow and not self.config.endpoint
-                and config.eval.general.validate_llm_endpoints):
+        if (not self.config.skip_workflow and not self.config.endpoint and config.eval.general.validate_llm_endpoints):
             try:
                 logger.info("Validating LLM endpoints before evaluation (enabled via config)...")
                 await validate_llm_endpoints(config)
@@ -643,7 +642,9 @@ class EvaluationRun:
                 raise
             except Exception as e:
                 # Non-critical errors (missing packages, config issues) - warn but continue
-                logger.warning("LLM endpoint validation incomplete: %s. Continuing with evaluation...", e, exc_info=True)
+                logger.warning("LLM endpoint validation incomplete: %s. Continuing with evaluation...",
+                               e,
+                               exc_info=True)
 
         # Run workflow and evaluate
         async with WorkflowEvalBuilder.from_config(config=config) as eval_workflow:

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -192,7 +192,7 @@ async def _validate_single_llm(
                 f"  2. The model name is incorrect\n"
                 f"  3. A training job was canceled and the model was never deployed\n"
                 f"\nLLM Configuration:\n"
-                f"  Type: {llm_config.type}\n"
+                f"  Type: {str(llm_config.type)}\n"
                 f"  Endpoint: {base_url or 'N/A'}\n"
                 f"  Model: {model_name or 'N/A'}\n"
                 f"\nACTION REQUIRED:\n"

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -23,18 +23,28 @@ training cancellation) and provides actionable error messages.
 The validation uses NAT's WorkflowBuilder to instantiate LLMs in a framework-agnostic way,
 then tests them with a minimal ainvoke() call. This approach works for all LLM types
 (OpenAI, NIM, AWS Bedrock, vLLM, etc.) and respects NAT's native auth and config system.
+
+Note: Validation invokes actual LLM endpoints with minimal test prompts. This may incur
+small API costs for cloud-hosted models.
 """
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.workflow_builder import WorkflowBuilder
+from nat.data_models.llm import LLMBaseConfig
 
 if TYPE_CHECKING:
     from nat.data_models.config import Config
 
 logger = logging.getLogger(__name__)
+
+# Constants
+VALIDATION_TIMEOUT_SECONDS = 30  # Timeout for each LLM validation
+MAX_ERROR_MESSAGE_LENGTH = 500  # Truncate long error messages
+CONCURRENT_VALIDATION_BATCH_SIZE = 5  # Max LLMs to validate in parallel
 
 
 def _is_404_error(exception: Exception) -> bool:
@@ -43,7 +53,7 @@ def _is_404_error(exception: Exception) -> bool:
 
     This handles various 404 error formats from different LLM providers:
     - OpenAI SDK: openai.NotFoundError
-    - HTTP responses: 404 in error message
+    - HTTP responses: HTTP 404 or status code 404
     - LangChain wrappers: Various wrapped 404s
 
     Args:
@@ -59,18 +69,20 @@ def _is_404_error(exception: Exception) -> bool:
     if "notfounderror" in exception_type.lower():
         return True
 
-    # Check for 404 in error message
-    if "404" in exception_str:
+    # Check for HTTP 404 specifically (not just "404" which could appear in other contexts)
+    if any(pattern in exception_str for pattern in ["http 404", "status code 404", "status_code=404"]):
         return True
 
-    # Check for common "not found" phrases
-    if any(phrase in exception_str for phrase in ["not found", "does not exist", "not deployed"]):
+    # Check for model-specific not found errors
+    if "model" in exception_str and any(
+        phrase in exception_str for phrase in ["not found", "does not exist", "not deployed", "not available"]
+    ):
         return True
 
     return False
 
 
-def _get_llm_endpoint_info(llm_config) -> tuple[str | None, str | None]:
+def _get_llm_endpoint_info(llm_config: LLMBaseConfig) -> tuple[str | None, str | None]:
     """
     Extract endpoint and model information from an LLM config.
 
@@ -90,6 +102,99 @@ def _get_llm_endpoint_info(llm_config) -> tuple[str | None, str | None]:
     return base_url, model_name
 
 
+def _truncate_error_message(message: str, max_length: int = MAX_ERROR_MESSAGE_LENGTH) -> str:
+    """
+    Truncate error messages to prevent memory issues with large stack traces.
+
+    Args:
+        message: The error message to truncate.
+        max_length: Maximum length to keep.
+
+    Returns:
+        Truncated message with ellipsis if needed.
+    """
+    if len(message) <= max_length:
+        return message
+    return message[:max_length] + "... (truncated)"
+
+
+async def _validate_single_llm(
+    builder: WorkflowBuilder, llm_name: str, llm_config: LLMBaseConfig
+) -> tuple[str, str | None, str | None]:
+    """
+    Validate a single LLM endpoint.
+
+    Args:
+        builder: The WorkflowBuilder instance.
+        llm_name: Name of the LLM to validate.
+        llm_config: Configuration for the LLM.
+
+    Returns:
+        Tuple of (llm_name, error_type, error_message):
+        - error_type: "404" for model not found, "warning" for non-critical, None for success
+        - error_message: Description of the error, or None if successful
+    """
+    try:
+        logger.info("Validating LLM '%s' (type: %s)", llm_name, llm_config.type)
+
+        # Add LLM to builder (handles all LLM types)
+        await asyncio.wait_for(builder.add_llm(llm_name, llm_config), timeout=VALIDATION_TIMEOUT_SECONDS)
+
+        # Get LangChain-wrapped LLM instance
+        llm = await asyncio.wait_for(
+            builder.get_llm(llm_name, LLMFrameworkEnum.LANGCHAIN), timeout=VALIDATION_TIMEOUT_SECONDS
+        )
+
+        # Test with minimal prompt - this will hit the endpoint
+        await asyncio.wait_for(llm.ainvoke("test"), timeout=VALIDATION_TIMEOUT_SECONDS)
+        logger.info("LLM '%s' validated successfully", llm_name)
+        return (llm_name, None, None)
+
+    except TimeoutError:
+        error_msg = f"Validation timed out after {VALIDATION_TIMEOUT_SECONDS}s"
+        logger.warning("LLM '%s' validation timed out", llm_name)
+        return (llm_name, "warning", _truncate_error_message(error_msg))
+
+    except (KeyboardInterrupt, SystemExit):
+        # Don't catch system-level interrupts
+        raise
+
+    except Exception as invoke_error:
+        # Check if this is a 404 error (model not deployed)
+        if _is_404_error(invoke_error):
+            base_url, model_name = _get_llm_endpoint_info(llm_config)
+
+            error_msg = (
+                f"LLM '{llm_name}' validation failed: Model not found (404).\n"
+                f"\nThis typically means:\n"
+                f"  1. The model has not been deployed yet\n"
+                f"  2. The model name is incorrect\n"
+                f"  3. A training job was canceled and the model was never deployed\n"
+                f"\nLLM Configuration:\n"
+                f"  Type: {llm_config.type}\n"
+                f"  Endpoint: {base_url or 'N/A'}\n"
+                f"  Model: {model_name or 'N/A'}\n"
+                f"\nACTION REQUIRED:\n"
+                f"  1. Verify the model is deployed (check your deployment service)\n"
+                f"  2. If using NeMo Customizer, ensure training completed successfully\n"
+                f"  3. Check model deployment status in your platform\n"
+                f"  4. Verify the model name matches the deployed model\n"
+                f"\nOriginal error: {_truncate_error_message(str(invoke_error))}"
+            )
+            logger.error(error_msg)
+            return (llm_name, "404", error_msg)
+
+        else:
+            # Non-404 error - might be auth, rate limit, temporary issue, etc.
+            error_msg = (
+                f"Could not fully validate LLM '{llm_name}': {_truncate_error_message(str(invoke_error))}. "
+                f"This might be due to auth requirements, rate limits, or temporary issues. "
+                f"Evaluation will proceed, but may fail if the LLM is truly inaccessible."
+            )
+            logger.warning(error_msg)
+            return (llm_name, "warning", _truncate_error_message(str(invoke_error)))
+
+
 async def validate_llm_endpoints(config: "Config") -> None:
     """
     Validate that all LLM endpoints in the config are accessible.
@@ -103,78 +208,63 @@ async def validate_llm_endpoints(config: "Config") -> None:
     - 404 errors: Fail fast with detailed troubleshooting guidance
     - Other errors: Log warning but continue (to avoid false positives)
 
+    LLMs are validated in parallel batches to improve performance while respecting
+    rate limits. Each validation has a timeout to prevent hanging.
+
+    Note: This function invokes actual LLM endpoints, which may incur small API costs.
+
     Args:
         config: The NAT configuration object containing LLM definitions.
 
     Raises:
         RuntimeError: If any LLM endpoint has a 404 error (model not deployed).
+        ValueError: If config.llms is not properly structured.
     """
+    # Validate config structure
+    if not hasattr(config, "llms"):
+        raise ValueError("Config object does not have 'llms' attribute")
+
     if not config.llms:
         logger.debug("No LLMs defined in config, skipping validation")
         return
+
+    if not isinstance(config.llms, dict):
+        raise ValueError(f"config.llms must be a dict, got {type(config.llms)}")
 
     failed_llms = []  # List of (llm_name, error_message) tuples for 404 errors
     validation_warnings = []  # List of (llm_name, warning_message) tuples for non-critical errors
 
     # Use WorkflowBuilder to instantiate and test LLMs
     async with WorkflowBuilder() as builder:
-        for llm_name, llm_config in config.llms.items():
-            try:
-                logger.info("Validating LLM '%s' (type: %s)", llm_name, llm_config.type)
+        # Get list of LLMs to validate
+        llm_items = list(config.llms.items())
 
-                # Add LLM to builder (handles all LLM types)
-                await builder.add_llm(llm_name, llm_config)
+        # Validate in batches to respect rate limits
+        for batch_start in range(0, len(llm_items), CONCURRENT_VALIDATION_BATCH_SIZE):
+            batch = llm_items[batch_start : batch_start + CONCURRENT_VALIDATION_BATCH_SIZE]
 
-                # Get LangChain-wrapped LLM instance
-                llm = await builder.get_llm(llm_name, LLMFrameworkEnum.LANGCHAIN)
+            # Validate batch in parallel
+            validation_tasks = [_validate_single_llm(builder, llm_name, llm_config) for llm_name, llm_config in batch]
 
-                # Test with minimal prompt - this will hit the endpoint
-                try:
-                    await llm.ainvoke("test")
-                    logger.info("LLM '%s' validated successfully", llm_name)
+            results = await asyncio.gather(*validation_tasks, return_exceptions=True)
 
-                except Exception as invoke_error:
-                    # Check if this is a 404 error (model not deployed)
-                    if _is_404_error(invoke_error):
-                        base_url, model_name = _get_llm_endpoint_info(llm_config)
+            # Process results
+            for result in results:
+                if isinstance(result, BaseException):
+                    # Unexpected exception during validation
+                    # Note: SystemExit and KeyboardInterrupt are re-raised in _validate_single_llm
+                    # so we shouldn't see them here
+                    logger.warning("Unexpected error during validation: %s", _truncate_error_message(str(result)))
+                    validation_warnings.append(("unknown", _truncate_error_message(str(result))))
+                else:
+                    # Normal result: (llm_name, error_type, error_message)
+                    llm_name, error_type, error_message = result
 
-                        error_msg = (
-                            f"LLM '{llm_name}' validation failed: Model not found (404).\n"
-                            f"This typically means:\n"
-                            f"  1. The model has not been deployed yet\n"
-                            f"  2. The model name is incorrect\n"
-                            f"  3. A training job was canceled and the model was never deployed\n"
-                            f"\nLLM Configuration:\n"
-                            f"  Type: {llm_config.type}\n"
-                            f"  Endpoint: {base_url or 'N/A'}\n"
-                            f"  Model: {model_name or 'N/A'}\n"
-                            f"\nACTION REQUIRED:\n"
-                            f"  1. Verify the model is deployed: Check your deployment service\n"
-                            f"  2. If using NeMo Customizer, ensure training completed successfully\n"
-                            f"  3. Check model deployment status in your platform\n"
-                            f"  4. Verify the model name matches the deployed model\n"
-                            f"\nOriginal error: {invoke_error}"
-                        )
-                        logger.error(error_msg)
-                        failed_llms.append((llm_name, error_msg))
-
-                    else:
-                        # Non-404 error - might be auth, rate limit, temporary issue, etc.
-                        # Don't fail validation, but warn the user
-                        warning_msg = (
-                            f"Could not fully validate LLM '{llm_name}': {invoke_error}. "
-                            f"This might be due to auth requirements, rate limits, or temporary issues. "
-                            f"Evaluation will proceed, but may fail if the LLM is truly inaccessible."
-                        )
-                        logger.warning(warning_msg)
-                        validation_warnings.append((llm_name, str(invoke_error)))
-
-            except Exception as e:
-                # Error during builder setup (before ainvoke)
-                # This could be import errors, config errors, etc.
-                warning_msg = f"Could not validate LLM '{llm_name}' due to setup error: {e}"
-                logger.warning(warning_msg)
-                validation_warnings.append((llm_name, str(e)))
+                    if error_type == "404":
+                        failed_llms.append((llm_name, error_message))
+                    elif error_type == "warning":
+                        validation_warnings.append((llm_name, error_message))
+                    # If error_type is None, validation succeeded (no action needed)
 
     # Report non-critical warnings
     if validation_warnings:

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -241,16 +241,6 @@ async def validate_llm_endpoints(config: "Config") -> None:
         RuntimeError: If any LLM endpoint has a 404 error (model not deployed).
         ValueError: If config.llms is not properly structured.
     """
-    # Validate config structure
-    if not hasattr(config, "llms"):
-        raise ValueError("Config object does not have 'llms' attribute")
-
-    if not config.llms:
-        logger.debug("No LLMs defined in config, skipping validation")
-        return
-
-    if not isinstance(config.llms, dict):
-        raise ValueError(f"config.llms must be a dict, got {type(config.llms)}")
 
     failed_llms = []  # List of (llm_name, error_message) tuples for 404 errors
     validation_warnings = []  # List of (llm_name, warning_message) tuples for non-critical errors

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -12,7 +12,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """
 LLM Endpoint Validator for NeMo Agent Toolkit evaluation.
 
@@ -76,9 +75,8 @@ def _is_404_error(exception: Exception) -> bool:
         return True
 
     # Check for model-specific not found errors
-    if "model" in exception_str and any(
-        phrase in exception_str for phrase in ["not found", "does not exist", "not deployed", "not available"]
-    ):
+    if "model" in exception_str and any(phrase in exception_str
+                                        for phrase in ["not found", "does not exist", "not deployed", "not available"]):
         return True
 
     return False
@@ -132,9 +130,8 @@ def _truncate_error_message(message: str, max_length: int = MAX_ERROR_MESSAGE_LE
     return f"{message[:keep_length]}{separator}{message[-keep_length:]}"
 
 
-async def _validate_single_llm(
-    builder: WorkflowBuilder, llm_name: str, llm_config: LLMBaseConfig
-) -> tuple[str | None, str | None]:
+async def _validate_single_llm(builder: WorkflowBuilder, llm_name: str,
+                               llm_config: LLMBaseConfig) -> tuple[str | None, str | None]:
     """
     Validate a single LLM endpoint.
 
@@ -169,12 +166,10 @@ async def _validate_single_llm(
         if llm is None:
             # Log all attempted frameworks for debugging
             attempted = [f.value for f in LLMFrameworkEnum]
-            error_msg = (
-                f"Could not instantiate LLM '{llm_name}' with any known framework. "
-                f"Attempted: {', '.join(attempted)}. "
-                f"If this LLM uses a custom framework, this warning can be safely ignored. "
-                f"Otherwise, verify the LLM type '{llm_config.type}' is supported and configured correctly."
-            )
+            error_msg = (f"Could not instantiate LLM '{llm_name}' with any known framework. "
+                         f"Attempted: {', '.join(attempted)}. "
+                         f"If this LLM uses a custom framework, this warning can be safely ignored. "
+                         f"Otherwise, verify the LLM type '{llm_config.type}' is supported and configured correctly.")
             logger.warning("LLM '%s' - Framework instantiation failed: %s", llm_name, error_msg)
             return ("warning", error_msg)
 
@@ -199,33 +194,29 @@ async def _validate_single_llm(
         if _is_404_error(invoke_error):
             base_url, model_name = _get_llm_endpoint_info(llm_config)
 
-            error_msg = (
-                f"LLM '{llm_name}' validation failed: Model not found (404).\n"
-                f"\nThis typically means:\n"
-                f"  1. The model has not been deployed yet\n"
-                f"  2. The model name is incorrect\n"
-                f"  3. A training job was canceled and the model was never deployed\n"
-                f"\nLLM Configuration:\n"
-                f"  Type: {str(llm_config.type)}\n"
-                f"  Endpoint: {base_url or 'N/A'}\n"
-                f"  Model: {model_name or 'N/A'}\n"
-                f"\nACTION REQUIRED:\n"
-                f"  1. Verify the model is deployed (check your deployment service)\n"
-                f"  2. If using NeMo Customizer, ensure training completed successfully\n"
-                f"  3. Check model deployment status in your platform\n"
-                f"  4. Verify the model name matches the deployed model\n"
-                f"\nOriginal error: {_truncate_error_message(str(invoke_error))}"
-            )
+            error_msg = (f"LLM '{llm_name}' validation failed: Model not found (404).\n"
+                         f"\nThis typically means:\n"
+                         f"  1. The model has not been deployed yet\n"
+                         f"  2. The model name is incorrect\n"
+                         f"  3. A training job was canceled and the model was never deployed\n"
+                         f"\nLLM Configuration:\n"
+                         f"  Type: {str(llm_config.type)}\n"
+                         f"  Endpoint: {base_url or 'N/A'}\n"
+                         f"  Model: {model_name or 'N/A'}\n"
+                         f"\nACTION REQUIRED:\n"
+                         f"  1. Verify the model is deployed (check your deployment service)\n"
+                         f"  2. If using NeMo Customizer, ensure training completed successfully\n"
+                         f"  3. Check model deployment status in your platform\n"
+                         f"  4. Verify the model name matches the deployed model\n"
+                         f"\nOriginal error: {_truncate_error_message(str(invoke_error))}")
             logger.exception(error_msg)
             return ("404", error_msg)
 
         else:
             # Non-404 error - might be auth, rate limit, temporary issue, etc.
-            error_msg = (
-                f"Could not fully validate LLM '{llm_name}': {_truncate_error_message(str(invoke_error))}. "
-                f"This might be due to auth requirements, rate limits, or temporary issues. "
-                f"Evaluation will proceed, but may fail if the LLM is truly inaccessible."
-            )
+            error_msg = (f"Could not fully validate LLM '{llm_name}': {_truncate_error_message(str(invoke_error))}. "
+                         f"This might be due to auth requirements, rate limits, or temporary issues. "
+                         f"Evaluation will proceed, but may fail if the LLM is truly inaccessible.")
             logger.exception(error_msg)
             return ("warning", _truncate_error_message(error_msg))
 
@@ -262,9 +253,7 @@ async def validate_llm_endpoints(config: "Config") -> None:
 
     if not isinstance(config.llms, dict):
         raise ValueError(
-            f"Config.llms must be a dict, got {type(config.llms).__name__}. "
-            "Cannot validate LLM endpoints."
-        )
+            f"Config.llms must be a dict, got {type(config.llms).__name__}. Cannot validate LLM endpoints.")
 
     if not config.llms:
         logger.info("No LLMs configured - skipping endpoint validation")
@@ -280,7 +269,7 @@ async def validate_llm_endpoints(config: "Config") -> None:
 
         # Validate in batches to respect rate limits
         for batch_start in range(0, len(llm_items), CONCURRENT_VALIDATION_BATCH_SIZE):
-            batch = llm_items[batch_start : batch_start + CONCURRENT_VALIDATION_BATCH_SIZE]
+            batch = llm_items[batch_start:batch_start + CONCURRENT_VALIDATION_BATCH_SIZE]
 
             # Validate batch in parallel
             validation_tasks = [_validate_single_llm(builder, llm_name, llm_config) for llm_name, llm_config in batch]
@@ -333,12 +322,10 @@ async def validate_llm_endpoints(config: "Config") -> None:
             len(failed_llms),
         )
 
-        raise RuntimeError(
-            f"LLM endpoint validation failed for {len(failed_llms)} LLM(s) with 404 errors:\n\n"
-            f"{error_summary}\n\n"
-            f"Evaluation cannot proceed with undeployed models. "
-            f"Please resolve the deployment issues above before retrying."
-        )
+        raise RuntimeError(f"LLM endpoint validation failed for {len(failed_llms)} LLM(s) with 404 errors:\n\n"
+                           f"{error_summary}\n\n"
+                           f"Evaluation cannot proceed with undeployed models. "
+                           f"Please resolve the deployment issues above before retrying.")
 
     # Log success metrics
     logger.info(

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -202,7 +202,7 @@ async def _validate_single_llm(
                 f"  4. Verify the model name matches the deployed model\n"
                 f"\nOriginal error: {_truncate_error_message(str(invoke_error))}"
             )
-            logger.error(error_msg)
+            logger.exception(error_msg)
             return ("404", error_msg)
 
         else:

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -162,7 +162,16 @@ async def _validate_single_llm(
                 continue  # Try next framework
 
         if llm is None:
-            return ("warning", "Could not instantiate LLM with any framework")
+            # Log all attempted frameworks for debugging
+            attempted = [f.value for f in LLMFrameworkEnum]
+            error_msg = (
+                f"Could not instantiate LLM '{llm_name}' with any known framework. "
+                f"Attempted: {', '.join(attempted)}. "
+                f"If this LLM uses a custom framework, this warning can be safely ignored. "
+                f"Otherwise, verify the LLM type '{llm_config.type}' is supported and configured correctly."
+            )
+            logger.warning("LLM '%s' - Framework instantiation failed: %s", llm_name, error_msg)
+            return ("warning", error_msg)
 
         # Test with minimal prompt - this will hit the endpoint
         await asyncio.wait_for(llm.ainvoke(VALIDATION_PROMPT), timeout=VALIDATION_TIMEOUT_SECONDS)

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -150,14 +150,23 @@ async def _validate_single_llm(
         # Add LLM to builder (handles all LLM types)
         builder.add_llm(llm_name, llm_config)
 
-        # Get LangChain-wrapped LLM instance
-        llm = await asyncio.wait_for(
-            builder.get_llm(llm_name, LLMFrameworkEnum.LANGCHAIN), timeout=VALIDATION_TIMEOUT_SECONDS
-        )
+        # Try all frameworks to find one that works with this LLM
+        llm = None
+        for framework in LLMFrameworkEnum:
+            try:
+                llm = await builder.get_llm(llm_name, framework)
+                logger.debug("LLM '%s' successfully loaded with framework '%s'", llm_name, framework.value)
+                break  # Found a working framework
+            except Exception as e:
+                logger.debug("LLM '%s' failed with framework '%s': %s", llm_name, framework.value, e)
+                continue  # Try next framework
+
+        if llm is None:
+            return ("warning", "Could not instantiate LLM with any framework")
 
         # Test with minimal prompt - this will hit the endpoint
         await asyncio.wait_for(llm.ainvoke(VALIDATION_PROMPT), timeout=VALIDATION_TIMEOUT_SECONDS)
-
+        
         duration = time.time() - start_time
         logger.info("LLM '%s' validated successfully in %.2fs", llm_name, duration)
         return (llm_name, None, None)

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -129,7 +129,7 @@ def _truncate_error_message(message: str, max_length: int = MAX_ERROR_MESSAGE_LE
 
 async def _validate_single_llm(
     builder: WorkflowBuilder, llm_name: str, llm_config: LLMBaseConfig
-) -> tuple[str, str | None, str | None]:
+) -> tuple[str | None, str | None]:
     """
     Validate a single LLM endpoint.
 
@@ -139,7 +139,7 @@ async def _validate_single_llm(
         llm_config: Configuration for the LLM.
 
     Returns:
-        Tuple of (llm_name, error_type, error_message):
+        Tuple of (error_type, error_message):
         - error_type: "404" for model not found, "warning" for non-critical, None for success
         - error_message: Description of the error, or None if successful
     """
@@ -169,12 +169,12 @@ async def _validate_single_llm(
         
         duration = time.time() - start_time
         logger.info("LLM '%s' validated successfully in %.2fs", llm_name, duration)
-        return (llm_name, None, None)
+        return (None, None)
 
     except TimeoutError:
         error_msg = f"Validation timed out after {VALIDATION_TIMEOUT_SECONDS}s"
         logger.warning("LLM '%s' validation timed out", llm_name)
-        return (llm_name, "warning", _truncate_error_message(error_msg))
+        return ("warning", _truncate_error_message(error_msg))
 
     except (KeyboardInterrupt, SystemExit):
         # Don't catch system-level interrupts
@@ -203,7 +203,7 @@ async def _validate_single_llm(
                 f"\nOriginal error: {_truncate_error_message(str(invoke_error))}"
             )
             logger.error(error_msg)
-            return (llm_name, "404", error_msg)
+            return ("404", error_msg)
 
         else:
             # Non-404 error - might be auth, rate limit, temporary issue, etc.
@@ -213,7 +213,7 @@ async def _validate_single_llm(
                 f"Evaluation will proceed, but may fail if the LLM is truly inaccessible."
             )
             logger.warning(error_msg)
-            return (llm_name, "warning", _truncate_error_message(str(invoke_error)))
+            return ("warning", _truncate_error_message(str(invoke_error)))
 
 
 async def validate_llm_endpoints(config: "Config") -> None:
@@ -269,28 +269,26 @@ async def validate_llm_endpoints(config: "Config") -> None:
 
             results = await asyncio.gather(*validation_tasks, return_exceptions=True)
 
-            # Process results
-            for result in results:
+            # Process results - zip with batch to maintain llm_name association
+            for (llm_name, llm_config), result in zip(batch, results):
                 if isinstance(result, BaseException):
                     # Re-raise system interrupts if they somehow got through
                     if isinstance(result, (KeyboardInterrupt, SystemExit)):
                         raise result
 
                     # Unexpected exception during validation
-                    # Note: SystemExit and KeyboardInterrupt should be re-raised in _validate_single_llm
-                    # but we check again here as a defensive measure
                     logger.warning("Unexpected error during validation: %s", _truncate_error_message(str(result)))
-                    validation_warnings.append(("unknown", _truncate_error_message(str(result))))
+                    validation_warnings.append((llm_name, _truncate_error_message(str(result))))
                 else:
-                    # Normal result: (llm_name, error_type, error_message)
-                    llm_name, error_type, error_message = result
+                    # Normal result: (error_type, error_message)
+                    error_type, error_message = result
 
                     if error_type == "404":
                         failed_llms.append((llm_name, error_message))
                     elif error_type == "warning":
                         validation_warnings.append((llm_name, error_message))
                     # If error_type is None, validation succeeded (no action needed)
-
+    
     # Calculate validation metrics
     total_llms = len(llm_items)
     succeeded_count = total_llms - len(failed_llms) - len(validation_warnings)

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -148,7 +148,7 @@ async def _validate_single_llm(
         start_time = time.time()
 
         # Add LLM to builder (handles all LLM types)
-        builder.add_llm(llm_name, llm_config)
+        await builder.add_llm(llm_name, llm_config)
 
         # Try all frameworks to find one that works with this LLM
         llm = None
@@ -182,7 +182,7 @@ async def _validate_single_llm(
 
     except TimeoutError:
         error_msg = f"Validation timed out after {VALIDATION_TIMEOUT_SECONDS}s"
-        logger.warning("LLM '%s' validation timed out", llm_name)
+        logger.exception("LLM '%s' validation timed out", llm_name)
         return ("warning", _truncate_error_message(error_msg))
 
     except (KeyboardInterrupt, SystemExit):
@@ -221,7 +221,7 @@ async def _validate_single_llm(
                 f"This might be due to auth requirements, rate limits, or temporary issues. "
                 f"Evaluation will proceed, but may fail if the LLM is truly inaccessible."
             )
-            logger.warning(error_msg)
+            logger.exception(error_msg)
             return ("warning", _truncate_error_message(str(invoke_error)))
 
 

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -1,0 +1,145 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""LLM endpoint validation utilities for evaluation."""
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def validate_llm_endpoints(config: "Config") -> None:  # noqa: F821
+    """
+    Validate that all LLM endpoints in the config are accessible.
+    
+    This function checks OpenAI-compatible LLM endpoints to ensure they are
+    reachable before running evaluation. This prevents cryptic 404 errors
+    during evaluation when models are not deployed.
+    
+    Args:
+        config: The NAT configuration object containing LLM definitions.
+        
+    Raises:
+        RuntimeError: If any LLM endpoint validation fails.
+    """
+    if not config.llms:
+        logger.debug("No LLMs defined in config, skipping validation")
+        return
+    
+    failed_llms = []
+    
+    for llm_name, llm_config in config.llms.items():
+        try:
+            # Only validate OpenAI-compatible endpoints
+            if llm_config.type not in ["openai", "nim"]:
+                logger.debug(f"Skipping validation for LLM '{llm_name}' (type: {llm_config.type})")
+                continue
+            
+            base_url = getattr(llm_config, "base_url", None)
+            model_name = getattr(llm_config, "model_name", None)
+            
+            if not base_url:
+                logger.debug(f"LLM '{llm_name}' has no base_url, skipping validation")
+                continue
+            
+            logger.info(f"Validating LLM endpoint '{llm_name}': {base_url}")
+            
+            # Try to connect to the endpoint
+            try:
+                import openai
+                
+                # Get API key if available
+                api_key = getattr(llm_config, "api_key", None) or "unused"
+                
+                # Create client and test connection
+                client = openai.OpenAI(base_url=base_url, api_key=api_key)
+                
+                # Simple connectivity check - list models
+                try:
+                    models = client.models.list()
+                    logger.info(f"✓ LLM endpoint '{llm_name}' is accessible ({len(list(models.data))} models available)")
+                except Exception as list_error:
+                    # Some endpoints don't support /models, try a simple completion instead
+                    logger.debug(f"Models list failed for '{llm_name}', trying completion test: {list_error}")
+                    
+                    # Try a minimal completion request
+                    try:
+                        client.completions.create(
+                            model=model_name or "test",
+                            prompt="test",
+                            max_tokens=1,
+                        )
+                        logger.info(f"✓ LLM endpoint '{llm_name}' is accessible (completion test passed)")
+                    except openai.NotFoundError as nf_error:
+                        # 404 means endpoint is reachable but model doesn't exist
+                        error_msg = (
+                            f"LLM endpoint '{llm_name}' is reachable but model '{model_name}' was not found (404). "
+                            f"This typically means:\n"
+                            f"  1. The model has not been deployed yet\n"
+                            f"  2. The model name is incorrect\n"
+                            f"  3. A training job was canceled and the model was never deployed\n"
+                            f"\nEndpoint: {base_url}\n"
+                            f"Model: {model_name}\n"
+                            f"\nACTION REQUIRED:\n"
+                            f"  1. Verify the model is deployed: Check your NIM deployment service\n"
+                            f"  2. If using NeMo Customizer, ensure training completed successfully\n"
+                            f"  3. Check model deployment status in your NeMo MS platform\n"
+                            f"  4. Verify the model name matches the deployed model\n"
+                            f"\nOriginal error: {nf_error}"
+                        )
+                        logger.error(error_msg)
+                        failed_llms.append((llm_name, error_msg))
+                        continue
+                    except Exception as comp_error:
+                        # Other errors might be okay (auth, rate limit, etc.)
+                        logger.warning(
+                            f"LLM endpoint '{llm_name}' validation inconclusive: {comp_error}. "
+                            f"Proceeding with evaluation (endpoint may still work)."
+                        )
+                
+            except ImportError:
+                logger.warning(
+                    f"Cannot validate LLM '{llm_name}': openai package not installed. "
+                    f"Install with: pip install openai"
+                )
+            except Exception as e:
+                error_msg = (
+                    f"Failed to connect to LLM endpoint '{llm_name}' at {base_url}: {e}\n"
+                    f"\nACTION REQUIRED:\n"
+                    f"  1. Check that the endpoint is running and accessible\n"
+                    f"  2. Verify network connectivity to {base_url}\n"
+                    f"  3. Ensure API credentials are correct\n"
+                    f"  4. Check firewall and proxy settings\n"
+                )
+                logger.error(error_msg)
+                failed_llms.append((llm_name, error_msg))
+                
+        except Exception as e:
+            logger.warning(f"Error during validation of LLM '{llm_name}': {e}")
+    
+    # If any critical LLMs failed, raise an error
+    if failed_llms:
+        error_summary = "\n\n".join([
+            f"LLM '{name}':\n{msg}" for name, msg in failed_llms
+        ])
+        raise RuntimeError(
+            f"LLM endpoint validation failed for {len(failed_llms)} LLM(s):\n\n"
+            f"{error_summary}\n\n"
+            f"Evaluation cannot proceed with inaccessible LLM endpoints. "
+            f"Please resolve the issues above before retrying."
+        )
+    
+    logger.info("✓ All LLM endpoints validated successfully")
+

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -13,10 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""LLM endpoint validation utilities for evaluation."""
+"""
+LLM Endpoint Validator for NAT Evaluation.
+
+This module provides functionality to validate LLM endpoints before running evaluation
+workflows. This helps catch deployment issues early (e.g., models not deployed after
+training cancellation) and provides actionable error messages.
+
+The validation uses NAT's WorkflowBuilder to instantiate LLMs in a framework-agnostic way,
+then tests them with a minimal ainvoke() call. This approach works for all LLM types
+(OpenAI, NIM, AWS Bedrock, vLLM, etc.) and respects NAT's native auth and config system.
+"""
 
 import logging
 from typing import TYPE_CHECKING
+
+from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.builder.workflow_builder import WorkflowBuilder
 
 if TYPE_CHECKING:
     from nat.data_models.config import Config
@@ -24,115 +37,162 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _is_404_error(exception: Exception) -> bool:
+    """
+    Detect if an exception represents a 404 (model not found) error.
+
+    This handles various 404 error formats from different LLM providers:
+    - OpenAI SDK: openai.NotFoundError
+    - HTTP responses: 404 in error message
+    - LangChain wrappers: Various wrapped 404s
+
+    Args:
+        exception: The exception to check.
+
+    Returns:
+        True if this is a 404 error, False otherwise.
+    """
+    exception_str = str(exception).lower()
+    exception_type = type(exception).__name__
+
+    # Check for NotFoundError type (OpenAI SDK)
+    if "notfounderror" in exception_type.lower():
+        return True
+
+    # Check for 404 in error message
+    if "404" in exception_str:
+        return True
+
+    # Check for common "not found" phrases
+    if any(phrase in exception_str for phrase in ["not found", "does not exist", "not deployed"]):
+        return True
+
+    return False
+
+
+def _get_llm_endpoint_info(llm_config) -> tuple[str | None, str | None]:
+    """
+    Extract endpoint and model information from an LLM config.
+
+    Args:
+        llm_config: The LLM configuration object.
+
+    Returns:
+        Tuple of (base_url, model_name), either may be None.
+    """
+    base_url = getattr(llm_config, "base_url", None)
+
+    # Try multiple attributes for model name
+    model_name = getattr(llm_config, "model_name", None)
+    if model_name is None:
+        model_name = getattr(llm_config, "model", None)
+
+    return base_url, model_name
+
+
 async def validate_llm_endpoints(config: "Config") -> None:
     """
     Validate that all LLM endpoints in the config are accessible.
 
-    This function checks OpenAI-compatible LLM endpoints to ensure they are
-    reachable before running evaluation. This prevents cryptic 404 errors
-    during evaluation when models are not deployed.
+    This function uses NAT's WorkflowBuilder to instantiate each configured LLM
+    and tests it with a minimal ainvoke() call. This approach is framework-agnostic
+    and works for all LLM types (OpenAI, NIM, AWS Bedrock, vLLM, etc.).
+
+    The validation distinguishes between critical errors (404s indicating model not
+    deployed) and non-critical errors (auth issues, rate limits, etc.):
+    - 404 errors: Fail fast with detailed troubleshooting guidance
+    - Other errors: Log warning but continue (to avoid false positives)
 
     Args:
         config: The NAT configuration object containing LLM definitions.
 
     Raises:
-        RuntimeError: If any LLM endpoint validation fails.
+        RuntimeError: If any LLM endpoint has a 404 error (model not deployed).
     """
     if not config.llms:
         logger.debug("No LLMs defined in config, skipping validation")
         return
 
-    failed_llms = []
+    failed_llms = []  # List of (llm_name, error_message) tuples for 404 errors
+    validation_warnings = []  # List of (llm_name, warning_message) tuples for non-critical errors
 
-    for llm_name, llm_config in config.llms.items():
-        try:
-            # Only validate OpenAI-compatible endpoints
-            if llm_config.type not in ["openai", "nim"]:
-                logger.debug("Skipping validation for LLM '%s' (type: %s)", llm_name, llm_config.type)
-                continue
-
-            base_url = getattr(llm_config, "base_url", None)
-            model_name = getattr(llm_config, "model_name", None)
-
-            if not base_url:
-                logger.debug("LLM '%s' has no base_url, skipping validation", llm_name)
-                continue
-
-            logger.info("Validating LLM endpoint '%s': %s", llm_name, base_url)
-
-            # Try to connect to the endpoint
+    # Use WorkflowBuilder to instantiate and test LLMs
+    async with WorkflowBuilder() as builder:
+        for llm_name, llm_config in config.llms.items():
             try:
-                import openai
+                logger.info("Validating LLM '%s' (type: %s)", llm_name, llm_config.type)
 
-                # Get API key if available
-                api_key = getattr(llm_config, "api_key", None) or "unused"
+                # Add LLM to builder (handles all LLM types)
+                await builder.add_llm(llm_name, llm_config)
 
-                # Create client and test connection
-                client = openai.OpenAI(base_url=base_url, api_key=api_key)
+                # Get LangChain-wrapped LLM instance
+                llm = await builder.get_llm(llm_name, LLMFrameworkEnum.LANGCHAIN)
 
-                # Simple connectivity check - list models
+                # Test with minimal prompt - this will hit the endpoint
                 try:
-                    client.models.list()  # Just check if endpoint is accessible
-                    logger.info("LLM endpoint '%s' is accessible", llm_name)
-                except openai.NotFoundError as nf_error:
-                    # 404 means endpoint is reachable but model doesn't exist
-                    error_msg = (
-                        f"LLM endpoint '{llm_name}' is reachable but model '{model_name}' was not found (404). "
-                        f"This typically means:\n"
-                        f"  1. The model has not been deployed yet\n"
-                        f"  2. The model name is incorrect\n"
-                        f"  3. A training job was canceled and the model was never deployed\n"
-                        f"\nEndpoint: {base_url}\n"
-                        f"Model: {model_name}\n"
-                        f"\nACTION REQUIRED:\n"
-                        f"  1. Verify the model is deployed: Check your NIM deployment service\n"
-                        f"  2. If using NeMo Customizer, ensure training completed successfully\n"
-                        f"  3. Check model deployment status in your NeMo MS platform\n"
-                        f"  4. Verify the model name matches the deployed model\n"
-                        f"\nOriginal error: {nf_error}"
-                    )
-                    logger.error(error_msg)
-                    failed_llms.append((llm_name, error_msg))
-                    continue
-                except (ConnectionError, OSError, TimeoutError) as conn_error:
-                    # Connection errors are critical - re-raise to be caught by outer handler
-                    raise
-                except Exception as list_error:
-                    # Other errors might be okay (auth, rate limit, etc.) or endpoint doesn't support /models
-                    logger.warning(
-                        "LLM endpoint '%s' validation inconclusive: %s. "
-                        "Proceeding with evaluation (endpoint may still work).",
-                        llm_name,
-                        list_error,
-                    )
+                    await llm.ainvoke("test")
+                    logger.info("LLM '%s' validated successfully", llm_name)
 
-            except ImportError:
-                logger.warning(
-                    "Cannot validate LLM '%s': openai package not installed. Install with: pip install openai", llm_name
-                )
+                except Exception as invoke_error:
+                    # Check if this is a 404 error (model not deployed)
+                    if _is_404_error(invoke_error):
+                        base_url, model_name = _get_llm_endpoint_info(llm_config)
+
+                        error_msg = (
+                            f"LLM '{llm_name}' validation failed: Model not found (404).\n"
+                            f"This typically means:\n"
+                            f"  1. The model has not been deployed yet\n"
+                            f"  2. The model name is incorrect\n"
+                            f"  3. A training job was canceled and the model was never deployed\n"
+                            f"\nLLM Configuration:\n"
+                            f"  Type: {llm_config.type}\n"
+                            f"  Endpoint: {base_url or 'N/A'}\n"
+                            f"  Model: {model_name or 'N/A'}\n"
+                            f"\nACTION REQUIRED:\n"
+                            f"  1. Verify the model is deployed: Check your deployment service\n"
+                            f"  2. If using NeMo Customizer, ensure training completed successfully\n"
+                            f"  3. Check model deployment status in your platform\n"
+                            f"  4. Verify the model name matches the deployed model\n"
+                            f"\nOriginal error: {invoke_error}"
+                        )
+                        logger.error(error_msg)
+                        failed_llms.append((llm_name, error_msg))
+
+                    else:
+                        # Non-404 error - might be auth, rate limit, temporary issue, etc.
+                        # Don't fail validation, but warn the user
+                        warning_msg = (
+                            f"Could not fully validate LLM '{llm_name}': {invoke_error}. "
+                            f"This might be due to auth requirements, rate limits, or temporary issues. "
+                            f"Evaluation will proceed, but may fail if the LLM is truly inaccessible."
+                        )
+                        logger.warning(warning_msg)
+                        validation_warnings.append((llm_name, str(invoke_error)))
+
             except Exception as e:
-                error_msg = (
-                    f"Failed to connect to LLM endpoint '{llm_name}' at {base_url}: {e}\n"
-                    f"\nACTION REQUIRED:\n"
-                    f"  1. Check that the endpoint is running and accessible\n"
-                    f"  2. Verify network connectivity to {base_url}\n"
-                    f"  3. Ensure API credentials are correct\n"
-                    f"  4. Check firewall and proxy settings\n"
-                )
-                logger.error(error_msg)
-                failed_llms.append((llm_name, error_msg))
+                # Error during builder setup (before ainvoke)
+                # This could be import errors, config errors, etc.
+                warning_msg = f"Could not validate LLM '{llm_name}' due to setup error: {e}"
+                logger.warning(warning_msg)
+                validation_warnings.append((llm_name, str(e)))
 
-        except Exception as e:
-            logger.warning("Error during validation of LLM '%s': %s", llm_name, e)
+    # Report non-critical warnings
+    if validation_warnings:
+        warning_summary = "\n".join([f"  - {name}: {msg}" for name, msg in validation_warnings])
+        logger.warning(
+            "LLM validation completed with %d warning(s):\n%s\nThese LLMs may still work during evaluation.",
+            len(validation_warnings),
+            warning_summary,
+        )
 
-    # If any critical LLMs failed, raise an error
+    # If any LLMs have 404 errors, fail validation
     if failed_llms:
         error_summary = "\n\n".join([f"LLM '{name}':\n{msg}" for name, msg in failed_llms])
         raise RuntimeError(
-            f"LLM endpoint validation failed for {len(failed_llms)} LLM(s):\n\n"
+            f"LLM endpoint validation failed for {len(failed_llms)} LLM(s) with 404 errors:\n\n"
             f"{error_summary}\n\n"
-            f"Evaluation cannot proceed with inaccessible LLM endpoints. "
-            f"Please resolve the issues above before retrying."
+            f"Evaluation cannot proceed with undeployed models. "
+            f"Please resolve the deployment issues above before retrying."
         )
 
     logger.info("All LLM endpoints validated successfully")

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -14,15 +14,15 @@
 # limitations under the License.
 
 """
-LLM Endpoint Validator for NAT Evaluation.
+LLM Endpoint Validator for NeMo Agent Toolkit evaluation.
 
 This module provides functionality to validate LLM endpoints before running evaluation
 workflows. This helps catch deployment issues early (e.g., models not deployed after
 training cancellation) and provides actionable error messages.
 
-The validation uses NAT's WorkflowBuilder to instantiate LLMs in a framework-agnostic way,
-then tests them with a minimal ainvoke() call. This approach works for all LLM types
-(OpenAI, NIM, AWS Bedrock, vLLM, etc.) and respects NAT's native auth and config system.
+The validation uses the NeMo Agent Toolkit `WorkflowBuilder` to instantiate LLMs in a framework-agnostic way,
+then tests them with a minimal `ainvoke()` call. This approach works for all LLM types
+(OpenAI, NIM, AWS Bedrock, vLLM, etc.) and respects the auth and config system.
 
 Note: Validation invokes actual LLM endpoints with minimal test prompts. This may incur
 small API costs for cloud-hosted models.
@@ -123,6 +123,11 @@ def _truncate_error_message(message: str, max_length: int = MAX_ERROR_MESSAGE_LE
 
     # Keep first and last portions to preserve both error description and stack trace
     separator = " ... (truncated) ... "
+
+    # Guard for very small max_length values
+    if max_length <= len(separator) + 2:
+        return message[:max_length]
+
     keep_length = (max_length - len(separator)) // 2
     return f"{message[:keep_length]}{separator}{message[-keep_length:]}"
 
@@ -211,7 +216,7 @@ async def _validate_single_llm(
                 f"  4. Verify the model name matches the deployed model\n"
                 f"\nOriginal error: {_truncate_error_message(str(invoke_error))}"
             )
-            logger.error(error_msg)
+            logger.exception(error_msg)
             return ("404", error_msg)
 
         else:
@@ -222,7 +227,7 @@ async def _validate_single_llm(
                 f"Evaluation will proceed, but may fail if the LLM is truly inaccessible."
             )
             logger.exception(error_msg)
-            return ("warning", _truncate_error_message(str(invoke_error)))
+            return ("warning", _truncate_error_message(error_msg))
 
 
 async def validate_llm_endpoints(config: "Config") -> None:
@@ -251,6 +256,20 @@ async def validate_llm_endpoints(config: "Config") -> None:
         ValueError: If config.llms is not properly structured.
     """
 
+    # Validate config structure
+    if not hasattr(config, "llms"):
+        raise ValueError("Config does not have 'llms' attribute. Cannot validate LLM endpoints.")
+
+    if not isinstance(config.llms, dict):
+        raise ValueError(
+            f"Config.llms must be a dict, got {type(config.llms).__name__}. "
+            "Cannot validate LLM endpoints."
+        )
+
+    if not config.llms:
+        logger.info("No LLMs configured - skipping endpoint validation")
+        return
+
     failed_llms = []  # List of (llm_name, error_message) tuples for 404 errors
     validation_warnings = []  # List of (llm_name, warning_message) tuples for non-critical errors
 
@@ -269,7 +288,7 @@ async def validate_llm_endpoints(config: "Config") -> None:
             results = await asyncio.gather(*validation_tasks, return_exceptions=True)
 
             # Process results - zip with batch to maintain llm_name association
-            for (llm_name, llm_config), result in zip(batch, results):
+            for (llm_name, _llm_config), result in zip(batch, results, strict=True):
                 if isinstance(result, BaseException):
                     # Re-raise system interrupts if they somehow got through
                     if isinstance(result, KeyboardInterrupt | SystemExit):

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -30,6 +30,7 @@ small API costs for cloud-hosted models.
 
 import asyncio
 import logging
+import time
 from typing import TYPE_CHECKING
 
 from nat.builder.framework_enum import LLMFrameworkEnum
@@ -45,6 +46,7 @@ logger = logging.getLogger(__name__)
 VALIDATION_TIMEOUT_SECONDS = 30  # Timeout for each LLM validation
 MAX_ERROR_MESSAGE_LENGTH = 500  # Truncate long error messages
 CONCURRENT_VALIDATION_BATCH_SIZE = 5  # Max LLMs to validate in parallel
+VALIDATION_PROMPT = "test"  # Minimal prompt for endpoint validation
 
 
 def _is_404_error(exception: Exception) -> bool:
@@ -106,6 +108,9 @@ def _truncate_error_message(message: str, max_length: int = MAX_ERROR_MESSAGE_LE
     """
     Truncate error messages to prevent memory issues with large stack traces.
 
+    Keeps both the start and end of the message to preserve context from both
+    the error description (start) and the stack trace (end).
+
     Args:
         message: The error message to truncate.
         max_length: Maximum length to keep.
@@ -115,7 +120,11 @@ def _truncate_error_message(message: str, max_length: int = MAX_ERROR_MESSAGE_LE
     """
     if len(message) <= max_length:
         return message
-    return message[:max_length] + "... (truncated)"
+
+    # Keep first and last portions to preserve both error description and stack trace
+    separator = " ... (truncated) ... "
+    keep_length = (max_length - len(separator)) // 2
+    return f"{message[:keep_length]}{separator}{message[-keep_length:]}"
 
 
 async def _validate_single_llm(
@@ -136,6 +145,7 @@ async def _validate_single_llm(
     """
     try:
         logger.info("Validating LLM '%s' (type: %s)", llm_name, llm_config.type)
+        start_time = time.time()
 
         # Add LLM to builder (handles all LLM types)
         await asyncio.wait_for(builder.add_llm(llm_name, llm_config), timeout=VALIDATION_TIMEOUT_SECONDS)
@@ -146,8 +156,10 @@ async def _validate_single_llm(
         )
 
         # Test with minimal prompt - this will hit the endpoint
-        await asyncio.wait_for(llm.ainvoke("test"), timeout=VALIDATION_TIMEOUT_SECONDS)
-        logger.info("LLM '%s' validated successfully", llm_name)
+        await asyncio.wait_for(llm.ainvoke(VALIDATION_PROMPT), timeout=VALIDATION_TIMEOUT_SECONDS)
+
+        duration = time.time() - start_time
+        logger.info("LLM '%s' validated successfully in %.2fs", llm_name, duration)
         return (llm_name, None, None)
 
     except TimeoutError:
@@ -251,9 +263,13 @@ async def validate_llm_endpoints(config: "Config") -> None:
             # Process results
             for result in results:
                 if isinstance(result, BaseException):
+                    # Re-raise system interrupts if they somehow got through
+                    if isinstance(result, (KeyboardInterrupt, SystemExit)):
+                        raise result
+
                     # Unexpected exception during validation
-                    # Note: SystemExit and KeyboardInterrupt are re-raised in _validate_single_llm
-                    # so we shouldn't see them here
+                    # Note: SystemExit and KeyboardInterrupt should be re-raised in _validate_single_llm
+                    # but we check again here as a defensive measure
                     logger.warning("Unexpected error during validation: %s", _truncate_error_message(str(result)))
                     validation_warnings.append(("unknown", _truncate_error_message(str(result))))
                 else:
@@ -265,6 +281,10 @@ async def validate_llm_endpoints(config: "Config") -> None:
                     elif error_type == "warning":
                         validation_warnings.append((llm_name, error_message))
                     # If error_type is None, validation succeeded (no action needed)
+
+    # Calculate validation metrics
+    total_llms = len(llm_items)
+    succeeded_count = total_llms - len(failed_llms) - len(validation_warnings)
 
     # Report non-critical warnings
     if validation_warnings:
@@ -278,6 +298,16 @@ async def validate_llm_endpoints(config: "Config") -> None:
     # If any LLMs have 404 errors, fail validation
     if failed_llms:
         error_summary = "\n\n".join([f"LLM '{name}':\n{msg}" for name, msg in failed_llms])
+
+        # Log metrics before raising error
+        logger.error(
+            "Validation summary: %d total, %d succeeded, %d warned, %d failed (404)",
+            total_llms,
+            succeeded_count,
+            len(validation_warnings),
+            len(failed_llms),
+        )
+
         raise RuntimeError(
             f"LLM endpoint validation failed for {len(failed_llms)} LLM(s) with 404 errors:\n\n"
             f"{error_summary}\n\n"
@@ -285,4 +315,10 @@ async def validate_llm_endpoints(config: "Config") -> None:
             f"Please resolve the deployment issues above before retrying."
         )
 
-    logger.info("All LLM endpoints validated successfully")
+    # Log success metrics
+    logger.info(
+        "All LLM endpoints validated successfully - %d total, %d succeeded, %d warned",
+        total_llms,
+        succeeded_count,
+        len(validation_warnings),
+    )

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -182,7 +182,7 @@ async def _validate_single_llm(
 
     except TimeoutError:
         error_msg = f"Validation timed out after {VALIDATION_TIMEOUT_SECONDS}s"
-        logger.exception("LLM '%s' validation timed out", llm_name)
+        logger.warning("LLM '%s' validation timed out", llm_name)
         return ("warning", _truncate_error_message(error_msg))
 
     except (KeyboardInterrupt, SystemExit):
@@ -211,7 +211,7 @@ async def _validate_single_llm(
                 f"  4. Verify the model name matches the deployed model\n"
                 f"\nOriginal error: {_truncate_error_message(str(invoke_error))}"
             )
-            logger.exception(error_msg)
+            logger.error(error_msg)
             return ("404", error_msg)
 
         else:

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -148,7 +148,7 @@ async def _validate_single_llm(
         start_time = time.time()
 
         # Add LLM to builder (handles all LLM types)
-        await asyncio.wait_for(builder.add_llm(llm_name, llm_config), timeout=VALIDATION_TIMEOUT_SECONDS)
+        builder.add_llm(llm_name, llm_config)
 
         # Get LangChain-wrapped LLM instance
         llm = await asyncio.wait_for(

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -23,57 +23,57 @@ logger = logging.getLogger(__name__)
 async def validate_llm_endpoints(config: "Config") -> None:  # noqa: F821
     """
     Validate that all LLM endpoints in the config are accessible.
-    
+
     This function checks OpenAI-compatible LLM endpoints to ensure they are
     reachable before running evaluation. This prevents cryptic 404 errors
     during evaluation when models are not deployed.
-    
+
     Args:
         config: The NAT configuration object containing LLM definitions.
-        
+
     Raises:
         RuntimeError: If any LLM endpoint validation fails.
     """
     if not config.llms:
         logger.debug("No LLMs defined in config, skipping validation")
         return
-    
+
     failed_llms = []
-    
+
     for llm_name, llm_config in config.llms.items():
         try:
             # Only validate OpenAI-compatible endpoints
             if llm_config.type not in ["openai", "nim"]:
                 logger.debug(f"Skipping validation for LLM '{llm_name}' (type: {llm_config.type})")
                 continue
-            
+
             base_url = getattr(llm_config, "base_url", None)
             model_name = getattr(llm_config, "model_name", None)
-            
+
             if not base_url:
                 logger.debug(f"LLM '{llm_name}' has no base_url, skipping validation")
                 continue
-            
+
             logger.info(f"Validating LLM endpoint '{llm_name}': {base_url}")
-            
+
             # Try to connect to the endpoint
             try:
                 import openai
-                
+
                 # Get API key if available
                 api_key = getattr(llm_config, "api_key", None) or "unused"
-                
+
                 # Create client and test connection
                 client = openai.OpenAI(base_url=base_url, api_key=api_key)
-                
+
                 # Simple connectivity check - list models
                 try:
                     models = client.models.list()
-                    logger.info(f"✓ LLM endpoint '{llm_name}' is accessible ({len(list(models.data))} models available)")
+                    logger.info(f"LLM endpoint '{llm_name}' is accessible ({len(list(models.data))} models available)")
                 except Exception as list_error:
                     # Some endpoints don't support /models, try a simple completion instead
                     logger.debug(f"Models list failed for '{llm_name}', trying completion test: {list_error}")
-                    
+
                     # Try a minimal completion request
                     try:
                         client.completions.create(
@@ -81,7 +81,7 @@ async def validate_llm_endpoints(config: "Config") -> None:  # noqa: F821
                             prompt="test",
                             max_tokens=1,
                         )
-                        logger.info(f"✓ LLM endpoint '{llm_name}' is accessible (completion test passed)")
+                        logger.info(f"LLM endpoint '{llm_name}' is accessible (completion test passed)")
                     except openai.NotFoundError as nf_error:
                         # 404 means endpoint is reachable but model doesn't exist
                         error_msg = (
@@ -108,11 +108,10 @@ async def validate_llm_endpoints(config: "Config") -> None:  # noqa: F821
                             f"LLM endpoint '{llm_name}' validation inconclusive: {comp_error}. "
                             f"Proceeding with evaluation (endpoint may still work)."
                         )
-                
+
             except ImportError:
                 logger.warning(
-                    f"Cannot validate LLM '{llm_name}': openai package not installed. "
-                    f"Install with: pip install openai"
+                    f"Cannot validate LLM '{llm_name}': openai package not installed. Install with: pip install openai"
                 )
             except Exception as e:
                 error_msg = (
@@ -125,21 +124,18 @@ async def validate_llm_endpoints(config: "Config") -> None:  # noqa: F821
                 )
                 logger.error(error_msg)
                 failed_llms.append((llm_name, error_msg))
-                
+
         except Exception as e:
             logger.warning(f"Error during validation of LLM '{llm_name}': {e}")
-    
+
     # If any critical LLMs failed, raise an error
     if failed_llms:
-        error_summary = "\n\n".join([
-            f"LLM '{name}':\n{msg}" for name, msg in failed_llms
-        ])
+        error_summary = "\n\n".join([f"LLM '{name}':\n{msg}" for name, msg in failed_llms])
         raise RuntimeError(
             f"LLM endpoint validation failed for {len(failed_llms)} LLM(s):\n\n"
             f"{error_summary}\n\n"
             f"Evaluation cannot proceed with inaccessible LLM endpoints. "
             f"Please resolve the issues above before retrying."
         )
-    
-    logger.info("✓ All LLM endpoints validated successfully")
 
+    logger.info("All LLM endpoints validated successfully")

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -166,7 +166,7 @@ async def _validate_single_llm(
 
         # Test with minimal prompt - this will hit the endpoint
         await asyncio.wait_for(llm.ainvoke(VALIDATION_PROMPT), timeout=VALIDATION_TIMEOUT_SECONDS)
-        
+
         duration = time.time() - start_time
         logger.info("LLM '%s' validated successfully in %.2fs", llm_name, duration)
         return (None, None)
@@ -263,7 +263,7 @@ async def validate_llm_endpoints(config: "Config") -> None:
             for (llm_name, llm_config), result in zip(batch, results):
                 if isinstance(result, BaseException):
                     # Re-raise system interrupts if they somehow got through
-                    if isinstance(result, (KeyboardInterrupt, SystemExit)):
+                    if isinstance(result, KeyboardInterrupt | SystemExit):
                         raise result
 
                     # Unexpected exception during validation
@@ -278,7 +278,7 @@ async def validate_llm_endpoints(config: "Config") -> None:
                     elif error_type == "warning":
                         validation_warnings.append((llm_name, error_message))
                     # If error_type is None, validation succeeded (no action needed)
-    
+
     # Calculate validation metrics
     total_llms = len(llm_items)
     succeeded_count = total_llms - len(failed_llms) - len(validation_warnings)

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -94,6 +94,9 @@ async def validate_llm_endpoints(config: "Config") -> None:
                     logger.error(error_msg)
                     failed_llms.append((llm_name, error_msg))
                     continue
+                except (ConnectionError, OSError, TimeoutError) as conn_error:
+                    # Connection errors are critical - re-raise to be caught by outer handler
+                    raise
                 except Exception as list_error:
                     # Other errors might be okay (auth, rate limit, etc.) or endpoint doesn't support /models
                     logger.warning(

--- a/src/nat/eval/llm_validator.py
+++ b/src/nat/eval/llm_validator.py
@@ -16,11 +16,15 @@
 """LLM endpoint validation utilities for evaluation."""
 
 import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nat.data_models.config import Config
 
 logger = logging.getLogger(__name__)
 
 
-async def validate_llm_endpoints(config: "Config") -> None:  # noqa: F821
+async def validate_llm_endpoints(config: "Config") -> None:
     """
     Validate that all LLM endpoints in the config are accessible.
 
@@ -44,17 +48,17 @@ async def validate_llm_endpoints(config: "Config") -> None:  # noqa: F821
         try:
             # Only validate OpenAI-compatible endpoints
             if llm_config.type not in ["openai", "nim"]:
-                logger.debug(f"Skipping validation for LLM '{llm_name}' (type: {llm_config.type})")
+                logger.debug("Skipping validation for LLM '%s' (type: %s)", llm_name, llm_config.type)
                 continue
 
             base_url = getattr(llm_config, "base_url", None)
             model_name = getattr(llm_config, "model_name", None)
 
             if not base_url:
-                logger.debug(f"LLM '{llm_name}' has no base_url, skipping validation")
+                logger.debug("LLM '%s' has no base_url, skipping validation", llm_name)
                 continue
 
-            logger.info(f"Validating LLM endpoint '{llm_name}': {base_url}")
+            logger.info("Validating LLM endpoint '%s': %s", llm_name, base_url)
 
             # Try to connect to the endpoint
             try:
@@ -68,50 +72,40 @@ async def validate_llm_endpoints(config: "Config") -> None:  # noqa: F821
 
                 # Simple connectivity check - list models
                 try:
-                    models = client.models.list()
-                    logger.info(f"LLM endpoint '{llm_name}' is accessible ({len(list(models.data))} models available)")
+                    client.models.list()  # Just check if endpoint is accessible
+                    logger.info("LLM endpoint '%s' is accessible", llm_name)
+                except openai.NotFoundError as nf_error:
+                    # 404 means endpoint is reachable but model doesn't exist
+                    error_msg = (
+                        f"LLM endpoint '{llm_name}' is reachable but model '{model_name}' was not found (404). "
+                        f"This typically means:\n"
+                        f"  1. The model has not been deployed yet\n"
+                        f"  2. The model name is incorrect\n"
+                        f"  3. A training job was canceled and the model was never deployed\n"
+                        f"\nEndpoint: {base_url}\n"
+                        f"Model: {model_name}\n"
+                        f"\nACTION REQUIRED:\n"
+                        f"  1. Verify the model is deployed: Check your NIM deployment service\n"
+                        f"  2. If using NeMo Customizer, ensure training completed successfully\n"
+                        f"  3. Check model deployment status in your NeMo MS platform\n"
+                        f"  4. Verify the model name matches the deployed model\n"
+                        f"\nOriginal error: {nf_error}"
+                    )
+                    logger.error(error_msg)
+                    failed_llms.append((llm_name, error_msg))
+                    continue
                 except Exception as list_error:
-                    # Some endpoints don't support /models, try a simple completion instead
-                    logger.debug(f"Models list failed for '{llm_name}', trying completion test: {list_error}")
-
-                    # Try a minimal completion request
-                    try:
-                        client.completions.create(
-                            model=model_name or "test",
-                            prompt="test",
-                            max_tokens=1,
-                        )
-                        logger.info(f"LLM endpoint '{llm_name}' is accessible (completion test passed)")
-                    except openai.NotFoundError as nf_error:
-                        # 404 means endpoint is reachable but model doesn't exist
-                        error_msg = (
-                            f"LLM endpoint '{llm_name}' is reachable but model '{model_name}' was not found (404). "
-                            f"This typically means:\n"
-                            f"  1. The model has not been deployed yet\n"
-                            f"  2. The model name is incorrect\n"
-                            f"  3. A training job was canceled and the model was never deployed\n"
-                            f"\nEndpoint: {base_url}\n"
-                            f"Model: {model_name}\n"
-                            f"\nACTION REQUIRED:\n"
-                            f"  1. Verify the model is deployed: Check your NIM deployment service\n"
-                            f"  2. If using NeMo Customizer, ensure training completed successfully\n"
-                            f"  3. Check model deployment status in your NeMo MS platform\n"
-                            f"  4. Verify the model name matches the deployed model\n"
-                            f"\nOriginal error: {nf_error}"
-                        )
-                        logger.error(error_msg)
-                        failed_llms.append((llm_name, error_msg))
-                        continue
-                    except Exception as comp_error:
-                        # Other errors might be okay (auth, rate limit, etc.)
-                        logger.warning(
-                            f"LLM endpoint '{llm_name}' validation inconclusive: {comp_error}. "
-                            f"Proceeding with evaluation (endpoint may still work)."
-                        )
+                    # Other errors might be okay (auth, rate limit, etc.) or endpoint doesn't support /models
+                    logger.warning(
+                        "LLM endpoint '%s' validation inconclusive: %s. "
+                        "Proceeding with evaluation (endpoint may still work).",
+                        llm_name,
+                        list_error,
+                    )
 
             except ImportError:
                 logger.warning(
-                    f"Cannot validate LLM '{llm_name}': openai package not installed. Install with: pip install openai"
+                    "Cannot validate LLM '%s': openai package not installed. Install with: pip install openai", llm_name
                 )
             except Exception as e:
                 error_msg = (
@@ -126,7 +120,7 @@ async def validate_llm_endpoints(config: "Config") -> None:  # noqa: F821
                 failed_llms.append((llm_name, error_msg))
 
         except Exception as e:
-            logger.warning(f"Error during validation of LLM '{llm_name}': {e}")
+            logger.warning("Error during validation of LLM '%s': %s", llm_name, e)
 
     # If any critical LLMs failed, raise an error
     if failed_llms:

--- a/tests/nat/eval/test_llm_validator.py
+++ b/tests/nat/eval/test_llm_validator.py
@@ -16,15 +16,17 @@
 """Tests for LLM endpoint validation before evaluation."""
 
 import pytest
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from nat.data_models.config import Config
 from nat.llm.openai_llm import OpenAIModelConfig
-from nat.eval.llm_validator import validate_llm_endpoints
+from nat.llm.nim_llm import NIMModelConfig
+from nat.llm.aws_bedrock_llm import AWSBedrockModelConfig
+from nat.eval.llm_validator import validate_llm_endpoints, _is_404_error
 
 
 class TestLLMEndpointValidation:
-    """Tests for LLM endpoint validation functionality."""
+    """Tests for LLM endpoint validation functionality using WorkflowBuilder."""
 
     @pytest.fixture
     def config_with_openai_llm(self):
@@ -39,16 +41,40 @@ class TestLLMEndpointValidation:
         return config
 
     @pytest.fixture
-    def config_with_multiple_llms(self):
-        """Create config with multiple LLMs."""
+    def config_with_nim_llm(self):
+        """Create config with NIM LLM."""
         config = Config()
         config.llms = {
-            "llm1": OpenAIModelConfig(
-                model_name="model1",
+            "nim_llm": NIMModelConfig(
+                model_name="meta/llama-3.1-8b-instruct",
+                base_url="http://localhost:8000/v1"
+            )
+        }
+        return config
+
+    @pytest.fixture
+    def config_with_bedrock_llm(self):
+        """Create config with AWS Bedrock LLM."""
+        config = Config()
+        config.llms = {
+            "bedrock_llm": AWSBedrockModelConfig(
+                model_name="anthropic.claude-v2",
+                region_name="us-east-1"
+            )
+        }
+        return config
+
+    @pytest.fixture
+    def config_with_multiple_llms(self):
+        """Create config with multiple LLMs of different types."""
+        config = Config()
+        config.llms = {
+            "openai_llm": OpenAIModelConfig(
+                model_name="gpt-4",
                 base_url="http://localhost:8000/v1"
             ),
-            "llm2": OpenAIModelConfig(
-                model_name="model2",
+            "nim_llm": NIMModelConfig(
+                model_name="llama-3.1-8b-instruct",
                 base_url="http://localhost:8001/v1"
             )
         }
@@ -66,42 +92,49 @@ class TestLLMEndpointValidation:
         # Should not raise any error
         await validate_llm_endpoints(config_without_llms)
 
-    @patch("openai.OpenAI")
-    async def test_validation_detects_unreachable_endpoint(self, mock_openai_class):
-        """Test that validation detects unreachable endpoints."""
-        # Mock connection error
-        mock_client = MagicMock()
-        mock_client.models.list.side_effect = ConnectionError("Connection refused")
-        mock_openai_class.return_value = mock_client
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_validation_succeeds_with_accessible_endpoint(self, mock_builder_class, config_with_openai_llm):
+        """Test that validation succeeds when LLM endpoint is accessible."""
+        # Mock the builder and LLM
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value="test response")
+        
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
 
-        config = Config()
-        config.llms = {
-            "unreachable_llm": OpenAIModelConfig(
-                model_name="test-model",
-                base_url="http://localhost:9999/v1"
-            )
-        }
+        # Should not raise any error
+        await validate_llm_endpoints(config_with_openai_llm)
+        
+        # Verify builder was used correctly
+        mock_builder.add_llm.assert_called_once()
+        mock_builder.get_llm.assert_called_once()
+        mock_llm.ainvoke.assert_called_once()
 
-        with pytest.raises(RuntimeError) as exc_info:
-            await validate_llm_endpoints(config)
-
-        error_msg = str(exc_info.value)
-        assert "LLM endpoint validation failed" in error_msg
-        assert "ACTION REQUIRED" in error_msg
-
-    @patch("openai.OpenAI")
-    async def test_validation_detects_model_not_found_404(self, mock_openai_class, config_with_openai_llm):
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_validation_detects_404_error(self, mock_builder_class, config_with_openai_llm):
         """Test that validation detects 404 errors when model doesn't exist."""
-        import openai
-
-        # Mock OpenAI client to raise NotFoundError (404)
-        mock_client = MagicMock()
-        mock_client.models.list.side_effect = openai.NotFoundError(
-            message="Model not found",
-            response=MagicMock(status_code=404),
-            body=None
-        )
-        mock_openai_class.return_value = mock_client
+        # Mock 404 error from ainvoke
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        
+        # Simulate NotFoundError (404) - create actual NotFoundError class
+        class NotFoundError(Exception):
+            pass
+        
+        error_404 = NotFoundError("404: Model not found")
+        mock_llm.ainvoke = AsyncMock(side_effect=error_404)
+        
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
 
         with pytest.raises(RuntimeError) as exc_info:
             await validate_llm_endpoints(config_with_openai_llm)
@@ -109,68 +142,161 @@ class TestLLMEndpointValidation:
         error_msg = str(exc_info.value)
         assert "404" in error_msg
         assert "not found" in error_msg.lower()
-        assert any(phrase in error_msg for phrase in [
-            "This typically means",
-            "ACTION REQUIRED",
-            "model has not been deployed"
-        ])
+        assert "ACTION REQUIRED" in error_msg
 
-    @patch("openai.OpenAI")
-    async def test_validation_succeeds_with_accessible_endpoint(self, mock_openai_class, config_with_openai_llm):
-        """Test that validation succeeds when endpoint is accessible."""
-        # Mock successful connection
-        mock_client = MagicMock()
-        mock_models_response = MagicMock()
-        mock_models_response.data = [MagicMock(id="test-model")]
-        mock_client.models.list.return_value = mock_models_response
-        mock_openai_class.return_value = mock_client
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_validation_handles_auth_errors_gracefully(self, mock_builder_class, config_with_openai_llm):
+        """Test that validation warns but continues on auth errors (not 404s)."""
+        # Mock auth error from ainvoke
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(side_effect=Exception("401: Unauthorized"))
+        
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
 
-        # Should not raise any error
+        # Should not raise RuntimeError for non-404 errors
+        # (just logs warning)
         await validate_llm_endpoints(config_with_openai_llm)
 
-    async def test_validation_skips_non_openai_llm_types(self):
-        """Test that validation skips non-OpenAI compatible LLM types."""
-        config = Config()
-        # Mock a non-OpenAI LLM type
-        mock_llm = MagicMock()
-        mock_llm.type = "bedrock"  # Non-OpenAI type
-        config.llms = {"bedrock_llm": mock_llm}
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_validation_works_for_nim_llm(self, mock_builder_class, config_with_nim_llm):
+        """Test that validation works for NIM LLM type."""
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value="test response")
+        
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
 
-        # Should not raise error for non-OpenAI LLMs
-        await validate_llm_endpoints(config)
+        # Should validate NIM LLMs (not skip them)
+        await validate_llm_endpoints(config_with_nim_llm)
+        
+        mock_builder.add_llm.assert_called_once()
+        mock_llm.ainvoke.assert_called_once()
 
-    async def test_validation_handles_llm_without_base_url(self):
-        """Test that validation handles LLMs without base_url gracefully."""
-        config = Config()
-        mock_llm = MagicMock()
-        mock_llm.type = "openai"
-        mock_llm.base_url = None  # No base_url
-        config.llms = {"no_url_llm": mock_llm}
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_validation_works_for_bedrock_llm(self, mock_builder_class, config_with_bedrock_llm):
+        """Test that validation works for AWS Bedrock LLM type (framework-agnostic)."""
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value="test response")
+        
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
 
-        # Should not raise error, just skip validation
-        await validate_llm_endpoints(config)
+        # Should validate Bedrock LLMs (framework-agnostic approach)
+        await validate_llm_endpoints(config_with_bedrock_llm)
+        
+        mock_builder.add_llm.assert_called_once()
+        mock_llm.ainvoke.assert_called_once()
 
-    @patch("openai.OpenAI")
-    async def test_validation_fails_on_first_bad_endpoint(self, mock_openai_class, config_with_multiple_llms):
-        """Test that validation fails fast on first bad endpoint."""
-        # First endpoint fails
-        mock_client = MagicMock()
-        mock_client.models.list.side_effect = ConnectionError("Connection refused")
-        mock_openai_class.return_value = mock_client
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_validation_with_multiple_llms(self, mock_builder_class, config_with_multiple_llms):
+        """Test that validation checks all configured LLMs."""
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value="test response")
+        
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
+
+        await validate_llm_endpoints(config_with_multiple_llms)
+        
+        # Should have validated both LLMs
+        assert mock_builder.add_llm.call_count == 2
+        assert mock_builder.get_llm.call_count == 2
+        assert mock_llm.ainvoke.call_count == 2
+
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_validation_collects_all_404_errors(self, mock_builder_class, config_with_multiple_llms):
+        """Test that validation collects all 404 errors before failing."""
+        # Create actual NotFoundError class
+        class NotFoundError(Exception):
+            pass
+        
+        mock_builder = AsyncMock()
+        
+        # First LLM succeeds, second LLM has 404
+        mock_llm_success = AsyncMock()
+        mock_llm_success.ainvoke = AsyncMock(return_value="ok")
+        
+        mock_llm_404 = AsyncMock()
+        error_404 = NotFoundError("404: Model not found")
+        mock_llm_404.ainvoke = AsyncMock(side_effect=error_404)
+        
+        # Return different LLMs for different calls
+        mock_builder.get_llm = AsyncMock(side_effect=[mock_llm_success, mock_llm_404])
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
 
         with pytest.raises(RuntimeError) as exc_info:
             await validate_llm_endpoints(config_with_multiple_llms)
 
         error_msg = str(exc_info.value)
-        # Should mention the first failing LLM
-        assert "llm1" in error_msg or "LLM endpoint validation failed" in error_msg
+        # Should mention the failing LLM
+        assert "nim_llm" in error_msg or "404" in error_msg
+
+
+class Test404ErrorDetection:
+    """Tests for the _is_404_error helper function."""
+
+    def test_detects_notfounderror_type(self):
+        """Test detection of NotFoundError exception type."""
+        class NotFoundError(Exception):
+            pass
+        
+        error = NotFoundError("Model not found")
+        assert _is_404_error(error)
+
+    def test_detects_404_in_message(self):
+        """Test detection of 404 in error message."""
+        error = Exception("HTTP 404: Model not found")
+        assert _is_404_error(error)
+
+    def test_detects_not_found_phrase(self):
+        """Test detection of 'not found' phrase."""
+        error = Exception("The model does not exist")
+        assert _is_404_error(error)
+
+    def test_does_not_detect_other_errors(self):
+        """Test that non-404 errors are not detected as 404s."""
+        auth_error = Exception("401: Unauthorized")
+        rate_limit_error = Exception("429: Rate limit exceeded")
+        
+        assert not _is_404_error(auth_error)
+        assert not _is_404_error(rate_limit_error)
 
 
 class TestLLMValidationErrorMessages:
     """Tests for error message quality and actionability."""
 
-    async def test_error_message_includes_endpoint_details(self):
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_error_message_includes_endpoint_details(self, mock_builder_class):
         """Test that error messages include specific endpoint details."""
+        # Create actual NotFoundError class
+        class NotFoundError(Exception):
+            pass
+        
         config = Config()
         config.llms = {
             "training_llm": OpenAIModelConfig(
@@ -179,58 +305,57 @@ class TestLLMValidationErrorMessages:
             )
         }
 
-        try:
+        # Mock 404 error
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        error_404 = NotFoundError("404: Not found")
+        mock_llm.ainvoke = AsyncMock(side_effect=error_404)
+        
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
+
+        with pytest.raises(RuntimeError) as exc_info:
             await validate_llm_endpoints(config)
-        except RuntimeError as e:
-            error_msg = str(e)
-            # Should include the LLM name
-            assert "training_llm" in error_msg
-            # Should include the base URL
-            assert "http://custom-host:8000/v1" in error_msg
 
-    async def test_error_message_provides_troubleshooting_steps(self):
-        """Test that error messages include actionable troubleshooting steps."""
-        config = Config()
-        config.llms = {
-            "test_llm": OpenAIModelConfig(
-                model_name="test-model",
-                base_url="http://localhost:9999/v1"
-            )
-        }
+        error_msg = str(exc_info.value)
+        # Should include the LLM name
+        assert "training_llm" in error_msg
+        # Should include the base URL
+        assert "http://custom-host:8000/v1" in error_msg
+        # Should include model name
+        assert "custom-model-name" in error_msg
 
-        try:
-            await validate_llm_endpoints(config)
-        except RuntimeError as e:
-            error_msg = str(e)
-            # Should include actionable guidance
-            assert any(keyword in error_msg for keyword in [
-                "ACTION REQUIRED",
-                "Check",
-                "Verify",
-                "Ensure"
-            ])
-
-    @patch("openai.OpenAI")
-    async def test_404_error_message_mentions_training_cancellation(self, mock_openai_class):
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_404_error_message_mentions_training_cancellation(self, mock_builder_class):
         """Test that 404 error message mentions potential training cancellation."""
-        import openai
-
+        # Create actual NotFoundError class
+        class NotFoundError(Exception):
+            pass
+        
         config = Config()
         config.llms = {
-            "finetuned_model": OpenAIModelConfig(
+            "finetuned_model": NIMModelConfig(
                 model_name="finetuned-llama",
                 base_url="http://localhost:8000/v1"
             )
         }
 
         # Mock 404 error
-        mock_client = MagicMock()
-        mock_client.models.list.side_effect = openai.NotFoundError(
-            message="Not found",
-            response=MagicMock(status_code=404),
-            body=None
-        )
-        mock_openai_class.return_value = mock_client
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        error_404 = NotFoundError("404: Model not found")
+        mock_llm.ainvoke = AsyncMock(side_effect=error_404)
+        
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
 
         with pytest.raises(RuntimeError) as exc_info:
             await validate_llm_endpoints(config)
@@ -243,6 +368,8 @@ class TestLLMValidationErrorMessages:
             "canceled",
             "model has not been deployed"
         ])
+        # Should include actionable guidance
+        assert "ACTION REQUIRED" in error_msg
 
 
 class TestLLMValidationIntegration:
@@ -253,48 +380,58 @@ class TestLLMValidationIntegration:
         """Create config simulating post-training scenario."""
         config = Config()
         config.llms = {
-            "training_llm": OpenAIModelConfig(
+            "training_llm": NIMModelConfig(
                 model_name="default/meta-llama-3.1-8b-instruct-nat-dpo",
                 base_url="http://nim-endpoint:8000/v1"
             )
         }
         return config
 
-    @patch("openai.OpenAI")
-    async def test_validation_scenario_after_canceled_training(self, mock_openai_class, config_for_finetuned_model):
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_validation_scenario_after_canceled_training(self, mock_builder_class, config_for_finetuned_model):
         """
-        Test validation behavior in the scenario that caused the original bug:
+        Test validation behavior in the scenario that caused NVBug 5789819:
         Training was canceled, model never deployed, user tries to run eval.
+        
+        This should:
+        1. Detect the missing model BEFORE eval starts (0/24 cases)
+        2. Provide clear error about what went wrong
+        3. Give actionable next steps
         """
-        import openai
+        # Create actual NotFoundError class
+        class NotFoundError(Exception):
+            pass
+        
+        # Mock the exact bug scenario: endpoint is up but model doesn't exist (404)
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        
+        error_404 = NotFoundError("404: Model not found - the model default/meta-llama-3.1-8b-instruct-nat-dpo does not exist")
+        mock_llm.ainvoke = AsyncMock(side_effect=error_404)
+        
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
 
-        # Simulate the exact bug: endpoint is up but model doesn't exist (404)
-        mock_client = MagicMock()
-        mock_client.models.list.side_effect = openai.NotFoundError(
-            message="Model not found",
-            response=MagicMock(status_code=404),
-            body=None
-        )
-        mock_openai_class.return_value = mock_client
-
-        # This simulates the exact bug scenario:
-        # 1. Training was canceled at 93.3%
-        # 2. Model was never deployed
-        # 3. User tries to run evaluation
-
+        # Validation should fail with detailed error
         with pytest.raises(RuntimeError) as exc_info:
             await validate_llm_endpoints(config_for_finetuned_model)
 
         error_msg = str(exc_info.value)
 
-        # Validation should:
-        # 1. Detect the missing model early (before eval starts)
-        # 2. Provide clear error about what went wrong
-        # 3. Give actionable next steps
-
+        # Validation should catch the issue BEFORE eval starts
         assert any(check in error_msg for check in [
             "LLM endpoint validation failed",
             "not found",
             "404"
         ])
-
+        
+        # Should mention training-related causes
+        assert any(phrase in error_msg.lower() for phrase in [
+            "training",
+            "canceled",
+            "deployed"
+        ])

--- a/tests/nat/eval/test_llm_validator.py
+++ b/tests/nat/eval/test_llm_validator.py
@@ -66,13 +66,19 @@ class TestLLMEndpointValidation:
         # Should not raise any error
         await validate_llm_endpoints(config_without_llms)
 
-    async def test_validation_detects_unreachable_endpoint(self):
+    @patch("openai.OpenAI")
+    async def test_validation_detects_unreachable_endpoint(self, mock_openai_class):
         """Test that validation detects unreachable endpoints."""
+        # Mock connection error
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = ConnectionError("Connection refused")
+        mock_openai_class.return_value = mock_client
+
         config = Config()
         config.llms = {
             "unreachable_llm": OpenAIModelConfig(
                 model_name="test-model",
-                base_url="http://localhost:9999/v1"  # Non-existent endpoint
+                base_url="http://localhost:9999/v1"
             )
         }
 
@@ -83,10 +89,9 @@ class TestLLMEndpointValidation:
         assert "LLM endpoint validation failed" in error_msg
         assert "ACTION REQUIRED" in error_msg
 
-    @patch('nat.eval.llm_validator.openai')
-    async def test_validation_detects_model_not_found_404(self, mock_openai, config_with_openai_llm):
+    @patch("openai.OpenAI")
+    async def test_validation_detects_model_not_found_404(self, mock_openai_class, config_with_openai_llm):
         """Test that validation detects 404 errors when model doesn't exist."""
-        # Import after patching to get the right exception class
         import openai
 
         # Mock OpenAI client to raise NotFoundError (404)
@@ -96,7 +101,7 @@ class TestLLMEndpointValidation:
             response=MagicMock(status_code=404),
             body=None
         )
-        mock_openai.OpenAI.return_value = mock_client
+        mock_openai_class.return_value = mock_client
 
         with pytest.raises(RuntimeError) as exc_info:
             await validate_llm_endpoints(config_with_openai_llm)
@@ -110,15 +115,15 @@ class TestLLMEndpointValidation:
             "model has not been deployed"
         ])
 
-    @patch('nat.eval.llm_validator.openai')
-    async def test_validation_succeeds_with_accessible_endpoint(self, mock_openai, config_with_openai_llm):
+    @patch("openai.OpenAI")
+    async def test_validation_succeeds_with_accessible_endpoint(self, mock_openai_class, config_with_openai_llm):
         """Test that validation succeeds when endpoint is accessible."""
         # Mock successful connection
         mock_client = MagicMock()
         mock_models_response = MagicMock()
         mock_models_response.data = [MagicMock(id="test-model")]
         mock_client.models.list.return_value = mock_models_response
-        mock_openai.OpenAI.return_value = mock_client
+        mock_openai_class.return_value = mock_client
 
         # Should not raise any error
         await validate_llm_endpoints(config_with_openai_llm)
@@ -145,13 +150,13 @@ class TestLLMEndpointValidation:
         # Should not raise error, just skip validation
         await validate_llm_endpoints(config)
 
-    @patch('nat.eval.llm_validator.openai')
-    async def test_validation_fails_on_first_bad_endpoint(self, mock_openai, config_with_multiple_llms):
+    @patch("openai.OpenAI")
+    async def test_validation_fails_on_first_bad_endpoint(self, mock_openai_class, config_with_multiple_llms):
         """Test that validation fails fast on first bad endpoint."""
         # First endpoint fails
         mock_client = MagicMock()
         mock_client.models.list.side_effect = ConnectionError("Connection refused")
-        mock_openai.OpenAI.return_value = mock_client
+        mock_openai_class.return_value = mock_client
 
         with pytest.raises(RuntimeError) as exc_info:
             await validate_llm_endpoints(config_with_multiple_llms)
@@ -205,8 +210,8 @@ class TestLLMValidationErrorMessages:
                 "Ensure"
             ])
 
-    @patch('nat.eval.llm_validator.openai')
-    async def test_404_error_message_mentions_training_cancellation(self, mock_openai):
+    @patch("openai.OpenAI")
+    async def test_404_error_message_mentions_training_cancellation(self, mock_openai_class):
         """Test that 404 error message mentions potential training cancellation."""
         import openai
 
@@ -225,7 +230,7 @@ class TestLLMValidationErrorMessages:
             response=MagicMock(status_code=404),
             body=None
         )
-        mock_openai.OpenAI.return_value = mock_client
+        mock_openai_class.return_value = mock_client
 
         with pytest.raises(RuntimeError) as exc_info:
             await validate_llm_endpoints(config)
@@ -255,11 +260,23 @@ class TestLLMValidationIntegration:
         }
         return config
 
-    async def test_validation_scenario_after_canceled_training(self, config_for_finetuned_model):
+    @patch("openai.OpenAI")
+    async def test_validation_scenario_after_canceled_training(self, mock_openai_class, config_for_finetuned_model):
         """
         Test validation behavior in the scenario that caused the original bug:
         Training was canceled, model never deployed, user tries to run eval.
         """
+        import openai
+
+        # Simulate the exact bug: endpoint is up but model doesn't exist (404)
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = openai.NotFoundError(
+            message="Model not found",
+            response=MagicMock(status_code=404),
+            body=None
+        )
+        mock_openai_class.return_value = mock_client
+
         # This simulates the exact bug scenario:
         # 1. Training was canceled at 93.3%
         # 2. Model was never deployed
@@ -278,6 +295,6 @@ class TestLLMValidationIntegration:
         assert any(check in error_msg for check in [
             "LLM endpoint validation failed",
             "not found",
-            "not permitted"  # May get connection error instead
+            "404"
         ])
 

--- a/tests/nat/eval/test_llm_validator.py
+++ b/tests/nat/eval/test_llm_validator.py
@@ -98,7 +98,7 @@ class TestLLMEndpointValidation:
         # Config without llms attribute
         config = Config()
         delattr(config, "llms")
-        
+
         with pytest.raises(ValueError, match="does not have 'llms' attribute"):
             await validate_llm_endpoints(config)
 
@@ -106,7 +106,7 @@ class TestLLMEndpointValidation:
         """Test that validation rejects configs where llms is not a dict."""
         config = Config()
         config.llms = ["not", "a", "dict"]
-        
+
         with pytest.raises(ValueError, match="must be a dict"):
             await validate_llm_endpoints(config)
 
@@ -117,17 +117,17 @@ class TestLLMEndpointValidation:
         mock_builder = AsyncMock()
         mock_llm = AsyncMock()
         mock_llm.ainvoke = AsyncMock(return_value="test response")
-        
+
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         # Should not raise any error
         await validate_llm_endpoints(config_with_openai_llm)
-        
+
         # Verify builder was used correctly
         mock_builder.add_llm.assert_called_once()
         mock_builder.get_llm.assert_called_once()
@@ -139,19 +139,19 @@ class TestLLMEndpointValidation:
         # Mock 404 error from ainvoke
         mock_builder = AsyncMock()
         mock_llm = AsyncMock()
-        
+
         # Simulate NotFoundError (404) - create actual NotFoundError class
         class NotFoundError(Exception):
             pass
-        
+
         error_404 = NotFoundError("404: Model not found")
         mock_llm.ainvoke = AsyncMock(side_effect=error_404)
-        
+
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         with pytest.raises(RuntimeError) as exc_info:
@@ -169,12 +169,12 @@ class TestLLMEndpointValidation:
         mock_builder = AsyncMock()
         mock_llm = AsyncMock()
         mock_llm.ainvoke = AsyncMock(side_effect=Exception("401: Unauthorized"))
-        
+
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         # Should not raise RuntimeError for non-404 errors
@@ -187,17 +187,17 @@ class TestLLMEndpointValidation:
         mock_builder = AsyncMock()
         mock_llm = AsyncMock()
         mock_llm.ainvoke = AsyncMock(return_value="test response")
-        
+
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         # Should validate NIM LLMs (not skip them)
         await validate_llm_endpoints(config_with_nim_llm)
-        
+
         mock_builder.add_llm.assert_called_once()
         mock_llm.ainvoke.assert_called_once()
 
@@ -207,17 +207,17 @@ class TestLLMEndpointValidation:
         mock_builder = AsyncMock()
         mock_llm = AsyncMock()
         mock_llm.ainvoke = AsyncMock(return_value="test response")
-        
+
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         # Should validate Bedrock LLMs (framework-agnostic approach)
         await validate_llm_endpoints(config_with_bedrock_llm)
-        
+
         mock_builder.add_llm.assert_called_once()
         mock_llm.ainvoke.assert_called_once()
 
@@ -227,16 +227,16 @@ class TestLLMEndpointValidation:
         mock_builder = AsyncMock()
         mock_llm = AsyncMock()
         mock_llm.ainvoke = AsyncMock(return_value="test response")
-        
+
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         await validate_llm_endpoints(config_with_multiple_llms)
-        
+
         # Should have validated both LLMs
         assert mock_builder.add_llm.call_count == 2
         assert mock_builder.get_llm.call_count == 2
@@ -248,23 +248,23 @@ class TestLLMEndpointValidation:
         # Create actual NotFoundError class
         class NotFoundError(Exception):
             pass
-        
+
         mock_builder = AsyncMock()
-        
+
         # First LLM succeeds, second LLM has 404
         mock_llm_success = AsyncMock()
         mock_llm_success.ainvoke = AsyncMock(return_value="ok")
-        
+
         mock_llm_404 = AsyncMock()
         error_404 = NotFoundError("404: Model not found")
         mock_llm_404.ainvoke = AsyncMock(side_effect=error_404)
-        
+
         # Return different LLMs for different calls
         mock_builder.get_llm = AsyncMock(side_effect=[mock_llm_success, mock_llm_404])
         mock_builder.add_llm = AsyncMock()
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         with pytest.raises(RuntimeError) as exc_info:
@@ -292,22 +292,22 @@ class TestTimeoutAndParallelValidation:
         # Mock builder that hangs
         mock_builder = AsyncMock()
         mock_llm = AsyncMock()
-        
+
         # Make ainvoke hang (longer than timeout)
         async def slow_invoke(*args, **kwargs):
             await asyncio.sleep(100)
-        
+
         mock_llm.ainvoke = slow_invoke
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         # Should not raise, just warn about timeout
         await validate_llm_endpoints(config)
-        
+
         # Verify it completed quickly (not hung)
         # The actual timeout is handled by asyncio.wait_for in the implementation
 
@@ -326,16 +326,16 @@ class TestTimeoutAndParallelValidation:
         mock_builder = AsyncMock()
         mock_llm = AsyncMock()
         mock_llm.ainvoke = AsyncMock(return_value="ok")
-        
+
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         await validate_llm_endpoints(config)
-        
+
         # All 10 LLMs should have been validated
         assert mock_builder.add_llm.call_count == 10
         assert mock_llm.ainvoke.call_count == 10
@@ -348,7 +348,7 @@ class Test404ErrorDetection:
         """Test detection of NotFoundError exception type."""
         class NotFoundError(Exception):
             pass
-        
+
         error = NotFoundError("Model not found")
         assert _is_404_error(error)
 
@@ -356,7 +356,7 @@ class Test404ErrorDetection:
         """Test detection of HTTP 404 in error message."""
         error = Exception("HTTP 404: Model not found")
         assert _is_404_error(error)
-        
+
         error2 = Exception("status code 404")
         assert _is_404_error(error2)
 
@@ -364,7 +364,7 @@ class Test404ErrorDetection:
         """Test detection of model-specific not found errors."""
         error = Exception("The model does not exist")
         assert _is_404_error(error)
-        
+
         error2 = Exception("Model not found on server")
         assert _is_404_error(error2)
 
@@ -373,7 +373,7 @@ class Test404ErrorDetection:
         auth_error = Exception("401: Unauthorized")
         rate_limit_error = Exception("429: Rate limit exceeded")
         config_error = Exception("Configuration key not found")
-        
+
         assert not _is_404_error(auth_error)
         assert not _is_404_error(rate_limit_error)
         assert not _is_404_error(config_error)  # Generic "not found" without "model"
@@ -382,7 +382,7 @@ class Test404ErrorDetection:
         """Test that generic 'not found' without model context is not classified as 404."""
         error = Exception("Resource not found in cache")
         assert not _is_404_error(error)
-        
+
         error2 = Exception("Service not deployed")
         assert not _is_404_error(error2)
 
@@ -396,7 +396,7 @@ class TestLLMValidationErrorMessages:
         # Create actual NotFoundError class
         class NotFoundError(Exception):
             pass
-        
+
         config = Config()
         config.llms = {
             "training_llm": OpenAIModelConfig(
@@ -410,12 +410,12 @@ class TestLLMValidationErrorMessages:
         mock_llm = AsyncMock()
         error_404 = NotFoundError("404: Not found")
         mock_llm.ainvoke = AsyncMock(side_effect=error_404)
-        
+
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         with pytest.raises(RuntimeError) as exc_info:
@@ -435,7 +435,7 @@ class TestLLMValidationErrorMessages:
         # Create actual NotFoundError class
         class NotFoundError(Exception):
             pass
-        
+
         config = Config()
         config.llms = {
             "finetuned_model": NIMModelConfig(
@@ -449,12 +449,12 @@ class TestLLMValidationErrorMessages:
         mock_llm = AsyncMock()
         error_404 = NotFoundError("404: Model not found")
         mock_llm.ainvoke = AsyncMock(side_effect=error_404)
-        
+
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         with pytest.raises(RuntimeError) as exc_info:
@@ -492,7 +492,7 @@ class TestLLMValidationIntegration:
         """
         Test validation behavior in the scenario that caused NVBug 5789819:
         Training was canceled, model never deployed, user tries to run eval.
-        
+
         This should:
         1. Detect the missing model BEFORE eval starts (0/24 cases)
         2. Provide clear error about what went wrong
@@ -501,19 +501,19 @@ class TestLLMValidationIntegration:
         # Create actual NotFoundError class
         class NotFoundError(Exception):
             pass
-        
+
         # Mock the exact bug scenario: endpoint is up but model doesn't exist (404)
         mock_builder = AsyncMock()
         mock_llm = AsyncMock()
-        
+
         error_404 = NotFoundError("404: Model not found - the model default/meta-llama-3.1-8b-instruct-nat-dpo does not exist")
         mock_llm.ainvoke = AsyncMock(side_effect=error_404)
-        
+
         mock_builder.add_llm = AsyncMock()
         mock_builder.get_llm = AsyncMock(return_value=mock_llm)
         mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
         mock_builder.__aexit__ = AsyncMock(return_value=None)
-        
+
         mock_builder_class.return_value = mock_builder
 
         # Validation should fail with detailed error
@@ -528,7 +528,7 @@ class TestLLMValidationIntegration:
             "not found",
             "404"
         ])
-        
+
         # Should mention training-related causes
         assert any(phrase in error_msg.lower() for phrase in [
             "training",

--- a/tests/nat/eval/test_llm_validator.py
+++ b/tests/nat/eval/test_llm_validator.py
@@ -1,0 +1,283 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for LLM endpoint validation before evaluation."""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+from nat.data_models.config import Config
+from nat.llm.openai_llm import OpenAIModelConfig
+from nat.eval.llm_validator import validate_llm_endpoints
+
+
+class TestLLMEndpointValidation:
+    """Tests for LLM endpoint validation functionality."""
+
+    @pytest.fixture
+    def config_with_openai_llm(self):
+        """Create config with OpenAI-compatible LLM."""
+        config = Config()
+        config.llms = {
+            "test_llm": OpenAIModelConfig(
+                model_name="test-model",
+                base_url="http://localhost:8000/v1"
+            )
+        }
+        return config
+
+    @pytest.fixture
+    def config_with_multiple_llms(self):
+        """Create config with multiple LLMs."""
+        config = Config()
+        config.llms = {
+            "llm1": OpenAIModelConfig(
+                model_name="model1",
+                base_url="http://localhost:8000/v1"
+            ),
+            "llm2": OpenAIModelConfig(
+                model_name="model2",
+                base_url="http://localhost:8001/v1"
+            )
+        }
+        return config
+
+    @pytest.fixture
+    def config_without_llms(self):
+        """Create config without any LLMs."""
+        config = Config()
+        config.llms = {}
+        return config
+
+    async def test_validation_with_no_llms_configured(self, config_without_llms):
+        """Test validation succeeds when no LLMs are configured."""
+        # Should not raise any error
+        await validate_llm_endpoints(config_without_llms)
+
+    async def test_validation_detects_unreachable_endpoint(self):
+        """Test that validation detects unreachable endpoints."""
+        config = Config()
+        config.llms = {
+            "unreachable_llm": OpenAIModelConfig(
+                model_name="test-model",
+                base_url="http://localhost:9999/v1"  # Non-existent endpoint
+            )
+        }
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await validate_llm_endpoints(config)
+
+        error_msg = str(exc_info.value)
+        assert "LLM endpoint validation failed" in error_msg
+        assert "ACTION REQUIRED" in error_msg
+
+    @patch('nat.eval.llm_validator.openai')
+    async def test_validation_detects_model_not_found_404(self, mock_openai, config_with_openai_llm):
+        """Test that validation detects 404 errors when model doesn't exist."""
+        # Import after patching to get the right exception class
+        import openai
+
+        # Mock OpenAI client to raise NotFoundError (404)
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = openai.NotFoundError(
+            message="Model not found",
+            response=MagicMock(status_code=404),
+            body=None
+        )
+        mock_openai.OpenAI.return_value = mock_client
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await validate_llm_endpoints(config_with_openai_llm)
+
+        error_msg = str(exc_info.value)
+        assert "404" in error_msg
+        assert "not found" in error_msg.lower()
+        assert any(phrase in error_msg for phrase in [
+            "This typically means",
+            "ACTION REQUIRED",
+            "model has not been deployed"
+        ])
+
+    @patch('nat.eval.llm_validator.openai')
+    async def test_validation_succeeds_with_accessible_endpoint(self, mock_openai, config_with_openai_llm):
+        """Test that validation succeeds when endpoint is accessible."""
+        # Mock successful connection
+        mock_client = MagicMock()
+        mock_models_response = MagicMock()
+        mock_models_response.data = [MagicMock(id="test-model")]
+        mock_client.models.list.return_value = mock_models_response
+        mock_openai.OpenAI.return_value = mock_client
+
+        # Should not raise any error
+        await validate_llm_endpoints(config_with_openai_llm)
+
+    async def test_validation_skips_non_openai_llm_types(self):
+        """Test that validation skips non-OpenAI compatible LLM types."""
+        config = Config()
+        # Mock a non-OpenAI LLM type
+        mock_llm = MagicMock()
+        mock_llm.type = "bedrock"  # Non-OpenAI type
+        config.llms = {"bedrock_llm": mock_llm}
+
+        # Should not raise error for non-OpenAI LLMs
+        await validate_llm_endpoints(config)
+
+    async def test_validation_handles_llm_without_base_url(self):
+        """Test that validation handles LLMs without base_url gracefully."""
+        config = Config()
+        mock_llm = MagicMock()
+        mock_llm.type = "openai"
+        mock_llm.base_url = None  # No base_url
+        config.llms = {"no_url_llm": mock_llm}
+
+        # Should not raise error, just skip validation
+        await validate_llm_endpoints(config)
+
+    @patch('nat.eval.llm_validator.openai')
+    async def test_validation_fails_on_first_bad_endpoint(self, mock_openai, config_with_multiple_llms):
+        """Test that validation fails fast on first bad endpoint."""
+        # First endpoint fails
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = ConnectionError("Connection refused")
+        mock_openai.OpenAI.return_value = mock_client
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await validate_llm_endpoints(config_with_multiple_llms)
+
+        error_msg = str(exc_info.value)
+        # Should mention the first failing LLM
+        assert "llm1" in error_msg or "LLM endpoint validation failed" in error_msg
+
+
+class TestLLMValidationErrorMessages:
+    """Tests for error message quality and actionability."""
+
+    async def test_error_message_includes_endpoint_details(self):
+        """Test that error messages include specific endpoint details."""
+        config = Config()
+        config.llms = {
+            "training_llm": OpenAIModelConfig(
+                model_name="custom-model-name",
+                base_url="http://custom-host:8000/v1"
+            )
+        }
+
+        try:
+            await validate_llm_endpoints(config)
+        except RuntimeError as e:
+            error_msg = str(e)
+            # Should include the LLM name
+            assert "training_llm" in error_msg
+            # Should include the base URL
+            assert "http://custom-host:8000/v1" in error_msg
+
+    async def test_error_message_provides_troubleshooting_steps(self):
+        """Test that error messages include actionable troubleshooting steps."""
+        config = Config()
+        config.llms = {
+            "test_llm": OpenAIModelConfig(
+                model_name="test-model",
+                base_url="http://localhost:9999/v1"
+            )
+        }
+
+        try:
+            await validate_llm_endpoints(config)
+        except RuntimeError as e:
+            error_msg = str(e)
+            # Should include actionable guidance
+            assert any(keyword in error_msg for keyword in [
+                "ACTION REQUIRED",
+                "Check",
+                "Verify",
+                "Ensure"
+            ])
+
+    @patch('nat.eval.llm_validator.openai')
+    async def test_404_error_message_mentions_training_cancellation(self, mock_openai):
+        """Test that 404 error message mentions potential training cancellation."""
+        import openai
+
+        config = Config()
+        config.llms = {
+            "finetuned_model": OpenAIModelConfig(
+                model_name="finetuned-llama",
+                base_url="http://localhost:8000/v1"
+            )
+        }
+
+        # Mock 404 error
+        mock_client = MagicMock()
+        mock_client.models.list.side_effect = openai.NotFoundError(
+            message="Not found",
+            response=MagicMock(status_code=404),
+            body=None
+        )
+        mock_openai.OpenAI.return_value = mock_client
+
+        try:
+            await validate_llm_endpoints(config)
+        except RuntimeError as e:
+            error_msg = str(e)
+            # Should mention training-related causes
+            assert any(phrase in error_msg.lower() for phrase in [
+                "training",
+                "deployed",
+                "canceled",
+                "model has not been deployed"
+            ])
+
+
+class TestLLMValidationIntegration:
+    """Integration tests for LLM validation with evaluation flow."""
+
+    @pytest.fixture
+    def config_for_finetuned_model(self):
+        """Create config simulating post-training scenario."""
+        config = Config()
+        config.llms = {
+            "training_llm": OpenAIModelConfig(
+                model_name="default/meta-llama-3.1-8b-instruct-nat-dpo",
+                base_url="http://nim-endpoint:8000/v1"
+            )
+        }
+        return config
+
+    async def test_validation_scenario_after_canceled_training(self, config_for_finetuned_model):
+        """
+        Test validation behavior in the scenario that caused the original bug:
+        Training was canceled, model never deployed, user tries to run eval.
+        """
+        # This simulates the exact bug scenario:
+        # 1. Training was canceled at 93.3%
+        # 2. Model was never deployed
+        # 3. User tries to run evaluation
+
+        with pytest.raises(RuntimeError) as exc_info:
+            await validate_llm_endpoints(config_for_finetuned_model)
+
+        error_msg = str(exc_info.value)
+
+        # Validation should:
+        # 1. Detect the missing model early (before eval starts)
+        # 2. Provide clear error about what went wrong
+        # 3. Give actionable next steps
+
+        assert any(check in error_msg for check in [
+            "LLM endpoint validation failed",
+            "not found",
+            "not permitted"  # May get connection error instead
+        ])
+

--- a/tests/nat/eval/test_llm_validator.py
+++ b/tests/nat/eval/test_llm_validator.py
@@ -15,6 +15,7 @@
 
 """Tests for LLM endpoint validation before evaluation."""
 
+import asyncio
 import pytest
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -22,7 +23,7 @@ from nat.data_models.config import Config
 from nat.llm.openai_llm import OpenAIModelConfig
 from nat.llm.nim_llm import NIMModelConfig
 from nat.llm.aws_bedrock_llm import AWSBedrockModelConfig
-from nat.eval.llm_validator import validate_llm_endpoints, _is_404_error
+from nat.eval.llm_validator import validate_llm_endpoints, _is_404_error, _validate_single_llm
 
 
 class TestLLMEndpointValidation:
@@ -91,6 +92,23 @@ class TestLLMEndpointValidation:
         """Test validation succeeds when no LLMs are configured."""
         # Should not raise any error
         await validate_llm_endpoints(config_without_llms)
+
+    async def test_validation_rejects_invalid_config_structure(self):
+        """Test that validation rejects configs with invalid structure."""
+        # Config without llms attribute
+        config = Config()
+        delattr(config, "llms")
+        
+        with pytest.raises(ValueError, match="does not have 'llms' attribute"):
+            await validate_llm_endpoints(config)
+
+    async def test_validation_rejects_non_dict_llms(self):
+        """Test that validation rejects configs where llms is not a dict."""
+        config = Config()
+        config.llms = ["not", "a", "dict"]
+        
+        with pytest.raises(ValueError, match="must be a dict"):
+            await validate_llm_endpoints(config)
 
     @patch("nat.eval.llm_validator.WorkflowBuilder")
     async def test_validation_succeeds_with_accessible_endpoint(self, mock_builder_class, config_with_openai_llm):
@@ -257,6 +275,72 @@ class TestLLMEndpointValidation:
         assert "nim_llm" in error_msg or "404" in error_msg
 
 
+class TestTimeoutAndParallelValidation:
+    """Tests for timeout handling and parallel validation."""
+
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_validation_times_out_gracefully(self, mock_builder_class):
+        """Test that validation handles timeouts without hanging."""
+        config = Config()
+        config.llms = {
+            "slow_llm": OpenAIModelConfig(
+                model_name="test-model",
+                base_url="http://localhost:8000/v1"
+            )
+        }
+
+        # Mock builder that hangs
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        
+        # Make ainvoke hang (longer than timeout)
+        async def slow_invoke(*args, **kwargs):
+            await asyncio.sleep(100)
+        
+        mock_llm.ainvoke = slow_invoke
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
+
+        # Should not raise, just warn about timeout
+        await validate_llm_endpoints(config)
+        
+        # Verify it completed quickly (not hung)
+        # The actual timeout is handled by asyncio.wait_for in the implementation
+
+    @patch("nat.eval.llm_validator.WorkflowBuilder")
+    async def test_parallel_validation_of_multiple_llms(self, mock_builder_class):
+        """Test that multiple LLMs are validated in parallel batches."""
+        config = Config()
+        config.llms = {
+            f"llm_{i}": OpenAIModelConfig(
+                model_name=f"model-{i}",
+                base_url=f"http://localhost:800{i}/v1"
+            )
+            for i in range(10)
+        }
+
+        mock_builder = AsyncMock()
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(return_value="ok")
+        
+        mock_builder.add_llm = AsyncMock()
+        mock_builder.get_llm = AsyncMock(return_value=mock_llm)
+        mock_builder.__aenter__ = AsyncMock(return_value=mock_builder)
+        mock_builder.__aexit__ = AsyncMock(return_value=None)
+        
+        mock_builder_class.return_value = mock_builder
+
+        await validate_llm_endpoints(config)
+        
+        # All 10 LLMs should have been validated
+        assert mock_builder.add_llm.call_count == 10
+        assert mock_llm.ainvoke.call_count == 10
+
+
 class Test404ErrorDetection:
     """Tests for the _is_404_error helper function."""
 
@@ -268,23 +352,39 @@ class Test404ErrorDetection:
         error = NotFoundError("Model not found")
         assert _is_404_error(error)
 
-    def test_detects_404_in_message(self):
-        """Test detection of 404 in error message."""
+    def test_detects_404_in_http_message(self):
+        """Test detection of HTTP 404 in error message."""
         error = Exception("HTTP 404: Model not found")
         assert _is_404_error(error)
+        
+        error2 = Exception("status code 404")
+        assert _is_404_error(error2)
 
-    def test_detects_not_found_phrase(self):
-        """Test detection of 'not found' phrase."""
+    def test_detects_model_not_found(self):
+        """Test detection of model-specific not found errors."""
         error = Exception("The model does not exist")
         assert _is_404_error(error)
+        
+        error2 = Exception("Model not found on server")
+        assert _is_404_error(error2)
 
     def test_does_not_detect_other_errors(self):
         """Test that non-404 errors are not detected as 404s."""
         auth_error = Exception("401: Unauthorized")
         rate_limit_error = Exception("429: Rate limit exceeded")
+        config_error = Exception("Configuration key not found")
         
         assert not _is_404_error(auth_error)
         assert not _is_404_error(rate_limit_error)
+        assert not _is_404_error(config_error)  # Generic "not found" without "model"
+
+    def test_does_not_false_positive_on_generic_not_found(self):
+        """Test that generic 'not found' without model context is not classified as 404."""
+        error = Exception("Resource not found in cache")
+        assert not _is_404_error(error)
+        
+        error2 = Exception("Service not deployed")
+        assert not _is_404_error(error2)
 
 
 class TestLLMValidationErrorMessages:

--- a/tests/nat/eval/test_llm_validator.py
+++ b/tests/nat/eval/test_llm_validator.py
@@ -227,17 +227,17 @@ class TestLLMValidationErrorMessages:
         )
         mock_openai.OpenAI.return_value = mock_client
 
-        try:
+        with pytest.raises(RuntimeError) as exc_info:
             await validate_llm_endpoints(config)
-        except RuntimeError as e:
-            error_msg = str(e)
-            # Should mention training-related causes
-            assert any(phrase in error_msg.lower() for phrase in [
-                "training",
-                "deployed",
-                "canceled",
-                "model has not been deployed"
-            ])
+
+        error_msg = str(exc_info.value)
+        # Should mention training-related causes
+        assert any(phrase in error_msg.lower() for phrase in [
+            "training",
+            "deployed",
+            "canceled",
+            "model has not been deployed"
+        ])
 
 
 class TestLLMValidationIntegration:

--- a/tests/nat/eval/test_llm_validator.py
+++ b/tests/nat/eval/test_llm_validator.py
@@ -12,18 +12,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Tests for LLM endpoint validation before evaluation."""
 
 import asyncio
+from unittest.mock import AsyncMock
+from unittest.mock import patch
+
 import pytest
-from unittest.mock import AsyncMock, MagicMock, patch
 
 from nat.data_models.config import Config
-from nat.llm.openai_llm import OpenAIModelConfig
-from nat.llm.nim_llm import NIMModelConfig
+from nat.eval.llm_validator import _is_404_error
+from nat.eval.llm_validator import validate_llm_endpoints
 from nat.llm.aws_bedrock_llm import AWSBedrockModelConfig
-from nat.eval.llm_validator import validate_llm_endpoints, _is_404_error, _validate_single_llm
+from nat.llm.nim_llm import NIMModelConfig
+from nat.llm.openai_llm import OpenAIModelConfig
 
 
 class TestLLMEndpointValidation:
@@ -33,12 +35,7 @@ class TestLLMEndpointValidation:
     def config_with_openai_llm(self):
         """Create config with OpenAI-compatible LLM."""
         config = Config()
-        config.llms = {
-            "test_llm": OpenAIModelConfig(
-                model_name="test-model",
-                base_url="http://localhost:8000/v1"
-            )
-        }
+        config.llms = {"test_llm": OpenAIModelConfig(model_name="test-model", base_url="http://localhost:8000/v1")}
         return config
 
     @pytest.fixture
@@ -46,10 +43,7 @@ class TestLLMEndpointValidation:
         """Create config with NIM LLM."""
         config = Config()
         config.llms = {
-            "nim_llm": NIMModelConfig(
-                model_name="meta/llama-3.1-8b-instruct",
-                base_url="http://localhost:8000/v1"
-            )
+            "nim_llm": NIMModelConfig(model_name="meta/llama-3.1-8b-instruct", base_url="http://localhost:8000/v1")
         }
         return config
 
@@ -57,12 +51,7 @@ class TestLLMEndpointValidation:
     def config_with_bedrock_llm(self):
         """Create config with AWS Bedrock LLM."""
         config = Config()
-        config.llms = {
-            "bedrock_llm": AWSBedrockModelConfig(
-                model_name="anthropic.claude-v2",
-                region_name="us-east-1"
-            )
-        }
+        config.llms = {"bedrock_llm": AWSBedrockModelConfig(model_name="anthropic.claude-v2", region_name="us-east-1")}
         return config
 
     @pytest.fixture
@@ -70,14 +59,8 @@ class TestLLMEndpointValidation:
         """Create config with multiple LLMs of different types."""
         config = Config()
         config.llms = {
-            "openai_llm": OpenAIModelConfig(
-                model_name="gpt-4",
-                base_url="http://localhost:8000/v1"
-            ),
-            "nim_llm": NIMModelConfig(
-                model_name="llama-3.1-8b-instruct",
-                base_url="http://localhost:8001/v1"
-            )
+            "openai_llm": OpenAIModelConfig(model_name="gpt-4", base_url="http://localhost:8000/v1"),
+            "nim_llm": NIMModelConfig(model_name="llama-3.1-8b-instruct", base_url="http://localhost:8001/v1")
         }
         return config
 
@@ -245,6 +228,7 @@ class TestLLMEndpointValidation:
     @patch("nat.eval.llm_validator.WorkflowBuilder")
     async def test_validation_collects_all_404_errors(self, mock_builder_class, config_with_multiple_llms):
         """Test that validation collects all 404 errors before failing."""
+
         # Create actual NotFoundError class
         class NotFoundError(Exception):
             pass
@@ -282,12 +266,7 @@ class TestTimeoutAndParallelValidation:
     async def test_validation_times_out_gracefully(self, mock_builder_class):
         """Test that validation handles timeouts without hanging."""
         config = Config()
-        config.llms = {
-            "slow_llm": OpenAIModelConfig(
-                model_name="test-model",
-                base_url="http://localhost:8000/v1"
-            )
-        }
+        config.llms = {"slow_llm": OpenAIModelConfig(model_name="test-model", base_url="http://localhost:8000/v1")}
 
         # Mock builder that hangs
         mock_builder = AsyncMock()
@@ -316,10 +295,7 @@ class TestTimeoutAndParallelValidation:
         """Test that multiple LLMs are validated in parallel batches."""
         config = Config()
         config.llms = {
-            f"llm_{i}": OpenAIModelConfig(
-                model_name=f"model-{i}",
-                base_url=f"http://localhost:800{i}/v1"
-            )
+            f"llm_{i}": OpenAIModelConfig(model_name=f"model-{i}", base_url=f"http://localhost:800{i}/v1")
             for i in range(10)
         }
 
@@ -346,6 +322,7 @@ class Test404ErrorDetection:
 
     def test_detects_notfounderror_type(self):
         """Test detection of NotFoundError exception type."""
+
         class NotFoundError(Exception):
             pass
 
@@ -393,16 +370,14 @@ class TestLLMValidationErrorMessages:
     @patch("nat.eval.llm_validator.WorkflowBuilder")
     async def test_error_message_includes_endpoint_details(self, mock_builder_class):
         """Test that error messages include specific endpoint details."""
+
         # Create actual NotFoundError class
         class NotFoundError(Exception):
             pass
 
         config = Config()
         config.llms = {
-            "training_llm": OpenAIModelConfig(
-                model_name="custom-model-name",
-                base_url="http://custom-host:8000/v1"
-            )
+            "training_llm": OpenAIModelConfig(model_name="custom-model-name", base_url="http://custom-host:8000/v1")
         }
 
         # Mock 404 error
@@ -432,16 +407,14 @@ class TestLLMValidationErrorMessages:
     @patch("nat.eval.llm_validator.WorkflowBuilder")
     async def test_404_error_message_mentions_training_cancellation(self, mock_builder_class):
         """Test that 404 error message mentions potential training cancellation."""
+
         # Create actual NotFoundError class
         class NotFoundError(Exception):
             pass
 
         config = Config()
         config.llms = {
-            "finetuned_model": NIMModelConfig(
-                model_name="finetuned-llama",
-                base_url="http://localhost:8000/v1"
-            )
+            "finetuned_model": NIMModelConfig(model_name="finetuned-llama", base_url="http://localhost:8000/v1")
         }
 
         # Mock 404 error
@@ -462,12 +435,8 @@ class TestLLMValidationErrorMessages:
 
         error_msg = str(exc_info.value)
         # Should mention training-related causes
-        assert any(phrase in error_msg.lower() for phrase in [
-            "training",
-            "deployed",
-            "canceled",
-            "model has not been deployed"
-        ])
+        assert any(phrase in error_msg.lower()
+                   for phrase in ["training", "deployed", "canceled", "model has not been deployed"])
         # Should include actionable guidance
         assert "ACTION REQUIRED" in error_msg
 
@@ -480,10 +449,9 @@ class TestLLMValidationIntegration:
         """Create config simulating post-training scenario."""
         config = Config()
         config.llms = {
-            "training_llm": NIMModelConfig(
-                model_name="default/meta-llama-3.1-8b-instruct-nat-dpo",
-                base_url="http://nim-endpoint:8000/v1"
-            )
+            "training_llm":
+                NIMModelConfig(model_name="default/meta-llama-3.1-8b-instruct-nat-dpo",
+                               base_url="http://nim-endpoint:8000/v1")
         }
         return config
 
@@ -498,6 +466,7 @@ class TestLLMValidationIntegration:
         2. Provide clear error about what went wrong
         3. Give actionable next steps
         """
+
         # Create actual NotFoundError class
         class NotFoundError(Exception):
             pass
@@ -506,7 +475,8 @@ class TestLLMValidationIntegration:
         mock_builder = AsyncMock()
         mock_llm = AsyncMock()
 
-        error_404 = NotFoundError("404: Model not found - the model default/meta-llama-3.1-8b-instruct-nat-dpo does not exist")
+        error_404 = NotFoundError(
+            "404: Model not found - the model default/meta-llama-3.1-8b-instruct-nat-dpo does not exist")
         mock_llm.ainvoke = AsyncMock(side_effect=error_404)
 
         mock_builder.add_llm = AsyncMock()
@@ -523,15 +493,7 @@ class TestLLMValidationIntegration:
         error_msg = str(exc_info.value)
 
         # Validation should catch the issue BEFORE eval starts
-        assert any(check in error_msg for check in [
-            "LLM endpoint validation failed",
-            "not found",
-            "404"
-        ])
+        assert any(check in error_msg for check in ["LLM endpoint validation failed", "not found", "404"])
 
         # Should mention training-related causes
-        assert any(phrase in error_msg.lower() for phrase in [
-            "training",
-            "canceled",
-            "deployed"
-        ])
+        assert any(phrase in error_msg.lower() for phrase in ["training", "canceled", "deployed"])


### PR DESCRIPTION
## Description

Closes: nvbugs-5789819

### Fix: Fail-fast on training cancellation and validate LLM endpoints before eval

Adds fail-fast error handling when training jobs are canceled/failed and validates LLM endpoints before starting evaluation to prevent cryptic 404 errors.

When a finetuning job gets canceled (e.g., timeout at 93.3% progress), the current behavior:
- Logs cancellation as status update but doesn't raise error
- Attempts to deploy a non-existent model
- Evaluation starts and fails with "404 page not found" mid-run

This wastes user time debugging unclear errors.

1. Fail-fast on training failure: Raise `RuntimeError` immediately when training status is `CANCELED` or `FAILED` with actionable error messages
2. Pre-validation: Check LLM endpoints are reachable before starting eval workflow
3. Better error messages: Include troubleshooting steps in error output

### Changes
- `trainer_adapter.py` - Added explicit error handling for canceled/failed training jobs
- `evaluate.py` - Integrated LLM validation before workflow execution  
- `llm_validator.py` (new) - Validates OpenAI-compatible endpoints and catches 404s early
- `test_llm_validator.py` (new) - 11 tests covering validation scenarios

### Testing
-  All new tests pass (11/11)
-  No linter errors
-  Tested scenario: canceled training → immediate error with guidance

### Notes
- Related: PR #1350 (merged) improved status logging; this adds fail-fast behavior
- Target: `release/1.4`
- No breaking changes


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Opt-in LLM endpoint validation before evaluations via a new config flag (defaults off). Batched async checks with actionable messages; fatal on unreachable endpoints.

* **Bug Fixes**
  * Improved training terminal-state handling: explicit errors for FAILED/CANCELED when deployment expected, clearer deployment logs, and safer non-deploy paths.

* **Tests**
  * Comprehensive tests for endpoint validation across providers, 404 vs other errors, timeouts, parallel execution, and messaging.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->