### PR TITLE
Add health endpoint to FastAPI server

### DIFF
--- a/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
@@ -341,6 +341,7 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
         await self.add_authorization_route(app)
         await self.add_mcp_client_tool_list_route(app, builder)
         await self.add_monitor_route(app)
+        await self.add_health_route(app)
 
         for ep in self.front_end_config.endpoints:
 
@@ -1511,6 +1512,37 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                           })
 
         logger.info("Added per-user monitoring endpoint at /monitor/users")
+
+    async def add_health_route(self, app: FastAPI) -> None:
+        """Add a health check endpoint to the FastAPI app."""
+
+        class HealthResponse(BaseModel):
+            status: str = Field(description="Health status of the server")
+
+        async def health_check() -> HealthResponse:
+            """Health check endpoint for liveness/readiness probes."""
+            return HealthResponse(status="healthy")
+
+        app.add_api_route(path="/health",
+                          endpoint=health_check,
+                          methods=["GET"],
+                          response_model=HealthResponse,
+                          description="Health check endpoint for liveness/readiness probes",
+                          tags=["Health"],
+                          responses={
+                              200: {
+                                  "description": "Server is healthy",
+                                  "content": {
+                                      "application/json": {
+                                          "example": {
+                                              "status": "healthy"
+                                          }
+                                      }
+                                  }
+                              }
+                          })
+
+        logger.info("Added health check endpoint at /health")
 
     async def _add_flow(self, state: str, flow_state: FlowState):
         async with self._outstanding_flows_lock:

--- a/tests/nat/front_ends/fastapi/test_fastapi_front_end_plugin.py
+++ b/tests/nat/front_ends/fastapi/test_fastapi_front_end_plugin.py
@@ -335,3 +335,17 @@ async def test_static_file_endpoints():
         # GET: Should now 404
         response = await client.get(f"/static/{file_path}")
         assert response.status_code == 404
+
+
+async def test_health_endpoint():
+    """Test that the health endpoint returns healthy status."""
+    config = Config(
+        general=GeneralConfig(front_end=FastApiFrontEndConfig()),
+        workflow=EchoFunctionConfig(),
+    )
+
+    async with build_nat_client(config) as client:
+        response = await client.get("/health")
+
+        assert response.status_code == 200
+        assert response.json() == {"status": "healthy"}


### PR DESCRIPTION
Add GET /health endpoint to nat serve for liveness/readiness probes. Returns {"status": "healthy"} with 200 status code.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
 - Add GET /health endpoint to the FastAPI server (nat serve) for liveness/readiness probes                                                                                                          
 - Endpoint returns {"status": "healthy"} with 200 status code                                                                                                                                       
 - Add unit test for the health endpoint                                                                                                                                                             
                                                                                                                                                                                                      
## Test plan                                                                                                                                                                                           
                                                                                                                                                                                                      
 - Run nat serve with any workflow config and verify curl http://localhost:8000/health returns {"status":"healthy"}                                                                                  
 - Verify endpoint appears in OpenAPI docs at /docs                                                                                                                                                  
 - CI tests pass (test runs when Dask is available) 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a health check endpoint (GET /health) that returns {"status":"healthy"} for real-time availability monitoring.

* **Tests**
  * Added tests verifying the health endpoint returns HTTP 200 and the expected status payload.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->