### PR TITLE
Handle consecutive status check failures with retry logic in DPO trainer adapter

### DIFF
--- a/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/config.py
+++ b/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/config.py
@@ -350,6 +350,13 @@ class NeMoCustomizerTrainerAdapterConfig(TrainerAdapterConfig, name="nemo_custom
         description="Maximum time in seconds to wait for deployment to be ready. "
         "Default is 30 minutes (1800 seconds).",
     )
+    max_consecutive_status_failures: int = Field(
+        default=3,
+        ge=1,
+        le=10,
+        description="Maximum consecutive status check failures before treating as job failure. "
+        "Helps handle transient HTTP errors without failing the training job.",
+    )
 
     @model_validator(mode="after")
     def validate_config(self) -> "NeMoCustomizerTrainerAdapterConfig":

--- a/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
+++ b/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
@@ -381,7 +381,7 @@ class NeMoCustomizerTrainerAdapter(TrainerAdapter):
 
         last_status: str | None = None
         consecutive_status_failures = 0
-        max_status_failures = 3
+        max_status_failures = self.adapter_config.max_consecutive_status_failures
 
         while True:
             status = await self.status(ref)
@@ -392,14 +392,21 @@ class NeMoCustomizerTrainerAdapter(TrainerAdapter):
 
             if is_status_check_failure:
                 consecutive_status_failures += 1
-                logger.warning(f"Failed to get status for job {ref.run_id} "
-                               f"(attempt {consecutive_status_failures}/{max_status_failures}): {status.message}")
                 if consecutive_status_failures >= max_status_failures:
-                    logger.error(f"Giving up after {max_status_failures} consecutive status check failures")
+                    logger.error(f"Failed to get status for job {ref.run_id} after {max_status_failures} "
+                                 f"consecutive attempts. Last error: {status.message}. "
+                                 f"This may indicate a persistent NeMo Customizer service issue. "
+                                 f"Check service health at {self.adapter_config.entity_host}/health")
                     # Fall through to let the normal failure handling take over
                 else:
-                    # Continue polling - don't treat this as a real failure yet
-                    await asyncio.sleep(interval)
+                    logger.warning(f"Transient failure checking status for job {ref.run_id} "
+                                   f"(attempt {consecutive_status_failures}/{max_status_failures}). "
+                                   f"Error: {status.message}. "
+                                   f"This is likely a temporary NeMo Customizer service issue. Retrying...")
+                    # Exponential backoff: wait longer on repeated failures
+                    backoff_multiplier = 1.5**consecutive_status_failures
+                    wait_time = interval * backoff_multiplier
+                    await asyncio.sleep(wait_time)
                     continue
             else:
                 # Reset counter on successful status check

--- a/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
+++ b/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
@@ -380,9 +380,30 @@ class NeMoCustomizerTrainerAdapter(TrainerAdapter):
         interval = poll_interval or self.adapter_config.poll_interval_seconds
 
         last_status: str | None = None
+        consecutive_status_failures = 0
+        max_status_failures = 3
 
         while True:
             status = await self.status(ref)
+
+            # Check if this was a status check failure (not an actual job failure)
+            is_status_check_failure = (status.status == TrainingStatusEnum.FAILED and status.message
+                                       and status.message.startswith("Error getting status:"))
+
+            if is_status_check_failure:
+                consecutive_status_failures += 1
+                logger.warning(f"Failed to get status for job {ref.run_id} "
+                               f"(attempt {consecutive_status_failures}/{max_status_failures}): {status.message}")
+                if consecutive_status_failures >= max_status_failures:
+                    logger.error(f"Giving up after {max_status_failures} consecutive status check failures")
+                    # Fall through to let the normal failure handling take over
+                else:
+                    # Continue polling - don't treat this as a real failure yet
+                    await asyncio.sleep(interval)
+                    continue
+            else:
+                # Reset counter on successful status check
+                consecutive_status_failures = 0
 
             # Log when status changes
             current_status = status.status.value

--- a/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
+++ b/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
@@ -387,7 +387,8 @@ class NeMoCustomizerTrainerAdapter(TrainerAdapter):
             status = await self.status(ref)
 
             # Check if this was a status check failure (not an actual job failure)
-            is_status_check_failure = (status.status == TrainingStatusEnum.FAILED)
+            is_status_check_failure = (status.status == TrainingStatusEnum.FAILED and status.message
+                                       and status.message.startswith("Error getting status:"))
 
             if is_status_check_failure:
                 consecutive_status_failures += 1

--- a/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
+++ b/packages/nvidia_nat_nemo_customizer/src/nat/plugins/customizer/dpo/trainer_adapter.py
@@ -387,8 +387,7 @@ class NeMoCustomizerTrainerAdapter(TrainerAdapter):
             status = await self.status(ref)
 
             # Check if this was a status check failure (not an actual job failure)
-            is_status_check_failure = (status.status == TrainingStatusEnum.FAILED and status.message
-                                       and status.message.startswith("Error getting status:"))
+            is_status_check_failure = (status.status == TrainingStatusEnum.FAILED)
 
             if is_status_check_failure:
                 consecutive_status_failures += 1

