### PR TITLE
Update help string and doc for "nat run --input_file"

### DIFF
--- a/docs/source/run-workflows/about-running-workflows.md
+++ b/docs/source/run-workflows/about-running-workflows.md
@@ -56,16 +56,22 @@ A typical invocation of the `nat run` command follows this pattern:
 nat run --config_file <path/to/config.yml> [--input "question?" | --input_file <path/to/input.txt>]
 ```
 
+Where `--input_file` accepts a plain text file containing a single input string.
+
 The following command runs the `examples/getting_started/simple_web_query` workflow with a single input question "What is LangSmith?":
 ```bash
 nat run --config_file examples/getting_started/simple_web_query/configs/config.yml --input "What is LangSmith?"
 ```
 
-The following command runs the same workflow with the input question provided in a file:
+The following command runs the same workflow with the input question provided in a plain text file. The `--input_file` option is intended for single (typically verbose) inputs that are better stored in a file than passed on the command line:
 ```bash
 echo "What is LangSmith?" > .tmp/input.txt
 nat run --config_file examples/getting_started/simple_web_query/configs/config.yml --input_file .tmp/input.txt
 ```
+
+:::{note}
+The `--input_file` option accepts a plain text file containing a single input, not an array of inputs. For batch evaluation of multiple inputs, use `nat eval` instead.
+:::
 
 ## Using the `nat serve` Command
 The `nat serve` command starts a web server that listens for incoming requests and runs the specified workflow. The server can be accessed with a web browser or by sending a POST request to the server's endpoint. Similar to the `nat run` command, the `nat serve` command requires a configuration file specified by the `--config_file` flag.

--- a/src/nat/front_ends/console/console_front_end_config.py
+++ b/src/nat/front_ends/console/console_front_end_config.py
@@ -28,8 +28,11 @@ class ConsoleFrontEndConfig(FrontEndBaseConfig, name="console"):
     input_query: list[str] | None = Field(default=None,
                                           alias="input",
                                           description="A single input to submit the the workflow.")
-    input_file: Path | None = Field(default=None,
-                                    description="Path to a json file of inputs to submit to the workflow.")
+    input_file: Path | None = Field(
+        default=None,
+        description="Path to a plain text file containing a single input to submit to the workflow. "
+        "Intended for verbose inputs that are better stored in a file than passed on the command line. "
+        "For batch evaluation of multiple inputs, use 'nat eval' instead.")
     user_id: str = Field(default="nat_run_user_id",
                          description="User ID to use for the workflow session. "
                          "Defaults to 'nat_run_user_id' for single-user CLI execution.")

--- a/src/nat/front_ends/console/console_front_end_config.py
+++ b/src/nat/front_ends/console/console_front_end_config.py
@@ -31,7 +31,6 @@ class ConsoleFrontEndConfig(FrontEndBaseConfig, name="console"):
     input_file: Path | None = Field(
         default=None,
         description="Path to a plain text file containing a single input to submit to the workflow. "
-        "Intended for verbose inputs that are better stored in a file than passed on the command line. "
         "For batch evaluation of multiple inputs, use 'nat eval' instead.")
     user_id: str = Field(default="nat_run_user_id",
                          description="User ID to use for the workflow session. "

--- a/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/src/nat/front_ends/console/console_front_end_plugin.py
@@ -90,9 +90,10 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
 
             # Run the workflow
             with open(self.front_end_config.input_file, encoding="utf-8") as f:
-                async with session_manager.session(user_id=self.front_end_config.user_id) as session:
-                    async with session.run(f) as runner:
-                        runner_outputs = await runner.result(to_type=str)
+                input_content = f.read()
+            async with session_manager.session(user_id=self.front_end_config.user_id) as session:
+                async with session.run(input_content) as runner:
+                    runner_outputs = await runner.result(to_type=str)
         else:
             assert False, "Should not reach here. Should have been caught by pre_run"
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
1. Docs update to clarify that "nat run --input_file" accepts single plain text inputs only, distinguishing it from "nat eval" for batch evaluation.
2. Fixed file handling in console_front_end_plugin.py to read content immediately and pass string instead of file object

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `--input_file` accepts a single plain text input file instead of multiple inputs
  * Updated guidance to use `nat eval` for batch evaluation of multiple inputs
  * Enhanced documentation with explicit notes on single-input usage and batch evaluation scenarios

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->