### PR TITLE
bug fix: dynamo integration - model download and instructions clarification

### DIFF
--- a/examples/dynamo_integration/.env.example
+++ b/examples/dynamo_integration/.env.example
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/dynamo_integration/.env.example
+++ b/examples/dynamo_integration/.env.example
@@ -15,7 +15,7 @@
 
 export HF_HOME=/path/to/local/storage/.cache/huggingface
 
-export HF_TOKEN=<my_huggingface_read_token>
+export HF_TOKEN=my_huggingface_read_token
 
 # Required: Set your model directory path with model weights
 # EXAMPLE ls from properly configured directory
@@ -27,10 +27,10 @@ export HF_TOKEN=<my_huggingface_read_token>
 # generation_config.json            model-00007-of-00030.safetensors  model-00014-of-00030.safetensors  model-00021-of-00030.safetensors  model-00028-of-00030.safetensors  tokenizer_config.json
 # model-00001-of-00030.safetensors  model-00008-of-00030.safetensors  model-00015-of-00030.safetensors  model-00022-of-00030.safetensors  model-00029-of-00030.safetensors
 # model-00002-of-00030.safetensors  model-00009-of-00030.safetensors  model-00016-of-00030.safetensors  model-00023-of-00030.safetensors  model-00030-of-00030.safetensors
-export DYNAMO_MODEL_DIR="/path/to/your/models/Llama-3.3-70B-Instruct"
+export DYNAMO_MODEL_DIR=/path/to/your/models/Llama-3.3-70B-Instruct
 
 # Set repository directory (for Thompson Sampling router)
-export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit/external/dynamo"
+export DYNAMO_REPO_DIR=/path/to/NeMo-Agent-Toolkit/external/dynamo
 
 # =============================================================================
 # OPTIONAL VARIABLES - GPU Configuration
@@ -38,19 +38,19 @@ export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit/external/dynamo"
 
 # GPU device IDs for unified mode (comma-separated)
 # Default: 0,1,2,3
-export DYNAMO_GPU_DEVICES="0,1,2,3"
+export DYNAMO_GPU_DEVICES=0,1,2,3
 
 # GPU device IDs for disaggregated mode prefill workers
 # Default: 0,1
-# DYNAMO_PREFILL_GPUS="0,1"
+# DYNAMO_PREFILL_GPUS=0,1
 
 # GPU device IDs for disaggregated mode decode workers
 # Default: 2,3
-# DYNAMO_DECODE_GPUS="2,3"
+# DYNAMO_DECODE_GPUS=2,3
 
 # Tensor parallelism size (number of GPUs per worker)
 # Default: 4 for unified mode, 2 for disaggregated mode
-# DYNAMO_TP_SIZE="4"
+# DYNAMO_TP_SIZE=4
 
 # =============================================================================
 # OPTIONAL VARIABLES - Network Configuration
@@ -58,19 +58,19 @@ export DYNAMO_GPU_DEVICES="0,1,2,3"
 
 # HTTP port for Dynamo frontend API
 # Default: 8099
-# DYNAMO_HTTP_PORT="8099"
+# DYNAMO_HTTP_PORT=8099
 
 # ETCD client port for metadata and discovery
 # Default: 2379
-# DYNAMO_ETCD_PORT="2379"
+# DYNAMO_ETCD_PORT=2379
 
 # ETCD peer port
 # Default: 2390
-# DYNAMO_ETCD_PEER_PORT="2390"
+# DYNAMO_ETCD_PEER_PORT=2390
 
 # NATS messaging port
 # Default: 4222
-# DYNAMO_NATS_PORT="4222"
+# DYNAMO_NATS_PORT=4222
 
 # =============================================================================
 # OPTIONAL VARIABLES - Model Configuration
@@ -78,11 +78,11 @@ export DYNAMO_GPU_DEVICES="0,1,2,3"
 
 # Model name as exposed by the API
 # Default: llama-3.3-70b
-# DYNAMO_MODEL_NAME="llama-3.3-70b"
+# DYNAMO_MODEL_NAME=llama-3.3-70b
 
 # Shared memory size for Docker container
 # Default: 16g
-# DYNAMO_SHM_SIZE="16g"
+# DYNAMO_SHM_SIZE=16g
 
 # =============================================================================
 # OPTIONAL VARIABLES - Disaggregated Mode
@@ -90,8 +90,8 @@ export DYNAMO_GPU_DEVICES="0,1,2,3"
 
 # Bootstrap port for disaggregated mode communication
 # Default: 12345
-# DYNAMO_DISAGG_BOOTSTRAP_PORT="12345"
+# DYNAMO_DISAGG_BOOTSTRAP_PORT=12345
 
 # Transfer backend for KV cache (nixl, nccl, or gloo)
 # Default: nixl
-# DYNAMO_DISAGG_TRANSFER_BACKEND="nixl"
+# DYNAMO_DISAGG_TRANSFER_BACKEND=nixl

--- a/examples/dynamo_integration/.env.example
+++ b/examples/dynamo_integration/.env.example
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,42 +13,84 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
-# Environment variables for Dynamo Integration Example
-# Copy this file to .env and modify as needed:
-#   cp .env.example .env
-#   source .env
-
-# =============================================================================
-# Hugging Face Configuration
-# =============================================================================
-# Cache directory for HF models and datasets
-HF_HOME=~/.cache/huggingface
-# Your HuggingFace token to pull the dataset and model weights (account and necessary permissions required)
-HF_TOKEN=<your-huggingface-read-token>
+# Required: Set your model directory path
+export DYNAMO_MODEL_DIR="/path/to/your/models/Llama-3.3-70B-Instruct"
+# Optional: Set repository directory (for Thompson Sampling router)
+export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit"
 
 # =============================================================================
-# Dynamo Backend Configuration
+# OPTIONAL VARIABLES - GPU Configuration
 # =============================================================================
-# Backend type: sglang or vllm
-DYNAMO_BACKEND=sglang
 
-# Model to serve (must match what's loaded in Dynamo)
-DYNAMO_MODEL=llama-3.3-70b
+# GPU device IDs for unified mode (comma-separated)
+# Default: 0,1,2,3
+DYNAMO_GPU_DEVICES="0,1,2,3"
 
-# Dynamo frontend port
-DYNAMO_PORT=8099
+# GPU device IDs for disaggregated mode prefill workers
+# Default: 0,1
+# DYNAMO_PREFILL_GPUS="0,1"
+
+# GPU device IDs for disaggregated mode decode workers
+# Default: 2,3
+# DYNAMO_DECODE_GPUS="2,3"
+
+# Tensor parallelism size (number of GPUs per worker)
+# Default: 4 for unified mode, 2 for disaggregated mode
+# DYNAMO_TP_SIZE="4"
 
 # =============================================================================
-# Optional: NVIDIA API Key (for NIM LLM testing without Dynamo)
+# OPTIONAL VARIABLES - Network Configuration
 # =============================================================================
-# NVIDIA_API_KEY=nvapi-...
+
+# HTTP port for Dynamo frontend API
+# Default: 8099
+# DYNAMO_HTTP_PORT="8099"
+
+# ETCD client port for metadata and discovery
+# Default: 2379
+# DYNAMO_ETCD_PORT="2379"
+
+# ETCD peer port
+# Default: 2390
+# DYNAMO_ETCD_PEER_PORT="2390"
+
+# NATS messaging port
+# Default: 4222
+# DYNAMO_NATS_PORT="4222"
 
 # =============================================================================