--- a/packages/nvidia_nat_nemo_customizer/tests/test_nemo_customizer.py
+++ b/packages/nvidia_nat_nemo_customizer/tests/test_nemo_customizer.py
@@ -197,6 +197,49 @@ class TestNeMoCustomizerTrainerAdapterConfig:
         """Test config is registered with correct name."""
         assert NeMoCustomizerTrainerAdapterConfig._typed_model_name == "nemo_customizer_trainer_adapter"
 
+    def test_max_consecutive_status_failures_default(self):
+        """Test default value for max_consecutive_status_failures."""
+        config = NeMoCustomizerTrainerAdapterConfig(
+            entity_host="https://nmp.example.com",
+            datastore_host="https://datastore.example.com",
+            namespace="test-namespace",
+            customization_config="meta/llama-3.2-1b-instruct@v1.0.0+A100",
+        )
+        assert config.max_consecutive_status_failures == 3
+
+    def test_max_consecutive_status_failures_custom(self):
+        """Test custom value for max_consecutive_status_failures."""
+        config = NeMoCustomizerTrainerAdapterConfig(
+            entity_host="https://nmp.example.com",
+            datastore_host="https://datastore.example.com",
+            namespace="test-namespace",
+            customization_config="meta/llama-3.2-1b-instruct@v1.0.0+A100",
+            max_consecutive_status_failures=5,
+        )
+        assert config.max_consecutive_status_failures == 5
+
+    def test_max_consecutive_status_failures_min_bound(self):
+        """Test min bound validation for max_consecutive_status_failures."""
+        with pytest.raises(ValueError):
+            NeMoCustomizerTrainerAdapterConfig(
+                entity_host="https://nmp.example.com",
+                datastore_host="https://datastore.example.com",
+                namespace="test-namespace",
+                customization_config="meta/llama-3.2-1b-instruct@v1.0.0+A100",
+                max_consecutive_status_failures=0,
+            )
+
+    def test_max_consecutive_status_failures_max_bound(self):
+        """Test max bound validation for max_consecutive_status_failures."""
+        with pytest.raises(ValueError):
+            NeMoCustomizerTrainerAdapterConfig(
+                entity_host="https://nmp.example.com",
+                datastore_host="https://datastore.example.com",
+                namespace="test-namespace",
+                customization_config="meta/llama-3.2-1b-instruct@v1.0.0+A100",
+                max_consecutive_status_failures=11,
+            )
+
 
 # =============================================================================
 # TrainerAdapter Tests
@@ -480,6 +523,163 @@ class TestNeMoCustomizerTrainerAdapter:
         assert log_entry["backend"] == "nemo-customizer"
         assert log_entry["status"] == "running"
         assert log_entry["progress"] == 50
