### PR TITLE
Add pytest-timeout and set a global 5min timeout

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -322,10 +322,11 @@ dev = [
   "nvidia-nat_test",
   "nvidia-sphinx-theme>=0.0.9",
   "pre-commit>=4.0,<5.0",
-  "pytest_httpserver==1.1.*",
+  "pytest~=8.3",
   "pytest-asyncio==0.24.*",
   "pytest-cov~=6.1",
-  "pytest~=8.3",
+  "pytest_httpserver==1.1.*",
+  "pytest-timeout~=2.4",
   "python-docx~=1.1.0",
   "ruff~=0.12",
   "setuptools >= 64",
@@ -406,6 +407,7 @@ filterwarnings = [
 testpaths = ["tests", "examples/**/tests", "packages/**/tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
+timeout = 300
 
 
 [tool.ruff]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -407,6 +407,9 @@ filterwarnings = [
 testpaths = ["tests", "examples/**/tests", "packages/**/tests"]
 asyncio_mode = "auto"
 asyncio_default_fixture_loop_scope = "session"
+
+# Global timeout of 5 minutes per test to catch hanging tests.
+# Individual tests can override with @pytest.mark.timeout(seconds) or disable with @pytest.mark.timeout(0)
 timeout = 300
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -6230,6 +6230,7 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-httpserver" },
+    { name = "pytest-timeout" },
     { name = "python-docx" },
     { name = "ruff" },
     { name = "setuptools" },
@@ -6384,6 +6385,7 @@ dev = [
     { name = "pytest-asyncio", specifier = "==0.24.*" },
     { name = "pytest-cov", specifier = "~=6.1" },
     { name = "pytest-httpserver", specifier = "==1.1.*" },
+    { name = "pytest-timeout", specifier = "~=2.4" },
     { name = "python-docx", specifier = "~=1.1.0" },
     { name = "ruff", specifier = "~=0.12" },
     { name = "setuptools", specifier = ">=64" },
@@ -8829,6 +8831,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f1/d8/def15ba33bd696dd72dd4562a5287c0cba4d18a591eeb82e0b08ab385afc/pytest_httpserver-1.1.3.tar.gz", hash = "sha256:af819d6b533f84b4680b9416a5b3f67f1df3701f1da54924afd4d6e4ba5917ec", size = 68870, upload-time = "2025-04-10T08:17:15.6Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0d/d2/dfc2f25f3905921c2743c300a48d9494d29032f1389fc142e718d6978fb2/pytest_httpserver-1.1.3-py3-none-any.whl", hash = "sha256:5f84757810233e19e2bb5287f3826a71c97a3740abe3a363af9155c0f82fdbb9", size = 21000, upload-time = "2025-04-10T08:17:13.906Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated development dependencies ordering and added a test timeout utility.
  * Set a global test execution timeout (with guidance that individual tests can override it).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->