### PR TITLE
Escape special characters in Redis user_id for vector search

### DIFF
--- a/packages/nvidia_nat_redis/src/nat/plugins/redis/redis_editor.py
+++ b/packages/nvidia_nat_redis/src/nat/plugins/redis/redis_editor.py
@@ -128,10 +128,10 @@ class RedisEditor(MemoryEditor):
             logger.error("Failed to generate embedding: %s", e)
             raise
 
-        # Create vector search query
-        search_query = (
-            Query(f"(@user_id:{user_id})=>[KNN {top_k} @embedding $vec AS score]").sort_by("score").return_fields(
-                "conversation", "user_id", "tags", "metadata", "memory", "score").dialect(2))
+        # Create vector search query; escape special characters in user_id
+        escaped_user_id = user_id.replace("\\", "\\\\").replace("\"", "\\\"")
+        search_query = (Query(f'(@user_id:"{escaped_user_id}")=>[KNN {top_k} @embedding $vec AS score]').sort_by(
+            "score").return_fields("conversation", "user_id", "tags", "metadata", "memory", "score").dialect(2))
         logger.debug("Created search query: %s", search_query)
         logger.debug("Query string: %s", search_query.query_string())
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

This PR escapes special characters in Redis user_id to prevent unexpected search results. For example, unescaped hyphen may get interpreted as a negation operator and always return 0 results.

Closes #1493 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Search now safely handles special characters in user IDs by escaping them before querying.
  * Prevents syntax errors and ensures consistent matching of user IDs in search results.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->