-# Usage
+# OPTIONAL VARIABLES - Model Configuration
 # =============================================================================
-# Load these environment variables:
-#   export $(cat .env | grep -v '^#' | xargs)
-#
-# Or source this file directly:
-#   source .env
+
+# Model name as exposed by the API
+# Default: llama-3.3-70b
+# DYNAMO_MODEL_NAME="llama-3.3-70b"
+
+# Shared memory size for Docker container
+# Default: 16g
+# DYNAMO_SHM_SIZE="16g"
+
+# =============================================================================
+# OPTIONAL VARIABLES - Disaggregated Mode
+# =============================================================================
+
+# Bootstrap port for disaggregated mode communication
+# Default: 12345
+# DYNAMO_DISAGG_BOOTSTRAP_PORT="12345"
+
+# Transfer backend for KV cache (nixl, nccl, or gloo)
+# Default: nixl
+# DYNAMO_DISAGG_TRANSFER_BACKEND="nixl"
+
+
+# =============================================================================
+# OPTIONAL VARIABLES - Custom Thompson Sampler
+# =============================================================================
+
+# Path to CSV file for router decision logging
+# Default: router_metrics.csv
+# ROUTER_METRICS_CSV = "router_metrics.csv"
+
+# timeout period for dynamo worker initialization
+# Default: 300
+# DYNAMO_WORKER_INIT_TIMEOUT_S = 300

--- a/examples/dynamo_integration/.env.example
+++ b/examples/dynamo_integration/.env.example
@@ -95,3 +95,12 @@ export DYNAMO_GPU_DEVICES=0,1,2,3
 # Transfer backend for KV cache (nixl, nccl, or gloo)
 # Default: nixl
 # DYNAMO_DISAGG_TRANSFER_BACKEND=nixl
+
+# =============================================================================
+# OPTIONAL VARIABLES - Performance Tuning
+# =============================================================================
+
+# Worker initialization timeout (seconds)
+# Increase for large models (70B+) or cold starts
+# Default: 1800 (30 minutes)
+# DYNAMO_WORKER_INIT_TIMEOUT_S=1800

--- a/examples/dynamo_integration/.env.example
+++ b/examples/dynamo_integration/.env.example
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Required: Set your model directory path
+export HF_HOME=/path/to/local/storage/.cache/huggingface
+
+export HF_TOKEN=<my_huggingface_read_token>
+
+# Required: Set your model directory path with model weights
+# EXAMPLE ls from properly configured directory
+# ~/models/Llama-3.3-70B-Instruct$ ls
+# LICENSE                           model-00003-of-00030.safetensors  model-00010-of-00030.safetensors  model-00017-of-00030.safetensors  model-00024-of-00030.safetensors  model.safetensors.index.json
+# README.md                         model-00004-of-00030.safetensors  model-00011-of-00030.safetensors  model-00018-of-00030.safetensors  model-00025-of-00030.safetensors  original
+# USE_POLICY.md                     model-00005-of-00030.safetensors  model-00012-of-00030.safetensors  model-00019-of-00030.safetensors  model-00026-of-00030.safetensors  special_tokens_map.json
+# config.json                       model-00006-of-00030.safetensors  model-00013-of-00030.safetensors  model-00020-of-00030.safetensors  model-00027-of-00030.safetensors  tokenizer.json
+# generation_config.json            model-00007-of-00030.safetensors  model-00014-of-00030.safetensors  model-00021-of-00030.safetensors  model-00028-of-00030.safetensors  tokenizer_config.json
+# model-00001-of-00030.safetensors  model-00008-of-00030.safetensors  model-00015-of-00030.safetensors  model-00022-of-00030.safetensors  model-00029-of-00030.safetensors
+# model-00002-of-00030.safetensors  model-00009-of-00030.safetensors  model-00016-of-00030.safetensors  model-00023-of-00030.safetensors  model-00030-of-00030.safetensors
 export DYNAMO_MODEL_DIR="/path/to/your/models/Llama-3.3-70B-Instruct"
-# Optional: Set repository directory (for Thompson Sampling router)
-export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit"
+
+# Set repository directory (for Thompson Sampling router)
+export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit/external/dynamo"
 
 # =============================================================================
 # OPTIONAL VARIABLES - GPU Configuration
@@ -24,7 +38,7 @@ export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit"
 
 # GPU device IDs for unified mode (comma-separated)
 # Default: 0,1,2,3
-DYNAMO_GPU_DEVICES="0,1,2,3"
+export DYNAMO_GPU_DEVICES="0,1,2,3"
 
 # GPU device IDs for disaggregated mode prefill workers
 # Default: 0,1
@@ -81,16 +95,3 @@ DYNAMO_GPU_DEVICES="0,1,2,3"
 # Transfer backend for KV cache (nixl, nccl, or gloo)
 # Default: nixl
 # DYNAMO_DISAGG_TRANSFER_BACKEND="nixl"
-
-
-# =============================================================================
-# OPTIONAL VARIABLES - Custom Thompson Sampler
-# =============================================================================
-
-# Path to CSV file for router decision logging
-# Default: router_metrics.csv
-# ROUTER_METRICS_CSV = "router_metrics.csv"
-
-# timeout period for dynamo worker initialization
-# Default: 300
-# DYNAMO_WORKER_INIT_TIMEOUT_S = 300

--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -48,10 +48,11 @@ uv pip install matplotlib scipy
 
 # 2. Install the workflow package
 # <!-- path-check-skip-next-line -->
-cd examples/dynamo_integration/react_benchmark_agent # NeMo-Agent-Toolkit/examples/dynamo_integration/react_benchmark_agent
+cd examples/dynamo_integration/react_benchmark_agent
 uv pip install -e .
 
 # 3. Source environment variables
+# <!-- path-check-skip-next-line -->
 cd ../ # NeMo-Agent-Toolkit/examples/dynamo_integration
 source .env
 
@@ -60,8 +61,9 @@ source .env
 python scripts/download_agent_leaderboard_v2.py --domains banking
 
 # 5. Download the model weights (requires HuggingFace account)
-cd $(dirname $DYNAMO_MODEL_DIR) # parent directory of the intended model weights directory
-huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --local-dir $DYNAMO_MODEL_DIR
+cd "$(dirname $DYNAMO_MODEL_DIR)" # parent directory of the intended model weights directory
+# <!-- path-check-skip-next-line -->
+hf download meta-llama/Llama-3.3-70B-Instruct --local-dir $DYNAMO_MODEL_DIR
 
 # 6. Start Dynamo backend (see Dynamo README for details)
 # <!-- path-check-skip-next-line -->
@@ -83,7 +85,7 @@ nat eval --config_file examples/dynamo_integration/react_benchmark_agent/configs
 > The first load of model weights to `SGLang` workers can take significant time.
 
 > [!NOTE]
-> To customize GPU workers and tensor parallelism, edit the configuration variables at the top of external/dynamo/start_dynamo_unified.sh.
+> To customize GPU workers and tensor parallelism, edit the configuration variables at the top of [start_dynamo_unified.sh](../../external/dynamo/start_dynamo_unified.sh).
 
 After running this end-to-end evaluation, you will have confirmed functional model services on Dynamo, dataset access, and agent execution.
 

--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -61,9 +61,9 @@ source .env
 python scripts/download_agent_leaderboard_v2.py --domains banking
 
 # 5. Download the model weights (requires HuggingFace account)
