### PR TITLE
chore: speed up tests

### DIFF
--- a/src/nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py
+++ b/src/nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py
@@ -49,14 +49,18 @@ class WebSocketAuthenticationFlowHandler(FlowHandlerBase):
     def __init__(self,
                  add_flow_cb: Callable[[str, FlowState], Awaitable[None]],
                  remove_flow_cb: Callable[[str], Awaitable[None]],
-                 web_socket_message_handler: WebSocketMessageHandler):
+                 web_socket_message_handler: WebSocketMessageHandler,
+                 auth_timeout_seconds: float = 300.0):
 
         self._add_flow_cb: Callable[[str, FlowState], Awaitable[None]] = add_flow_cb
         self._remove_flow_cb: Callable[[str], Awaitable[None]] = remove_flow_cb
         self._web_socket_message_handler: WebSocketMessageHandler = web_socket_message_handler
+        self._auth_timeout_seconds: float = auth_timeout_seconds
 
-    async def authenticate(self, config: OAuth2AuthCodeFlowProviderConfig,
-                           method: AuthFlowType) -> AuthenticatedContext:
+    async def authenticate(
+            self,
+            config: OAuth2AuthCodeFlowProviderConfig,  # type: ignore[override]
+            method: AuthFlowType) -> AuthenticatedContext:
         if method == AuthFlowType.OAUTH2_AUTHORIZATION_CODE:
             return await self._handle_oauth2_auth_code_flow(config)
 
@@ -80,8 +84,8 @@ class WebSocketAuthenticationFlowHandler(FlowHandlerBase):
                                   client: AsyncOAuth2Client,
                                   config: OAuth2AuthCodeFlowProviderConfig,
                                   state: str,
