### PR TITLE
add support for langchain agents that are wrapped as async context managers

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
@@ -107,15 +107,28 @@ class LanggraphWrapperFunction(Function[LanggraphWrapperInput, NoneType, Langgra
     async def _ainvoke(self, value: LanggraphWrapperInput) -> LanggraphWrapperOutput:
 
         try:
-            output = await self._graph.ainvoke(value.model_dump())
+            # Check if the graph is an async context manager (e.g., from @asynccontextmanager)
+            if hasattr(self._graph, '__aenter__') and hasattr(self._graph, '__aexit__'):
+                logger.info("Graph is an async context manager")
+                async with self._graph as graph:
+                    output = await graph.ainvoke(value.model_dump())
+            else:
+                output = await self._graph.ainvoke(value.model_dump())
             return LanggraphWrapperOutput.model_validate(output)
         except Exception as e:
             raise RuntimeError(f"Error in LangGraph workflow: {e}") from e
 
     async def _astream(self, value: LanggraphWrapperInput) -> AsyncGenerator[LanggraphWrapperOutput, None]:
         try:
-            async for output in self._graph.astream(value.model_dump()):
-                yield LanggraphWrapperOutput.model_validate(output)
+
+            if hasattr(self._graph, '__aenter__') and hasattr(self._graph, '__aexit__'):
+                logger.info("Graph is an async context manager")
+                async with self._graph as graph:
+                    async for output in graph.astream(value.model_dump()):
+                        yield LanggraphWrapperOutput.model_validate(output)
+            else:
+                async for output in self._graph.astream(value.model_dump()):
+                    yield LanggraphWrapperOutput.model_validate(output)
         except Exception as e:
             raise RuntimeError(f"Error in LangGraph workflow: {e}") from e
 


### PR DESCRIPTION
## Description

The PR fixes a bug that causes an error when defining a langgraph agent as an async context manager. 

<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes #1370


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced workflow to support graphs that are async context managers during invocation and streaming operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->