-cd "$(dirname $DYNAMO_MODEL_DIR)" # parent directory of the intended model weights directory
+cd "$(dirname "$DYNAMO_MODEL_DIR")" # parent directory of the intended model weights directory
 # <!-- path-check-skip-next-line -->
-hf download meta-llama/Llama-3.3-70B-Instruct --local-dir $DYNAMO_MODEL_DIR
+hf download meta-llama/Llama-3.3-70B-Instruct --local-dir "$DYNAMO_MODEL_DIR"
 
 # 6. Start Dynamo backend (see Dynamo README for details)
 # <!-- path-check-skip-next-line -->

--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -54,27 +54,27 @@ uv pip install -e .
 # 3. Source environment variables
 # <!-- path-check-skip-next-line -->
 cd ../ # NeMo-Agent-Toolkit/examples/dynamo_integration
-source .env
+[ -f .env ] && source .env || { echo "Warning: .env not found" >&2; false; }
 
 # 4. Download the dataset (requires HuggingFace account)
 # <!-- path-check-skip-next-line -->
 python scripts/download_agent_leaderboard_v2.py --domains banking
 
 # 5. Download the model weights (requires HuggingFace account)
-cd "$(dirname "$DYNAMO_MODEL_DIR")" # parent directory of the intended model weights directory
+mkdir -p "$(dirname "$DYNAMO_MODEL_DIR")"
 # <!-- path-check-skip-next-line -->
 hf download meta-llama/Llama-3.3-70B-Instruct --local-dir "$DYNAMO_MODEL_DIR"
 
 # 6. Start Dynamo backend (see Dynamo README for details)
 # <!-- path-check-skip-next-line -->
-cd /path/to/NeMo-Agent-Toolkit/external/dynamo # NeMo-Agent-Toolkit/external/dynamo
+cd "$DYNAMO_REPO_DIR" # cd /path/to/NeMo-Agent-Toolkit/external/dynamo
 bash start_dynamo_unified.sh > startup_output.txt 2>&1 # wait ~5 minutes for the server to start
 
 # Requirements for start_dynamo_unified.sh:
 #   - Docker with NVIDIA Container Toolkit (nvidia-docker)
 #   - 4x NVIDIA GPUs (set WORKER_GPUS to the available set of machines)
 #   - Model weights: downloaded per previous instructions
-#   - Check that default ports are available: 8099 (HTTP API), 2389 (ETCD), 4232 (NATS)
+#   - Check that default ports are available: 8099 (HTTP API), 2379 (ETCD), 4222 (NATS)
 
 # 7. Run evaluation
 cd ../../ # NeMo-Agent-Toolkit/

--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -91,6 +91,7 @@ After running this end-to-end evaluation, you will have confirmed functional mod
 ## Quick Stop
 ```bash
 # 1. When testing is complete don't forget to stop workers and free GPU memory
+# <!-- path-check-skip-next-line -->
 cd /path/to/NeMo-Agent-Toolkit/external/dynamo # NeMo-Agent-Toolkit/external/dynamo
 bash stop_dynamo.sh
 ```

--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -52,38 +52,48 @@ uv pip install matplotlib scipy
 cd examples/dynamo_integration/react_benchmark_agent # NeMo-Agent-Toolkit/examples/dynamo_integration/react_benchmark_agent
 uv pip install -e .
 
+# 3. Source environment variables
+cd ../ # NeMo-Agent-Toolkit/examples/dynamo_integration
+source .env
+
 # 3. Download the dataset (requires HuggingFace account)
 # <!-- path-check-skip-next-line -->
-cd ../ # NeMo-Agent-Toolkit/examples/dynamo_integration
-export HF_TOKEN=<your_huggingface_token>
-export HF_HOME=<your-user-path/.cache/huggingface>
 python scripts/download_agent_leaderboard_v2.py --domains banking
+
+# 4. Download the model weights (requires HuggingFace account)
+cd $(dirname $DYNAMO_MODEL_DIR) # parent directory of the intended model weights directory
+huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --local-dir $DYNAMO_MODEL_DIR
 
 # 4. Start Dynamo backend (see Dynamo README for details)
 # <!-- path-check-skip-next-line -->
-cd ../../external/dynamo # NeMo-Agent-Toolkit/external/dynamo
-bash start_dynamo_unified.sh # wait ~5 minutes for the server to start
+cd /path/to/NeMo-Agent-Toolkit/external/dynamo # NeMo-Agent-Toolkit/external/dynamo
+bash start_dynamo_unified.sh > startup_output.txt 2>&1 # wait ~5 minutes for the server to start
 
 # Requirements for start_dynamo_unified.sh:
 #   - Docker with NVIDIA Container Toolkit (nvidia-docker)
-#   - 4x NVIDIA GPUs (default: device IDs 4,5,6,7, configurable via WORKER_GPUS)
-#   - Model weights: either local path or HF_TOKEN to download Llama-3.3-70B-Instruct
-#   - Ports available: 8099 (HTTP API), 2389 (ETCD), 4232 (NATS)
-#   - curl and jq for health checks
-
-# Note: To customize GPU workers and tensor parallelism, edit the configuration
-# variables at the top of external/dynamo/start_dynamo_unified.sh:
-#   WORKER_GPUS="4,5,6,7"  # GPU device IDs to use (e.g., "0,1" for first 2 GPUs)
-#   TP_SIZE=4              # Tensor parallel size (must match number of GPUs)
-#   HTTP_PORT=8099         # API endpoint port
-#   LOCAL_MODEL_DIR="..."  # Path to your local model weights
+#   - 4x NVIDIA GPUs (set WORKER_GPUS to teh available set of machines)
+#   - Model weights: downloaded per previous instructions
+#   - Check that default ports are available: 8099 (HTTP API), 2389 (ETCD), 4232 (NATS)
 
 # 5. Run evaluation
 cd ../../ # NeMo-Agent-Toolkit/
 nat eval --config_file examples/dynamo_integration/react_benchmark_agent/configs/eval_config_no_rethinking_full_test.yml
 ```
 
+> [!WARNING]
+> The first load of model weights to `SGLang` workers can take significant time.
+
+> [!NOTE]
+> To customize GPU workers and tensor parallelism, edit the configuration variables at the top of external/dynamo/start_dynamo_unified.sh.
+
 After running this end-to-end evaluation, you will have confirmed functional model services on Dynamo, dataset access, and agent execution.
+
+## Quick Stop
+```
+# 1. When testing is complete don't forget to stop workers and free GPU memory
+cd /path/to/NeMo-Agent-Toolkit/external/dynamo # NeMo-Agent-Toolkit/external/dynamo
+bash stop_dynamo.sh
+```
 
 ### Understanding Evaluation Artifacts
 
@@ -163,7 +173,6 @@ examples/dynamo_integration/
     │   ├── banking_tools.py           # Tool stub registration
     │   ├── tool_intent_stubs.py       # Intent capture system
     │   ├── self_evaluating_agent_with_feedback.py  # Self-evaluation wrapper
-    │   ├── prefix_utils.py            # Prefix header utilities
     │   └── evaluators/
     │       ├── __init__.py            # Evaluators package
     │       ├── tsq_evaluator.py       # Tool Selection Quality evaluator
@@ -172,10 +181,9 @@ examples/dynamo_integration/
     ├── tests/                         # Unit tests
     │   ├── test_tsq_formula.py        # TSQ calculation tests
     │   ├── test_self_evaluation.py    # Self-evaluation tests
-    │   ├── test_prefix_utils.py       # Prefix utilities tests
-    │   └── validate_prefix_config.py  # Prefix configuration validation
+    │   └── test_tool_intent_buffer.py # Tool intent buffer tests
     │
-    └── outputs/                       # Evaluation results
+    └── outputs/                       # Evaluation results (generated at runtime)
         ├── benchmarks/                # Concurrency benchmark results
         │   └── <benchmark_run>/
         │       ├── benchmark_report.md

--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -55,26 +55,26 @@ uv pip install -e .
 cd ../ # NeMo-Agent-Toolkit/examples/dynamo_integration
 source .env
 
-# 3. Download the dataset (requires HuggingFace account)
+# 4. Download the dataset (requires HuggingFace account)
 # <!-- path-check-skip-next-line -->
 python scripts/download_agent_leaderboard_v2.py --domains banking
 
-# 4. Download the model weights (requires HuggingFace account)
+# 5. Download the model weights (requires HuggingFace account)
 cd $(dirname $DYNAMO_MODEL_DIR) # parent directory of the intended model weights directory
 huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --local-dir $DYNAMO_MODEL_DIR
 
-# 4. Start Dynamo backend (see Dynamo README for details)
+# 6. Start Dynamo backend (see Dynamo README for details)
 # <!-- path-check-skip-next-line -->
 cd /path/to/NeMo-Agent-Toolkit/external/dynamo # NeMo-Agent-Toolkit/external/dynamo
 bash start_dynamo_unified.sh > startup_output.txt 2>&1 # wait ~5 minutes for the server to start
 
 # Requirements for start_dynamo_unified.sh:
 #   - Docker with NVIDIA Container Toolkit (nvidia-docker)
-#   - 4x NVIDIA GPUs (set WORKER_GPUS to teh available set of machines)
+#   - 4x NVIDIA GPUs (set WORKER_GPUS to the available set of machines)
 #   - Model weights: downloaded per previous instructions
 #   - Check that default ports are available: 8099 (HTTP API), 2389 (ETCD), 4232 (NATS)
 
-# 5. Run evaluation
+# 7. Run evaluation
 cd ../../ # NeMo-Agent-Toolkit/
 nat eval --config_file examples/dynamo_integration/react_benchmark_agent/configs/eval_config_no_rethinking_full_test.yml
 ```
