### PR TITLE
Fix/agno flaky test release 1.4

### DIFF
--- a/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
+++ b/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
@@ -185,34 +185,49 @@ class TestToolWrapper:
         # Call the function under test
         agno_tool_wrapper("test_tool", mock_function, mock_builder)
 
-        # Verify that get_running_loop was called with architecture-specific expectations
-        # Known behavior: 1 call on x86_64/amd64, 3 calls on arm64/aarch64
-        # (due to pydantic-core C extension architecture differences in function introspection)
+        # Verify that get_running_loop was called
+        # The call count varies by architecture and Python version due to pydantic-core C extension
+        # differences in function introspection. This is an implementation detail we track to detect
+        # unexpected changes, but the actual functionality (event loop access) is what matters.
+        #
+        # Known behavior from CI observations:
+        # - x86_64/amd64: 1 call across all Python versions (confirmed)
+        # - aarch64 Python 3.11: 1 call (confirmed)
+        # - aarch64 Python 3.12+: Unknown - accepting [1, 3] until confirmed in CI
         call_count = mock_get_running_loop.call_count
         machine = platform.machine().lower()
+        py_version_tuple = platform.python_version_tuple()
+        py_major, py_minor = py_version_tuple[0], py_version_tuple[1]
 
-        # Define expected call counts based on architecture
+        # Define expected call counts based on architecture and Python version
+        # This mapping is based on observed CI behavior and will be updated as we gather more data
+        # For Python 3.14+, the fallback [1, 3] will be used until we add explicit entries
         expected_counts = {
-            'arm64': 3,
-            'aarch64': 3,  # ARM 64-bit (Linux naming)
-            'x86_64': 1,  # AMD/Intel 64-bit (Linux/macOS naming)
-            'amd64': 1,  # AMD/Intel 64-bit (Windows naming)
+            # ARM architectures
+            ('arm64', '3', '11'): [1],      # macOS ARM Python 3.11 (assumed same as Linux)
+            ('arm64', '3', '12'): [1, 3],   # macOS ARM Python 3.12+ (not yet confirmed in CI)
+            ('arm64', '3', '13'): [1, 3],   # macOS ARM Python 3.13+ (not yet confirmed in CI)
+            ('aarch64', '3', '11'): [1],    # Linux ARM Python 3.11 (confirmed: CI job 60115041673)
+            ('aarch64', '3', '12'): [1, 3], # Linux ARM Python 3.12+ (not yet confirmed - job cancelled)
+            ('aarch64', '3', '13'): [1, 3], # Linux ARM Python 3.13+ (not yet confirmed - job cancelled)
+            # x86_64 architectures - consistently return 1 call
+            ('x86_64', '3', '11'): [1],     # Linux/macOS x86_64 (confirmed: CI job 60115041674)
+            ('x86_64', '3', '12'): [1],     # Linux/macOS x86_64 (assumed same as 3.11/3.13)
+            ('x86_64', '3', '13'): [1],     # Linux/macOS x86_64 (confirmed: CI job 60115041704)
+            ('amd64', '3', '11'): [1],      # Windows x86_64 (assumed same as Linux x86_64)
+            ('amd64', '3', '12'): [1],      # Windows x86_64 (assumed same as Linux x86_64)
+            ('amd64', '3', '13'): [1],      # Windows x86_64 (assumed same as Linux x86_64)
         }
 
-        if machine in expected_counts:
-            expected_count = expected_counts[machine]
-            assert call_count == expected_count, (
-                f"Expected {expected_count} call(s) on {machine}, but got {call_count}. "
-                f"This may indicate a pydantic-core or agno library update. "
-                f"Verify the integration still works correctly and update this test if the new behavior is expected."
-            )
-        else:
-            # For unknown architectures, accept known values but provide guidance
-            assert call_count in [1, 3], (
-                f"Unknown architecture '{machine}' returned {call_count} call(s). "
-                f"Expected 1 (x86_64) or 3 (arm64) based on known platforms. "
-                f"Please verify this is correct and update the expected_counts dict in this test."
-            )
+        key = (machine, py_major, py_minor)
+        expected = expected_counts.get(key, [1, 3])  # Default to accepting both for unknown combinations
+
+        assert call_count in expected, (
+            f"get_running_loop was called {call_count} time(s) on {machine} Python {py_major}.{py_minor}. "
+            f"Expected {expected} call(s) based on known behavior. "
+            f"If this is due to a library update (pydantic-core or agno), verify the integration still works "
+            f"correctly and update the expected_counts dict in this test with the new behavior."
+        )
 
     @patch("nat.plugins.agno.tool_wrapper.asyncio.new_event_loop")
     @patch("nat.plugins.agno.tool_wrapper.asyncio.set_event_loop")

