### PR TITLE
fix: bump NAT version to 1.5 for packages that were added under `release/1.4`

### DIFF
--- a/examples/frameworks/nat_autogen_demo/pyproject.toml
+++ b/examples/frameworks/nat_autogen_demo/pyproject.toml
@@ -26,7 +26,7 @@ root = "../../.."
 name = "nat_autogen_demo"
 dynamic = ["version"]
 dependencies = [
-  "nvidia-nat[autogen]~=1.4",
+  "nvidia-nat[autogen]~=1.5",
 ]
 requires-python = ">=3.11,<3.14"
 description = "AutoGen Workflow Example"

--- a/examples/safety_and_security/retail_agent/pyproject.toml
+++ b/examples/safety_and_security/retail_agent/pyproject.toml
@@ -9,7 +9,7 @@ root = "../../.."
 [project]
 name = "nat_retail_agent"
 dynamic = ["version"]
-dependencies = ["nvidia-nat[langchain]~=1.4"]
+dependencies = ["nvidia-nat[langchain]~=1.5"]
 requires-python = ">=3.11,<3.14"
 description = "Retail Agent NeMo Agent toolkit example"
 keywords = ["ai", "agents", "retail"]

--- a/packages/nvidia_nat_autogen/pyproject.toml
+++ b/packages/nvidia_nat_autogen/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
   "autogen-agentchat~=0.7",
   "autogen-core~=0.7",
   "autogen-ext[anthropic]~=0.7",
-  "nvidia-nat~=1.4",
+  "nvidia-nat~=1.5",
 ]
 requires-python = ">=3.11,<3.14"
 description = "Subpackage for AutoGen integration in NeMo Agent toolkit"


### PR DESCRIPTION
## Description

This PR is a followup to the forward merge `release/1.4` -> `develop` PR (#1392)

It updates the versions of packages that existed on the `release/1.4` branch that did not exist on the `develop` branch.

<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated nvidia-nat package dependencies to version 1.5 across autogen, langchain, and framework integration components.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->