@@ -88,7 +88,7 @@ nat eval --config_file examples/dynamo_integration/react_benchmark_agent/configs
 After running this end-to-end evaluation, you will have confirmed functional model services on Dynamo, dataset access, and agent execution.
 
 ## Quick Stop
-```
+```bash
 # 1. When testing is complete don't forget to stop workers and free GPU memory
 cd /path/to/NeMo-Agent-Toolkit/external/dynamo # NeMo-Agent-Toolkit/external/dynamo
 bash stop_dynamo.sh
@@ -275,7 +275,7 @@ If you see `PermissionError: [Errno 13] Permission denied` when downloading the 
 
 ```bash
 export HF_HOME=/path/to/local/storage/.cache/huggingface
-export HF_TOKEN=<my_huggingface_read_token>
+export HF_TOKEN=my_huggingface_read_token
 ```
 
 ## Support

--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -83,7 +83,6 @@ nat eval --config_file examples/dynamo_integration/react_benchmark_agent/configs
 
 > [!WARNING]
 > The first load of model weights to `SGLang` workers can take significant time.
-
 > [!NOTE]
 > To customize GPU workers and tensor parallelism, edit the configuration variables at the top of [start_dynamo_unified.sh](../../external/dynamo/start_dynamo_unified.sh).
 

--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -46,7 +46,6 @@ source "${HOME}/.venvs/nat_dynamo_eval/bin/activate"
 uv pip install -e ".[langchain]"
 uv pip install matplotlib scipy
 
-
 # 2. Install the workflow package
 # <!-- path-check-skip-next-line -->
 cd examples/dynamo_integration/react_benchmark_agent # NeMo-Agent-Toolkit/examples/dynamo_integration/react_benchmark_agent

--- a/external/dynamo/.env.example
+++ b/external/dynamo/.env.example
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/external/dynamo/.env.example
+++ b/external/dynamo/.env.example
@@ -15,7 +15,7 @@
 
 export HF_HOME=/path/to/local/storage/.cache/huggingface
 
-export HF_TOKEN=<my_huggingface_read_token>
+export HF_TOKEN=my_huggingface_read_token
 
 # Required: Set your model directory path with model weights
 # EXAMPLE ls from properly configured directory
@@ -27,10 +27,10 @@ export HF_TOKEN=<my_huggingface_read_token>
 # generation_config.json            model-00007-of-00030.safetensors  model-00014-of-00030.safetensors  model-00021-of-00030.safetensors  model-00028-of-00030.safetensors  tokenizer_config.json
 # model-00001-of-00030.safetensors  model-00008-of-00030.safetensors  model-00015-of-00030.safetensors  model-00022-of-00030.safetensors  model-00029-of-00030.safetensors
 # model-00002-of-00030.safetensors  model-00009-of-00030.safetensors  model-00016-of-00030.safetensors  model-00023-of-00030.safetensors  model-00030-of-00030.safetensors
-export DYNAMO_MODEL_DIR="/path/to/your/models/Llama-3.3-70B-Instruct"
+export DYNAMO_MODEL_DIR=/path/to/your/models/Llama-3.3-70B-Instruct
 
 # Set repository directory (for Thompson Sampling router)
-export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit/external/dynamo"
+export DYNAMO_REPO_DIR=/path/to/NeMo-Agent-Toolkit/external/dynamo
 
 # =============================================================================
 # OPTIONAL VARIABLES - GPU Configuration
@@ -38,19 +38,19 @@ export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit/external/dynamo"
 
 # GPU device IDs for unified mode (comma-separated)
 # Default: 0,1,2,3
-export DYNAMO_GPU_DEVICES="0,1,2,3"
+export DYNAMO_GPU_DEVICES=0,1,2,3
 
 # GPU device IDs for disaggregated mode prefill workers
 # Default: 0,1
-# DYNAMO_PREFILL_GPUS="0,1"
+# DYNAMO_PREFILL_GPUS=0,1
 
 # GPU device IDs for disaggregated mode decode workers
 # Default: 2,3
-# DYNAMO_DECODE_GPUS="2,3"
+# DYNAMO_DECODE_GPUS=2,3
 
 # Tensor parallelism size (number of GPUs per worker)
 # Default: 4 for unified mode, 2 for disaggregated mode
-# DYNAMO_TP_SIZE="4"
+# DYNAMO_TP_SIZE=4
 
 # =============================================================================
 # OPTIONAL VARIABLES - Network Configuration
@@ -58,19 +58,19 @@ export DYNAMO_GPU_DEVICES="0,1,2,3"
 
 # HTTP port for Dynamo frontend API
 # Default: 8099
-# DYNAMO_HTTP_PORT="8099"
+# DYNAMO_HTTP_PORT=8099
 
 # ETCD client port for metadata and discovery
 # Default: 2379
-# DYNAMO_ETCD_PORT="2379"
+# DYNAMO_ETCD_PORT=2379
 
 # ETCD peer port
 # Default: 2390
-# DYNAMO_ETCD_PEER_PORT="2390"
+# DYNAMO_ETCD_PEER_PORT=2390
 
 # NATS messaging port
 # Default: 4222
-# DYNAMO_NATS_PORT="4222"
+# DYNAMO_NATS_PORT=4222
 
 # =============================================================================
 # OPTIONAL VARIABLES - Model Configuration
