### PR TITLE
fix: strands demo reliability improvements

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -124,7 +124,7 @@ _Additional information can be found in the [Agents README](./agents/README.md).
 - **[`langchain_deep_research`](frameworks/auto_wrapper/langchain_deep_research/README.md)**: An example that integrates any existing LangGraph agent with NeMo Agent toolkit using the `langgraph_wrapper` workflow type **[🟨 Intermediate]**
 - **[`multi_frameworks`](frameworks/multi_frameworks/README.md)**: Supervisor agent coordinating LangChain/LangGraph, LlamaIndex, and Haystack agents for research, RAG, and chitchat tasks **[🟨 Intermediate]**
 - **[`semantic_kernel_demo`](frameworks/semantic_kernel_demo/README.md)**: Multi-agent travel planning system using Microsoft Semantic Kernel with specialized agents for itinerary creation, budget management, and report formatting, including long-term memory for user preferences **[🟢 Beginner]**
-- **[`strands_demo`](frameworks/strands_demo/README.md)**: A minimal example showcasing a Strands agent that answers questions about Strands documentation using a curated URL knowledge base and the native Strands `http_request` tool **[🟢 Beginner]**
+- **[`strands_demo`](frameworks/strands_demo/README.md)**: A minimal example showcasing a Strands agent that answers questions about Strands documentation using a curated URL knowledge base and the native Strands `http_request` tool **[🟨 Intermediate]**
 - **[`strands_demo - bedrock_agentcore`](frameworks/strands_demo/bedrock_agentcore/README.md)**: Deploying NVIDIA NeMo Agent toolkit with Strands on AWS AgentCore, including OpenTelemetry instrumentation for monitoring **[🛑 Advanced]**
 
 ### Front Ends

