### PR TITLE
Add `use_native_tool_calling` option to `ReAct` agent

### DIFF
--- a/src/nat/agent/react_agent/agent.py
+++ b/src/nat/agent/react_agent/agent.py
@@ -224,7 +224,7 @@ class ReActAgentGraph(DualNodeAgent):
                                                                 'tool_calls') and output_message.tool_calls:
                         # Extract tool call from structured response
                         tool_call = output_message.tool_calls[0]
-                        tool_name = tool_call.get('name', '')
+                        tool_name = tool_call.get('name', '').strip()
                         tool_args = tool_call.get('args', {})
 
                         # Convert tool args to JSON string for consistency with text parsing

--- a/src/nat/agent/react_agent/agent.py
+++ b/src/nat/agent/react_agent/agent.py
@@ -80,7 +80,8 @@ class ReActAgentGraph(DualNodeAgent):
                  parse_agent_response_max_retries: int = 1,
                  tool_call_max_retries: int = 1,
                  pass_tool_call_errors_to_agent: bool = True,
-                 normalize_tool_input_quotes: bool = True):
+                 normalize_tool_input_quotes: bool = True,
+                 use_native_tool_calling: bool = False):
         super().__init__(llm=llm,
                          tools=tools,
                          callbacks=callbacks,
@@ -91,6 +92,7 @@ class ReActAgentGraph(DualNodeAgent):
         self.tool_call_max_retries = tool_call_max_retries
         self.pass_tool_call_errors_to_agent = pass_tool_call_errors_to_agent
         self.normalize_tool_input_quotes = normalize_tool_input_quotes
+        self.use_native_tool_calling = use_native_tool_calling
         logger.debug(
             "%s Filling the prompt variables 'tools' and 'tool_names', using the tools provided in the config.",
             AGENT_LOG_PREFIX)
@@ -108,19 +110,33 @@ class ReActAgentGraph(DualNodeAgent):
                          f"{INPUT_SCHEMA_MESSAGE.format(schema=tools[-1].input_schema.model_fields)}")
         prompt = prompt.partial(tools=tool_names_and_descriptions, tool_names=tool_names)
         # construct the ReAct Agent
-        self.agent = prompt | self._maybe_bind_llm_and_yield()
+        self.agent = prompt | self._maybe_bind_llm_and_yield(tools if use_native_tool_calling else None)
         self.tools_dict = {tool.name: tool for tool in tools}
         logger.debug("%s Initialized ReAct Agent Graph", AGENT_LOG_PREFIX)
 
-    def _maybe_bind_llm_and_yield(self) -> Runnable[LanguageModelInput, BaseMessage]:
+    def _maybe_bind_llm_and_yield(self,
+                                  tools: list[BaseTool] | None = None) -> Runnable[LanguageModelInput, BaseMessage]:
         """
         Bind additional parameters to the LLM if needed
+        - if native tool calling is enabled, bind tools to the LLM for structured tool_calls
         - if the LLM is a smart model, no need to bind any additional parameters
         - if the LLM is a non-smart model, bind a stop sequence to the LLM
+
+        Args:
+            tools: List of tools to bind for native tool calling. If None, native tool calling is disabled.
 
         Returns:
             Runnable[LanguageModelInput, BaseMessage]: The LLM with any additional parameters bound.
         """
+        # If native tool calling is enabled, bind tools to the LLM
+        if tools is not None:
+            logger.debug("%s Binding tools to LLM for native tool calling", AGENT_LOG_PREFIX)
+            try:
+                return self.llm.bind_tools(tools)
+            except NotImplementedError:
+                logger.warning("%s LLM does not support bind_tools, falling back to text parsing", AGENT_LOG_PREFIX)
+                self.use_native_tool_calling = False
+
         # models that don't need (or don't support)a stop sequence
         smart_models = re.compile(r"gpt-?5", re.IGNORECASE)
         if smart_models.search(str(getattr(self.llm, "model", ""))):
@@ -202,6 +218,27 @@ class ReActAgentGraph(DualNodeAgent):
                 try:
                     # check if the agent has the final answer yet
                     logger.debug("%s Successfully obtained agent response. Parsing agent's response", AGENT_LOG_PREFIX)
