### PR TITLE
fix: update configs for autogen example; fix MCP tool wrapping

### DIFF
--- a/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/autogen_team.py
+++ b/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/autogen_team.py
@@ -87,10 +87,8 @@ async def autogen_team(config: AutoGenFunctionConfig, builder: Builder) -> Async
                 final_response_agent = AssistantAgent(
                     name=config.final_response_agent_name,
                     model_client=llm_client,
-                    tools=tools,  # Give FinalResponseAgent tools to fetch missing data
+                    tools=[],  # No tools - only review and format the data collected by other agents
                     system_message=config.final_response_agent_instructions,
-                    reflect_on_tool_use=True,
-                    max_tool_iterations=3,
                 )
 
                 # Create a new team for each invocation

--- a/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/configs/config-eval.yml
+++ b/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/configs/config-eval.yml
@@ -46,24 +46,25 @@ llms:
     temperature: 0.0
     max_tokens: 2048
 
-# MCP tools defined as individual functions
+function_groups:
+  mcp_functions:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      url: "http://localhost:9901/mcp"
+    include:
+      - current_datetime
+
 functions:
   weather_update_tool:
     _type: nat_autogen_demo/weather_update_autogen
     description: "Get the current weather for a specified city"
-  
-  current_datetime:
-    _type: mcp_tool_wrapper
-    transport: streamable-http
-    url: "http://localhost:9901/mcp"
-    mcp_tool_name: current_datetime
-    description: "Get the current date and time. Pass any string value for the 'unused' parameter (e.g., 'now')."
 
 workflow:
   _type: autogen_team
   llm_name: nim_llm
   description: "To get the current weather and time in a specific city"
-  tool_names: [weather_update_tool, current_datetime]
+  tool_names: [weather_update_tool, mcp_functions__current_datetime]
   query_processing_agent_name: WeatherAndTimeAgent
   query_processing_agent_instructions: |
     You are an agent that provides the current weather and time information.
@@ -71,13 +72,13 @@ workflow:
     
     REQUIRED WORKFLOW when asked about weather AND time:
     1. FIRST call weather_update_tool with the city name
-    2. THEN call current_datetime with any string (e.g., "now") to get the current time
+    2. THEN call mcp_functions__current_datetime with any string (e.g., "now") to get the current time
     3. ONLY after calling BOTH tools, say 'DONE'
     
     CRITICAL: You must call BOTH tools before finishing. Do NOT say 'DONE' until you have results from BOTH tools.
     
     If asked about only weather: call weather_update_tool, then say 'DONE'.
-    If asked about only time: call current_datetime, then say 'DONE'.
+    If asked about only time: call mcp_functions__current_datetime, then say 'DONE'.
     If asked about anything else, respond with 'I can only provide weather and time information.'
   final_response_agent_name: FinalResponseAgent
   final_response_agent_instructions: |

--- a/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/configs/config-eval.yml
+++ b/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/configs/config-eval.yml
@@ -31,7 +31,7 @@ general:
 llms:
   nim_llm:
     _type: nim
-    model_name: meta/llama-3.1-70b-instruct
+    model_name: meta/llama-3.3-70b-instruct
     api_key: ${NVIDIA_API_KEY}
     base_url: https://integrate.api.nvidia.com/v1
     temperature: 0.0

--- a/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/configs/config.yml
+++ b/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/configs/config.yml
@@ -23,7 +23,7 @@ general:
 llms:
   nim_llm:
     _type: nim
-    model_name: meta/llama-3.1-70b-instruct
+    model_name: meta/llama-3.3-70b-instruct
     api_key: ${NVIDIA_API_KEY}
     base_url: https://integrate.api.nvidia.com/v1
     temperature: 0.0
@@ -66,18 +66,20 @@ workflow:
     You are an agent that provides the current weather and time information.
     You MUST use your available tools to get accurate information - do NOT make up or guess any data.
     
-    REQUIRED WORKFLOW when asked about weather AND time:
-    1. FIRST call weather_update_tool with the city name
-    2. THEN call mcp_functions__current_datetime with any string (e.g., "now") to get the current time
-    3. ONLY after calling BOTH tools, say 'DONE'
+    WORKFLOW:
+    1. Call weather_update_tool with the city name to get weather
+    2. Call mcp_functions__current_datetime with any string (e.g., "now") to get the current time
+    3. After calling BOTH tools, clearly report the results you received
     