--- a/examples/frameworks/strands_demo/README.md
+++ b/examples/frameworks/strands_demo/README.md
@@ -29,10 +29,10 @@ A minimal example showcasing a Strands agent that answers questions about Strand
 - [Key Features](#key-features)
 - [Prerequisites](#prerequisites)
   - [Local Development Tools](#local-development-tools)
-  - [NeMo Agent Toolkit](#nemo-agent-toolkit)
+  - [NeMo Agent toolkit](#nemo-agent-toolkit)
   - [API Keys](#api-keys)
 - [Installation and Setup](#installation-and-setup)
-  - [Install NeMo Agent Toolkit and Workflow](#install-nemo-agent-toolkit-and-workflow)
+  - [Install NeMo Agent toolkit and Workflow](#install-nemo-agent-toolkit-and-workflow)
   - [Set Up API Keys](#set-up-api-keys)
 - [Run the Workflow locally](#run-the-workflow-locally)
   - [1) Run the workflow (config.yml)](#1-run-the-workflow-configyml)
@@ -43,7 +43,7 @@ A minimal example showcasing a Strands agent that answers questions about Strand
 
 ## Key Features
 
-- **Strands framework integration**: Demonstrates support for Strands Agents in the NeMo Agent Toolkit.
+- **Strands framework integration**: Demonstrates support for Strands Agents in the NeMo Agent toolkit.
 - **AgentCore Integration**: Demonstrates an agent that can be run on Amazon Bedrock AgentCore runtime.
 - **Evaluation and Performance Metrics**: Runs dataset-driven evaluation and performance analysis via `nat eval`.
 - **Support for Model Providers**: Configuration includes NIM, OpenAI, and AWS Bedrock options.
@@ -122,7 +122,7 @@ Workflow Result:
 
 ### 2) Evaluate accuracy and performance (eval_config.yml)
 
-Runs the workflow over a dataset and computes evaluation and performance metrics.  Refer to the the [evaluation](../../../docs/source/improve-workflows/evaluate.md) and [profiling](../../../docs/source/improve-workflows/profiler.md) guides in the documentation for more information.
+Runs the workflow over a dataset and computes evaluation and performance metrics.  Refer to the [evaluation](../../../docs/source/improve-workflows/evaluate.md) and [profiling](../../../docs/source/improve-workflows/profiler.md) guides in the documentation for more information.
 
 ```bash
 nat eval --config_file examples/frameworks/strands_demo/configs/eval_config.yml
@@ -134,15 +134,15 @@ nat eval --config_file examples/frameworks/strands_demo/configs/eval_config.yml
 
 ### 3) Optimize workflow parameters (optimizer_config.yml)
 
-Automatically finds optimal LLM parameters (temperature, top_p, max_tokens) through systematic experimentation. The optimizer evaluates multiple parameter combinations across multiple trials and repetitions, balancing accuracy, groundedness, relevance, trajectory correctness, latency, and token efficiency.
+Automatically finds optimal LLM parameters (`temperature`, `top_p`, `max_tokens`) through systematic experimentation. The optimizer evaluates multiple parameter combinations across multiple trials and repetitions, balancing accuracy, groundedness, relevance, trajectory correctness, latency, and token efficiency.
 
 ```bash
 nat optimize --config_file examples/frameworks/strands_demo/configs/optimizer_config.yml
 ```
 
 **What it optimizes:**
-- **temperature**: Tests values from 0.0 to 0.6 (step: 0.2)
-- **max_tokens**: Tests values from 4096 to 8192 (step: 2048)
+- **`temperature`**: Tests values from 0.0 to 0.6 (step: 0.2)
+- **`max_tokens`**: Tests values from 4096 to 8192 (step: 2048)
 
 The optimizer runs a grid search with 3 repetitions each combination for statistical stability and generates a report showing the best parameter combination based on weighted multi-objective scoring.
 
@@ -221,4 +221,4 @@ curl -X POST http://localhost:8080/invocations \
   -d '{"inputs": "What is the Strands agent loop?"}'
 ```
 
-Next, to deploy the AgentCore-compatible NeMo Agent Toolkit workflow on Amazon Bedrock AgentCore, follow [Running Strands with NeMo Agent Toolkit on AWS AgentCore](./bedrock_agentcore/README.md).
+Next, to deploy the AgentCore-compatible NeMo Agent toolkit workflow on Amazon Bedrock AgentCore, follow [Running Strands with NeMo Agent toolkit on AWS AgentCore](./bedrock_agentcore/README.md).

--- a/examples/frameworks/strands_demo/README.md
+++ b/examples/frameworks/strands_demo/README.md
@@ -17,9 +17,12 @@ limitations under the License.
 
 # Strands Example
 
-**Complexity:** 🟢 Beginner
+**Complexity:** 🟨 Intermediate
 
 A minimal example showcasing a Strands agent that answers questions about Strands documentation using a curated URL knowledge base and the native Strands `http_request` tool.
+
+> [!NOTE]
+> The CLI `optimize` workflow at the end of this example can take 10-20 minutes to run.
 
 ## Table of Contents
 
@@ -103,7 +106,7 @@ The `configs/` directory contains five ready-to-use configurations. Use the comm
 
 ```bash
 nat run --config_file examples/frameworks/strands_demo/configs/config.yml \
-  --input "How do I use the Strands Agents API?"
+  --input "Use the provided tools and cite information about how to use the Strands API from the tool call results"
 ```
 
 **Expected Workflow Output**
@@ -111,7 +114,10 @@ The workflow produces a large amount of output, the end of the output should con
 
 ```console
 Workflow Result:
-['To answer your question about using the Strands Agents API, I\'ll need to search for the relevant documentation. Let me do that for you.Thank you for providing that information. To get the most relevant information about using the Strands Agents API, I\'ll fetch the content from the "strands_agent_loop" URL, as it seems to be the most relevant to your question about using the API.Based on the information from the Strands Agents documentation, I can provide you with an overview of how to use the Strands Agents API. Here\'s a summary of the key points:\n\n1. Initialization:\n   To use the Strands Agents API, you start by initializing an agent with the necessary components:\n\n   ```python\n   from strands import Agent\n   from strands_tools import calculator\n\n   agent = Agent(\n       tools=[calculator],\n       system_prompt="You are a helpful assistant."\n   )\n   ```\n\n   This sets up the agent with tools (like a calculator in this example) and a system prompt.\n\n2. Processing User Input:\n   You can then use the agent to process user input:\n\n   ```python\n   result = agent("Calculate 25 * 48")\n   ```\n\n3. Agent Loop:\n   The Strands Agents API uses an "agent loop" to process requests. This loop includes:\n   - Receiving user input and context\n   - Processing the input using a language model (LLM)\n   - Deciding whether to use tools to gather information or perform actions\n   - Executing tools and receiving results\n   - Continuing reasoning with new information\n   - Producing a final response or iterating through the loop again\n\n4. Tool Execution:\n   The agent can use tools as part of its processing. When the model decides to use a tool, it will format a request like this:\n\n   ```json\n   {\n     "role": "assistant",\n     "content": [\n       {\n         "toolUse": {\n           "toolUseId": "tool_123",\n           "name": "calculator",\n           "input": {\n             "expression": "25 * 48"\n           }\n         }\n       }\n     ]\n   }\n   ```\n\n   The API then executes the tool and returns the result to the model for further processing.\n\n5. Recursive Processing:\n   The agent loop can continue recursively if more tool executions or multi-step reasoning is required.\n\n6. Completion:\n   The loop completes when the model generates a final text response or when an unhandled exception occurs.\n\nTo effectively use the Strands Agents API, you should:\n- Initialize your agent with appropriate tools and system prompts\n- Design your tools carefully, considering token limits and complexity\n- Handle potential exceptions, such as the MaxTokensReachedException\n\nRemember that the API is designed to support complex, multi-step reasoning and actions with seamless integration of tools and language models. It\'s flexible enough to handle a wide range of tasks and can be customized to your specific needs.']
+-----------------------------
+Workflow Result:
+['The provided information is about the Strands API and its usage. The Strands API is a platform for building conversational AI models, and it provides a range of tools and features for developers to create and deploy their own conversational AI models.\n\nTo use the Strands API, developers can start by creating an account on the Strands website and obtaining an API key. They can then use the API key to authenticate their requests to the Strands API.\n\nThe Strands API provides a range of endpoints for different tasks, such as creating and managing models, training and testing models, and deploying models to production. Developers can use these endpoints to build and deploy their own conversational AI models using the Strands API.\n\nIn addition to the API endpoints, the Strands API also provides a range of tools and features for developers, such as a model builder, a testing framework, and a deployment platform. These tools and features can help developers to build, test, and deploy their conversational AI models more efficiently and effectively.\n\nOverall, the Strands API is a powerful platform for building conversational AI models, and it provides a range of tools and features for developers to create and deploy their own conversational AI models.']
+--------------------------------------------------
 ```
 
 ### 2) Evaluate accuracy and performance (eval_config.yml)
@@ -121,6 +127,7 @@ Runs the workflow over a dataset and computes evaluation and performance metrics
 ```bash
 nat eval --config_file examples/frameworks/strands_demo/configs/eval_config.yml
 ```
+
 > [!NOTE]
 > If you hit rate limits, lower concurrency: `--override eval.general.max_concurrency 1`
 > Refer to [the evaluation guide](../../../docs/source/improve-workflows/evaluate.md) for more details on evaluation metrics and configuration options.
@@ -134,11 +141,10 @@ nat optimize --config_file examples/frameworks/strands_demo/configs/optimizer_co
 ```
 
 **What it optimizes:**
-- **temperature**: Tests values from 0.1 to 0.7
-- **top_p**: Tests values from 0.7 to 1.0
-- **max_tokens**: Tests values from 4096 to 8192
+- **temperature**: Tests values from 0.0 to 0.6 (step: 0.2)
+- **max_tokens**: Tests values from 4096 to 8192 (step: 2048)
 
-The optimizer runs 20 trials with 3 repetitions each for statistical stability and generates a report showing the best parameter combination based on weighted multi-objective scoring.
+The optimizer runs a grid search with 3 repetitions each combination for statistical stability and generates a report showing the best parameter combination based on weighted multi-objective scoring.
 
 > [!NOTE]
 > Optimization can take significant time. Reduce `n_trials` or adjust the search space in the config for faster experimentation.
@@ -197,6 +203,22 @@ This configuration serves the workflow locally with the [endpoints](https://docs
 
 ```bash
 nat serve --config_file examples/frameworks/strands_demo/configs/agentcore_config.yml
+```
+
+**Test the endpoints:**
+
+In a separate terminal, verify the service is running with the health check endpoint:
+
+```bash
+curl http://localhost:8080/ping
+```
+
+Call the main workflow via the `/invocations` endpoint:
+
+```bash
+curl -X POST http://localhost:8080/invocations \
+  -H "Content-Type: application/json" \
+  -d '{"inputs": "What is the Strands agent loop?"}'
 ```
 
 Next, to deploy the AgentCore-compatible NeMo Agent Toolkit workflow on Amazon Bedrock AgentCore, follow [Running Strands with NeMo Agent Toolkit on AWS AgentCore](./bedrock_agentcore/README.md).

--- a/examples/frameworks/strands_demo/bedrock_agentcore/README.md
+++ b/examples/frameworks/strands_demo/bedrock_agentcore/README.md
@@ -301,7 +301,7 @@ curl -X 'POST' \
   'http://localhost:8080/invocations' \
   -H 'accept: application/json' \
   -H 'Content-Type: application/json' \
-  -d '{"inputs" : "How do I use the Strands Agents API?"}'
+  -d '{"inputs" : "Use the provided tools and cite information about how to use the Strands API from the tool call results"}'
 ```
 <!-- path-check-skip-end -->
 

--- a/examples/frameworks/strands_demo/bedrock_agentcore/README.md
+++ b/examples/frameworks/strands_demo/bedrock_agentcore/README.md
@@ -28,7 +28,7 @@ A comprehensive guide for deploying NVIDIA NeMo Agent toolkit with Strands on AW
   - [IAM Permissions for Deployment](#iam-permissions-for-deployment)
   - [AWS Console Access](#aws-console-access)
   - [Additional Requirements](#additional-requirements)
-- [Step 1: Setup NeMo Agent Toolkit Environment](#step-1-setup-nemo-agent-toolkit-environment)
+- [Step 1: Setup NeMo Agent toolkit Environment](#step-1-setup-nemo-agent-toolkit-environment)
 - [Step 2: Configure AWS CLI](#step-2-configure-aws-cli)
   - [Option A: Using Long-Term Credentials](#option-a-using-long-term-credentials)
   - [Option B: Using AWS SSO (Recommended for Organizations)](#option-b-using-aws-sso-recommended-for-organizations)
@@ -1033,7 +1033,7 @@ Regions like `us-west-1` are **not supported** for Bedrock AgentCore.
 
 ## Additional Resources
 
-- [NVIDIA NeMo Agent Toolkit Documentation](https://docs.nvidia.com/nemo/agent-toolkit/latest/)
+- [NVIDIA NeMo Agent toolkit Documentation](https://docs.nvidia.com/nemo/agent-toolkit/latest/)
 - [AWS Bedrock AgentCore Documentation](https://docs.aws.amazon.com/bedrock/)
 - [OpenTelemetry Python Documentation](https://opentelemetry.io/docs/languages/python/)
 - [AWS CloudWatch Logs Documentation](https://docs.aws.amazon.com/cloudwatch/)

--- a/examples/frameworks/strands_demo/src/nat_strands_demo/configs/agentcore_config.yml
+++ b/examples/frameworks/strands_demo/src/nat_strands_demo/configs/agentcore_config.yml
@@ -47,17 +47,21 @@ llms:
   nim_llm:
     _type: nim
     model_name: meta/llama-3.3-70b-instruct
-    temperature: 0.5
-    max_tokens: 4000
+    temperature: 0.0
+    max_tokens: 4096
+
   bedrock_llm:
     _type: aws_bedrock
     model_name: anthropic.claude-3-5-sonnet-20240620-v1:0
     region_name: us-east-1
-    max_tokens: 4000
+    temperature: 0.0
+    max_tokens: 4096
+
   openai_llm:
     _type: openai
     model_name: gpt-4o-mini
     temperature: 0.0
+    max_tokens: 4096
 
 workflow:
   _type: strands_demo

--- a/examples/frameworks/strands_demo/src/nat_strands_demo/configs/config.yml
+++ b/examples/frameworks/strands_demo/src/nat_strands_demo/configs/config.yml
@@ -27,17 +27,21 @@ llms:
   nim_llm:
     _type: nim
     model_name: meta/llama-3.3-70b-instruct
-    temperature: 0.5
-    max_tokens: 4000
+    temperature: 0.0
+    max_tokens: 4096
+
   bedrock_llm:
     _type: aws_bedrock
     model_name: anthropic.claude-3-5-sonnet-20240620-v1:0
     region_name: us-east-1
-    max_tokens: 4000
+    temperature: 0.0
+    max_tokens: 4096
+
   openai_llm:
     _type: openai
     model_name: gpt-4o-mini
     temperature: 0.0
+    max_tokens: 4096
 
 workflow:
   _type: strands_demo

--- a/examples/frameworks/strands_demo/src/nat_strands_demo/configs/eval_config.yml
+++ b/examples/frameworks/strands_demo/src/nat_strands_demo/configs/eval_config.yml
@@ -29,24 +29,26 @@ llms:
   nim_llm:
     _type: nim
     model_name: meta/llama-3.3-70b-instruct
-    temperature: 0.6
-    top_p: 0.9
+    temperature: 0.0
     max_tokens: 4096
+
   bedrock_llm:
     _type: aws_bedrock
     model_name: anthropic.claude-3-5-sonnet-20240620-v1:0
     region_name: us-east-1
+    temperature: 0.0
     max_tokens: 4096
+    
   openai_llm:
     _type: openai
     model_name: gpt-4o-mini
     temperature: 0.0
-
-  # Evaluator LLM (used for evaluation metrics)
+    max_tokens: 4096
+    
   evaluator_llm:
     _type: nim
     model_name: meta/llama-3.3-70b-instruct
-    temperature: 0.0
+    temperature: 0.0 
     max_tokens: 8192
 
 workflow:

--- a/examples/frameworks/strands_demo/src/nat_strands_demo/configs/optimizer_config.yml
+++ b/examples/frameworks/strands_demo/src/nat_strands_demo/configs/optimizer_config.yml
@@ -29,34 +29,28 @@ llms:
   nim_llm:
     _type: nim
     model_name: meta/llama-3.3-70b-instruct
-    temperature: 0.5
-    top_p: 0.9
+    temperature: 0.0
     max_tokens: 4096
     # Enable optimization for these parameters
     optimizable_params:
       - temperature
-      - top_p
       - max_tokens
     # Define search spaces
     search_space:
       temperature:
-        low: 0.1
-        high: 0.7
-        step: 0.2  # Tests: 0.1, 0.3, 0.5, 0.7
-      top_p:
-        low: 0.7
-        high: 1.0
-        step: 0.1  # Tests: 0.7, 0.8, 0.9, 1.0
+        low: 0.0
+        high: 0.6
+        step: 0.2  # Tests: 0.0, 0.2, 0.4, 0.6
       max_tokens:
         low: 4096
         high: 8192
-        step: 512  # Tests: 4096, 4608, 5120, 5632, 6144, 6656, 7168, 7680, 8192
+        step: 2048  # Tests: 4096, 6144, 8192
   
   # Optimizer LLM (used for prompt optimization)
   optimizer_llm:
     _type: nim
     model_name: meta/llama-3.3-70b-instruct
-    temperature: 0.7
+    temperature: 0.0
     max_tokens: 4096
   
   # Evaluator LLM (used for evaluation metrics)
@@ -112,8 +106,7 @@ optimizer:
   # Numeric optimization (Optuna)
   numeric:
     enabled: true
-    n_trials: 20              # number of trials for numeric parameters
-    sampler: null             # Use TPE (Bayesian) sampling
+    sampler: grid             # Use TPE (Bayesian) sampling
  
   # Evaluation settings
   reps_per_param_set: 3      # Run each config 3 times for stability

--- a/examples/frameworks/strands_demo/src/nat_strands_demo/configs/optimizer_config.yml
+++ b/examples/frameworks/strands_demo/src/nat_strands_demo/configs/optimizer_config.yml
@@ -106,7 +106,7 @@ optimizer:
   # Numeric optimization (Optuna)
   numeric:
     enabled: true
-    sampler: grid             # Use TPE (Bayesian) sampling
+    sampler: grid
  
   # Evaluation settings
   reps_per_param_set: 3      # Run each config 3 times for stability

--- a/examples/frameworks/strands_demo/src/nat_strands_demo/configs/sizing_config.yml
+++ b/examples/frameworks/strands_demo/src/nat_strands_demo/configs/sizing_config.yml
@@ -29,18 +29,22 @@ llms:
   nim_llm:
     _type: nim
     model_name: meta/llama-3.3-70b-instruct
-    temperature: 0.7
-    max_tokens: 6144
-    top_p: 1.0
+    temperature: 0.0
+    max_tokens: 4096
     base_url: <base url to NIM instance>
+
   bedrock_llm:
     _type: aws_bedrock
     model_name: anthropic.claude-3-5-sonnet-20240620-v1:0
     region_name: us-east-1
+    temperature: 0.0
+    max_tokens: 4096
+
   openai_llm:
     _type: openai
     model_name: gpt-4o-mini
     temperature: 0.0
+    max_tokens: 4096
 
 workflow:
   _type: strands_demo


### PR DESCRIPTION
## Description
This PR improves the reliability of the Strands demo by reducing the temperature parameter of the config files for both README walk-throughs in /examples/frameworks/strands_demo. I also reduced the hyperparameter search space of the `nat optimize` workflow run so that the demo runs in a more reasonable amount of time (changed from `Beginner` to `Intermediate` as the root demo can take 5-10 minutes to run.
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Strands demo README: difficulty set to Intermediate, clearer workflow instructions, shorter expected output example, and note that optimization can take 10–20 minutes.
  * Improved example API payloads and added local endpoint testing examples (health and /invocations) with updated deployment reference.

* **Chores**
  * Standardized LLM defaults and token limits across demos for consistency.
  * Switched optimizer guidance to grid-search semantics and tightened optimization ranges.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->