@@ -78,11 +78,11 @@ export DYNAMO_GPU_DEVICES="0,1,2,3"
 
 # Model name as exposed by the API
 # Default: llama-3.3-70b
-# DYNAMO_MODEL_NAME="llama-3.3-70b"
+# DYNAMO_MODEL_NAME=llama-3.3-70b
 
 # Shared memory size for Docker container
 # Default: 16g
-# DYNAMO_SHM_SIZE="16g"
+# DYNAMO_SHM_SIZE=16g
 
 # =============================================================================
 # OPTIONAL VARIABLES - Disaggregated Mode
@@ -90,8 +90,8 @@ export DYNAMO_GPU_DEVICES="0,1,2,3"
 
 # Bootstrap port for disaggregated mode communication
 # Default: 12345
-# DYNAMO_DISAGG_BOOTSTRAP_PORT="12345"
+# DYNAMO_DISAGG_BOOTSTRAP_PORT=12345
 
 # Transfer backend for KV cache (nixl, nccl, or gloo)
 # Default: nixl
-# DYNAMO_DISAGG_TRANSFER_BACKEND="nixl"
+# DYNAMO_DISAGG_TRANSFER_BACKEND=nixl

--- a/external/dynamo/.env.example
+++ b/external/dynamo/.env.example
@@ -95,3 +95,12 @@ export DYNAMO_GPU_DEVICES=0,1,2,3
 # Transfer backend for KV cache (nixl, nccl, or gloo)
 # Default: nixl
 # DYNAMO_DISAGG_TRANSFER_BACKEND=nixl
+
+# =============================================================================
+# OPTIONAL VARIABLES - Performance Tuning
+# =============================================================================
+
+# Worker initialization timeout (seconds)
+# Increase for large models (70B+) or cold starts
+# Default: 1800 (30 minutes)
+# DYNAMO_WORKER_INIT_TIMEOUT_S=1800

--- a/external/dynamo/.env.example
+++ b/external/dynamo/.env.example
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,10 +13,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Required: Set your model directory path
+export HF_HOME=/path/to/local/storage/.cache/huggingface
+
+export HF_TOKEN=<my_huggingface_read_token>
+
+# Required: Set your model directory path with model weights
+# EXAMPLE ls from properly configured directory
+# ~/models/Llama-3.3-70B-Instruct$ ls
+# LICENSE                           model-00003-of-00030.safetensors  model-00010-of-00030.safetensors  model-00017-of-00030.safetensors  model-00024-of-00030.safetensors  model.safetensors.index.json
+# README.md                         model-00004-of-00030.safetensors  model-00011-of-00030.safetensors  model-00018-of-00030.safetensors  model-00025-of-00030.safetensors  original
+# USE_POLICY.md                     model-00005-of-00030.safetensors  model-00012-of-00030.safetensors  model-00019-of-00030.safetensors  model-00026-of-00030.safetensors  special_tokens_map.json
+# config.json                       model-00006-of-00030.safetensors  model-00013-of-00030.safetensors  model-00020-of-00030.safetensors  model-00027-of-00030.safetensors  tokenizer.json
+# generation_config.json            model-00007-of-00030.safetensors  model-00014-of-00030.safetensors  model-00021-of-00030.safetensors  model-00028-of-00030.safetensors  tokenizer_config.json
+# model-00001-of-00030.safetensors  model-00008-of-00030.safetensors  model-00015-of-00030.safetensors  model-00022-of-00030.safetensors  model-00029-of-00030.safetensors
+# model-00002-of-00030.safetensors  model-00009-of-00030.safetensors  model-00016-of-00030.safetensors  model-00023-of-00030.safetensors  model-00030-of-00030.safetensors
 export DYNAMO_MODEL_DIR="/path/to/your/models/Llama-3.3-70B-Instruct"
-# Optional: Set repository directory (for Thompson Sampling router)
-export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit"
+
+# Set repository directory (for Thompson Sampling router)
+export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit/external/dynamo"
 
 # =============================================================================
 # OPTIONAL VARIABLES - GPU Configuration
@@ -24,7 +38,7 @@ export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit"
 
 # GPU device IDs for unified mode (comma-separated)
 # Default: 0,1,2,3
-DYNAMO_GPU_DEVICES="0,1,2,3"
+export DYNAMO_GPU_DEVICES="0,1,2,3"
 
 # GPU device IDs for disaggregated mode prefill workers
 # Default: 0,1
@@ -81,16 +95,3 @@ DYNAMO_GPU_DEVICES="0,1,2,3"
 # Transfer backend for KV cache (nixl, nccl, or gloo)
 # Default: nixl
 # DYNAMO_DISAGG_TRANSFER_BACKEND="nixl"
-
-
-# =============================================================================
-# OPTIONAL VARIABLES - Custom Thompson Sampler
-# =============================================================================
-
-# Path to CSV file for router decision logging
-# Default: router_metrics.csv
-# ROUTER_METRICS_CSV = "router_metrics.csv"
-
-# timeout period for dynamo worker initialization
-# Default: 300
-# DYNAMO_WORKER_INIT_TIMEOUT_S = 300

--- a/external/dynamo/README.md
+++ b/external/dynamo/README.md
@@ -202,7 +202,7 @@ source "${HOME}/.venvs/nat_dynamo_eval/bin/activate"
 ### Download model weights (can skip if already done)
 
 ```bash
-source .env
+[ -f .env ] && source .env || { echo "Warning: .env not found" >&2; false; }
 
 # Change to the target model directory (create it if still needed)
 cd "$(dirname "$DYNAMO_MODEL_DIR")"

--- a/external/dynamo/README.md
+++ b/external/dynamo/README.md
@@ -241,16 +241,16 @@ Or set variables directly:
 ```bash
 export HF_HOME=/path/to/local/storage/.cache/huggingface
 
-export HF_TOKEN=<my_huggingface_read_token>
+export HF_TOKEN=my_huggingface_read_token
 
 # Required: Set your model directory path
-export DYNAMO_MODEL_DIR="/path/to/your/models/Llama-3.3-70B-Instruct" # or Llama-3.1-3B-Instruct for QA on H100 machines
+export DYNAMO_MODEL_DIR=/path/to/your/models/Llama-3.3-70B-Instruct # or Llama-3.1-3B-Instruct for QA on H100 machines
 
 # Optional: Set repository directory (for Thompson Sampling router)
-export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit/external/dynamo"
+export DYNAMO_REPO_DIR=/path/to/NeMo-Agent-Toolkit/external/dynamo
 
 # Optional: Configure GPU devices (default: 0,1,2,3)
-export DYNAMO_GPU_DEVICES="0,1,2,3"
+export DYNAMO_GPU_DEVICES=0,1,2,3
 ```
 
 ### Verify GPU Access
@@ -399,8 +399,8 @@ Separate `prefill` and `decode` workers for maximum throughput. More complex set
 ```bash
 cd /path/to/NeMo-Agent-Toolkit/external/dynamo
 
-export DYNAMO_PREFILL_GPUS="0,1"
-export DYNAMO_DECODE_GPUS="2,3"
+export DYNAMO_PREFILL_GPUS=0,1
+export DYNAMO_DECODE_GPUS=2,3
 
 # Start Dynamo disaggregated
 bash start_dynamo_disagg.sh > startup_output.txt 2>&1