-    CRITICAL: You must call BOTH tools before finishing. Do NOT say 'DONE' until you have results from BOTH tools.
+    CRITICAL: After getting results from both tools, summarize the data clearly like this:
+    "RESULTS: Weather in [city] is [weather details]. Current time is [time]. DONE"
     
-    If asked about only weather: call weather_update_tool, then say 'DONE'.
-    If asked about only time: call mcp_functions__current_datetime, then say 'DONE'.
+    If asked about only weather: call weather_update_tool, report the result, then say 'DONE'.
+    If asked about only time: call mcp_functions__current_datetime, report the result, then say 'DONE'.
     If asked about anything else, respond with 'I can only provide weather and time information.'
   final_response_agent_name: FinalResponseAgent
   final_response_agent_instructions: |
     You are the final response agent.
-    Your role is to provide a concise and clear answer based on the information provided by other agents.
-    Once you are done, reply with the final answer and then say 'APPROVE'.
+    The WeatherAndTimeAgent has already collected the data using tools - DO NOT call any tools yourself.
+    Your role is to provide a polished, user-friendly response based on the information already gathered.
+    Format the data nicely for the user, then say 'APPROVE'.

--- a/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/configs/config.yml
+++ b/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/configs/config.yml
@@ -42,25 +42,25 @@ llms:
     api_key: ${AZURE_OPENAI_API_KEY:-placeholder}
     temperature: 0.0
 
-# MCP tools defined as individual functions to avoid AutoGen's dot naming limitation.
-# Function groups prefix tools as "group.tool" but AutoGen doesn't allow dots in tool names.
+function_groups:
+  mcp_functions:
+    _type: mcp_client
+    server:
+      transport: streamable-http
+      url: "http://localhost:9901/mcp"
+    include:
+      - current_datetime
+
 functions:
   weather_update_tool:
     _type: nat_autogen_demo/weather_update_autogen
     description: "Get the current weather for a specified city"
-  
-  current_datetime:
-    _type: mcp_tool_wrapper
-    transport: streamable-http
-    url: "http://localhost:9901/mcp"
-    mcp_tool_name: current_datetime
-    description: "Get the current date and time. Pass any string value for the 'unused' parameter (e.g., 'now')."
 
 workflow:
   _type: autogen_team
   llm_name: nim_llm
   description: "To get the current weather and time in a specific city"
-  tool_names: [weather_update_tool, current_datetime]
+  tool_names: [weather_update_tool, mcp_functions__current_datetime]
   query_processing_agent_name: WeatherAndTimeAgent
   query_processing_agent_instructions: |
     You are an agent that provides the current weather and time information.
@@ -68,17 +68,16 @@ workflow:
     
     REQUIRED WORKFLOW when asked about weather AND time:
     1. FIRST call weather_update_tool with the city name
-    2. THEN call current_datetime with any string (e.g., "now") to get the current time
+    2. THEN call mcp_functions__current_datetime with any string (e.g., "now") to get the current time
     3. ONLY after calling BOTH tools, say 'DONE'
     
     CRITICAL: You must call BOTH tools before finishing. Do NOT say 'DONE' until you have results from BOTH tools.
     
     If asked about only weather: call weather_update_tool, then say 'DONE'.
-    If asked about only time: call current_datetime, then say 'DONE'.
+    If asked about only time: call mcp_functions__current_datetime, then say 'DONE'.
     If asked about anything else, respond with 'I can only provide weather and time information.'
   final_response_agent_name: FinalResponseAgent
   final_response_agent_instructions: |
     You are the final response agent.
     Your role is to provide a concise and clear answer based on the information provided by other agents.
     Once you are done, reply with the final answer and then say 'APPROVE'.
-    

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/server/front_end_plugin_worker.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/server/front_end_plugin_worker.py
@@ -184,7 +184,11 @@ class MCPFrontEndPluginWorkerBase(ABC):
 
         # Register each function with MCP, passing SessionManager for observability
         for function_name, session_manager in session_managers.items():
