### PR TITLE
fix: langchain<>huggingface integration

### DIFF
--- a/docs/source/build-workflows/llms/index.md
+++ b/docs/source/build-workflows/llms/index.md
@@ -162,7 +162,7 @@ The HuggingFace LLM provider is defined by the {py:class}`~nat.llm.huggingface_l
 
 * `model_name` - The HuggingFace model name or path (for example, `Qwen/Qwen3Guard-Gen-0.6B`)
 * `device` - Device for model execution: `cpu`, `cuda`, `cuda:0`, or `auto` (default: `auto`)
-* `torch_dtype` - Torch data type: `float16`, `bfloat16`, `float32`, or `auto` (default: `auto`)
+* `dtype` - Torch data type: `float16`, `bfloat16`, `float32`, or `auto` (default: `auto`)
 * `max_new_tokens` - Maximum number of new tokens to generate (default: `128`)
 * `temperature` - Sampling temperature (default: `0.0`)
 * `trust_remote_code` - Whether to trust remote code when loading the model (default: `false`)

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -16,6 +16,7 @@
 
 import logging
 from collections.abc import Sequence
+from typing import Any
 from typing import TypeVar
 
 from nat.builder.builder import Builder
@@ -143,7 +144,7 @@ async def azure_openai_langchain(llm_config: AzureOpenAIModelConfig, _builder: B
                                 by_alias=True,
                                 exclude_none=True,
                                 exclude_unset=True),
-        api_version=llm_config.api_version,
+        api_version=llm_config.api_version,  # type: ignore[call-arg]
     )
 
     yield _patch_llm_based_on_config(client, llm_config)
@@ -267,6 +268,10 @@ async def litellm_langchain(llm_config: LiteLlmModelConfig, _builder: Builder):
 @register_llm_client(config_type=HuggingFaceConfig, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
 async def huggingface_langchain(llm_config: HuggingFaceConfig, _builder: Builder):
 
+    import asyncio
+
+    from langchain_core.callbacks.manager import AsyncCallbackManagerForLLMRun
+    from langchain_core.messages import BaseMessage
     from langchain_huggingface import ChatHuggingFace
     from langchain_huggingface import HuggingFacePipeline
     from transformers import pipeline
@@ -281,19 +286,42 @@ async def huggingface_langchain(llm_config: HuggingFaceConfig, _builder: Builder
 
     model_param = next(cached.model.parameters())
 
-    pipe = pipeline(
-        "text-generation",
-        model=cached.model,
-        tokenizer=cached.tokenizer,
-        torch_dtype=model_param.dtype,
-        device=model_param.device,
-        max_new_tokens=llm_config.max_new_tokens,
-        do_sample=llm_config.temperature > 0,
-        temperature=llm_config.temperature if llm_config.temperature > 0 else None,
-        pad_token_id=cached.tokenizer.eos_token_id,
-    )
+    # Avoid passing an explicit device when the model is sharded via accelerate;
+    # transformers raises if device is provided alongside an accelerate-loaded model.
+    extra_kwargs = {}
+    if getattr(cached.model, "hf_device_map", None) is None:
+        extra_kwargs["device"] = model_param.device
+
+    pipe = pipeline("text-generation",
+                    model=cached.model,
+                    tokenizer=cached.tokenizer,
+                    dtype=model_param.dtype,
+                    max_new_tokens=llm_config.max_new_tokens,
+                    do_sample=llm_config.temperature > 0,
+                    temperature=llm_config.temperature if llm_config.temperature > 0 else None,
+                    pad_token_id=cached.tokenizer.eos_token_id,
+                    **extra_kwargs)
 
     llm = HuggingFacePipeline(pipeline=pipe)
-    client = ChatHuggingFace(llm=llm)
+
+    class AsyncChatHuggingFace(ChatHuggingFace):
+        """Adds async support for local HuggingFacePipeline-backed chat models."""
+
+        async def _agenerate(self,
+                             messages: list[BaseMessage],
+                             stop: list[str] | None = None,
+                             run_manager: AsyncCallbackManagerForLLMRun | None = None,
+                             stream: bool | None = None,
+                             **kwargs: Any):
+            return await asyncio.to_thread(
+                self._generate,
+                messages,
+                stop,
+                run_manager.get_sync() if run_manager else None,
+                stream,
+                **kwargs,
+            )
+
+    client = AsyncChatHuggingFace(llm=llm)
 
     yield _patch_llm_based_on_config(client, llm_config)

--- a/src/nat/llm/huggingface_llm.py
+++ b/src/nat/llm/huggingface_llm.py
@@ -78,8 +78,7 @@ class HuggingFaceConfig(LLMBaseConfig, name="huggingface"):
 
     device: str = Field(default="auto", description="Device: 'cpu', 'cuda', 'cuda:0', or 'auto'")
 
-    torch_dtype: str | None = Field(default="auto",
-                                    description="Torch dtype: 'float16', 'bfloat16', 'float32', or 'auto'")
+    dtype: str | None = Field(default="auto", description="Torch dtype: 'float16', 'bfloat16', 'float32', or 'auto'")
 
     max_new_tokens: int = Field(default=128, description="Maximum number of new tokens to generate")
 
@@ -160,7 +159,7 @@ async def huggingface_provider(
 
         # Load model
         model = AutoModelForCausalLM.from_pretrained(config.model_name,
-                                                     torch_dtype=config.torch_dtype,
+                                                     dtype=config.dtype,
                                                      device_map=config.device,
                                                      trust_remote_code=config.trust_remote_code)
 

--- a/tests/nat/llm_providers/test_langchain_agents.py
+++ b/tests/nat/llm_providers/test_langchain_agents.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import os
+from typing import Any
 
 import pytest
 from langchain_core.messages import AIMessage
@@ -26,7 +27,7 @@ from nat.llm.nim_llm import NIMModelConfig
 from nat.llm.openai_llm import OpenAIModelConfig
 
 try:
-    from nat.llm.huggingface_llm import HuggingFaceConfig
+    from nat.llm.huggingface_llm import HuggingFaceConfig  # noqa: F401
     HAS_HUGGINGFACE = True
 except ImportError:
     HAS_HUGGINGFACE = False
@@ -119,7 +120,7 @@ async def test_azure_openai_langchain_agent(api_version: str | None):
     """
     prompt = ChatPromptTemplate.from_messages([("system", "You are a helpful AI assistant."), ("human", "{input}")])
 
-    config_args = {"azure_deployment": os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1")}
+    config_args: dict[str, Any] = {"azure_deployment": os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4.1")}
     if api_version is not None:
         config_args["api_version"] = api_version
     llm_config = AzureOpenAIModelConfig(**config_args)
@@ -152,13 +153,13 @@ async def test_huggingface_langchain_agent():
     """
     Test HuggingFace LLM with LangChain/LangGraph agent.
     Requires transformers and torch to be installed (optional dependencies).
-    Uses a small model for testing. Set HUGGINGFACE_MODEL_NAME environment variable to override.
     """
+    from nat.llm.huggingface_llm import HuggingFaceConfig
+
     prompt = ChatPromptTemplate.from_messages([("system", "You are a helpful AI assistant."), ("human", "{input}")])
 
-    # Use a small, fast model for testing, or allow override via env var
-    model_name = os.environ.get("HUGGINGFACE_MODEL_NAME", "gpt2")
-    llm_config = HuggingFaceConfig(model_name=model_name, temperature=0.0, max_new_tokens=50)  # type: ignore[misc]
+    # Use a small, fast model for testing
+    llm_config = HuggingFaceConfig(model_name="TinyLlama/TinyLlama-1.1B-Chat-v1.0", temperature=0.0, max_new_tokens=50)
 
     async with WorkflowBuilder() as builder:
         await builder.add_llm("huggingface_llm", llm_config)
@@ -170,5 +171,4 @@ async def test_huggingface_langchain_agent():
         assert isinstance(response, AIMessage)
         assert response.content is not None
         assert isinstance(response.content, str)
-        # For small models like gpt2, we just verify we got a response
-        assert len(response.content) > 0
+        assert "3" in response.content.lower()


### PR DESCRIPTION
## Description

The nightly CI ran with this error:
```
tests.nat.llm_providers.test_langchain_agents::test_huggingface_langchain_agent
ValueError: The model has been loaded with `accelerate` and therefore cannot be moved to a specific device. Please discard the `device` argument when creating your pipeline object.
```

This PR resolves that error in addition to the following changes:
- Renaming HuggingFace config field to `dtype` (from deprecated `torch_dtype`) and uses it when loading models.
- Updating LangChain HuggingFace client to avoid passing `device` when accelerate sharding is present, passes `dtype` to pipelines, and wraps `ChatHuggingFace` with an async `_agenerate` using `asyncio.to_thread`.
- Fixing test to now use TinyLlama (newer, small model) for the HuggingFace agent test, and assert response contains “3” instead of just non-empty content.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Breaking Changes**
  * Updated HuggingFace LLM configuration parameter name; users may need to update their configuration.

* **Improvements**
  * Enhanced HuggingFace model compatibility with distributed architectures to prevent errors.
  * Added async execution support for HuggingFace LLMs.

* **Documentation**
  * Updated HuggingFace LLM configuration documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->