### PR TITLE
Update test models to nemotron 3 and fix test assertions

### DIFF
--- a/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/configs/config_live_mode.yml
+++ b/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/configs/config_live_mode.yml
@@ -70,31 +70,31 @@ workflow:
 llms:
   ata_agent_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.2
     max_tokens: 2048
 
   tool_reasoning_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.2
     top_p: 0.7
     max_tokens: 2048
 
   telemetry_metrics_analysis_agent_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0
     max_tokens: 2048
 
   maintenance_check_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0
     max_tokens: 2048
 
   categorizer_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0
     max_tokens: 2048

--- a/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/configs/config_offline_mode.yml
+++ b/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/configs/config_offline_mode.yml
@@ -72,38 +72,38 @@ workflow:
 llms:
   ata_agent_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.2
     max_tokens: 2048
 
   tool_reasoning_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.2
     top_p: 0.7
     max_tokens: 2048
 
   telemetry_metrics_analysis_agent_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0
     max_tokens: 2048
 
   maintenance_check_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0
     max_tokens: 2048
 
   categorizer_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0
     max_tokens: 2048
 
   nim_rag_eval_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     max_tokens: 8
 
 eval:

--- a/examples/agents/react/configs/config.yml
+++ b/examples/agents/react/configs/config.yml
@@ -17,7 +17,7 @@
 llms:
   nim_llm:
     _type: nim
-    model_name: meta/llama-3.1-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 250
 

--- a/examples/agents/rewoo/configs/config.yml
+++ b/examples/agents/rewoo/configs/config.yml
@@ -17,7 +17,7 @@
 llms:
   nim_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 4096
 
@@ -30,7 +30,7 @@ functions:
     _type: tavily_internet_search
   haystack_chitchat_agent:
     _type: haystack_chitchat_agent
-    llm_name: meta/llama-3.1-405b-instruct
+    llm_name: nvidia/nemotron-mini-4b-instruct
 
 workflow:
   _type: rewoo_agent

--- a/examples/agents/tests/test_agents.py
+++ b/examples/agents/tests/test_agents.py
@@ -109,4 +109,4 @@ async def test_react_agent_full_workflow_validate_re(examples_dir: Path):
                                 question="What are LLMs?",
                                 expected_answer="",
                                 assert_expected_answer=False)
-    assert re.match(r".*large language model.*", result, re.IGNORECASE) is not None
+    assert re.search(r"large language model", result, re.IGNORECASE) is not None

--- a/examples/observability/simple_calculator_observability/configs/config-phoenix.yml
+++ b/examples/observability/simple_calculator_observability/configs/config-phoenix.yml
@@ -51,7 +51,7 @@ functions:
 llms:
   nim_llm:
     _type: nim
-    model_name: meta/llama-3.1-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 1024
 

--- a/packages/nvidia_nat_test/src/nat/test/utils.py
+++ b/packages/nvidia_nat_test/src/nat/test/utils.py
@@ -86,7 +86,9 @@ async def run_workflow(*,
     result = await nat_run_workflow(config=config, config_file=config_file, prompt=question, to_type=str, **kwargs)
 
     if assert_expected_answer:
-        assert expected_answer.lower() in result.lower(), f"Expected '{expected_answer}' in '{result}'"
+        # sometimes LLMs use fancy unicode space characters like \u202f, normalize before comparing
+        normalized_result = ' '.join(result.split())
+        assert expected_answer.lower() in normalized_result.lower(), f"Expected '{expected_answer}' in '{result}'"
 
     return result
 


### PR DESCRIPTION
This PR updates the default LLM models used in example workflows and tests from Meta Llama models to NVIDIA Nemotron 3 models, and fixes flaky test assertions related to string matching.

### Changes

#### Model Updates
Migrated LLM configurations from Meta Llama models to NVIDIA Nemotron 3 models across multiple example workflows:

| Previous Model | New Model |
|----------------|-----------|
| `meta/llama-3.3-70b-instruct` | `nvidia/nemotron-3-nano-30b-a3b` |
| `meta/llama-3.1-70b-instruct` | `nvidia/nemotron-3-nano-30b-a3b` |
| `meta/llama-3.1-405b-instruct` | `nvidia/nemotron-mini-4b-instruct` |

**Affected configs:**
- `examples/advanced_agents/alert_triage_agent` (live & offline modes)
- `examples/agents/react`
- `examples/agents/rewoo`
- `examples/observability/simple_calculator_observability`

#### Test Assertion Fixes

1. **`test_agents.py`**: Changed `re.match()` to `re.search()` for the "large language model" assertion. `re.match()` only matches at the beginning of the string, causing false negatives when the pattern appears later in the response.

2. **`nat/test/utils.py`**: Added Unicode whitespace normalization before string comparison. Some LLMs return fancy Unicode space characters (e.g., `\u202f` narrow no-break space) which caused assertion failures when comparing expected answers.

### Testing
- Ran affected example workflows
- Verified test assertions pass with new models 3 times in a row

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated underlying LLM model configurations across multiple examples and observability utilities to use more efficient model versions.
  * Improved test utilities with enhanced result normalization and case-insensitive comparison for more robust test validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->