+
+                    # Check for native tool calls first (when use_native_tool_calling is enabled)
+                    if self.use_native_tool_calling and hasattr(output_message,
+                                                                'tool_calls') and output_message.tool_calls:
+                        # Extract tool call from structured response
+                        tool_call = output_message.tool_calls[0]
+                        tool_name = tool_call.get('name', '')
+                        tool_args = tool_call.get('args', {})
+
+                        # Convert tool args to JSON string for consistency with text parsing
+                        tool_input_str = json.dumps(tool_args) if isinstance(tool_args, dict) else str(tool_args)
+
+                        agent_output = AgentAction(
+                            tool=tool_name,
+                            tool_input=tool_input_str,
+                            log=str(output_message.content) if output_message.content else f"Calling {tool_name}")
+                        logger.debug("%s Native tool call detected: %s", AGENT_LOG_PREFIX, tool_name)
+                        state.agent_scratchpad += [agent_output]
+                        return state
+
+                    # Fall back to text parsing
                     agent_output = await ReActOutputParser().aparse(output_message.content)
                     logger.debug("%s Successfully parsed agent response after %s attempts", AGENT_LOG_PREFIX, attempt)
                     if isinstance(agent_output, AgentFinish):

--- a/src/nat/agent/react_agent/output_parser.py
+++ b/src/nat/agent/react_agent/output_parser.py
@@ -23,6 +23,7 @@ from langchain_core.exceptions import LangChainException
 from .prompt import SYSTEM_PROMPT
 
 FINAL_ANSWER_ACTION = "Final Answer:"
