### PR TITLE
For tagged and nightly builds use GIT_TAG as-is

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -103,7 +103,7 @@ jobs:
     name: Test
     needs: [check]
     runs-on:  linux-${{ matrix.arch }}-cpu4
-    timeout-minutes: 30
+    timeout-minutes: 60
     container:
       image: ${{ matrix.container }}
     strategy:

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -107,7 +107,7 @@ function get_num_proc() {
 function set_versions() {
    # Update internal dependencies to the current git tag
 
-   if [[ "${CI_CRON_NIGHTLY}" == "1" || ${IS_TAGGED} == "1" ]]; then
+   if [[ "${CI_CRON_NIGHTLY}" == "1" || "${IS_TAGGED}" == "1" ]]; then
       # For tagged releases and nightly builds, use the git tag as the version as-is
       local NAT_VERSION="${GIT_TAG}"
    else

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -106,20 +106,26 @@ function get_num_proc() {
 
 function set_versions() {
    # Update internal dependencies to the current git tag
-   set +e
-   local SETUPTOOLS_SCM_OUTPUT=$(python -m setuptools_scm)
-   local SETUPTOOLS_SCM_RESULT=$?
-   set -e
 
-   if [[ ${SETUPTOOLS_SCM_RESULT} -ne 0 ]]; then
-       rapids-logger "Error, setuptools_scm failed to determine the version: ${SETUPTOOLS_SCM_OUTPUT}"
-       exit ${SETUPTOOLS_SCM_RESULT}
+   if [[ "${CI_CRON_NIGHTLY}" == "1" || ${IS_TAGGED} == "1" ]]; then
+      # For tagged releases and nightly builds, use the git tag as the version as-is
+      local NAT_VERSION="${GIT_TAG}"
+   else
+      set +e
+      local NAT_VERSION=$(python -m setuptools_scm)
+      local SETUPTOOLS_SCM_RESULT=$?
+      set -e
+
+      if [[ ${SETUPTOOLS_SCM_RESULT} -ne 0 ]]; then
+         rapids-logger "Error, setuptools_scm failed to determine the version: ${NAT_VERSION}"
+         exit ${SETUPTOOLS_SCM_RESULT}
+      fi
    fi
 
-   export SETUPTOOLS_SCM_PRETEND_VERSION="${SETUPTOOLS_SCM_OUTPUT}"
+   export SETUPTOOLS_SCM_PRETEND_VERSION="${NAT_VERSION}"
    export USE_FULL_VERSION="1"
 
-   SKIP_MD_UPDATE=1 ${PROJECT_ROOT}/ci/release/update-version.sh "${SETUPTOOLS_SCM_OUTPUT}"
+   SKIP_MD_UPDATE=1 ${PROJECT_ROOT}/ci/release/update-version.sh "${NAT_VERSION}"
 }
 
 function build_wheel() {

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -109,10 +109,10 @@ function set_versions() {
 
    if [[ "${CI_CRON_NIGHTLY}" == "1" || "${IS_TAGGED}" == "1" ]]; then
       # For tagged releases and nightly builds, use the git tag as the version as-is
-      local NAT_VERSION="${GIT_TAG}"
+      NAT_VERSION="${GIT_TAG}"
    else
       set +e
-      local NAT_VERSION=$(python -m setuptools_scm)
+      NAT_VERSION=$(python -m setuptools_scm)
       local SETUPTOOLS_SCM_RESULT=$?
       set -e
 


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Use the release/tag value as the canonical version for nightly and tagged CI runs to simplify versioning.
  * Export and propagate the resolved version consistently through the release workflow.
  * Improved error handling and reporting in automated version resolution for clearer diagnostics.
  * Increased CI Test job timeout from 30 to 60 minutes to accommodate longer-running tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->