### PR TITLE
Standardize RAG service response schema parsing

### DIFF
--- a/src/nat/tool/nvidia_rag.py
+++ b/src/nat/tool/nvidia_rag.py
@@ -15,8 +15,13 @@
 
 import json
 import logging
+from collections.abc import AsyncGenerator
+from typing import Any
 
+from langchain_core.documents import Document
+from pydantic import BaseModel
 from pydantic import Field
+from pydantic import ValidationError
 
 from nat.builder.builder import Builder
 from nat.builder.function_info import FunctionInfo
@@ -24,6 +29,66 @@ from nat.cli.register_workflow import register_function
 from nat.data_models.function import FunctionBaseConfig
 
 logger = logging.getLogger(__name__)
+
+# =============================================================================
+# RAG Service Schema Models
+# =============================================================================
+
+
+class BaseRagResult(BaseModel):
+    """Base class for RAG service response schemas."""
+
+    content: str
+    score: float
+
+    def get_document_title(self) -> str:
+        """Override in subclass to return the document name field."""
+        raise NotImplementedError
+
+    def to_document(self) -> Document:
+        return Document(
+            page_content=self.content,
+            metadata={
+                "document_title": self.get_document_title(),
+                "document_url": "nemo_framework",
+                "document_full_text": self.content,
+                "score_rerank": self.score,
+            },
+            type="Document",
+        )
+
+
+class SourceResult(BaseRagResult):
+    """RAG Blueprint /search endpoint schema."""
+
+    document_name: str
+
+    def get_document_title(self) -> str:
+        return self.document_name
+
+
+class DocumentChunk(BaseRagResult):
+    """GenerativeAIExamples chain server /search endpoint schema."""
+
+    filename: str
+
+    def get_document_title(self) -> str:
+        return self.filename
+
+
+def parse_rag_response(data: dict[str, Any]) -> list[Document]:
+    """Auto-detect RAG schema and return Documents."""
+    if "results" in data:
+        return [SourceResult.model_validate(r).to_document() for r in data["results"]]
+    elif "chunks" in data:
+        return [DocumentChunk.model_validate(r).to_document() for r in data["chunks"]]
+    else:
+        raise ValueError("Unknown RAG response format: expected 'results' or 'chunks' key")
+
+
+# =============================================================================
+# Tool Configuration and Registration
+# =============================================================================
 
 
 class NVIDIARAGToolConfig(FunctionBaseConfig, name="nvidia_rag"):
@@ -42,13 +107,12 @@ class NVIDIARAGToolConfig(FunctionBaseConfig, name="nvidia_rag"):
 
 
 @register_function(config_type=NVIDIARAGToolConfig)
-async def nvidia_rag_tool(config: NVIDIARAGToolConfig, builder: Builder):
+async def nvidia_rag_tool(config: NVIDIARAGToolConfig, builder: Builder) -> AsyncGenerator[FunctionInfo, None]:
     import httpx
-    from langchain_core.documents import Document
     from langchain_core.prompts import PromptTemplate
     from langchain_core.prompts import aformat_document
 
-    document_prompt = PromptTemplate.from_template(config.document_prompt)
+    document_prompt: PromptTemplate = PromptTemplate.from_template(config.document_prompt)
 
     async with httpx.AsyncClient(headers={
             "accept": "application/json", "Content-Type": "application/json"
@@ -58,31 +122,24 @@ async def nvidia_rag_tool(config: NVIDIARAGToolConfig, builder: Builder):
         async def runnable(query: str) -> str:
 
             try:
-                url = f"{config.base_url}/search"
+                url: str = f"{config.base_url}/search"
 
-                payload = {"query": query, "top_k": config.top_k, "collection_name": config.collection_name}
+                payload: dict[str, Any] = {
+                    "query": query, "top_k": config.top_k, "collection_name": config.collection_name
+                }
 
                 logger.debug("Sending request to the RAG endpoint %s.", url)
-                response = await client.post(url, content=json.dumps(payload))
+                response: httpx.Response = await client.post(url, content=json.dumps(payload))
 
                 response.raise_for_status()
 
-                output = response.json()
+                try:
+                    docs: list[Document] = parse_rag_response(response.json())
+                except (ValidationError, ValueError) as e:
+                    logger.error("RAG response validation failed: %s", e)
+                    return "Error: RAG service returned unexpected response format."
 
-                docs = [
-                    Document(
-                        page_content=ret["content"],
-                        metadata={
-                            "document_title": ret["filename"],
-                            "document_url": "nemo_framework",
-                            "document_full_text": ret["content"],
-                            "score_rerank": ret["score"]
-                        },
-                        type="Document",
-                    ) for ret in output["chunks"]
-                ]
-
-                parsed_output = config.document_separator.join(
+                parsed_output: str = config.document_separator.join(
                     [await aformat_document(doc, document_prompt) for doc in docs])
                 return parsed_output
             except Exception as e:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

Standardizes the `nvidia_rag` tool to handle both the newer **NVIDIA RAG Blueprint** and legacy **GenerativeAIExamples** chain server response schemas.

## Problem

The `nvidia_rag` tool was hardcoded to expect the legacy [GenerativeAIExamples schema](https://github.com/NVIDIA/GenerativeAIExamples/blob/main/RAG/src/chain_server/server.py#L173-L188) which uses `chunks` and `filename`. However, the expected response payload varies depending on the RAG service endpoint used—[RAG Blueprint](https://github.com/NVIDIA-AI-Blueprints/rag/blob/main/src/nvidia_rag/rag_server/response_generator.py#L177-L217) returns `results` and `document_name`. This caused unexpected parsing behavior when the tool was pointed at different RAG services.

This fix introduces Pydantic models (`BaseRagResult`, `SourceResult`, `DocumentChunk`) to validate and normalize both schemas. The `parse_rag_response()` function auto-detects the schema based on top-level keys (`results` vs `chunks`) and converts responses to LangChain `Document` objects with proper error handling for validation failures and unknown schemas.

## Related

- [NVIDIA RAG Blueprint](https://github.com/NVIDIA-AI-Blueprints/rag)
- [NVIDIA GenerativeAIExamples](https://github.com/NVIDIA/GenerativeAIExamples)
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for RAG responses with clearer, user-friendly error messages
  * Enhanced validation and parsing of RAG responses for increased reliability
  * More robust handling of malformed RAG data

* **Improvements**
  * Strengthened HTTP request timeout configuration for RAG API calls

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->