### PR TITLE
fix(eval): prevent awaited coroutine reuse on Exception

### DIFF
--- a/src/nat/eval/evaluate.py
+++ b/src/nat/eval/evaluate.py
@@ -187,30 +187,35 @@ class EvaluationRun:
                         # raise an error if the workflow has multiple outputs
                         raise NotImplementedError("Multiple outputs are not supported")
 
-                    runner_result = None
-                    intermediate_future = None
+                    runner_task = None
+                    intermediate_task = None
+
+                    async def cancel_pending_tasks():
+                        pending = []
+                        for awaitable in (runner_task, intermediate_task):
+                            if awaitable is not None:
+                                if not awaitable.done():
+                                    awaitable.cancel()
+                                pending.append(awaitable)
+                        if pending:
+                            await asyncio.gather(*pending, return_exceptions=True)
 
                     try:
                         # Start usage stats and intermediate steps collection in parallel
-                        intermediate_future = pull_intermediate()
-                        runner_result = runner.result()
-                        base_output = await runner_result
-                        intermediate_steps = await intermediate_future
+                        intermediate_task = asyncio.ensure_future(pull_intermediate())
+                        runner_task = asyncio.create_task(runner.result())
+                        base_output = await runner_task
+                        intermediate_steps = await intermediate_task
                     except NotImplementedError as e:
                         logger.error("Failed to run the workflow: %s", e)
+                        await cancel_pending_tasks()
                         # raise original error
                         raise
                     except Exception as e:
                         logger.exception("Failed to run the workflow: %s", e)
                         # stop processing if a workflow error occurs
                         self.workflow_interrupted = True
-
-                        # Cancel any coroutines that are still running, avoiding a warning about unawaited coroutines
-                        # (typically one of these two is what raised the exception and the other is still running)
-                        for coro in (runner_result, intermediate_future):
-                            if coro is not None:
-                                asyncio.ensure_future(coro).cancel()
-
+                        await cancel_pending_tasks()
                         stop_event.set()
                         return
 

--- a/tests/nat/eval/test_evaluate.py
+++ b/tests/nat/eval/test_evaluate.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import asyncio
+import inspect
 import json
 import os
 import time
@@ -312,6 +314,84 @@ async def test_run_workflow_local_workflow_interrupted(evaluation_run, eval_inpu
     # Check if workflow_interrupted is set to True
     await evaluation_run.run_workflow_local(session_manager)
     assert evaluation_run.workflow_interrupted, "Expected workflow_interrupted to be True after failure"
+
+
+async def test_run_workflow_local_reuse_coroutine_on_error(evaluation_run, eval_input, session_manager):
+    """Document coroutine reuse error after workflow failure."""
+    evaluation_run.eval_input = eval_input
+
+    mock_error_runner = AsyncMock()
+
+    async def mock_result():
+        raise RuntimeError("Simulated workflow timeout")
+
+    failing_coro = mock_result()
+    mock_error_runner.result = MagicMock(return_value=failing_coro)
+
+    @asynccontextmanager
+    async def mock_error_run(_message, runtime_type=None):
+        """Mock async context manager for runner."""
+        yield mock_error_runner
+
+    @asynccontextmanager
+    async def mock_error_session(user_id=None):
+        mock_session = MagicMock()
+        mock_session.run = mock_error_run
+        mock_session.workflow = session_manager.workflow
+        yield mock_session
+
+    session_manager.session = mock_error_session
+
+    # This should not raise a "cannot reuse already awaited coroutine" error
+    try:
+        await evaluation_run.run_workflow_local(session_manager)
+    except RuntimeError as e:
+        assert "cannot reuse already awaited coroutine" not in str(e), (
+            f"Did not expect coroutine reuse error, but got: {e}")
+
+
+async def test_run_workflow_local_cancels_pending_intermediate(evaluation_run, eval_input, session_manager):
+    """Test that pending intermediate futures are cancelled when workflow execution fails."""
+    evaluation_run.eval_input = eval_input
+    pending_future: asyncio.Future[list[dict]] = asyncio.Future()
+    intermediate_source: asyncio.Future[list[dict]] = asyncio.Future()
+
+    # Create a mock runner that will raise an exception when awaited
+    mock_error_runner = AsyncMock()
+
+    async def mock_result():
+        raise RuntimeError("Simulated workflow failure")
+
+    mock_error_runner.result = AsyncMock(side_effect=mock_result)
+
+    @asynccontextmanager
+    async def mock_error_run(_message, runtime_type=None):
+        """Mock async context manager for runner."""
+        yield mock_error_runner
+
+    @asynccontextmanager
+    async def mock_error_session(user_id=None):
+        mock_session = MagicMock()
+        mock_session.run = mock_error_run
+        mock_session.workflow = session_manager.workflow
+        yield mock_session
+
+    session_manager.session = mock_error_session
+
+    def ensure_future_stub(coro):
+        coro.close()
+        return pending_future
+
+    with patch("nat.eval.runtime_event_subscriber.pull_intermediate",
+               AsyncMock(return_value=intermediate_source)) as mock_pull_intermediate, \
+         patch("nat.eval.evaluate.asyncio.ensure_future", side_effect=ensure_future_stub) as mock_ensure_future:
+        await evaluation_run.run_workflow_local(session_manager)
+
+    assert evaluation_run.workflow_interrupted, "Expected workflow_interrupted to be True after failure"
+    mock_pull_intermediate.assert_called_once()
+    mock_ensure_future.assert_called_once()
+    assert inspect.iscoroutine(mock_ensure_future.call_args.args[0])
+    assert pending_future.cancelled(), "Pending intermediate future should be cancelled"
 
 
 async def test_run_workflow_remote_success(evaluation_run, generated_answer):


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

- Prevents coroutine reuse in `nat eval` by switching workflow execution and intermediate-step collection to task-based handling with explicit cancellation/cleanup.
- Adds regression coverage in `tests/nat/eval/test_evaluate.py` for error paths and coroutine reuse behavior.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling and cleanup for local workflow execution failures, ensuring pending tasks are properly cancelled
  * Improved asynchronous task management to prevent spurious coroutine warnings

* **Tests**
  * Added test coverage for error scenarios in local workflow execution

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->