### PR TITLE
Update the build_wheel CI script to test that built wheels are installable

### DIFF
--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -246,6 +246,7 @@ function install_python_versions() {
 
          # In common.sh we set this to never, we want to override that here
          UV_PYTHON_DOWNLOADS="manual" uv python install --managed-python ${pyver}
+         rapids-logger "✓ Successfully installed Python ${pyver}"
       fi
    done
 }

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -222,6 +222,7 @@ function get_lfs_files() {
     git lfs ls-files
 }
 
+
 function cleanup {
    # Restore the original directory
    popd &> /dev/null

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -15,6 +15,8 @@
 
 export SCRIPT_DIR=${SCRIPT_DIR:-"$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"}
 
+export SUPPORTED_PYTHON_VERSIONS=("3.11" "3.12" "3.13")
+
 # The root to the NAT repo
 export PROJECT_ROOT=${PROJECT_ROOT:-"$(realpath ${SCRIPT_DIR}/../..)"}
 
@@ -222,6 +224,24 @@ function get_lfs_files() {
     git lfs ls-files
 }
 
+function install_python_versions() {
+   # This is not normally needed as our containers contain the needed python version. This is only needed for CI stages
+   # which need to support multiple python versions in a single stage, such as the build_wheel stage.
+   for pyver in "${SUPPORTED_PYTHON_VERSIONS[@]}"; do
+      set +e
+      # The managed python flag is needed since the OS's copy of python does not include C headers needed to build some
+      # dependencies, specifically ruamel-yaml-clibz which is needed for semantic-kernel
+      uv python find --managed-python ${pyver} &> /dev/null
+      PYTHON_FIND_RESULT=$?
+      set -e
+      if [[ ${PYTHON_FIND_RESULT} -ne 0 ]]; then
+         rapids-logger "Downloading Python version ${pyver}"
+
+         # In common.sh we set this to never, we want to override that here
+         UV_PYTHON_DOWNLOADS="manual" uv python install --managed-python ${pyver}
+      fi
+   done
+}
 
 function cleanup {
    # Restore the original directory

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -238,7 +238,7 @@ function install_python_versions() {
       set +e
       # The managed python flag is needed since the OS's copy of python does not include C headers needed to build some
       # dependencies, specifically ruamel-yaml-clibz which is needed for semantic-kernel
-      uv python find --managed-python ${pyver} &> /dev/null
+      uv python find --managed-python "${pyver}" &> /dev/null
       PYTHON_FIND_RESULT=$?
       set -e
       if [[ ${PYTHON_FIND_RESULT} -ne 0 ]]; then

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -226,7 +226,7 @@ function get_lfs_files() {
 
 function install_python_versions() {
    # This is the version of python currently installed
-   local current_python_version=$(python --version | awk '{split($0, a, "."); print a[1]"."a[2]}')
+   local current_python_version=$(echo ${PYTHON_VERSION} | awk '{split($0, a, "."); print a[1]"."a[2]}')
 
    # This is not normally needed as our containers contain the needed python version. This is only needed for CI stages
    # which need to support multiple python versions in a single stage, such as the build_wheel stage.

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -225,9 +225,16 @@ function get_lfs_files() {
 }
 
 function install_python_versions() {
+   # This is the version of python currently installed
+   local current_python_version=$(python --version | awk '{split($0, a, "."); print a[1]"."a[2]}')
+
    # This is not normally needed as our containers contain the needed python version. This is only needed for CI stages
    # which need to support multiple python versions in a single stage, such as the build_wheel stage.
    for pyver in "${SUPPORTED_PYTHON_VERSIONS[@]}"; do
+      if [[ "${pyver}" == "${current_python_version}" ]]; then
+         continue
+      fi
+
       set +e
       # The managed python flag is needed since the OS's copy of python does not include C headers needed to build some
       # dependencies, specifically ruamel-yaml-clibz which is needed for semantic-kernel

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -90,7 +90,8 @@ for whl in "${MOVED_WHEELS[@]}"; do
         UV_VENV_RESULT=$?
 
         if [[ ${UV_VENV_RESULT} -ne 0 ]]; then
-            rapids-logger "Error, failed to create uv venv with Python ${pyver} for wheel ${whl} : ${UV_VENV_OUT}"
+            rapids-logger "Error, failed to create uv venv with Python ${pyver} for wheel ${whl}"
+            echo "${UV_VENV_OUT}"
             exit ${UV_VENV_RESULT}
         fi
 
@@ -101,7 +102,8 @@ for whl in "${MOVED_WHEELS[@]}"; do
         INSTALL_RESULT=$?
 
         if [[ ${INSTALL_RESULT} -ne 0 ]]; then
-            rapids-logger "Error, failed to install wheel ${whl} with Python ${pyver} : ${UV_PIP_OUT}"
+            rapids-logger "Error, failed to install wheel ${whl} with Python ${pyver}"
+            echo "${UV_PIP_OUT}"
             exit ${INSTALL_RESULT}
         fi
 
@@ -110,7 +112,8 @@ for whl in "${MOVED_WHEELS[@]}"; do
         IMPORT_TEST_RESULT=$?
 
        if [[ ${IMPORT_TEST_RESULT} -ne 0 ]]; then
-            rapids-logger "Error, failed to import nat from wheel ${whl} with Python ${pyver} : ${PYTHON_IMPORT_OUT}"
+            rapids-logger "Error, failed to import nat from wheel ${whl} with Python ${pyver}"
+            echo "${PYTHON_IMPORT_OUT}"
             exit ${IMPORT_TEST_RESULT}
         fi
 
@@ -118,7 +121,8 @@ for whl in "${MOVED_WHEELS[@]}"; do
         NAT_CMD_EXIT_CODE=$?
 
         if [[ ${NAT_CMD_EXIT_CODE} -ne 0 ]]; then
-            rapids-logger "Error 'nat --version' command failed exit code ${NAT_CMD_EXIT_CODE} from wheel ${whl} with Python ${pyver} : ${REPORTED_VERSION}"
+            rapids-logger "Error 'nat --version' command failed exit code ${NAT_CMD_EXIT_CODE} from wheel ${whl} with Python ${pyver}"
+            echo "${REPORTED_VERSION}"
             exit ${NAT_CMD_EXIT_CODE}
         fi
 

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -98,6 +98,8 @@ for whl in "${MOVED_WHEELS[@]}"; do
 
         if [[ ${IMPORT_TEST_RESULT} -ne 0 ]]; then
             rapids-logger "Error, failed to import nat from wheel ${whl} with Python ${pyver}"
+            rapids-logger "This may indicate missing dependencies, Python version incompatibility, or build issues"
+            rapids-logger "Check if the wheel includes all necessary binary extensions for this Python version"
             echo "${PYTHON_IMPORT_OUT}"
             exit ${IMPORT_TEST_RESULT}
          fi

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -57,3 +57,41 @@ BUILT_WHEELS=$(find "${WHEELS_BASE_DIR}"/**/ -type f -name "*.whl")
 for whl in ${BUILT_WHEELS}; do
     mv "${whl}" "${WHEELS_BASE_DIR}/"
 done
+
+
+# Test the built wheels
+deactivate
+TEMP_INSTALL_LOCATION="${WORKSPACE_TMP}/wheel_test_env"
+
+PYTHON_VERSIONS_TO_TEST=("3.11" "3.12" "3.13")
+BUILT_WHEELS=$(ls -1 "${WHEELS_BASE_DIR}"/*.whl)
+for whl in ${BUILT_WHEELS}; do
+
+    for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do
+        rapids-logger "Testing wheel: ${whl} with Python ${pyver}"
+        uv venv -p ${pyver} --seed "${TEMP_INSTALL_LOCATION}"
+        source "${TEMP_INSTALL_LOCATION}/bin/activate"
+
+        set +e
+        uv pip install --find-links "${WHEELS_BASE_DIR}" "${whl}"
+        INSTALL_RESULT=$?
+
+        if [[ ${INSTALL_RESULT} -ne 0 ]]; then
+            rapids-logger "Error, failed to install wheel ${whl} with Python ${pyver}"
+            exit ${INSTALL_RESULT}
+        fi
+
+        # run a simple command to verify installation
+        python -c "import nat; print(nat.__version__)"
+        IMPORT_TEST_RESULT=$?
+
+        if [[ ${IMPORT_TEST_RESULT} -ne 0 ]]; then
+            rapids-logger "Error, failed to import nat from wheel ${whl} with Python ${pyver}"
+            exit ${IMPORT_TEST_RESULT}
+        fi
+
+        set -e
+        deactivate
+        rm -rf "${TEMP_INSTALL_LOCATION}"
+    done
+done

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -54,8 +54,11 @@ fi
 
 # Flatten out the wheels into a single directory for upload
 BUILT_WHEELS=$(find "${WHEELS_BASE_DIR}"/**/ -type f -name "*.whl")
+MOVED_WHEELS=()
 for whl in ${BUILT_WHEELS}; do
-    mv "${whl}" "${WHEELS_BASE_DIR}/"
+    dest_wheel_name="${WHEELS_BASE_DIR}/$(basename "${whl}")"
+    mv "${whl}" "${dest_wheel_name}"
+    MOVED_WHEELS+=("${dest_wheel_name}")
 done
 
 
@@ -64,8 +67,6 @@ deactivate
 TEMP_INSTALL_LOCATION="${WORKSPACE_TMP}/wheel_test_env"
 
 PYTHON_VERSIONS_TO_TEST=("3.11" "3.12" "3.13")
-BUILT_WHEELS=$(ls -1 "${WHEELS_BASE_DIR}"/*.whl)
-
 for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do
     set +e
     uv python find ${pyver} &> /dev/null
@@ -79,7 +80,7 @@ for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do
     fi
 done
 
-for whl in ${BUILT_WHEELS}; do
+for whl in "${MOVED_WHEELS[@]}"; do
 
     for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do
         rapids-logger "Testing wheel: ${whl} with Python ${pyver}"

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -96,11 +96,11 @@ for whl in "${MOVED_WHEELS[@]}"; do
         PYTHON_IMPORT_OUT=$(python -c "import nat" 2>&1)
         IMPORT_TEST_RESULT=$?
 
-       if [[ ${IMPORT_TEST_RESULT} -ne 0 ]]; then
+        if [[ ${IMPORT_TEST_RESULT} -ne 0 ]]; then
             rapids-logger "Error, failed to import nat from wheel ${whl} with Python ${pyver}"
             echo "${PYTHON_IMPORT_OUT}"
             exit ${IMPORT_TEST_RESULT}
-        fi
+         fi
 
         REPORTED_VERSION=$(nat --version 2>&1)
         NAT_CMD_EXIT_CODE=$?

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -83,7 +83,7 @@ for whl in "${MOVED_WHEELS[@]}"; do
         source "${TEMP_INSTALL_LOCATION}/bin/activate"
 
         set +e
-        UV_PIP_OUT=$(uv pip install -q --prerelease=allow --no-build --find-links "${WHEELS_BASE_DIR}" "${whl}" 2>&1)
+        UV_PIP_OUT=$(uv pip install -q --prerelease=allow --find-links "${WHEELS_BASE_DIR}" "${whl}" 2>&1)
         INSTALL_RESULT=$?
 
         if [[ ${INSTALL_RESULT} -ne 0 ]]; then

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -65,26 +65,11 @@ done
 # Test the built wheels
 deactivate
 TEMP_INSTALL_LOCATION="${WORKSPACE_TMP}/wheel_test_env"
-
-PYTHON_VERSIONS_TO_TEST=("3.11" "3.12" "3.13")
-for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do
-    set +e
-    # The managed python flag is needed since the OS's copy of python does not include C headers needed to build some
-    # dependencies, specifically ruamel-yaml-clibz which is needed for semantic-kernel
-    uv python find --managed-python ${pyver} &> /dev/null
-    PYTHON_FIND_RESULT=$?
-    set -e
-    if [[ ${PYTHON_FIND_RESULT} -ne 0 ]]; then
-        rapids-logger "Downloading Python version ${pyver}"
-
-        # In common.sh we set this to never, we want to override that here
-        UV_PYTHON_DOWNLOADS="manual" uv python install --managed-python ${pyver}
-    fi
-done
+install_python_versions
 
 for whl in "${MOVED_WHEELS[@]}"; do
 
-    for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do
+    for pyver in "${SUPPORTED_PYTHON_VERSIONS[@]}"; do
         rapids-logger "Testing wheel: ${whl} with Python ${pyver}"
         UV_VENV_OUT=$(uv venv -p ${pyver} --seed "${TEMP_INSTALL_LOCATION}" 2>&1)
         UV_VENV_RESULT=$?

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -83,7 +83,7 @@ for whl in "${MOVED_WHEELS[@]}"; do
         source "${TEMP_INSTALL_LOCATION}/bin/activate"
 
         set +e
-        UV_PIP_OUT=$(uv pip install -q --prerelease=allow --find-links "${WHEELS_BASE_DIR}" "${whl}" 2>&1)
+        UV_PIP_OUT=$(uv pip install -q --prerelease=allow --no-build --find-links "${WHEELS_BASE_DIR}" "${whl}" 2>&1)
         INSTALL_RESULT=$?
 
         if [[ ${INSTALL_RESULT} -ne 0 ]]; then

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -86,24 +86,31 @@ for whl in "${MOVED_WHEELS[@]}"; do
 
     for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do
         rapids-logger "Testing wheel: ${whl} with Python ${pyver}"
-        uv venv -p ${pyver} --seed "${TEMP_INSTALL_LOCATION}"
+        UV_VENV_OUT=$(uv venv -p ${pyver} --seed "${TEMP_INSTALL_LOCATION}" 2>&1)
+        UV_VENV_RESULT=$?
+
+        if [[ ${UV_VENV_RESULT} -ne 0 ]]; then
+            rapids-logger "Error, failed to create uv venv with Python ${pyver} for wheel ${whl} : ${UV_VENV_OUT}"
+            exit ${UV_VENV_RESULT}
+        fi
+
         source "${TEMP_INSTALL_LOCATION}/bin/activate"
 
         set +e
-        uv pip install --prerelease=allow --find-links "${WHEELS_BASE_DIR}" "${whl}"
+        UV_PIP_OUT=$(uv pip install --prerelease=allow --find-links "${WHEELS_BASE_DIR}" "${whl}" 2>&1)
         INSTALL_RESULT=$?
 
         if [[ ${INSTALL_RESULT} -ne 0 ]]; then
-            rapids-logger "Error, failed to install wheel ${whl} with Python ${pyver}"
+            rapids-logger "Error, failed to install wheel ${whl} with Python ${pyver} : ${UV_PIP_OUT}"
             exit ${INSTALL_RESULT}
         fi
 
         # run a simple command to verify installation
-        python -c "import nat"
+        PYTHON_IMPORT_OUT=$(PYTHON_IMPpython -c "import nat" 2>&1)
         IMPORT_TEST_RESULT=$?
 
        if [[ ${IMPORT_TEST_RESULT} -ne 0 ]]; then
-            rapids-logger "Error, failed to import nat from wheel ${whl} with Python ${pyver}"
+            rapids-logger "Error, failed to import nat from wheel ${whl} with Python ${pyver} : ${PYTHON_IMPORT_OUT}"
             exit ${IMPORT_TEST_RESULT}
         fi
 

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -106,7 +106,7 @@ for whl in "${MOVED_WHEELS[@]}"; do
         fi
 
         # run a simple command to verify installation
-        PYTHON_IMPORT_OUT=$(PYTHON_IMPpython -c "import nat" 2>&1)
+        PYTHON_IMPORT_OUT=$(python -c "import nat" 2>&1)
         IMPORT_TEST_RESULT=$?
 
        if [[ ${IMPORT_TEST_RESULT} -ne 0 ]]; then

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -65,6 +65,20 @@ TEMP_INSTALL_LOCATION="${WORKSPACE_TMP}/wheel_test_env"
 
 PYTHON_VERSIONS_TO_TEST=("3.11" "3.12" "3.13")
 BUILT_WHEELS=$(ls -1 "${WHEELS_BASE_DIR}"/*.whl)
+
+for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do
+    set +e
+    uv python find ${pyver} &> /dev/null
+    PYTHON_FIND_RESULT=$?
+    set -e
+    if [[ ${PYTHON_FIND_RESULT} -ne 0 ]]; then
+        rapids-logger "Downloading Python version ${pyver} for testing"
+
+        # In common.sh we set this to never, we want to override that for testing
+        UV_PYTHON_DOWNLOADS="manual" uv python install ${pyver}
+    fi
+done
+
 for whl in ${BUILT_WHEELS}; do
 
     for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -82,12 +82,20 @@ for whl in ${BUILT_WHEELS}; do
         fi
 
         # run a simple command to verify installation
-        python -c "import nat; print(nat.__version__)"
+        python -c "import nat"
         IMPORT_TEST_RESULT=$?
 
-        if [[ ${IMPORT_TEST_RESULT} -ne 0 ]]; then
+       if [[ ${IMPORT_TEST_RESULT} -ne 0 ]]; then
             rapids-logger "Error, failed to import nat from wheel ${whl} with Python ${pyver}"
             exit ${IMPORT_TEST_RESULT}
+        fi
+
+        REPORTED_VERSION=$(nat --version 2>&1)
+        NAT_CMD_EXIT_CODE=$?
+
+        if [[ ${NAT_CMD_EXIT_CODE} -ne 0 ]]; then
+            rapids-logger "Error 'nat --version' command failed exit code ${NAT_CMD_EXIT_CODE} from wheel ${whl} with Python ${pyver} : ${REPORTED_VERSION}"
+            exit ${NAT_CMD_EXIT_CODE}
         fi
 
         set -e

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -72,9 +72,9 @@ for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do
     PYTHON_FIND_RESULT=$?
     set -e
     if [[ ${PYTHON_FIND_RESULT} -ne 0 ]]; then
-        rapids-logger "Downloading Python version ${pyver} for testing"
+        rapids-logger "Downloading Python version ${pyver}"
 
-        # In common.sh we set this to never, we want to override that for testing
+        # In common.sh we set this to never, we want to override that here
         UV_PYTHON_DOWNLOADS="manual" uv python install ${pyver}
     fi
 done
@@ -87,7 +87,7 @@ for whl in ${BUILT_WHEELS}; do
         source "${TEMP_INSTALL_LOCATION}/bin/activate"
 
         set +e
-        uv pip install --find-links "${WHEELS_BASE_DIR}" "${whl}"
+        uv pip install --prerelease=allow --find-links "${WHEELS_BASE_DIR}" "${whl}"
         INSTALL_RESULT=$?
 
         if [[ ${INSTALL_RESULT} -ne 0 ]]; then

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -71,7 +71,7 @@ for whl in "${MOVED_WHEELS[@]}"; do
 
     for pyver in "${SUPPORTED_PYTHON_VERSIONS[@]}"; do
         rapids-logger "Testing wheel: ${whl} with Python ${pyver}"
-        UV_VENV_OUT=$(uv venv -p ${pyver} --seed "${TEMP_INSTALL_LOCATION}" 2>&1)
+        UV_VENV_OUT=$(uv venv -q -p ${pyver} --seed "${TEMP_INSTALL_LOCATION}" 2>&1)
         UV_VENV_RESULT=$?
 
         if [[ ${UV_VENV_RESULT} -ne 0 ]]; then
@@ -83,7 +83,7 @@ for whl in "${MOVED_WHEELS[@]}"; do
         source "${TEMP_INSTALL_LOCATION}/bin/activate"
 
         set +e
-        UV_PIP_OUT=$(uv pip install --prerelease=allow --find-links "${WHEELS_BASE_DIR}" "${whl}" 2>&1)
+        UV_PIP_OUT=$(uv pip install -q --prerelease=allow --find-links "${WHEELS_BASE_DIR}" "${whl}" 2>&1)
         INSTALL_RESULT=$?
 
         if [[ ${INSTALL_RESULT} -ne 0 ]]; then

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -69,14 +69,16 @@ TEMP_INSTALL_LOCATION="${WORKSPACE_TMP}/wheel_test_env"
 PYTHON_VERSIONS_TO_TEST=("3.11" "3.12" "3.13")
 for pyver in "${PYTHON_VERSIONS_TO_TEST[@]}"; do
     set +e
-    uv python find ${pyver} &> /dev/null
+    # The managed python flag is needed since the OS's copy of python does not include C headers needed to build some
+    # dependencies, specifically ruamel-yaml-clibz which is needed for semantic-kernel
+    uv python find --managed-python ${pyver} &> /dev/null
     PYTHON_FIND_RESULT=$?
     set -e
     if [[ ${PYTHON_FIND_RESULT} -ne 0 ]]; then
         rapids-logger "Downloading Python version ${pyver}"
 
         # In common.sh we set this to never, we want to override that here
-        UV_PYTHON_DOWNLOADS="manual" uv python install ${pyver}
+        UV_PYTHON_DOWNLOADS="manual" uv python install --managed-python ${pyver}
     fi
 done
 

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -100,7 +100,7 @@ for whl in "${MOVED_WHEELS[@]}"; do
             rapids-logger "Error, failed to import nat from wheel ${whl} with Python ${pyver}"
             echo "${PYTHON_IMPORT_OUT}"
             exit ${IMPORT_TEST_RESULT}
-         fi
+        fi
 
         REPORTED_VERSION=$(nat --version 2>&1)
         NAT_CMD_EXIT_CODE=$?

--- a/packages/nvidia_nat_weave/pyproject.toml
+++ b/packages/nvidia_nat_weave/pyproject.toml
@@ -29,8 +29,8 @@ dependencies = [
   # transitive dependencies
   # Without this pin, anyone installing nvidia-nat-weave with Python 3.13 gets blis 0.7.11 which doesn't contain a
   # pre-built binary wheel for Python 3.13, leading to a build from source that fails to build.
-  "blis~=1.3"
-  "fickling>=0.1.7,<1.0.0",
+  "blis~=1.3",
+  "fickling>=0.1.7,<1.0.0"
 ]
 requires-python = ">=3.11,<3.14"
 description = "Subpackage for Weave integration in NeMo Agent toolkit"

--- a/packages/nvidia_nat_weave/pyproject.toml
+++ b/packages/nvidia_nat_weave/pyproject.toml
@@ -28,6 +28,7 @@ dependencies = [
   "weave==0.52.22",
   # transitive dependencies
   "fickling~=0.1.7",
+  "blis~=1.3"
 ]
 requires-python = ">=3.11,<3.14"
 description = "Subpackage for Weave integration in NeMo Agent toolkit"

--- a/packages/nvidia_nat_weave/pyproject.toml
+++ b/packages/nvidia_nat_weave/pyproject.toml
@@ -28,6 +28,8 @@ dependencies = [
   "weave==0.52.22",
   # transitive dependencies
   "fickling~=0.1.7",
+  # Without this pin, anyone installing nvidia-nat-weave with Python 3.13 gets blis 0.7.11 which doesn't contain a
+  # pre-built binary wheel for Python 3.13, leading to a build from source that fails to build.
   "blis~=1.3"
 ]
 requires-python = ">=3.11,<3.14"

--- a/uv.lock
+++ b/uv.lock
@@ -6875,6 +6875,7 @@ requires-dist = [
 name = "nvidia-nat-weave"
 source = { editable = "packages/nvidia_nat_weave" }
 dependencies = [
+    { name = "blis" },
     { name = "fickling" },
     { name = "nvidia-nat" },
     { name = "presidio-analyzer" },
@@ -6884,6 +6885,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "blis", specifier = "~=1.3" },
     { name = "fickling", specifier = ">=0.1.7,<1.0.0" },
     { name = "nvidia-nat", editable = "." },
     { name = "presidio-analyzer", specifier = "~=2.2" },


### PR DESCRIPTION
## Description
* Fix a build issue for nvidia-nat-weave using Python 3.13, currently this package attempts to install blis v0.7.11, which does not contain a pre-built wheel and fails to compile.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now supports Python 3.11, 3.12, and 3.13 and will auto-install missing versions for multi-version stages.
  * Added automated wheel testing that builds, installs, and validates packages across each supported Python version using isolated environments.

* **Bug Fixes**
  * Pinned a dependency to resolve build issues on Python 3.13.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->