@@ -811,9 +811,9 @@ Example configuration:
 
 ```bash
 # Configure environment before running scripts
-export DYNAMO_MODEL_DIR="/path/to/models/Llama-3.3-70B-Instruct"
-export DYNAMO_GPU_DEVICES="0,1,2,3"
-export DYNAMO_HTTP_PORT="8099"
+export DYNAMO_MODEL_DIR=/path/to/models/Llama-3.3-70B-Instruct
+export DYNAMO_GPU_DEVICES=0,1,2,3
+export DYNAMO_HTTP_PORT=8099
 
 # Then start Dynamo
 bash start_dynamo_unified.sh
@@ -847,7 +847,7 @@ LOCAL_MODEL_DIR="${DYNAMO_MODEL_DIR:?Error: DYNAMO_MODEL_DIR environment variabl
 Option 1: Use environment variable (recommended):
 
 ```bash
-export DYNAMO_GPU_DEVICES="0,1,2,3"
+export DYNAMO_GPU_DEVICES=0,1,2,3
 bash start_dynamo_unified.sh
 ```
 
@@ -880,9 +880,9 @@ TP_SIZE=2  # Smaller models may need fewer GPUs
 Option 1: Use environment variables:
 
 ```bash
-export DYNAMO_HTTP_PORT="8080"
-export DYNAMO_ETCD_PORT="2379"
-export DYNAMO_NATS_PORT="4222"
+export DYNAMO_HTTP_PORT=8080
+export DYNAMO_ETCD_PORT=2379
+export DYNAMO_NATS_PORT=4222
 bash start_dynamo_unified.sh
 ```
 

--- a/external/dynamo/README.md
+++ b/external/dynamo/README.md
@@ -38,11 +38,11 @@ This guide covers setting up, running, and configuring the NVIDIA Dynamo backend
 
 ## Overview
 
-Dynamo is NVIDIA's high-performance LLM serving platform with KV cache optimization. Scope of the current integration is based around two core aspects. First, we have implemented a [Dynamo LLM](../../src/nat/llm/dynamo_llm.py) support for NeMo Agent toolkit inference on Dynamo runtimes. Second, we provide a set of startup scripts for NVIDIA Hopper and Blackwell GPU servers supporting NAT runtimes at scale. The following **Table** defines each script: 
+Dynamo is NVIDIA's high-performance LLM serving platform with KV cache optimization. The scope of the current integration is based around two core aspects. First, we have implemented a [Dynamo LLM](../../src/nat/llm/dynamo_llm.py) support for NeMo Agent toolkit inference on Dynamo runtimes. Second, we provide a set of startup scripts for NVIDIA Hopper and Blackwell GPU servers supporting NeMo Agent toolkit runtimes at scale. The following **Table** defines each script: 
 
 | Mode | Script | Description | Best For |
 |------|--------|-------------|----------|
-| **Unified** | `start_dynamo_unified.sh` | Workers responsible for both prefill and decode | Development, testing |
+| **Unified** | `start_dynamo_unified.sh` | Workers responsible for both `prefill` and `decode` | Development, testing |
 | **Unified + Thompson** | `start_dynamo_unified_thompson_hints.sh` | Unified with a predictive KV-aware router | Production, KV optimization |
 | **Disaggregated** | `start_dynamo_disagg.sh` | Separate `prefill` and `decode` workers | High-throughput production |
 
@@ -204,12 +204,10 @@ source "${HOME}/.venvs/nat_dynamo_eval/bin/activate"
 ```bash
 source .env
 
-# Create the directory
-# mkdir -p "$(dirname "$DYNAMO_MODEL_DIR")"
-cd $(dirname $DYNAMO_MODEL_DIR)
+# Change to the target model directory (create it if still needed)
+cd "$(dirname "$DYNAMO_MODEL_DIR")"
 
-# We will download the model weights directly from HuggingFace. Usage of
-# llama models from requires approval from Meta. See `NOTE` below.
+# We will download the model weights directly from HuggingFace. See `NOTE` below.
 uv pip install huggingface_hub
 uv run huggingface-cli login  # Enter your HF token
 
@@ -217,7 +215,7 @@ uv run huggingface-cli download "meta-llama/Llama-3.3-70B-Instruct" --local-dir 
 ```
 
 > [!NOTE]
-> The Llama-3.3-70B-Instruct model requires approval from Meta. Request access at [huggingface.co/meta-llama/Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct) before downloading. You will need to create a HuggingFace Access Token with read access in order to download the model. On the huggingface website visit: "Access Tokens" -> "+ Create access token" to generate a token starting with "hf_". Enter your token when prompted. Respond "n" when asked "Add token as git credential? (Y/n)". Set HF_HOME and HF_TOKEN in .env..
+> The Llama-3.3-70B-Instruct model requires approval from Meta. Request access at [huggingface.co/meta-llama/Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct) before downloading. You will need to create a HuggingFace Access Token with read access in order to download the model. On the `HuggingFace` website visit: "Access Tokens" -> "+ Create access token" to generate a token starting with `hf_`. Enter your token when prompted. Respond "n" when asked "Add token as git credential? (Y/n)". Set HF_HOME and HF_TOKEN in .env..
 
 ### Environment Setup
 
@@ -307,17 +305,6 @@ Example output for an 8x H100 system:
 | N/A   35C    P0            139W / 1000W |       4MiB / 183359MiB |      0%      Default |
 |                                         |                        |             Disabled |
 +-----------------------------------------+------------------------+----------------------+
-
-+-----------------------------------------------------------------------------------------+
-| Processes:                                                                              |
-|  GPU   GI   CI              PID   Type   Process name                        GPU Memory |
-|        ID   ID                                                               Usage      |
-|=========================================================================================|
-|    0   N/A  N/A         2700092      C   VLLM::Worker_TP0_EP0                  16901... |
-|    1   N/A  N/A         2700093      C   VLLM::Worker_TP1_EP1                  16901... |
-|    2   N/A  N/A         2700094      C   VLLM::Worker_TP2_EP2                  16901... |
-|    3   N/A  N/A         2700095      C   VLLM::Worker_TP3_EP3                  16901... |
-+-----------------------------------------------------------------------------------------+
 ```
 
 ### Verify Docker and NVIDIA Container Toolkit

--- a/external/dynamo/README.md
+++ b/external/dynamo/README.md
@@ -38,12 +38,12 @@ This guide covers setting up, running, and configuring the NVIDIA Dynamo backend
 
 ## Overview
 
-Dynamo is NVIDIA's high-performance LLM serving platform with KV cache optimization. This project provides three deployment modes:
+Dynamo is NVIDIA's high-performance LLM serving platform with KV cache optimization. Scope of the current integration is based around two core aspects. First, we have implemented a [Dynamo LLM](../../src/nat/llm/dynamo_llm.py) support for NeMo Agent toolkit inference on Dynamo runtimes. Second, we provide a set of startup scripts for NVIDIA Hopper and Blackwell GPU servers supporting NAT runtimes at scale. The following **Table** defines each script: 
 
 | Mode | Script | Description | Best For |
 |------|--------|-------------|----------|
-| **Unified** | `start_dynamo_unified.sh` | Single worker, all operations | Development, testing |
-| **Unified + Thompson** | `start_dynamo_unified_thompson_hints.sh` | Unified with predictive KV-aware router | Production, KV optimization |
+| **Unified** | `start_dynamo_unified.sh` | Workers responsible for both prefill and decode | Development, testing |
+| **Unified + Thompson** | `start_dynamo_unified_thompson_hints.sh` | Unified with a predictive KV-aware router | Production, KV optimization |
 | **Disaggregated** | `start_dynamo_disagg.sh` | Separate `prefill` and `decode` workers | High-throughput production |
 
 ### Architecture Overview
