### PR TITLE
fix(weave): ensure contextmanager protocol is implemented for weave mock

### DIFF
--- a/packages/nvidia_nat_weave/tests/test_fastapi_plugin_worker.py
+++ b/packages/nvidia_nat_weave/tests/test_fastapi_plugin_worker.py
@@ -42,6 +42,8 @@ def fixture_setup_env() -> None:
 def fixture_mock_weave(monkeypatch):
     """Mock weave.init and weave client context to avoid authentication issues in unit tests."""
     mock_weave_client = MagicMock()
+    mock_weave_client.__enter__.return_value = mock_weave_client
+    mock_weave_client.__exit__.return_value = None
 
     # Mock weave.init
     monkeypatch.setattr("weave.init", lambda *args, **kwargs: mock_weave_client, raising=False)


### PR DESCRIPTION
## Description

Occasionally we observe the following error in CI, specifically on ARM runners:
```
packages/nvidia_nat_weave/tests/test_fastapi_plugin_worker.py::test_weave_worker_adds_standard_routes - TypeError: 'Mock' object does not support the context manager protocol
```

This PR fixes that by ensuring what is mocked always supports that protocol.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test infrastructure to support context manager patterns for improved test coverage compatibility.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->