-            register_function_with_mcp(mcp, function_name, session_manager, self.memory_profiler)
+            register_function_with_mcp(mcp,
+                                       function_name,
+                                       session_manager,
+                                       self.memory_profiler,
+                                       function=functions.get(function_name))
 
         # Add a simple fallback function if no functions were found
         if not session_managers:

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/server/tool_converter.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/server/tool_converter.py
@@ -257,7 +257,8 @@ def get_function_description(function: FunctionBase) -> str:
 def register_function_with_mcp(mcp: FastMCP,
                                function_name: str,
                                session_manager: 'SessionManager',
-                               memory_profiler: 'MemoryProfiler | None' = None) -> None:
+                               memory_profiler: 'MemoryProfiler | None' = None,
+                               function: FunctionBase | None = None) -> None:
     """Register a NAT Function as an MCP tool using SessionManager.
 
     Each function is wrapped in a SessionManager
@@ -274,12 +275,15 @@ def register_function_with_mcp(mcp: FastMCP,
     # Get the workflow from the session manager
     workflow = session_manager.workflow
 
-    # Get the input schema from the workflow
-    input_schema = workflow.input_schema
+    # Prefer the function's schema/description when available, fall back to workflow
+    target_function = function or workflow
+
+    # Get the input schema from the most specific object available
+    input_schema = getattr(target_function, "input_schema", workflow.input_schema)
     logger.info("Function %s has input schema: %s", function_name, input_schema)
 
     # Get function description
-    function_description = get_function_description(workflow)
+    function_description = get_function_description(target_function)
 
     # Create and register the wrapper function with MCP
     wrapper_func = create_function_wrapper(function_name, session_manager, input_schema, memory_profiler)

--- a/tests/nat/mcp/server/test_tool_converter.py
+++ b/tests/nat/mcp/server/test_tool_converter.py
@@ -377,11 +377,14 @@ class TestRegisterFunctionWithMcp:
     @patch('nat.plugins.mcp.server.tool_converter.create_function_wrapper')
     @patch('nat.plugins.mcp.server.tool_converter.get_function_description')
     @patch('nat.plugins.mcp.server.tool_converter.logger')
-    def test_register_function_with_mcp(self, mock_logger, mock_get_desc, mock_create_wrapper):
+    def test_register_function_with_mcp_uses_function_metadata(self, mock_logger, mock_get_desc, mock_create_wrapper):
         """Test registering a function with MCP using SessionManager."""
         # Arrange
         mock_mcp = MagicMock()
         mock_workflow = MagicMock(spec=Workflow)
+        mock_workflow.input_schema = "workflow_schema"
+        mock_function = MagicMock(spec=Function)
+        mock_function.input_schema = "function_schema"
         mock_session_manager = MagicMock(spec=SessionManager)
         mock_session_manager.workflow = mock_workflow
         function_name = "test_function"
@@ -391,25 +394,26 @@ class TestRegisterFunctionWithMcp:
         mock_create_wrapper.return_value = mock_wrapper
 
         # Act
-        register_function_with_mcp(mock_mcp, function_name, mock_session_manager)
+        register_function_with_mcp(mock_mcp, function_name, mock_session_manager, function=mock_function)
 
         # Assert - Check that logging happened
         assert mock_logger.info.call_count >= 1
-        mock_get_desc.assert_called_once_with(mock_workflow)
+        mock_get_desc.assert_called_once_with(mock_function)
         mock_create_wrapper.assert_called_once_with(function_name,
                                                     mock_session_manager,
-                                                    mock_workflow.input_schema,
+                                                    mock_function.input_schema,
                                                     None)  # memory_profiler defaults to None
         mock_mcp.tool.assert_called_once_with(name=function_name, description="Test description")
 
     @patch('nat.plugins.mcp.server.tool_converter.create_function_wrapper')
     @patch('nat.plugins.mcp.server.tool_converter.get_function_description')
     @patch('nat.plugins.mcp.server.tool_converter.logger')
-    def test_register_workflow_with_mcp(self, mock_logger, mock_get_desc, mock_create_wrapper):
+    def test_register_workflow_with_mcp_falls_back_to_workflow(self, mock_logger, mock_get_desc, mock_create_wrapper):
         """Test registering a workflow with MCP using SessionManager."""
         # Arrange
         mock_mcp = MagicMock()
         mock_workflow = MagicMock(spec=Workflow)
+        mock_workflow.input_schema = "workflow_schema"
         mock_session_manager = MagicMock(spec=SessionManager)
         mock_session_manager.workflow = mock_workflow
         function_name = "test_workflow"


### PR DESCRIPTION
## Description

- Fix tool wrapping for MCP serve
- Replace mcp_tool_wrapper with mcp_client in autogen example
- Minor updates to autogen example (thanks Bryan!)

Closes nvbugs-5801941

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated LLM backend to a newer model for improved responses.
  * Time retrieval now uses a unified MCP-backed time service; workflows aggregate time and weather results.

* **Refactor**
  * Reorganized tool usage into a grouped MCP client for cleaner tool management and metadata handling.
  * Final response agent no longer calls tools and instead formats collected data for users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->