+FINAL_ANSWER_PATTERN = re.compile(r"final\s+answer\s*:", re.IGNORECASE)
 MISSING_ACTION_AFTER_THOUGHT_ERROR_MESSAGE = "Invalid Format: Missing 'Action:' after 'Thought:'"
 MISSING_ACTION_INPUT_AFTER_ACTION_ERROR_MESSAGE = "Invalid Format: Missing 'Action Input:' after 'Action:'"
 FINAL_ANSWER_AND_PARSABLE_ACTION_ERROR_MESSAGE = ("Parsing LLM output produced both a final answer and a parse-able "
@@ -73,9 +74,17 @@ class ReActOutputParser(AgentOutputParser):
         return SYSTEM_PROMPT
 
     def parse(self, text: str) -> AgentAction | AgentFinish:
-        includes_answer = FINAL_ANSWER_ACTION in text
-        regex = r"Action\s*\d*\s*:[\s]*(.*?)\s*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*?)(?=\s*[\n|\s]\s*Observation\b|$)"
-        action_match = re.search(regex, text, re.DOTALL)
+        includes_answer = bool(FINAL_ANSWER_PATTERN.search(text))
+
+        # More lenient regex patterns (case-insensitive):
+        # 1. Primary pattern: "Action: X Action Input: Y" or "Action: X Input: Y"
+        # 2. Accepts variations in whitespace and optional "Action" prefix before "Input"
+        regex_primary = (
+            r"action\s*\d*\s*:\s*(.*?)\s*"  # "Action:" (case-insensitive)
+            r"(?:action\s*\d*\s*)?input\s*\d*\s*:\s*"  # "Action Input:" or just "Input:"
+            r"(.*?)(?=\s*[\n|\s]\s*observation\b|$)"  # Until "Observation" or end
+        )
+        action_match = re.search(regex_primary, text, re.DOTALL | re.IGNORECASE)
         if action_match:
             if includes_answer:
                 raise ReActOutputParserException(
@@ -89,12 +98,18 @@ class ReActOutputParser(AgentOutputParser):
             return AgentAction(action, tool_input, text)
 
         if includes_answer:
+            # Use case-insensitive split for final answer extraction
+            final_answer_match = FINAL_ANSWER_PATTERN.search(text)
+            if final_answer_match:
+                answer_text = text[final_answer_match.end():].strip()
+                return AgentFinish({"output": answer_text}, text)
             return AgentFinish({"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text)
 
-        if not re.search(r"Action\s*\d*\s*:[\s]*(.*?)", text, re.DOTALL):
+        # Check for missing components with case-insensitive patterns
+        if not re.search(r"action\s*\d*\s*:\s*(.*?)", text, re.DOTALL | re.IGNORECASE):
             raise ReActOutputParserException(observation=MISSING_ACTION_AFTER_THOUGHT_ERROR_MESSAGE,
                                              missing_action=True)
-        if not re.search(r"[\s]*Action\s*\d*\s*Input\s*\d*\s*:[\s]*(.*)", text, re.DOTALL):
+        if not re.search(r"[\s]*(?:action\s*\d*\s*)?input\s*\d*\s*:\s*(.*)", text, re.DOTALL | re.IGNORECASE):
             raise ReActOutputParserException(observation=MISSING_ACTION_INPUT_AFTER_ACTION_ERROR_MESSAGE,
                                              missing_action_input=True)
         raise ReActOutputParserException(f"Could not parse LLM output: `{text}`")

--- a/src/nat/agent/react_agent/register.py
+++ b/src/nat/agent/react_agent/register.py
@@ -67,6 +67,11 @@ class ReActAgentWorkflowConfig(AgentBaseConfig, OptimizableMixin, name="react_ag
         default=True,
         description="Whether to replace single quotes with double quotes in the tool input. "
         "This is useful for tools that expect structured json input.")
+    use_native_tool_calling: bool = Field(
+        default=False,
+        description="Whether to use native tool calling via the LLM's tool API (bind_tools). "
+        "When enabled, tool schemas are sent to the LLM, which returns structured tool_calls "
+        "instead of requiring text parsing. This is more reliable for LLMs that support tool calling.")
     system_prompt: str | None = Field(
         default=None,
         description="Provides the SYSTEM_PROMPT to use with the agent")  # defaults to SYSTEM_PROMPT in prompt.py
@@ -114,7 +119,8 @@ async def react_agent_workflow(config: ReActAgentWorkflowConfig, builder: Builde
         parse_agent_response_max_retries=config.parse_agent_response_max_retries,
         tool_call_max_retries=config.tool_call_max_retries,
         pass_tool_call_errors_to_agent=config.pass_tool_call_errors_to_agent,
-        normalize_tool_input_quotes=config.normalize_tool_input_quotes).build_graph()
+        normalize_tool_input_quotes=config.normalize_tool_input_quotes,
+        use_native_tool_calling=config.use_native_tool_calling).build_graph()
 
     async def _response_fn(chat_request_or_message: ChatRequestOrMessage) -> ChatResponse | str:
         """

--- a/tests/nat/agent/test_react.py
+++ b/tests/nat/agent/test_react.py
@@ -15,6 +15,7 @@
 
 import pytest
 from langchain_core.agents import AgentAction
+from langchain_core.agents import AgentFinish
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
 from langchain_core.messages.tool import ToolMessage
@@ -967,3 +968,235 @@ async def test_quote_normalization_json_parsing_logic(mock_config_react_agent, m
     # Should receive the raw string (JSON parsing failed due to no normalization)
     # The full JSON string should be passed as the query parameter
     assert tool_input_single in response_content and "type: str" in response_content
+
+
+# =============================================================================
+# Tests for lenient regex parsing (Issue #1308)
+# =============================================================================
+
+
+async def test_output_parser_case_insensitive_action(mock_react_output_parser):
+    """Test that lowercase 'action' is parsed correctly."""
+    mock_input = 'Thought: I need to search\naction: Tool A\nAction Input: search query\nObservation:'
+    test_output = await mock_react_output_parser.aparse(mock_input)
+    assert isinstance(test_output, AgentAction)
+    assert test_output.tool == "Tool A"
+    assert test_output.tool_input == "search query"
+
+
+async def test_output_parser_case_insensitive_action_input(mock_react_output_parser):
+    """Test that lowercase 'action input' is parsed correctly."""
+    mock_input = 'Thought: I need to search\nAction: Tool A\naction input: search query\nObservation:'
+    test_output = await mock_react_output_parser.aparse(mock_input)
+    assert isinstance(test_output, AgentAction)
+    assert test_output.tool == "Tool A"
+    assert test_output.tool_input == "search query"
+
+
+async def test_output_parser_all_lowercase(mock_react_output_parser):
+    """Test that all lowercase 'action' and 'action input' are parsed correctly."""
+    mock_input = 'thought: I need to search\naction: Tool A\naction input: search query\nobservation:'
+    test_output = await mock_react_output_parser.aparse(mock_input)
+    assert isinstance(test_output, AgentAction)
+    assert test_output.tool == "Tool A"
+    assert test_output.tool_input == "search query"
+
+
+async def test_output_parser_input_only_instead_of_action_input(mock_react_output_parser):
+    """Test that 'Input:' without 'Action' prefix is parsed correctly."""
+    mock_input = 'Thought: I need to search\nAction: Tool A\nInput: search query\nObservation:'
+    test_output = await mock_react_output_parser.aparse(mock_input)
+    assert isinstance(test_output, AgentAction)
+    assert test_output.tool == "Tool A"
+    assert test_output.tool_input == "search query"
+
+
+async def test_output_parser_input_lowercase(mock_react_output_parser):
+    """Test that lowercase 'input:' is parsed correctly."""
+    mock_input = 'Thought: I need to search\nAction: Tool A\ninput: search query\nObservation:'
+    test_output = await mock_react_output_parser.aparse(mock_input)
+    assert isinstance(test_output, AgentAction)
+    assert test_output.tool == "Tool A"
+    assert test_output.tool_input == "search query"
+
+
+async def test_output_parser_case_insensitive_final_answer(mock_react_output_parser):
+    """Test that case-insensitive 'Final Answer' is parsed correctly."""
+    mock_input = 'Thought: I now know the answer\nfinal answer: The result is 42'
+    test_output = await mock_react_output_parser.aparse(mock_input)
+    assert isinstance(test_output, AgentFinish)
+    assert test_output.return_values['output'] == 'The result is 42'
+
+
+async def test_output_parser_mixed_case_final_answer(mock_react_output_parser):
+    """Test that mixed case 'FINAL ANSWER' is parsed correctly."""
+    mock_input = 'Thought: I now know the answer\nFINAL ANSWER: The result is 42'
+    test_output = await mock_react_output_parser.aparse(mock_input)
+    assert isinstance(test_output, AgentFinish)
+    assert test_output.return_values['output'] == 'The result is 42'
+
+
+async def test_output_parser_extra_whitespace(mock_react_output_parser):
+    """Test that extra whitespace in action/input labels is handled correctly."""
+    mock_input = 'Thought: I need to search\nAction  :  Tool A\nAction   Input  :  search query\nObservation:'
+    test_output = await mock_react_output_parser.aparse(mock_input)
+    assert isinstance(test_output, AgentAction)
+    assert test_output.tool == "Tool A"
+    assert test_output.tool_input == "search query"
+
+
+async def test_output_parser_json_input_with_lowercase(mock_react_output_parser):
+    """Test that JSON input with lowercase action/input is parsed correctly."""
+    mock_action = 'SearchTool'
+    mock_json_input = '{"query": "what is NIM"}'
+    mock_input = \
+    f'thought: I need to call the search tool\naction: {mock_action}\ninput: {mock_json_input}\nobservation'
+    test_output = await mock_react_output_parser.aparse(mock_input)
+    assert isinstance(test_output, AgentAction)
+    assert test_output.tool == mock_action
+    assert test_output.tool_input == mock_json_input
+
+
+# =============================================================================
+# Tests for native tool calling support (Issue #1308)
+# =============================================================================
+
+
+def test_config_use_native_tool_calling_default():
+    """Test that use_native_tool_calling defaults to False."""
+    config = ReActAgentWorkflowConfig(tool_names=['test'], llm_name='test')
+    assert config.use_native_tool_calling is False
+
+
+def test_config_use_native_tool_calling_explicit_true():
+    """Test that use_native_tool_calling can be set to True."""
+    config = ReActAgentWorkflowConfig(tool_names=['test'], llm_name='test', use_native_tool_calling=True)
+    assert config.use_native_tool_calling is True
+
+
+def test_react_agent_init_with_native_tool_calling_disabled(mock_config_react_agent, mock_llm, mock_tool):
+    """Test ReActAgentGraph initialization with native tool calling disabled."""
+    tools = [mock_tool('Tool A'), mock_tool('Tool B')]
+    prompt = create_react_agent_prompt(mock_config_react_agent)
+
+    agent = ReActAgentGraph(llm=mock_llm,
+                            prompt=prompt,
+                            tools=tools,
+                            detailed_logs=False,
+                            use_native_tool_calling=False)
+    assert agent.use_native_tool_calling is False
+
+
+def test_react_agent_init_with_native_tool_calling_enabled(mock_config_react_agent, mock_llm, mock_tool):
+    """Test ReActAgentGraph initialization with native tool calling enabled."""
+    tools = [mock_tool('Tool A'), mock_tool('Tool B')]
+    prompt = create_react_agent_prompt(mock_config_react_agent)
+
+    agent = ReActAgentGraph(llm=mock_llm, prompt=prompt, tools=tools, detailed_logs=False, use_native_tool_calling=True)
+    assert agent.use_native_tool_calling is True
+
+
+async def test_agent_node_native_tool_calling(mock_config_react_agent, mock_llm, mock_tool):
+    """Test that native tool calls are properly extracted from LLM response."""
+    from unittest.mock import AsyncMock
+    from unittest.mock import patch
+
+    tools = [mock_tool('Tool A'), mock_tool('Tool B')]
+    prompt = create_react_agent_prompt(mock_config_react_agent)
+
+    agent = ReActAgentGraph(llm=mock_llm, prompt=prompt, tools=tools, detailed_logs=False, use_native_tool_calling=True)
+
+    # Create a mock message with tool_calls
+    mock_response = AIMessage(content="I need to call Tool A to get the answer",
+                              tool_calls=[{
+                                  "name": "Tool A",
+                                  "args": {
+                                      "query": "test query"
+                                  },
+                                  "id": "call_123",
+                                  "type": "tool_call"
+                              }])
+
+    state = ReActGraphState(messages=[HumanMessage(content="mock tool call")])
+
+    with patch.object(agent, '_stream_llm', new_callable=AsyncMock) as mock_stream_llm:
+        mock_stream_llm.return_value = mock_response
+
+        result_state = await agent.agent_node(state)
+
+        # Verify that the tool call was extracted
+        assert len(result_state.agent_scratchpad) == 1
+        agent_action = result_state.agent_scratchpad[0]
+        assert isinstance(agent_action, AgentAction)
+        assert agent_action.tool == "Tool A"
+        assert '"query": "test query"' in agent_action.tool_input
+
+
+async def test_agent_node_native_tool_calling_fallback_to_text_parsing(mock_config_react_agent, mock_llm, mock_tool):
+    """Test that agent falls back to text parsing when no tool_calls in response."""
+    from unittest.mock import AsyncMock
+    from unittest.mock import patch
+
+    tools = [mock_tool('Tool A'), mock_tool('Tool B')]
+    prompt = create_react_agent_prompt(mock_config_react_agent)
+
+    agent = ReActAgentGraph(llm=mock_llm, prompt=prompt, tools=tools, detailed_logs=False, use_native_tool_calling=True)
+
+    # Create a mock message without tool_calls (text-based response)
+    mock_response = AIMessage(
+        content="Thought: I need to search\nAction: Tool A\nAction Input: test query\nObservation:",
+        tool_calls=[]  # No tool calls
+    )
+
+    state = ReActGraphState(messages=[HumanMessage(content="test question")])
+
+    with patch.object(agent, '_stream_llm', new_callable=AsyncMock) as mock_stream_llm:
+        mock_stream_llm.return_value = mock_response
+
+        result_state = await agent.agent_node(state)
+
+        # Verify that text parsing was used as fallback
+        assert len(result_state.agent_scratchpad) == 1
+        agent_action = result_state.agent_scratchpad[0]
+        assert isinstance(agent_action, AgentAction)
+        assert agent_action.tool == "Tool A"
+        assert agent_action.tool_input == "test query"
+
+
+async def test_agent_node_native_tool_calling_with_dict_args(mock_config_react_agent, mock_llm, mock_tool):
+    """Test that tool call with dict args is properly converted to JSON string."""
+    from unittest.mock import AsyncMock
+    from unittest.mock import patch
+
+    tools = [mock_tool('Tool A')]
+    prompt = create_react_agent_prompt(mock_config_react_agent)
+
+    agent = ReActAgentGraph(llm=mock_llm, prompt=prompt, tools=tools, detailed_logs=False, use_native_tool_calling=True)
+
+    # Create a mock message with complex dict args
+    mock_response = AIMessage(content="Calling the tool",
+                              tool_calls=[{
+                                  "name": "Tool A",
+                                  "args": {
+                                      "query": "search term", "limit": 10, "nested": {
+                                          "key": "value"
+                                      }
+                                  },
+                                  "id": "call_456",
+                                  "type": "tool_call"
+                              }])
+
+    state = ReActGraphState(messages=[HumanMessage(content="test")])
+
+    with patch.object(agent, '_stream_llm', new_callable=AsyncMock) as mock_stream_llm:
+        mock_stream_llm.return_value = mock_response
+
+        result_state = await agent.agent_node(state)
+
+        agent_action = result_state.agent_scratchpad[0]
+        # Verify the tool input is a JSON string
+        import json
+        parsed = json.loads(agent_action.tool_input)
+        assert parsed["query"] == "search term"
+        assert parsed["limit"] == 10
+        assert parsed["nested"]["key"] == "value"


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes #1308 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional native tool-calling mode allowing the LLM to return structured tool_calls for direct tool invocation.
  * Configuration flag to enable/disable native tool calling.

* **Bug Fixes / Improvements**
  * More lenient, case-insensitive parsing for actions, inputs, and final answers; better handling of combined final-answer+action cases.
  * Fallback to text-based parsing when native binding isn't available.

* **Tests**
  * Expanded tests covering parsing variants, native tool-call behavior, and JSON tool inputs.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->