### PR TITLE
Fix/simplify event loop test

### DIFF
--- a/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
+++ b/packages/nvidia_nat_agno/tests/test_tool_wrapper.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import asyncio
-import platform
 import threading
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -176,58 +175,21 @@ class TestToolWrapper:
         assert result == "test_result"
 
     @patch("nat.plugins.agno.tool_wrapper.asyncio.get_running_loop")
-    def test_get_event_loop_called(self, mock_get_running_loop, mock_function, mock_builder):
-        """Test that get_running_loop is called when agno_tool_wrapper is executed."""
-        # Set up the mock event loop
+    def test_event_loop_is_accessed(self, mock_get_running_loop, mock_function, mock_builder):
+        """
+        Test that agno_tool_wrapper accesses the event loop.
+
+        Note: We only verify the event loop is accessed, not the exact call count.
+        The call count varies by architecture (ARM vs x86), Python version, and
+        library versions (pydantic-core). This is an implementation detail that
+        doesn't affect functionality.
+        """
         mock_loop = MagicMock()
         mock_get_running_loop.return_value = mock_loop
 
-        # Call the function under test
         agno_tool_wrapper("test_tool", mock_function, mock_builder)
 
-        # Verify that get_running_loop was called
-        # The call count varies by architecture and Python version due to pydantic-core C extension
-        # differences in function introspection. This is an implementation detail we track to detect
-        # unexpected changes, but the actual functionality (event loop access) is what matters.
-        #
-        # Known behavior from CI observations:
-        # - x86_64/amd64: 1 call across all Python versions (confirmed)
-        # - aarch64 Python 3.11: 1 call (confirmed)
-        # - aarch64 Python 3.12+: Unknown - accepting [1, 3] until confirmed in CI
-        call_count = mock_get_running_loop.call_count
-        machine = platform.machine().lower()
-        py_version_tuple = platform.python_version_tuple()
-        py_major, py_minor = py_version_tuple[0], py_version_tuple[1]
-
-        # Define expected call counts based on architecture and Python version
-        # This mapping is based on observed CI behavior and will be updated as we gather more data
-        # For Python 3.14+, the fallback [1, 3] will be used until we add explicit entries
-        expected_counts = {
-            # ARM architectures
-            ('arm64', '3', '11'): [1],  # macOS ARM Python 3.11 (assumed same as Linux)
-            ('arm64', '3', '12'): [1, 3],  # macOS ARM Python 3.12+ (not yet confirmed in CI)
-            ('arm64', '3', '13'): [1, 3],  # macOS ARM Python 3.13+ (not yet confirmed in CI)
-            ('aarch64', '3', '11'): [1],  # Linux ARM Python 3.11 (confirmed: CI job 60115041673)
-            ('aarch64', '3', '12'): [1, 3],  # Linux ARM Python 3.12+ (not yet confirmed - job cancelled)
-            ('aarch64', '3', '13'): [1, 3],  # Linux ARM Python 3.13+ (not yet confirmed - job cancelled)
-            # x86_64 architectures - consistently return 1 call
-            ('x86_64', '3', '11'): [1],  # Linux/macOS x86_64 (confirmed: CI job 60115041674)
-            ('x86_64', '3', '12'): [1],  # Linux/macOS x86_64 (assumed same as 3.11/3.13)
-            ('x86_64', '3', '13'): [1],  # Linux/macOS x86_64 (confirmed: CI job 60115041704)
-            ('amd64', '3', '11'): [1],  # Windows x86_64 (assumed same as Linux x86_64)
-            ('amd64', '3', '12'): [1],  # Windows x86_64 (assumed same as Linux x86_64)
-            ('amd64', '3', '13'): [1],  # Windows x86_64 (assumed same as Linux x86_64)
-        }
-
-        key = (machine, py_major, py_minor)
-        expected = expected_counts.get(key, [1, 3])  # Default to accepting both for unknown combinations
-
-        assert call_count in expected, (
-            f"get_running_loop was called {call_count} time(s) on {machine} Python {py_major}.{py_minor}. "
-            f"Expected {expected} call(s) based on known behavior. "
-            f"If this is due to a library update (pydantic-core or agno), verify the integration still works "
-            f"correctly and update the expected_counts dict in this test with the new behavior."
-        )
+        assert mock_get_running_loop.called, ("get_running_loop should be called to access the event loop")
 
     @patch("nat.plugins.agno.tool_wrapper.asyncio.new_event_loop")
     @patch("nat.plugins.agno.tool_wrapper.asyncio.set_event_loop")


### PR DESCRIPTION
## Description
fix: simplify event loop test to assert_called

The test was checking exact call counts of get_running_loop() which
varies by architecture, Python version, and pydantic-core version.
This caused repeated CI failures (#1383, #1396).

Simplified to assert_called() since:
- Exact call count is an implementation detail
- Other tests already cover the event loop code path
- The previous approach was not sustainable

Fixes: #1396

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified event-loop verification by replacing architecture-dependent assertions with a basic check that the running event loop is accessed.
  * Renamed and clarified the related test to reflect that only access is validated, improving cross-environment reliability and maintainability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->