### PR TITLE
Expose Dask threads per worker

### DIFF
--- a/src/nat/front_ends/fastapi/fastapi_front_end_config.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_config.py
@@ -248,9 +248,9 @@ class FastApiFrontEndConfig(FrontEndBaseConfig, name="fastapi"):
     dask_threads_per_worker: int = Field(
         default=1,
         description=(
-            "Number of threads to use per worker when dask_workers is set to 'processes'. This parameter is only used "
-            "when the value is greater than 0 and scheduler_address is `None` and a local Dask cluster is created. "
-            "When set to 0 the value uses the Dask default."))
+            "Number of threads to use per worker. This parameter is only used when the value is greater than 0 and "
+            "scheduler_address is `None` and a local Dask cluster is created. When set to 0 the value uses the Dask "
+            "default."))
     step_adaptor: StepAdaptorConfig = StepAdaptorConfig()
 
     workflow: typing.Annotated[EndpointBase, Field(description="Endpoint for the default workflow.")] = EndpointBase(

--- a/src/nat/front_ends/fastapi/fastapi_front_end_config.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_config.py
@@ -242,6 +242,12 @@ class FastApiFrontEndConfig(FrontEndBaseConfig, name="fastapi"):
         description=("Memory limit for each Dask worker. Can be 'auto', a memory string like '4GB' or a float "
                      "representing a fraction of the system memory. "
                      "Refer to https://docs.dask.org/en/stable/deploying-python.html#reference for details."))
+
+    dask_threads_per_worker: int = Field(
+        default=0,
+        description=(
+            "Number of threads to use per worker when dask_workers is set to 'processes'. This parameter is only used "
+            "when the value is greater than 0 and scheduler_address is `None` and a local Dask cluster is created."))
     step_adaptor: StepAdaptorConfig = StepAdaptorConfig()
 
     workflow: typing.Annotated[EndpointBase, Field(description="Endpoint for the default workflow.")] = EndpointBase(

--- a/src/nat/front_ends/fastapi/fastapi_front_end_config.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_config.py
@@ -223,7 +223,9 @@ class FastApiFrontEndConfig(FrontEndBaseConfig, name="fastapi"):
     max_running_async_jobs: int = Field(
         default=10,
         description=(
-            "Maximum number of async jobs to run concurrently, this controls the number of dask workers created. "
+            "Maximum number of Dask workers to create for running async jobs, the name of this parameter is "
+            "misleading as the actual number of concurrent async jobs is: "
+            "`max_running_async_jobs * dask_threads_per_worker` ."
             "This parameter is only used when scheduler_address is `None` and a Dask local cluster is created."),
         ge=1)
     dask_workers: typing.Literal["threads", "processes"] = Field(
@@ -244,10 +246,11 @@ class FastApiFrontEndConfig(FrontEndBaseConfig, name="fastapi"):
                      "Refer to https://docs.dask.org/en/stable/deploying-python.html#reference for details."))
 
     dask_threads_per_worker: int = Field(
-        default=0,
+        default=1,
         description=(
             "Number of threads to use per worker when dask_workers is set to 'processes'. This parameter is only used "
-            "when the value is greater than 0 and scheduler_address is `None` and a local Dask cluster is created."))
+            "when the value is greater than 0 and scheduler_address is `None` and a local Dask cluster is created. "
+            "When set to 0 the value uses the Dask default."))
     step_adaptor: StepAdaptorConfig = StepAdaptorConfig()
 
     workflow: typing.Annotated[EndpointBase, Field(description="Endpoint for the default workflow.")] = EndpointBase(

--- a/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
@@ -127,11 +127,6 @@ class FastApiFrontEndPlugin(DaskClientMixin, FrontEndBase[FastApiFrontEndConfig]
                     if self.front_end_config.dask_threads_per_worker > 0:
                         dask_kwargs["threads_per_worker"] = self.front_end_config.dask_threads_per_worker
 
-                    # TODO: Remove this log statement prior to merging
-                    logger.info("Creating local Dask cluster with %s %d workers and %d threads per worker",
-                                self.front_end_config.dask_workers,
-                                self.front_end_config.max_running_async_jobs + 1,
-                                self.front_end_config.dask_threads_per_worker)
                     # set n_workers to max_running_async_jobs + 1 to allow for one worker to handle the cleanup task
                     self._cluster = LocalCluster(processes=not self._use_dask_threads,
                                                  silence_logs=dask_log_level,

--- a/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
@@ -127,6 +127,11 @@ class FastApiFrontEndPlugin(DaskClientMixin, FrontEndBase[FastApiFrontEndConfig]
                     if self.front_end_config.dask_threads_per_worker > 0:
                         dask_kwargs["threads_per_worker"] = self.front_end_config.dask_threads_per_worker
 
+                    # TODO: Remove this log statement prior to merging
+                    logger.info("Creating local Dask cluster with %s %d workers and %d threads per worker",
+                                self.front_end_config.dask_workers,
+                                self.front_end_config.max_running_async_jobs + 1,
+                                self.front_end_config.dask_threads_per_worker)
                     # set n_workers to max_running_async_jobs + 1 to allow for one worker to handle the cleanup task
                     self._cluster = LocalCluster(processes=not self._use_dask_threads,
                                                  silence_logs=dask_log_level,

--- a/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
@@ -123,12 +123,17 @@ class FastApiFrontEndPlugin(DaskClientMixin, FrontEndBase[FastApiFrontEndConfig]
                         except Exception:
                             pass  # Keep as string (e.g., "auto", "4GB")
 
+                    dask_kwargs = {}
+                    if self.front_end_config.dask_threads_per_worker > 0:
+                        dask_kwargs["threads_per_worker"] = self.front_end_config.dask_threads_per_worker
+
                     # set n_workers to max_running_async_jobs + 1 to allow for one worker to handle the cleanup task
                     self._cluster = LocalCluster(processes=not self._use_dask_threads,
                                                  silence_logs=dask_log_level,
                                                  protocol="tcp",
                                                  memory_limit=memory_limit,
-                                                 n_workers=self.front_end_config.max_running_async_jobs + 1)
+                                                 n_workers=self.front_end_config.max_running_async_jobs + 1,
+                                                 **dask_kwargs)
 
                     self._scheduler_address = self._cluster.scheduler.address
 


### PR DESCRIPTION
## Description
* Add clarification to the description of the `max_running_async_jobs` parameter.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable per-worker thread setting to tune async job execution (default 1; 0 defers to system/Dask defaults).

* **Documentation**
  * Clarified concurrency docs: actual concurrency equals max running async jobs multiplied by per-worker threads, with guidance on behavior when scheduler is local or unset.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->