### PR TITLE
Fix Windows path parsing in find_package_root

### DIFF
--- a/src/nat/cli/commands/workflow/workflow_commands.py
+++ b/src/nat/cli/commands/workflow/workflow_commands.py
@@ -19,6 +19,7 @@ import shutil
 import subprocess
 from pathlib import Path
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 import click
 from jinja2 import Environment
@@ -151,7 +152,7 @@ def find_package_root(package_name: str) -> Path | None:
             logger.error("Invalid URL scheme in direct_url.json: %s", url)
             return None
 
-        package_root = Path(parsed_url.path).resolve()
+        package_root = Path(url2pathname(parsed_url.path)).resolve()
 
         # Ensure the path exists and is within an allowed base directory
         if not package_root.exists() or not package_root.is_dir():


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Fixes incorrect path parsing for editable package installations on Windows. The find_package_root() function was using Path(urlparse(url).path) to extract paths from file:// URLs in direct_url.json, but on Windows this produces malformed drive-relative paths. This change uses urllib.request.url2pathname() instead, which is the stdlib function designed for this exact conversion and correctly handles all platforms.
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of file paths with URL-encoded characters to ensure correct filesystem path resolution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->