### PR TITLE
fix: correct ReWOO planner prompt JSON example format

### DIFF
--- a/src/nat/agent/rewoo_agent/prompt.py
+++ b/src/nat/agent/rewoo_agent/prompt.py
@@ -54,6 +54,7 @@ Here is an example of how a valid JSON output should look:
 
 Note: {{ and }} are used for template escaping and will render as single braces { and } in the final prompt.
 
+```json
 [
   {{
     "plan": "Find Alex's schedule on Sep 25, 2025",
@@ -81,6 +82,7 @@ Alex's schedule: #E1; Bill's schedule: #E2?"
     }}
   }}
 ]
+```
 
 Begin!
 """

--- a/src/nat/agent/rewoo_agent/prompt.py
+++ b/src/nat/agent/rewoo_agent/prompt.py
@@ -52,32 +52,34 @@ The output must be a valid JSON array that can be parsed directly.
 
 Here is an example of how a valid JSON output should look:
 
+Note: {{ and }} are used for template escaping and will render as single braces { and } in the final prompt.
+
 [
-  \'{{
+  {{
     "plan": "Find Alex's schedule on Sep 25, 2025",
-    "evidence": \'{{
+    "evidence": {{
       "placeholder": "#E1",
       "tool": "search_calendar",
-      "tool_input": ("Alex", "09/25/2025")
-    }}\'
-  }}\',
-  \'{{
+      "tool_input": ["Alex", "09/25/2025"]
+    }}
+  }},
+  {{
     "plan": "Find Bill's schedule on sep 25, 2025",
-    "evidence": \'{{
+    "evidence": {{
       "placeholder": "#E2",
       "tool": "search_calendar",
-      "tool_input": ("Bill", "09/25/2025")
-    }}\'
-  }}\',
-  \'{{
+      "tool_input": ["Bill", "09/25/2025"]
+    }}
+  }},
+  {{
     "plan": "Suggest a time for 1-hour meeting given Alex's and Bill's schedule.",
-    "evidence": \'{{
+    "evidence": {{
       "placeholder": "#E3",
       "tool": "llm_chat",
       "tool_input": "Find a common 1-hour time slot for Alex and Bill given their schedules. \
 Alex's schedule: #E1; Bill's schedule: #E2?"
-    }}\'
-  }}\'
+    }}
+  }}
 ]
 
 Begin!

--- a/src/nat/agent/rewoo_agent/prompt.py
+++ b/src/nat/agent/rewoo_agent/prompt.py
@@ -52,7 +52,6 @@ The output must be a valid JSON array that can be parsed directly.
 
 Here is an example of how a valid JSON output should look:
 
-Note: {{ and }} are used for template escaping and will render as single braces { and } in the final prompt.
 
 [
   {{


### PR DESCRIPTION
The prompt example used malformed escaping (\'{{) that caused LLMs to output evidence as a string instead of an object, breaking Pydantic validation.

Changes:
- Remove \' escaped quotes from JSON example
- Change tool_input from tuples to arrays (valid JSON)
- Add comment explaining {{ template escaping
- Fix line length for ruff compliance

Fixes ReWOO agent failures with Nemotron and Llama 3.3 models.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed invalid JSON in AI agent prompt examples so sample outputs are valid, parseable JSON.
  * Normalized sample planning evidence to consistently use array-style inputs instead of mixed/escaped fragments.
  * Cleaned up formatting of example blocks to present clear, consistent planning-step JSON for end-user reference.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->