-                                  verifier: str = None,
-                                  challenge: str = None) -> str:
+                                  verifier: str | None = None,
+                                  challenge: str | None = None) -> str:
         """
         Create OAuth authorization URL with proper error handling.
 
@@ -129,7 +133,7 @@ class WebSocketAuthenticationFlowHandler(FlowHandlerBase):
         await self._web_socket_message_handler.create_websocket_message(_HumanPromptOAuthConsent(text=authorization_url)
                                                                         )
         try:
-            token = await asyncio.wait_for(flow_state.future, timeout=300)
+            token = await asyncio.wait_for(flow_state.future, timeout=self._auth_timeout_seconds)
         except TimeoutError as exc:
             raise RuntimeError("Authentication flow timed out after 5 minutes.") from exc
         finally:

--- a/src/nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py
+++ b/src/nat/front_ends/fastapi/auth_flow_handlers/websocket_flow_handler.py
@@ -135,7 +135,7 @@ class WebSocketAuthenticationFlowHandler(FlowHandlerBase):
         try:
             token = await asyncio.wait_for(flow_state.future, timeout=self._auth_timeout_seconds)
         except TimeoutError as exc:
-            raise RuntimeError("Authentication flow timed out after 5 minutes.") from exc
+            raise RuntimeError(f"Authentication flow timed out after {self._auth_timeout_seconds} seconds.") from exc
         finally:
 
             await self._remove_flow_cb(state)

--- a/tests/nat/a2a/auth/test_credential_service.py
+++ b/tests/nat/a2a/auth/test_credential_service.py
@@ -38,6 +38,7 @@ from nat.authentication.interfaces import AuthProviderBase
 from nat.data_models.authentication import AuthResult
 from nat.data_models.authentication import BasicAuthCred
 from nat.data_models.authentication import BearerTokenCred
+from nat.data_models.authentication import CredentialKind
 from nat.data_models.authentication import HeaderCred
 from nat.plugins.a2a.auth.credential_service import A2ACredentialService
 
@@ -50,7 +51,7 @@ class MockAuthProvider(AuthProviderBase):
     """Generic mock auth provider for testing."""
 
     def __init__(self, auth_result: AuthResult | None = None):
-        super().__init__(Mock())
+        super().__init__(Mock())  # type: ignore[arg-type]
         self.auth_result = auth_result
         self.authenticate_called_with = []
 
@@ -68,7 +69,7 @@ def mock_auth_provider():
     def _create(provider_name: str, auth_result: AuthResult | None = None):
 
         def mock_init(self, result):
-            AuthProviderBase.__init__(self, Mock())
+            AuthProviderBase.__init__(self, Mock())  # type: ignore[arg-type]
             self.auth_result = result
             self.authenticate_called_with = []
 
@@ -83,7 +84,7 @@ def mock_auth_provider():
             '__init__': mock_init,
             'authenticate': mock_authenticate,
         })
-        return cls(auth_result)
+        return cls(auth_result)  # type: ignore[call-arg]
 
     return _create
 
@@ -106,7 +107,7 @@ def oidc_scheme():
     """OpenID Connect security scheme fixture."""
     return SecurityScheme(root=OpenIdConnectSecurityScheme(
         type="openIdConnect",
-        openIdConnectUrl="https://auth.example.com/.well-known/openid-configuration",
+        open_id_connect_url="https://auth.example.com/.well-known/openid-configuration",
     ))
 
 
@@ -197,7 +198,8 @@ async def test_bearer_token_mapping(
 
 async def test_header_credential_with_api_key_scheme(api_key_scheme, mock_auth_provider, sample_agent_card):
     """Test HeaderCred maps to APIKeySecurityScheme in header."""
-    auth_result = AuthResult(credentials=[HeaderCred(kind="header", name="X-API-Key", value=SecretStr("test-api-key"))])
+    auth_result = AuthResult(
+        credentials=[HeaderCred(kind=CredentialKind.HEADER, name="X-API-Key", value=SecretStr("test-api-key"))])
     provider = mock_auth_provider("MockAPIKeyProvider", auth_result)
 
     card = sample_agent_card({"api_key": api_key_scheme})

--- a/tests/nat/eval/test_llm_validator.py
+++ b/tests/nat/eval/test_llm_validator.py
@@ -263,7 +263,7 @@ class TestTimeoutAndParallelValidation:
     """Tests for timeout handling and parallel validation."""
 
     @patch("nat.eval.llm_validator.WorkflowBuilder")
-    async def test_validation_times_out_gracefully(self, mock_builder_class):
+    async def test_validation_times_out_gracefully(self, mock_builder_class, monkeypatch):
         """Test that validation handles timeouts without hanging."""
         config = Config()
         config.llms = {"slow_llm": OpenAIModelConfig(model_name="test-model", base_url="http://localhost:8000/v1")}
@@ -274,7 +274,7 @@ class TestTimeoutAndParallelValidation:
 
         # Make ainvoke hang (longer than timeout)
         async def slow_invoke(*args, **kwargs):
-            await asyncio.sleep(100)
+            await asyncio.sleep(1)
 
         mock_llm.ainvoke = slow_invoke
         mock_builder.add_llm = AsyncMock()
@@ -283,6 +283,8 @@ class TestTimeoutAndParallelValidation:
         mock_builder.__aexit__ = AsyncMock(return_value=None)
 
         mock_builder_class.return_value = mock_builder
+        # Shorten timeout so the test finishes quickly
+        monkeypatch.setattr("nat.eval.llm_validator.VALIDATION_TIMEOUT_SECONDS", 0.05, raising=True)
 
         # Should not raise, just warn about timeout
         await validate_llm_endpoints(config)

--- a/tests/nat/front_ends/auth_flow_handlers/test_websocket_flow_handler.py
+++ b/tests/nat/front_ends/auth_flow_handlers/test_websocket_flow_handler.py
@@ -199,6 +199,7 @@ async def test_websocket_oauth2_flow_error_handling(monkeypatch, mock_server, tm
         add_flow_cb=worker._add_flow,
         remove_flow_cb=worker._remove_flow,
         web_socket_message_handler=_DummyWSHandler(),
+        auth_timeout_seconds=0.05,
     )
 
     # Use a config that will pass pydantic validation but fail OAuth client creation

--- a/tests/nat/front_ends/fastapi/test_job_store.py
+++ b/tests/nat/front_ends/fastapi/test_job_store.py
@@ -33,7 +33,7 @@ class _TestModel(BaseModel):
 
 async def simple_job_function(x: int, y: int = 10) -> int:
     """Simple function for testing job execution."""
-    await asyncio.sleep(0.1)  # Simulate some work
+    await asyncio.sleep(0)  # Yield to event loop without adding delay
     return x + y
 
 
@@ -579,7 +579,7 @@ async def test_cleanup_expired_jobs_with_output_files(db_engine: "AsyncEngine",
 
     with monkeypatch.context() as monkey_context:
         # Lower minimum expiry for testing
-        monkey_context.setattr(JobStore, "MIN_EXPIRY", 1, raising=True)
+        monkey_context.setattr(JobStore, "MIN_EXPIRY", 0.01, raising=True)
 
         job_store = JobStore(scheduler_address=dask_scheduler_address, db_engine=db_engine)
 
@@ -590,8 +590,8 @@ async def test_cleanup_expired_jobs_with_output_files(db_engine: "AsyncEngine",
         output_dir2.mkdir()
 
         # Create jobs with very short expiry
-        job_id1 = await job_store._create_job(expiry_seconds=1)
-        job_id2 = await job_store._create_job(expiry_seconds=1)
+        job_id1 = await job_store._create_job(expiry_seconds=0.01)
+        job_id2 = await job_store._create_job(expiry_seconds=0.01)
 
         # Update to finished status with output paths
         await job_store.update_status(job_id1, JobStatus.SUCCESS, output_path=str(output_dir1))
@@ -602,7 +602,7 @@ async def test_cleanup_expired_jobs_with_output_files(db_engine: "AsyncEngine",
         assert output_dir2.exists()
 
         # Wait for jobs to expire
-        await asyncio.sleep(3)
+        await asyncio.sleep(0.1)
 
         # Run cleanup
         await job_store.cleanup_expired_jobs()
@@ -632,21 +632,21 @@ async def test_cleanup_expired_jobs_keeps_active(db_engine: "AsyncEngine",
 
     with monkeypatch.context() as monkey_context:
         # Lower minimum expiry for testing
-        monkey_context.setattr(JobStore, "MIN_EXPIRY", 1, raising=True)
+        monkey_context.setattr(JobStore, "MIN_EXPIRY", 0.01, raising=True)
 
         job_store = JobStore(scheduler_address=dask_scheduler_address, db_engine=db_engine)
 
         # Create jobs with very short expiry
-        job_id1 = await job_store._create_job(expiry_seconds=1)
-        job_id2 = await job_store._create_job(expiry_seconds=1)
-        job_id3 = await job_store._create_job(expiry_seconds=1)
+        job_id1 = await job_store._create_job(expiry_seconds=0.01)
+        job_id2 = await job_store._create_job(expiry_seconds=0.01)
+        job_id3 = await job_store._create_job(expiry_seconds=0.01)
 
         # Keep one as submitted (active), update other to finished
         await job_store.update_status(job_id2, JobStatus.SUCCESS)
         await job_store.update_status(job_id3, JobStatus.SUCCESS)
 
         # Wait for expiry time to pass
-        await asyncio.sleep(2)
+        await asyncio.sleep(0.1)
 
         # Run cleanup
         await job_store.cleanup_expired_jobs()

--- a/tests/nat/profiler/test_callback_handler.py
+++ b/tests/nat/profiler/test_callback_handler.py
@@ -51,16 +51,16 @@ async def test_langchain_handler(reactive_stream: Subject):
 
     await handler.on_llm_start(serialized={}, prompts=prompts, run_id=run_id)
 
-    # Simulate a fake sleep for 1 second
-    await asyncio.sleep(1)
+    # Simulate a fake sleep for 0.05 second
+    await asyncio.sleep(0.05)
 
     # Simulate receiving new tokens with delay between them
     await handler.on_llm_new_token("hello", run_id=run_id)
-    await asyncio.sleep(0.1)  # Ensure a small delay between token events
+    await asyncio.sleep(0.05)  # Ensure a small delay between token events
     await handler.on_llm_new_token(" world", run_id=run_id)
 
     # Simulate a delay before ending
-    await asyncio.sleep(0.1)
+    await asyncio.sleep(0.05)
 
     # Build a fake LLMResult
     from langchain_core.messages import AIMessage
@@ -87,9 +87,8 @@ async def test_langchain_handler(reactive_stream: Subject):
     assert all_stats[1].event_timestamp <= all_stats[2].event_timestamp
     assert all_stats[2].event_timestamp <= all_stats[3].event_timestamp
 
-    # Check that there's a significant delay between start and first token
-    assert all_stats[1].event_timestamp - all_stats[
-        0].event_timestamp > 0.5  # 0.5 second between LLM start and new token
+    # Check that there's a delay between start and first token
+    assert all_stats[1].event_timestamp - all_stats[0].event_timestamp > 0.05
 
     # Check that the first usage stat has the correct chat_inputs
     assert all_stats[0].payload.metadata.chat_inputs == prompts
@@ -134,6 +133,7 @@ async def test_llama_index_handler_order(reactive_stream: Subject):
     # chat_responses is a bit short in this test, but we confirm at least we get something
 
 
+@pytest.mark.slow
 async def test_crewai_handler_time_between_calls(reactive_stream: Subject):
     """
     Test CrewAIProfilerHandler ensures seconds_between_calls is properly set for consecutive calls.