--- a/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
+++ b/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
@@ -190,15 +190,15 @@ class TestToolWrapper:
         # (due to pydantic-core C extension architecture differences in function introspection)
         call_count = mock_get_running_loop.call_count
         machine = platform.machine().lower()
-        
+
         # Define expected call counts based on architecture
         expected_counts = {
             'arm64': 3,
             'aarch64': 3,  # ARM 64-bit (Linux naming)
-            'x86_64': 1,   # AMD/Intel 64-bit (Linux/macOS naming)
-            'amd64': 1,    # AMD/Intel 64-bit (Windows naming)
+            'x86_64': 1,  # AMD/Intel 64-bit (Linux/macOS naming)
+            'amd64': 1,  # AMD/Intel 64-bit (Windows naming)
         }
-        
+
         if machine in expected_counts:
             expected_count = expected_counts[machine]
             assert call_count == expected_count, (

--- a/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
+++ b/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
@@ -204,19 +204,19 @@ class TestToolWrapper:
         # For Python 3.14+, the fallback [1, 3] will be used until we add explicit entries
         expected_counts = {
             # ARM architectures
-            ('arm64', '3', '11'): [1],      # macOS ARM Python 3.11 (assumed same as Linux)
-            ('arm64', '3', '12'): [1, 3],   # macOS ARM Python 3.12+ (not yet confirmed in CI)
-            ('arm64', '3', '13'): [1, 3],   # macOS ARM Python 3.13+ (not yet confirmed in CI)
-            ('aarch64', '3', '11'): [1],    # Linux ARM Python 3.11 (confirmed: CI job 60115041673)
-            ('aarch64', '3', '12'): [1, 3], # Linux ARM Python 3.12+ (not yet confirmed - job cancelled)
-            ('aarch64', '3', '13'): [1, 3], # Linux ARM Python 3.13+ (not yet confirmed - job cancelled)
+            ('arm64', '3', '11'): [1],  # macOS ARM Python 3.11 (assumed same as Linux)
+            ('arm64', '3', '12'): [1, 3],  # macOS ARM Python 3.12+ (not yet confirmed in CI)
+            ('arm64', '3', '13'): [1, 3],  # macOS ARM Python 3.13+ (not yet confirmed in CI)
+            ('aarch64', '3', '11'): [1],  # Linux ARM Python 3.11 (confirmed: CI job 60115041673)
+            ('aarch64', '3', '12'): [1, 3],  # Linux ARM Python 3.12+ (not yet confirmed - job cancelled)
+            ('aarch64', '3', '13'): [1, 3],  # Linux ARM Python 3.13+ (not yet confirmed - job cancelled)
             # x86_64 architectures - consistently return 1 call
-            ('x86_64', '3', '11'): [1],     # Linux/macOS x86_64 (confirmed: CI job 60115041674)
-            ('x86_64', '3', '12'): [1],     # Linux/macOS x86_64 (assumed same as 3.11/3.13)
-            ('x86_64', '3', '13'): [1],     # Linux/macOS x86_64 (confirmed: CI job 60115041704)
-            ('amd64', '3', '11'): [1],      # Windows x86_64 (assumed same as Linux x86_64)
-            ('amd64', '3', '12'): [1],      # Windows x86_64 (assumed same as Linux x86_64)
-            ('amd64', '3', '13'): [1],      # Windows x86_64 (assumed same as Linux x86_64)
+            ('x86_64', '3', '11'): [1],  # Linux/macOS x86_64 (confirmed: CI job 60115041674)
+            ('x86_64', '3', '12'): [1],  # Linux/macOS x86_64 (assumed same as 3.11/3.13)
+            ('x86_64', '3', '13'): [1],  # Linux/macOS x86_64 (confirmed: CI job 60115041704)
+            ('amd64', '3', '11'): [1],  # Windows x86_64 (assumed same as Linux x86_64)
+            ('amd64', '3', '12'): [1],  # Windows x86_64 (assumed same as Linux x86_64)
+            ('amd64', '3', '13'): [1],  # Windows x86_64 (assumed same as Linux x86_64)
         }
 
         key = (machine, py_major, py_minor)

--- a/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
+++ b/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
@@ -185,7 +185,14 @@ class TestToolWrapper:
         agno_tool_wrapper("test_tool", mock_function, mock_builder)
 
         # Verify that get_running_loop was called
-        mock_get_running_loop.assert_called_once()
+        # Known behavior: 1 call on amd64, 3 calls on arm64
+        # (due to pydantic-core C extension architecture differences in function introspection)
+        call_count = mock_get_running_loop.call_count
+        assert call_count in [1, 3], (
+            f"Expected 1 call (amd64) or 3 calls (arm64), but got {call_count}. "
+            f"This may indicate a pydantic-core or agno library update. "
+            f"Verify the integration still works correctly and update this test if the new behavior is expected."
+        )
 
     @patch("nat.plugins.agno.tool_wrapper.asyncio.new_event_loop")
     @patch("nat.plugins.agno.tool_wrapper.asyncio.set_event_loop")

--- a/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
+++ b/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import asyncio
+import platform
 import threading
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -184,15 +185,34 @@ class TestToolWrapper:
         # Call the function under test
         agno_tool_wrapper("test_tool", mock_function, mock_builder)
 
-        # Verify that get_running_loop was called
-        # Known behavior: 1 call on amd64, 3 calls on arm64
+        # Verify that get_running_loop was called with architecture-specific expectations
+        # Known behavior: 1 call on x86_64/amd64, 3 calls on arm64/aarch64
         # (due to pydantic-core C extension architecture differences in function introspection)
         call_count = mock_get_running_loop.call_count
-        assert call_count in [1, 3], (
-            f"Expected 1 call (amd64) or 3 calls (arm64), but got {call_count}. "
-            f"This may indicate a pydantic-core or agno library update. "
-            f"Verify the integration still works correctly and update this test if the new behavior is expected."
-        )
+        machine = platform.machine().lower()
+        
+        # Define expected call counts based on architecture
+        expected_counts = {
+            'arm64': 3,
+            'aarch64': 3,  # ARM 64-bit (Linux naming)
+            'x86_64': 1,   # AMD/Intel 64-bit (Linux/macOS naming)
+            'amd64': 1,    # AMD/Intel 64-bit (Windows naming)
+        }
+        
+        if machine in expected_counts:
+            expected_count = expected_counts[machine]
+            assert call_count == expected_count, (
+                f"Expected {expected_count} call(s) on {machine}, but got {call_count}. "
+                f"This may indicate a pydantic-core or agno library update. "
+                f"Verify the integration still works correctly and update this test if the new behavior is expected."
+            )
+        else:
+            # For unknown architectures, accept known values but provide guidance
+            assert call_count in [1, 3], (
+                f"Unknown architecture '{machine}' returned {call_count} call(s). "
+                f"Expected 1 (x86_64) or 3 (arm64) based on known platforms. "
+                f"Please verify this is correct and update the expected_counts dict in this test."
+            )
 
     @patch("nat.plugins.agno.tool_wrapper.asyncio.new_event_loop")
     @patch("nat.plugins.agno.tool_wrapper.asyncio.set_event_loop")


### PR DESCRIPTION
## Description
Fixes the flaky `test_get_event_loop_called` test that's failing on arm64 architectures.

The test was expecting `get_running_loop()` to be called exactly once, but on arm64 it gets called 3 times (vs 1 on amd64). This is due to pydantic-core's C extensions behaving differently across architectures during function introspection.

Changed the assertion to check for known values `[1, 3]` instead of `assert_called_once()`. Added inline comments explaining the architecture differences so future maintainers understand this is expected behavior.

**Fixes:** CI Pipeline / Test (arm64, 3.12) failure in #1349

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Made test validations architecture- and Python-version-aware to reduce flaky failures across ARM64 and x86_64 hosts.
  * Replaced a rigid single-call assertion with configurable call-count checks per environment and a safer fallback for unknown combos.
  * Improved failure messages to clearly explain mismatches and guide updates when CI behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->