### PR TITLE
fix: autogen example dataset symlink

### DIFF
--- a/examples/frameworks/nat_autogen_demo/README.md
+++ b/examples/frameworks/nat_autogen_demo/README.md
@@ -210,12 +210,6 @@ The evaluation dataset contains three test cases with different cities:
 
 The dataset is located at `examples/frameworks/nat_autogen_demo/data/eval_dataset.json`.
 
-> [!NOTE]
-> The `data` directory is a symlink to `src/nat_autogen_demo/data`. This symlink may not work correctly on Windows or when downloading the repository as a ZIP file. If you encounter issues, navigate directly to the source directory or clone the repository using Git.
-
-> [!NOTE]
-> The evaluation dataset is tracked with Git LFS. If you see a pointer file instead of the actual JSON content, ensure Git LFS is installed and run `git lfs pull` to download the full dataset.
-
 ### Run the Evaluation
 
 Ensure both the MCP server and Phoenix are running, then execute the evaluation:

--- a/examples/frameworks/nat_autogen_demo/README.md
+++ b/examples/frameworks/nat_autogen_demo/README.md
@@ -82,9 +82,11 @@ uv pip install matplotlib
 
 If you have not already done so, follow the [Obtaining API Keys](../../../docs/source/get-started/installation.md#obtain-api-keys) instructions to obtain API keys.
 
-For NVIDIA NIM, export the following:
+For NVIDIA NIM, set the following environment variable:
 
-- `NVIDIA_API_KEY`
+```
+export NVIDIA_API_KEY="YOUR-NVIDIA-API-KEY-HERE"
+```
 
 ## Run the Workflow
 
@@ -97,6 +99,9 @@ In a separate terminal, or in the background, run the MCP server with this comma
 ```bash
 nat mcp serve --config_file examples/getting_started/simple_calculator/configs/config.yml --tool_names current_datetime
 ```
+
+> [!NOTE]
+> If the MCP server is not started as a background task (using the `&` operator), you will need to open a new terminal session, activate the uv environment, and export NVIDIA_API_KEY again.
 
 Then, run the workflow with the CLI provided by the toolkit:
 
@@ -167,6 +172,9 @@ phoenix serve
 ```
 
 Phoenix runs on `http://localhost:6006` with the tracing endpoint at `http://localhost:6006/v1/traces`.
+
+> [!NOTE]
+> If Phoenix is not started as a background task (using the `&` operator), you will need to open a new terminal session, activate the uv environment, and export NVIDIA_API_KEY again.
 
 ### Run with Tracing Enabled
 

--- a/examples/frameworks/nat_autogen_demo/README.md
+++ b/examples/frameworks/nat_autogen_demo/README.md
@@ -84,7 +84,7 @@ If you have not already done so, follow the [Obtaining API Keys](../../../docs/s
 
 For NVIDIA NIM, set the following environment variable:
 
-```
+```bash
 export NVIDIA_API_KEY="YOUR-NVIDIA-API-KEY-HERE"
 ```
 

--- a/examples/frameworks/nat_autogen_demo/README.md
+++ b/examples/frameworks/nat_autogen_demo/README.md
@@ -210,6 +210,12 @@ The evaluation dataset contains three test cases with different cities:
 
 The dataset is located at `examples/frameworks/nat_autogen_demo/data/eval_dataset.json`.
 
+> [!NOTE]
+> The `data` directory is a symlink to `src/nat_autogen_demo/data`. This symlink may not work correctly on Windows or when downloading the repository as a ZIP file. If you encounter issues, navigate directly to the source directory or clone the repository using Git.
+
+> [!NOTE]
+> The evaluation dataset is tracked with Git LFS. If you see a pointer file instead of the actual JSON content, ensure Git LFS is installed and run `git lfs pull` to download the full dataset.
+
 ### Run the Evaluation
 
 Ensure both the MCP server and Phoenix are running, then execute the evaluation:

--- a/examples/frameworks/nat_autogen_demo/data
+++ b/examples/frameworks/nat_autogen_demo/data
@@ -1,0 +1,1 @@
+src/nat_autogen_demo/data

--- a/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/configs/config-eval.yml
+++ b/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/configs/config-eval.yml
@@ -70,21 +70,23 @@ workflow:
     You are an agent that provides the current weather and time information.
     You MUST use your available tools to get accurate information - do NOT make up or guess any data.
     
-    REQUIRED WORKFLOW when asked about weather AND time:
-    1. FIRST call weather_update_tool with the city name
-    2. THEN call mcp_functions__current_datetime with any string (e.g., "now") to get the current time
-    3. ONLY after calling BOTH tools, say 'DONE'
+    WORKFLOW:
+    1. Call weather_update_tool with the city name to get weather
+    2. Call mcp_functions__current_datetime with any string (e.g., "now") to get the current time
+    3. After calling BOTH tools, clearly report the results you received
     
-    CRITICAL: You must call BOTH tools before finishing. Do NOT say 'DONE' until you have results from BOTH tools.
+    CRITICAL: After getting results from both tools, summarize the data clearly like this:
+    "RESULTS: Weather in [city] is [weather details]. Current time is [time]. DONE"
     
-    If asked about only weather: call weather_update_tool, then say 'DONE'.
-    If asked about only time: call mcp_functions__current_datetime, then say 'DONE'.
+    If asked about only weather: call weather_update_tool, report the result, then say 'DONE'.
+    If asked about only time: call mcp_functions__current_datetime, report the result, then say 'DONE'.
     If asked about anything else, respond with 'I can only provide weather and time information.'
   final_response_agent_name: FinalResponseAgent
   final_response_agent_instructions: |
     You are the final response agent.
-    Your role is to provide a concise and clear answer based on the information provided by other agents.
-    Once you are done, reply with the final answer and then say 'APPROVE'.
+    The WeatherAndTimeAgent has already collected the data using tools - DO NOT call any tools yourself.
+    Your role is to provide a polished, user-friendly response based on the information already gathered.
+    Format the data nicely for the user, then say 'APPROVE'.
 
 eval:
   general:

--- a/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/data/eval_dataset.json
+++ b/examples/frameworks/nat_autogen_demo/src/nat_autogen_demo/data/eval_dataset.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:619ed29d501f0cde0ea1d35b6339f5717574e33573ab553346718b6204ecf0c2
+size 772


### PR DESCRIPTION
## Description
The eval dataset for the autogen example was missing. Added it to the repo along with the symlink for the data directory. Also made some small adjustments to the README and system prompt for eval-config.yaml to improve the consistency across runs for this example.
Closes
NVBug 5812113

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified NVIDIA API key setup with an explicit export command and added reminders to re-export the key when services aren't run in the background; noted evaluation dataset symlink and Git LFS requirements.

* **Chores**
  * Updated evaluation workflow to produce and present consolidated weather/time results and adjusted final agent reporting instructions.
  * Added evaluation dataset and supporting data directory.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->