### PR TITLE
Temporarily skip agent e2e tests

### DIFF
--- a/examples/agents/tests/test_agents.py
+++ b/examples/agents/tests/test_agents.py
@@ -56,6 +56,7 @@ def rewoo_answer_fixture(request: pytest.FixtureRequest, rewoo_data: list[dict])
     return rewoo_data[request.param]["answer"].lower()
 
 
+@pytest.mark.skip(reason="Temporarily skip rewoo tests due to long run times, re-enable once the workflows are updated.")
 @pytest.mark.usefixtures("nvidia_api_key", "tavily_api_key")
 @pytest.mark.integration
 @pytest.mark.parametrize("use_rest_api", [False, True], ids=["nat_run", "nat_serve"])
@@ -70,6 +71,7 @@ async def test_rewoo_full_workflow(agents_dir: Path, use_rest_api: bool, rewoo_q
         await run_workflow(config_file=config_file, question=rewoo_question, expected_answer=rewoo_answer)
 
 
+@pytest.mark.skip(reason="Temporarily skip agent tests due to long run times, re-enable once the workflows are updated.")
 @pytest.mark.slow
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key")
@@ -94,6 +96,7 @@ async def test_agent_full_workflow(agents_dir: Path, config_file: str, use_rest_
 
 # Code examples from `docs/source/resources/running-tests.md`
 # Intentionally not using the fixtures defined above to keep the examples clear
+@pytest.mark.skip(reason="Temporarily skip agent tests due to long run times, re-enable once the workflows are updated.")
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key")
 async def test_react_agent_full_workflow(examples_dir: Path):
@@ -101,6 +104,7 @@ async def test_react_agent_full_workflow(examples_dir: Path):
     await run_workflow(config_file=config_file, question="What are LLMs?", expected_answer="Large Language Model")
 
 
+@pytest.mark.skip(reason="Temporarily skip agent tests due to long run times, re-enable once the workflows are updated.")
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key")
 async def test_react_agent_full_workflow_validate_re(examples_dir: Path):


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Temporarily disabled long-running agent workflow tests to optimize test suite performance. Tests can be re-enabled after workflow updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->