@@ -201,6 +201,7 @@ async def test_crewai_handler_time_between_calls(reactive_stream: Subject):
     assert results[2].usage_info.seconds_between_calls == 7
 
 
+@pytest.mark.slow
 async def test_semantic_kernel_handler_tool_call(reactive_stream: Subject):
     """
     Test that the SK callback logs tool usage events.
@@ -348,7 +349,7 @@ async def test_agno_handler_llm_call(reactive_stream: Subject):
             result = captured_orig_func(*args, **kwargs)
 
             # Small delay to ensure events are processed in order
-            time.sleep(0.05)
+            time.sleep(0.01)
 
             # Create the end event
             end_payload = IntermediateStepPayload(
@@ -381,7 +382,7 @@ async def test_agno_handler_llm_call(reactive_stream: Subject):
     result = direct_wrapped(messages=messages, model="gpt-4")
 
     # Wait a small amount of time to ensure the reactive stream has time to process
-    time.sleep(0.5)  # Increase wait time to make sure events are processed
+    time.sleep(0.05)  # Wait briefly to allow reactive stream processing
 
     # Check the all_stats list from the subscription
     print(f"all_stats has {len(all_stats)} items")
@@ -405,55 +406,30 @@ async def test_agno_handler_llm_call(reactive_stream: Subject):
     # Find IntermediateStep objects in all_stats
     intermediate_steps = [event for event in all_stats if hasattr(event, 'payload')]
 
-    # If we don't have IntermediateStep objects, check step_manager
-    if len(intermediate_steps) < 2:
-        print("Not enough IntermediateStep objects in all_stats, checking step_manager...")
-        steps = step_manager.get_intermediate_steps()
-        print(f"Found {len(steps)} steps in step_manager")
-        for i, step in enumerate(steps):
-            print(f"Step {i}: {step.event_type}")
+    assert len(intermediate_steps) >= 2, "Expected at least 2 events in reactive stream"
 
-        # Verify steps in step_manager
-        assert len(steps) >= 2, f"Expected at least 2 steps in step_manager, got {len(steps)}"
+    # Find the START and END events in our intermediate steps
+    start_events = [e for e in intermediate_steps if e.payload.event_type == IntermediateStepType.LLM_START]
+    end_events = [e for e in intermediate_steps if e.payload.event_type == IntermediateStepType.LLM_END]
 
-        # Find the START and END events from step_manager
-        start_events = [s for s in steps if s.event_type == IntermediateStepType.LLM_START]
-        end_events = [s for s in steps if s.event_type == IntermediateStepType.LLM_END]
+    assert len(start_events) > 0, "No LLM_START events found in intermediate steps"
+    assert len(end_events) > 0, "No LLM_END events found in intermediate steps"
 
-        assert len(start_events) > 0, "No LLM_START events found in step_manager"
-        assert len(end_events) > 0, "No LLM_END events found in step_manager"
+    # Use the latest events for our test
+    start_event = start_events[-1]
+    end_event = end_events[-1]
 
-        # Use the latest events for our test
-        start_event = start_events[-1]
-        end_event = end_events[-1]
+    # Verify event types
+    assert start_event.payload.event_type == IntermediateStepType.LLM_START
+    assert end_event.payload.event_type == IntermediateStepType.LLM_END
 
-        # Check token usage values in the end event
-        assert end_event.usage_info.token_usage.prompt_tokens == token_usage_obj.prompt_tokens
-        assert end_event.usage_info.token_usage.completion_tokens == token_usage_obj.completion_tokens
-        assert end_event.usage_info.token_usage.total_tokens == token_usage_obj.total_tokens
-    else:
-        # Find the START and END events in our intermediate steps
-        start_events = [e for e in intermediate_steps if e.payload.event_type == IntermediateStepType.LLM_START]
-        end_events = [e for e in intermediate_steps if e.payload.event_type == IntermediateStepType.LLM_END]
+    # Check token usage values in the end event
+    assert end_event.payload.usage_info.token_usage.prompt_tokens == token_usage_obj.prompt_tokens
+    assert end_event.payload.usage_info.token_usage.completion_tokens == token_usage_obj.completion_tokens
+    assert end_event.payload.usage_info.token_usage.total_tokens == token_usage_obj.total_tokens
 
-        assert len(start_events) > 0, "No LLM_START events found in intermediate steps"
-        assert len(end_events) > 0, "No LLM_END events found in intermediate steps"
-
-        # Use the latest events for our test
-        start_event = start_events[-1]
-        end_event = end_events[-1]
-
-        # Verify event types
-        assert start_event.payload.event_type == IntermediateStepType.LLM_START
-        assert end_event.payload.event_type == IntermediateStepType.LLM_END
-
-        # Check token usage values in the end event
-        assert end_event.payload.usage_info.token_usage.prompt_tokens == token_usage_obj.prompt_tokens
-        assert end_event.payload.usage_info.token_usage.completion_tokens == token_usage_obj.completion_tokens
-        assert end_event.payload.usage_info.token_usage.total_tokens == token_usage_obj.total_tokens
-
-        # Verify the model output was captured correctly
-        assert "test output" in end_event.payload.data.output
+    # Verify the model output was captured correctly
+    assert "test output" in end_event.payload.data.output
 
 
 async def test_agno_handler_tool_execution(reactive_stream: Subject):
@@ -569,7 +545,7 @@ async def test_agno_handler_tool_execution(reactive_stream: Subject):
     result = execute_agno_tool(sample_tool, *tool_args, **tool_kwargs)
 
     # Wait for events to propagate
-    time.sleep(0.5)
+    time.sleep(0.05)
 
     # Check the results
     print(f"all_stats has {len(all_stats)} items for tool execution")

--- a/tests/nat/tools/test_code_execution.py
+++ b/tests/nat/tools/test_code_execution.py
@@ -96,7 +96,7 @@ async def test_code_gen(httpserver: HTTPServer):
     assert resp.get("stderr") == ""
 
     # Check Timeout
-    resp = await client.execute_code(generated_code="import time; time.sleep(5)", timeout_seconds=2)
+    resp = await client.execute_code(generated_code="import time; time.sleep(0.2)", timeout_seconds=0.05)
     assert resp.get("process_status") == "timeout"
     assert resp.get("stdout") == ""
     assert resp.get("stderr").rstrip() == "Timed out"


### PR DESCRIPTION
## Description

- Add a configurable time for `WebSocketAuthenticationFlowHandler`
- Add monkeypatch timeout for `test_llm_validator.py:TestTimeoutAndParallelValidation`
- Reduce recompute logic for `test_semantic_kernel_handler_tool_call`
- Reduce sleep times intelligently in several tests

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configurable WebSocket authentication timeout.
  * PKCE parameters in OAuth2 flows are now optional.

* **API Changes**
  * OpenID Connect scheme field renamed to open_id_connect_url.
  * Credential kind exposed as a typed enum for credential declarations.

* **Tests & Chores**
  * Test suite timing reduced and stabilized (shorter sleeps, timeout tweaks); some slow tests marked.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->