+
+    async def test_wait_until_complete_transient_failure_recovery(self, adapter_config):
+        """Test that transient status check failures are retried and recover."""
+        adapter = NeMoCustomizerTrainerAdapter(adapter_config=adapter_config)
+        adapter._active_jobs["test-run"] = "job-123"
+        adapter._job_output_models["test-run"] = "output-model"
+
+        # Create mock statuses: first call fails, second succeeds
+        failure_status = TrainingJobStatus(
+            run_id="test-run",
+            backend="nemo-customizer",
+            status=TrainingStatusEnum.FAILED,
+            message="Error getting status: Connection timeout",
+        )
+        success_status = TrainingJobStatus(
+            run_id="test-run",
+            backend="nemo-customizer",
+            status=TrainingStatusEnum.COMPLETED,
+            progress=100.0,
+        )
+
+        with patch.object(adapter, "status", new_callable=AsyncMock) as mock_status:
+            mock_status.side_effect = [failure_status, success_status]
+
+            ref = TrainingJobRef(run_id="test-run", backend="nemo-customizer")
+            result = await adapter.wait_until_complete(ref, poll_interval=0.01)
+
+            assert result.status == TrainingStatusEnum.COMPLETED
+            assert mock_status.call_count == 2
+
+    async def test_wait_until_complete_max_failures_reached(self, adapter_config):
+        """Test that max consecutive failures triggers job failure."""
+        adapter = NeMoCustomizerTrainerAdapter(adapter_config=adapter_config)
+        adapter._active_jobs["test-run"] = "job-123"
+        adapter._job_output_models["test-run"] = "output-model"
+
+        # Create mock status that always fails
+        failure_status = TrainingJobStatus(
+            run_id="test-run",
+            backend="nemo-customizer",
+            status=TrainingStatusEnum.FAILED,
+            message="Error getting status: Service unavailable",
+            progress=0.0,
+        )
+
+        with patch.object(adapter, "status", new_callable=AsyncMock) as mock_status:
+            mock_status.return_value = failure_status
+
+            ref = TrainingJobRef(run_id="test-run", backend="nemo-customizer")
+
+            # Should raise after max_consecutive_status_failures (default 3) attempts
+            with pytest.raises(RuntimeError, match="failed"):
+                await adapter.wait_until_complete(ref, poll_interval=0.01)
+
+            # Should have tried max_consecutive_status_failures times
+            assert mock_status.call_count == adapter_config.max_consecutive_status_failures
+
+    async def test_wait_until_complete_custom_max_failures(self):
+        """Test that custom max_consecutive_status_failures is respected."""
+        config = NeMoCustomizerTrainerAdapterConfig(
+            entity_host="https://nmp.example.com",
+            datastore_host="https://datastore.example.com",
+            namespace="test-namespace",
+            customization_config="meta/llama-3.2-1b-instruct@v1.0.0+A100",
+            max_consecutive_status_failures=5,
+        )
+        adapter = NeMoCustomizerTrainerAdapter(adapter_config=config)
+        adapter._active_jobs["test-run"] = "job-123"
+        adapter._job_output_models["test-run"] = "output-model"
+
+        failure_status = TrainingJobStatus(
+            run_id="test-run",
+            backend="nemo-customizer",
+            status=TrainingStatusEnum.FAILED,
+            message="Error getting status: Service unavailable",
+            progress=0.0,
+        )
+
+        with patch.object(adapter, "status", new_callable=AsyncMock) as mock_status:
+            mock_status.return_value = failure_status
+
+            ref = TrainingJobRef(run_id="test-run", backend="nemo-customizer")
+
+            with pytest.raises(RuntimeError, match="failed"):
+                await adapter.wait_until_complete(ref, poll_interval=0.01)
+
+            # Should have tried 5 times (custom value)
+            assert mock_status.call_count == 5
+
+    async def test_wait_until_complete_failure_counter_resets(self, adapter_config):
+        """Test that failure counter resets after successful status check."""
+        adapter = NeMoCustomizerTrainerAdapter(adapter_config=adapter_config)
+        adapter._active_jobs["test-run"] = "job-123"
+        adapter._job_output_models["test-run"] = "output-model"
+
+        failure_status = TrainingJobStatus(
+            run_id="test-run",
+            backend="nemo-customizer",
+            status=TrainingStatusEnum.FAILED,
+            message="Error getting status: Connection timeout",
+        )
+        running_status = TrainingJobStatus(
+            run_id="test-run",
+            backend="nemo-customizer",
+            status=TrainingStatusEnum.RUNNING,
+            progress=50.0,
+        )
+        completed_status = TrainingJobStatus(
+            run_id="test-run",
+            backend="nemo-customizer",
+            status=TrainingStatusEnum.COMPLETED,
+            progress=100.0,
+        )
+
+        # Sequence: fail, fail, succeed (running), fail, fail, succeed (completed)
+        # This tests that the counter resets after success
+        with patch.object(adapter, "status", new_callable=AsyncMock) as mock_status:
+            mock_status.side_effect = [
+                failure_status,  # fail 1
+                failure_status,  # fail 2
+                running_status,  # success - resets counter
+                failure_status,  # fail 1 (counter reset)
+                failure_status,  # fail 2
+                completed_status,  # success - completes
+            ]
+
+            ref = TrainingJobRef(run_id="test-run", backend="nemo-customizer")
+            result = await adapter.wait_until_complete(ref, poll_interval=0.01)
+
+            assert result.status == TrainingStatusEnum.COMPLETED
+            assert mock_status.call_count == 6
+
+    async def test_wait_until_complete_actual_job_failure_not_retried(self, adapter_config):
+        """Test that actual job failures (not status check errors) are not retried."""
+        adapter = NeMoCustomizerTrainerAdapter(adapter_config=adapter_config)
+        adapter._active_jobs["test-run"] = "job-123"
+        adapter._job_output_models["test-run"] = "output-model"
+
+        # This is an actual job failure, not a status check error
+        job_failure_status = TrainingJobStatus(
+            run_id="test-run",
+            backend="nemo-customizer",
+            status=TrainingStatusEnum.FAILED,
+            message="Training failed: Out of memory",
+            progress=50.0,
+        )
+
+        with patch.object(adapter, "status", new_callable=AsyncMock) as mock_status:
+            mock_status.return_value = job_failure_status
+
+            ref = TrainingJobRef(run_id="test-run", backend="nemo-customizer")
+
+            with pytest.raises(RuntimeError, match="failed"):
+                await adapter.wait_until_complete(ref, poll_interval=0.01)
+
+            # Should only be called once - actual job failures are not retried
+            assert mock_status.call_count == 1
 
 
 class TestTrainerAdapterIntegration:


### PR DESCRIPTION
## Description
Introduce logic to track and limit consecutive status check failures when polling job status. If the number of failures exceeds a configurable threshold, logging escalates, but regular failure handling remains unaffected.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved job status monitoring to treat transient status retrieval errors as temporary, automatically retrying with exponential backoff to reduce false job failures and clearer logging.

* **New Features**
  * Added a configurable threshold for how many consecutive status check failures are tolerated before marking a job as failed.

* **Tests**
  * Expanded unit tests covering status-retry behavior, threshold bounds, and recovery scenarios.

* **Chore**
  * No changes to public API or method signatures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->