### PR TITLE
Fix MCP tool UI display

### DIFF
--- a/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
@@ -1297,7 +1297,7 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                             accessible_functions = await group_instance.get_accessible_functions(
                                 filter_fn=pass_through_filter)
                             configured_full_to_fn = accessible_functions
-                            configured_short_names = {name.split('.', 1)[1] for name in accessible_functions.keys()}
+                            configured_short_names = {name.split('__', 1)[1] for name in accessible_functions.keys()}
                         except Exception as e:
                             logger.exception(f"Failed to get accessible functions for group {group_name}: {e}")
 

--- a/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
@@ -43,6 +43,7 @@ from nat.builder.context import Context
 from nat.builder.eval_builder import WorkflowEvalBuilder
 from nat.builder.evaluator import EvaluatorInfo
 from nat.builder.function import Function
+from nat.builder.function import FunctionGroup
 from nat.builder.workflow_builder import WorkflowBuilder
 from nat.data_models.api_server import ChatRequest
 from nat.data_models.api_server import ChatResponse
@@ -1297,7 +1298,10 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                             accessible_functions = await group_instance.get_accessible_functions(
                                 filter_fn=pass_through_filter)
                             configured_full_to_fn = accessible_functions
-                            configured_short_names = {name.split('__', 1)[1] for name in accessible_functions.keys()}
+                            configured_short_names = {
+                                name.split(FunctionGroup.SEPARATOR, 1)[1]
+                                for name in accessible_functions.keys()
+                            }
                         except Exception as e:
                             logger.exception(f"Failed to get accessible functions for group {group_name}: {e}")
 

--- a/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
@@ -1287,7 +1287,7 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                             session_healthy = False
 
                         # Get workflow function group configuration (configured client-side tools)
-                        configured_short_names: set[str] = set()
+                        configured_short_names: list[str] = []
                         configured_full_to_fn: dict[str, Function] = {}
                         try:
                             # Pass a no-op filter function to bypass any default filtering that might check
@@ -1298,10 +1298,14 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                             accessible_functions = await group_instance.get_accessible_functions(
                                 filter_fn=pass_through_filter)
                             configured_full_to_fn = accessible_functions
-                            configured_short_names = {
-                                name.split(FunctionGroup.SEPARATOR, 1)[1]
-                                for name in accessible_functions.keys()
-                            }
+                            configured_short_names = []
+                            for name in accessible_functions.keys():
+                                if FunctionGroup.SEPARATOR in name:
+                                    configured_short_names.append(name.split(FunctionGroup.SEPARATOR, 1)[1])
+                                elif FunctionGroup.LEGACY_SEPARATOR in name:
+                                    configured_short_names.append(name.split(FunctionGroup.LEGACY_SEPARATOR, 1)[1])
+                                else:
+                                    configured_short_names.append(name)
                         except Exception as e:
                             logger.exception(f"Failed to get accessible functions for group {group_name}: {e}")
 
@@ -1322,7 +1326,13 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                         # Create tool info list (always return configured tools; mark availability)
                         tools_info: list[dict[str, Any]] = []
                         available_count = 0
-                        for wf_fn, fn_short in zip(configured_full_to_fn.values(), configured_short_names):
+                        for full_name, wf_fn in configured_full_to_fn.items():
+                            if FunctionGroup.SEPARATOR in full_name:
+                                fn_short = full_name.split(FunctionGroup.SEPARATOR, 1)[1]
+                            elif FunctionGroup.LEGACY_SEPARATOR in full_name:
+                                fn_short = full_name.split(FunctionGroup.LEGACY_SEPARATOR, 1)[1]
+                            else:
+                                fn_short = full_name
                             orig_name = alias_to_original.get(fn_short, fn_short)
                             available = session_healthy and (orig_name in server_tools)
                             if available:

--- a/tests/nat/front_ends/fastapi/test_mcp_client_endpoint.py
+++ b/tests/nat/front_ends/fastapi/test_mcp_client_endpoint.py
@@ -18,6 +18,7 @@ import pytest_asyncio
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from nat.builder.function import FunctionGroup
 from nat.data_models.config import Config
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
 
@@ -100,7 +101,8 @@ async def test_mcp_client_tool_list_success_with_alias(app_worker):
 
     # Workflow configured function uses the alias name
     group_name = "mcp_group"
-    group_instance = _GroupInstanceStub(client, {f"{group_name}.alias_tool": _FnStub("Overridden desc")})
+    group_instance = _GroupInstanceStub(
+        client, {f"{group_name}{FunctionGroup.SEPARATOR}alias_tool": _FnStub("Overridden desc")})
     configured_group = _ConfiguredGroupStub(cfg, group_instance)
     builder = _BuilderStub({group_name: configured_group})
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Tools were not being displayed in the UI for `mcp_client` function groups. This PR fixes the issue by updating the separator from period to dunder.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed parsing of fully-qualified and aliased function names so tool discovery and initialization are more consistent across contexts, reducing missing or misnamed tools at startup.

* **Tests**
  * Updated tests to reflect the improved naming/lookup behavior for group-qualified functions.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->