@@ -175,7 +175,7 @@ Dynamo is NVIDIA's high-performance LLM serving platform with KV cache optimizat
 
 | Component | Minimum | Recommended |
 |-----------|---------|-------------|
-| **GPU Architecture** | NVIDIA Hopper (H100) or Blackwell (B200) | B200 for optimal performance |
+| **GPU Architecture** | NVIDIA Hopper (H100) or Blackwell (B200) | B200 for higher throughput |
 | **GPU Count** | 2 GPUs for small models (2 workers) | 8 GPUs for optimal performance |
 | **GPU Memory** | 80GB per GPU (H100) | 192GB per GPU (B200) |
 | **System RAM** | 256GB | 512GB+ |
@@ -202,28 +202,22 @@ source "${HOME}/.venvs/nat_dynamo_eval/bin/activate"
 ### Download model weights (can skip if already done)
 
 ```bash
-# Set your desired model directory
-export DYNAMO_MODEL_DIR="${HOME}/models/Llama-3.3-70B-Instruct"
+source .env
 
 # Create the directory
 # mkdir -p "$(dirname "$DYNAMO_MODEL_DIR")"
-mkdir -p $DYNAMO_MODEL_DIR
+cd $(dirname $DYNAMO_MODEL_DIR)
 
 # We will download the model weights directly from HuggingFace. Usage of
-# llama models from requires approval from Meta. See `Access Notes` below.
-# You will need to create a HuggingFace Access Token with read access in
-# order to download the model. On the huggingface website visit:
-# "Access Tokens" -> "+ Create access token" to generate a token starting
-# with "hf_". Enter your token when prompted.
-# Respond "n" when asked "Add token as git credential? (Y/n)"
+# llama models from requires approval from Meta. See `NOTE` below.
 uv pip install huggingface_hub
 uv run huggingface-cli login  # Enter your HF token
 
-uv run huggingface-cli download "meta-llama/Llama-3.3-70B-Instruct" \
-  --local-dir "$DYNAMO_MODEL_DIR"
+uv run huggingface-cli download "meta-llama/Llama-3.3-70B-Instruct" --local-dir "$DYNAMO_MODEL_DIR"
 ```
 
