### PR TITLE
Expose Dask `memory_limit` config

### DIFF
--- a/src/nat/front_ends/fastapi/fastapi_front_end_config.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_config.py
@@ -237,6 +237,11 @@ class FastApiFrontEndConfig(FrontEndBaseConfig, name="fastapi"):
         default="WARNING",
         description="Logging level for Dask.",
     )
+    dask_worker_memory_limit: str = Field(
+        default="auto",
+        description=("Memory limit for each Dask worker. Can be 'auto', a memory string like '4GB' or a float "
+                     "representing a fraction of the system memory. "
+                     "Refer to https://docs.dask.org/en/stable/deploying-python.html#reference for details."))
     step_adaptor: StepAdaptorConfig = StepAdaptorConfig()
 
     workflow: typing.Annotated[EndpointBase, Field(description="Endpoint for the default workflow.")] = EndpointBase(

--- a/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
@@ -107,10 +107,27 @@ class FastApiFrontEndPlugin(DaskClientMixin, FrontEndBase[FastApiFrontEndConfig]
 
                     self._use_dask_threads = self.front_end_config.dask_workers == 'threads'
 
+                    # Convert memory limit string to the appropriate type for Dask
+                    # per https://docs.dask.org/en/stable/deploying-python.html#reference
+                    # Dask treats the memory_limit parameter differently depending on the type, and specifically it
+                    # treats int (bytes) and float (fraction of total memory) differently.
+                    memory_limit = self.front_end_config.dask_worker_memory_limit
+                    if memory_limit.strip() == "":
+                        memory_limit = "auto"
+                    elif memory_limit.isdigit():
+                        memory_limit = int(memory_limit)
+                    else:
+                        # Try to convert to number if possible, otherwise leave as a string
+                        try:
+                            memory_limit = float(memory_limit)
+                        except Exception:
+                            pass  # Keep as string (e.g., "auto", "4GB")
+
                     # set n_workers to max_running_async_jobs + 1 to allow for one worker to handle the cleanup task
                     self._cluster = LocalCluster(processes=not self._use_dask_threads,
                                                  silence_logs=dask_log_level,
                                                  protocol="tcp",
+                                                 memory_limit=memory_limit,
                                                  n_workers=self.front_end_config.max_running_async_jobs + 1)
 
                     self._scheduler_address = self._cluster.scheduler.address


### PR DESCRIPTION
## Description
* Optionally allow the user to set the [memory_limit](https://docs.dask.org/en/stable/deploying-python.html#reference) value for a local Dask cluster.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new configuration option to set Dask worker memory limits, supporting "auto", numeric values, and custom memory specifications.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->