### PR TITLE
Fix multi_frameworks workflow CI failure 

### DIFF
--- a/examples/frameworks/multi_frameworks/src/nat_multi_frameworks/llama_index_rag_tool.py
+++ b/examples/frameworks/multi_frameworks/src/nat_multi_frameworks/llama_index_rag_tool.py
@@ -48,9 +48,7 @@ async def llama_index_rag_tool(tool_config: LlamaIndexRAGConfig, builder: Builde
     from llama_index.core import Settings
     from llama_index.core import SimpleDirectoryReader
     from llama_index.core import VectorStoreIndex
-    from llama_index.core.agent import FunctionAgent
     from llama_index.core.node_parser import SimpleFileNodeParser
-    from llama_index.core.tools import QueryEngineTool
 
     if (not tool_config.api_key):
         set_secret_from_env(tool_config, "api_key", "NVIDIA_API_KEY")
@@ -65,24 +63,13 @@ async def llama_index_rag_tool(tool_config: LlamaIndexRAGConfig, builder: Builde
     embedder = await builder.get_embedder(tool_config.embedding_name, wrapper_type=LLMFrameworkEnum.LLAMA_INDEX)
 
     Settings.embed_model = embedder
+    Settings.llm = llm
+
     md_docs = SimpleDirectoryReader(input_files=[tool_config.data_dir]).load_data()
     parser = SimpleFileNodeParser()
     nodes = parser.get_nodes_from_documents(md_docs)
     index = VectorStoreIndex(nodes)
-    Settings.llm = llm
     query_engine = index.as_query_engine(similarity_top_k=2)
-
-    is_nvdev = tool_config.model_name.startswith('nvdev')
-
-    if not is_nvdev:
-        tool = QueryEngineTool.from_defaults(
-            query_engine, name="rag", description="ingest data from README about this workflow with llama_index_rag")
-
-        agent = FunctionAgent(
-            tools=[tool],
-            llm=llm,
-            verbose=True,
-        )
 
     async def _arun(inputs: str) -> str:
         """
@@ -90,17 +77,21 @@ async def llama_index_rag_tool(tool_config: LlamaIndexRAGConfig, builder: Builde
         Args:
             inputs : user query
         """
-        output: str
-        if not is_nvdev:
-            agent_response = await agent.run(inputs)
-            response_content = agent_response.response
-            logger.info("response from llama-index Agent : \n %s %s", Fore.MAGENTA, response_content)
-            output = str(response_content) if response_content else ""
-        else:
-            logger.info("%s %s %s %s", Fore.MAGENTA, type(query_engine), query_engine, inputs)
+        try:
+            logger.info("Querying llama-index RAG with input: %s", inputs)
             response = await query_engine.aquery(inputs)
-            output = str(response) if response else ""
 
-        return output
+            if response is None:
+                logger.warning("Query engine returned None for input: %s", inputs)
+                return ""
+
+            # Extract the response text
+            response_text = str(response.response) if hasattr(response, 'response') else str(response)
+            logger.info("Response from llama-index RAG: %s%s", Fore.MAGENTA, response_text)
+            return response_text
+
+        except Exception as e:
+            logger.error("Error running llama-index RAG: %s", str(e), exc_info=True)
+            return f"Error processing query: {str(e)}"
 
     yield FunctionInfo.from_fn(_arun, description="extract relevant data via llama-index's RAG per user input query")

--- a/examples/frameworks/multi_frameworks/src/nat_multi_frameworks/register.py
+++ b/examples/frameworks/multi_frameworks/src/nat_multi_frameworks/register.py
@@ -32,7 +32,7 @@ logger = logging.getLogger(__name__)
 class MultiFrameworksWorkflowConfig(FunctionBaseConfig, name="multi_frameworks"):
     # Add your custom configuration parameters here
     llm: LLMRef = LLMRef("nim_llm")
-    data_dir: str = "/home/coder/dev/ai-query-engine/examples/frameworks/multi_frameworks/data/"
+    data_dir: str = ""
     research_tool: FunctionRef
     rag_tool: FunctionRef
     chitchat_agent: FunctionRef
@@ -52,6 +52,12 @@ async def multi_frameworks_workflow(config: MultiFrameworksWorkflowConfig, build
     from langchain_core.runnables.history import RunnableWithMessageHistory
     from langgraph.graph import END
     from langgraph.graph import StateGraph
+
+    # Validate data_dir is not empty
+    if not config.data_dir or config.data_dir.strip() == "":
+        raise ValueError(
+            "data_dir configuration parameter is required but was not set. "
+            "Please set data_dir in your configuration file to point to the README.md file for RAG ingestion.")
 
     # Use builder to generate framework specific tools and llms
     logger.info("workflow config = %s", config)
@@ -130,11 +136,11 @@ async def multi_frameworks_workflow(config: MultiFrameworksWorkflowConfig, build
         worker_choice = state["chosen_worker_agent"]
         logger.info("========== inside **workers node**  current status = \n %s, %s", Fore.YELLOW, state)
         if "retrieve" in worker_choice.lower():
-            out = (await rag_tool.ainvoke(query))
+            out = (await rag_tool.ainvoke({"inputs": query}))
             output = out
             logger.info("**using rag_tool via llama_index_rag_agent >>> output:  \n %s, %s", output, Fore.RESET)
         elif "general" in worker_choice.lower():
-            output = (await chitchat_agent.ainvoke(query))
+            output = (await chitchat_agent.ainvoke({"inputs": query}))
             logger.info("**using general chitchat chain >>> output:  \n %s, %s", output, Fore.RESET)
         elif 'research' in worker_choice.lower():
             inputs = {"inputs": query}


### PR DESCRIPTION
- Remove old 'ai-query-engine' project name from data_dir default
- Add validation to raise clear error when data_dir is empty
- Fix tool invocation: pass {"inputs": query} instead of raw query string
- Simplify llama_index_rag_tool: remove FunctionAgent, use query_engine directly
- Add proper error handling and None checks

Fixes TypeError: the JSON object must be str, bytes or bytearray, not NoneType Test verified passing locally with live API calls.



## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and logging for query execution; empty or failed responses now return a safe string and clear warnings.
  * Added runtime validation to detect a missing data directory and surface a descriptive error.

* **Refactor**
  * Simplified the query processing flow for more reliable execution.
  * Standardized tool input format to a consistent dictionary shape across the workflow.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->