-> **Access Note**: The Llama-3.3-70B-Instruct model requires approval from Meta. Request access at [huggingface.co/meta-llama/Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct) before downloading.
+> [!NOTE]
+> The Llama-3.3-70B-Instruct model requires approval from Meta. Request access at [huggingface.co/meta-llama/Llama-3.3-70B-Instruct](https://huggingface.co/meta-llama/Llama-3.3-70B-Instruct) before downloading. You will need to create a HuggingFace Access Token with read access in order to download the model. On the huggingface website visit: "Access Tokens" -> "+ Create access token" to generate a token starting with "hf_". Enter your token when prompted. Respond "n" when asked "Add token as git credential? (Y/n)". Set HF_HOME and HF_TOKEN in .env..
 
 ### Environment Setup
 
@@ -245,11 +239,15 @@ source .env
 Or set variables directly:
 
 ```bash
+export HF_HOME=/path/to/local/storage/.cache/huggingface
+
+export HF_TOKEN=<my_huggingface_read_token>
+
 # Required: Set your model directory path
 export DYNAMO_MODEL_DIR="/path/to/your/models/Llama-3.3-70B-Instruct" # or Llama-3.1-3B-Instruct for QA on H100 machines
 
 # Optional: Set repository directory (for Thompson Sampling router)
-export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit"
+export DYNAMO_REPO_DIR="/path/to/NeMo-Agent-Toolkit/external/dynamo"
 
 # Optional: Configure GPU devices (default: 0,1,2,3)
 export DYNAMO_GPU_DEVICES="0,1,2,3"
@@ -361,7 +359,7 @@ bash stop_dynamo.sh
 - `nats` container (`nats-dynamo`) on port 4232
 - Dynamo container (`dynamo-sglang`) with unified worker on GPUs 0,1,2,3 (TP=4)
 
-**Startup time**: ~5 minutes seconds for 70B model
+**Startup time**: Startup time may vary between 5-20 minutes for a 70B model, depending on the state of the system cache.
 
 ### Option 2: Unified + Thompson Sampling Router (Production)
 

--- a/external/dynamo/start_dynamo_disagg.sh
+++ b/external/dynamo/start_dynamo_disagg.sh
@@ -79,7 +79,7 @@ if [ -d "${DYNAMO_MODEL_DIR}" ]; then
         echo ""
         echo "This usually means incomplete/corrupted download. Try:"
         echo "  rm -rf ${DYNAMO_MODEL_DIR}"
-        echo "  huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --local-dir ${DYNAMO_MODEL_DIR}"
+        echo "  hf download meta-llama/Llama-3.3-70B-Instruct --local-dir ${DYNAMO_MODEL_DIR}"
         exit 1
     fi
 fi
@@ -213,7 +213,7 @@ if [ ! -d "$LOCAL_MODEL_DIR" ]; then
     echo "WARNING: Model directory not found at: $LOCAL_MODEL_DIR"
     echo ""
     echo "To download the model, run:"
-    echo "  huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --local-dir $LOCAL_MODEL_DIR"
+    echo "  hf download meta-llama/Llama-3.3-70B-Instruct --local-dir $LOCAL_MODEL_DIR"
     echo ""
     read -p "Continue anyway (model will be downloaded from HuggingFace)? [y/N] " -n 1 -r
     echo
@@ -409,8 +409,8 @@ docker run -d \
     # Wait for BOTH workers to register (expects 2 workers in ETCD)
     echo \"Waiting for both workers to initialize in parallel...\"
     wait_for_workers_parallel() {
-        # local max_wait=300
-        local max_wait=${WORKER_INIT_TIMEOUT_S:-600}
+        # Use WORKER_INIT_TIMEOUT_S (defaults to 1800s / 30 min)
+        local max_wait=$WORKER_INIT_TIMEOUT_S
         local elapsed=0
         local poll_interval=5
 

--- a/external/dynamo/start_dynamo_disagg.sh
+++ b/external/dynamo/start_dynamo_disagg.sh
@@ -41,7 +41,7 @@ MODEL="/workspace/models/Llama-3.3-70B-Instruct"
 SERVED_MODEL_NAME="${DYNAMO_MODEL_NAME:-llama-3.3-70b}"
 IMAGE="nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.1"
 SHM_SIZE="${DYNAMO_SHM_SIZE:-16g}"
-WORKER_INIT_TIMEOUT_S="${DYNAMO_WORKER_INIT_TIMEOUT_S:-600}"
+WORKER_INIT_TIMEOUT_S="${DYNAMO_WORKER_INIT_TIMEOUT_S:-1800}"
 
 # Disaggregation configuration
 DISAGG_BOOTSTRAP_PORT="${DYNAMO_DISAGG_BOOTSTRAP_PORT:-12345}"
@@ -602,8 +602,8 @@ if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
     echo ""
 
     # Wait for server to be ready (check /v1/models which only works when workers are discovered)
-    echo "Checking for API availability (timeout=15 minutes)..."
-    max_attempts=900
+    echo "Checking for API availability (timeout=${WORKER_INIT_TIMEOUT_S}s)..."
+    max_attempts=$WORKER_INIT_TIMEOUT_S
     attempt=0
 
     while [ $attempt -lt $max_attempts ]; do

--- a/external/dynamo/start_dynamo_unified.sh
+++ b/external/dynamo/start_dynamo_unified.sh
@@ -44,7 +44,7 @@ SHM_SIZE="${DYNAMO_SHM_SIZE:-16g}"
 ETCD_CLIENT_PORT="${DYNAMO_ETCD_PORT:-2379}"
 ETCD_PEER_PORT="${DYNAMO_ETCD_PEER_PORT:-2390}"
 NATS_PORT="${DYNAMO_NATS_PORT:-4222}"
-WORKER_INIT_TIMEOUT_S="${DYNAMO_WORKER_INIT_TIMEOUT_S:-600}"
+WORKER_INIT_TIMEOUT_S="${DYNAMO_WORKER_INIT_TIMEOUT_S:-1800}"
 
 # Compute container-internal GPU indices (GPUs are renumbered 0,1,2,... inside the container)
 NUM_GPUS=$(echo "$WORKER_GPUS" | tr ',' '\n' | wc -l)
@@ -484,8 +484,8 @@ if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
     echo ""
 
     # Wait for server to be ready (check /v1/models which only works when workers are discovered)
-    echo "Checking for API availability (timeout=15 minutes)..."
-    max_attempts=900
+    echo "Checking for API availability (timeout=${WORKER_INIT_TIMEOUT_S}s)..."
+    max_attempts=$WORKER_INIT_TIMEOUT_S
     attempt=0
 
     while [ $attempt -lt $max_attempts ]; do

--- a/external/dynamo/start_dynamo_unified.sh
+++ b/external/dynamo/start_dynamo_unified.sh
@@ -82,7 +82,7 @@ if [ -d "${DYNAMO_MODEL_DIR}" ]; then
         echo ""
         echo "This usually means incomplete/corrupted download. Try:"
         echo "  rm -rf ${DYNAMO_MODEL_DIR}"
-        echo "  huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --local-dir ${DYNAMO_MODEL_DIR}"
+        echo "  hf download meta-llama/Llama-3.3-70B-Instruct --local-dir ${DYNAMO_MODEL_DIR}"
         exit 1
     fi
 fi
@@ -217,7 +217,7 @@ if [ ! -d "$LOCAL_MODEL_DIR" ]; then
     echo "WARNING: Model directory not found at: $LOCAL_MODEL_DIR"
     echo ""
     echo "To download the model, run:"
-    echo "  huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --local-dir $LOCAL_MODEL_DIR"
+    echo "  hf download meta-llama/Llama-3.3-70B-Instruct --local-dir $LOCAL_MODEL_DIR"
     echo ""
     read -p "Continue anyway (model will be downloaded from HuggingFace)? [y/N] " -n 1 -r
     echo
@@ -277,8 +277,8 @@ docker run -d \
     wait_for_worker() {
         local worker_type=\$1
         local pid=\$2
-        # local max_wait=300
-        local max_wait=${DYNAMO_WORKER_INIT_TIMEOUT_S:-600}
+        # Use WORKER_INIT_TIMEOUT_S (defaults to 1800s / 30 min)
+        local max_wait=$WORKER_INIT_TIMEOUT_S
         local elapsed=0
         local poll_interval=5
 

--- a/external/dynamo/start_dynamo_unified_thompson_hints.sh
+++ b/external/dynamo/start_dynamo_unified_thompson_hints.sh
@@ -46,7 +46,7 @@ MODEL="/workspace/models/Llama-3.3-70B-Instruct"
 SERVED_MODEL_NAME="${DYNAMO_MODEL_NAME:-llama-3.3-70b}"
 IMAGE="nvcr.io/nvidia/ai-dynamo/sglang-runtime:0.7.1"
 SHM_SIZE="${DYNAMO_SHM_SIZE:-16g}"
-WORKER_INIT_TIMEOUT_S="${DYNAMO_WORKER_INIT_TIMEOUT_S:-600}"
+WORKER_INIT_TIMEOUT_S="${DYNAMO_WORKER_INIT_TIMEOUT_S:-1800}"
 
 # Local paths - DYNAMO_MODEL_DIR must be set or script will error
 if [ -z "${DYNAMO_MODEL_DIR}" ]; then
@@ -608,8 +608,8 @@ if docker ps --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$"; then
     # Wait for server to be ready (check /health for custom frontend)
     # Note: Custom frontend doesn't implement /v1/models, so we use /health
     # Worker registration is already confirmed via ETCD check above
-    echo "Checking for API availability (timeout=15 minutes)..."
-    max_attempts=900
+    echo "Checking for API availability (timeout=${WORKER_INIT_TIMEOUT_S}s)..."
+    max_attempts=$WORKER_INIT_TIMEOUT_S
     attempt=0
 
     while [ $attempt -lt $max_attempts ]; do

--- a/external/dynamo/start_dynamo_unified_thompson_hints.sh
+++ b/external/dynamo/start_dynamo_unified_thompson_hints.sh
@@ -80,7 +80,7 @@ if [ -d "${DYNAMO_MODEL_DIR}" ]; then
         echo ""
         echo "This usually means incomplete/corrupted download. Try:"
         echo "  rm -rf ${DYNAMO_MODEL_DIR}"
-        echo "  huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --local-dir ${DYNAMO_MODEL_DIR}"
+        echo "  hf download meta-llama/Llama-3.3-70B-Instruct --local-dir ${DYNAMO_MODEL_DIR}"
         exit 1
     fi
 fi
@@ -240,7 +240,7 @@ if [ ! -d "$LOCAL_MODEL_DIR" ]; then
     echo "WARNING: Model directory not found at: $LOCAL_MODEL_DIR"
     echo ""
     echo "To download the model, run:"
-    echo "  huggingface-cli download meta-llama/Llama-3.3-70B-Instruct --local-dir $LOCAL_MODEL_DIR"
+    echo "  hf download meta-llama/Llama-3.3-70B-Instruct --local-dir $LOCAL_MODEL_DIR"
     echo ""
     read -p "Continue anyway (model will be downloaded from HuggingFace)? [y/N] " -n 1 -r
     echo
@@ -308,8 +308,8 @@ docker run -d \
     wait_for_worker() {
         local worker_type=\$1
         local pid=\$2
-        # local max_wait=300
-        local max_wait=${WORKER_INIT_TIMEOUT_S:-600}
+        # Use WORKER_INIT_TIMEOUT_S (defaults to 1800s / 30 min)
+        local max_wait=$WORKER_INIT_TIMEOUT_S
         local elapsed=0
         local poll_interval=5
 


### PR DESCRIPTION
## Description
Clarify the download location for huggingface open source models onto the GPU workstation. Corrected by standardization of the .env.example files between the dynamo example and the external dynamo components, as they will likely be run back-to-back. Also fixed a race condition in the startup scripts so that model load and api availability both run up to 30 minutes (longer than original 15 min to account for cold start scenarios). General improvements to docs.
Closes
NVBug 5756833

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated quick-start and setup to use a sourced .env (explicit HF_HOME/HF_TOKEN), clarified model-weight download step, reordered startup flow, added warnings about initial model load time, updated evaluation/artifact guidance, and replaced huggingface-cli examples with hf.

* **Chores**
  * Exposed many configuration options as exported environment variables (model/repo paths, GPU workers, tensor-parallel settings, ports, etc.) and increased worker initialization timeout defaults for large-model readiness.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->