### PR TITLE
Expose MCP session ID and add custom headers support for session correlation

### DIFF
--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
@@ -530,12 +530,21 @@ class MCPStreamableHTTPClient(MCPBaseClient):
     Args:
       url (str): The url of the MCP server
       auth_provider (AuthProviderBase | None): Optional authentication provider for Bearer token injection
+      user_id (str | None): Optional user ID for session isolation
+      custom_headers (dict[str, str] | None): Optional custom HTTP headers to include in requests
+      tool_call_timeout (timedelta): Timeout for tool calls
+      auth_flow_timeout (timedelta): Extended timeout for interactive authentication
+      reconnect_enabled (bool): Whether to automatically reconnect on connection failures
+      reconnect_max_attempts (int): Maximum number of reconnection attempts
+      reconnect_initial_backoff (float): Initial backoff delay in seconds
+      reconnect_max_backoff (float): Maximum backoff delay in seconds
     """
 
     def __init__(self,
                  url: str,
                  auth_provider: AuthProviderBase | None = None,
                  user_id: str | None = None,
+                 custom_headers: dict[str, str] | None = None,
                  tool_call_timeout: timedelta = timedelta(seconds=60),
                  auth_flow_timeout: timedelta = timedelta(seconds=300),
                  reconnect_enabled: bool = True,
@@ -552,10 +561,33 @@ class MCPStreamableHTTPClient(MCPBaseClient):
                          reconnect_initial_backoff=reconnect_initial_backoff,
                          reconnect_max_backoff=reconnect_max_backoff)
         self._url = url
+        self._custom_headers = custom_headers or {}
+        # Callback to retrieve MCP session ID from the transport layer
+        self._get_mcp_session_id: Callable[[], str | None] | None = None
 
     @property
     def url(self) -> str:
         return self._url
+
+    @property
+    def custom_headers(self) -> dict[str, str]:
+        """Returns the custom headers configured for this client."""
+        return self._custom_headers
+
+    @property
+    def mcp_session_id(self) -> str | None:
+        """
+        Returns the MCP transport-level session ID if available.
+
+        This is the session ID assigned by the MCP server (from the mcp-session-id header),
+        which can be used for correlating backend sessions with MCP server sessions.
+
+        Returns:
+            The MCP session ID string, or None if not connected or not available.
+        """
+        if self._get_mcp_session_id is not None:
+            return self._get_mcp_session_id()
+        return None
 
     @property
     def server_name(self):
@@ -567,11 +599,21 @@ class MCPStreamableHTTPClient(MCPBaseClient):
         """
         Establish a session with an MCP server via streamable-http within an async context
         """
-        # Use httpx.Auth for authentication
-        async with streamablehttp_client(url=self._url, auth=self._httpx_auth) as (read, write, _):
-            async with ClientSession(read, write) as session:
-                await session.initialize()
-                yield session
+        try:
+            # Use httpx.Auth for authentication and headers for custom business context
+            async with streamablehttp_client(
+                url=self._url,
+                headers=self._custom_headers if self._custom_headers else None,
+                auth=self._httpx_auth
+            ) as (read, write, get_session_id):
+                # Store the session ID callback for later retrieval
+                self._get_mcp_session_id = get_session_id
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    yield session
+        finally:
+            # Clear the session ID callback when disconnected
+            self._get_mcp_session_id = None
 
 
 class MCPToolClient:

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
@@ -601,17 +601,13 @@ class MCPStreamableHTTPClient(MCPBaseClient):
         """
         # Create httpx client with custom headers and auth
         # streamable_http_client expects a pre-configured httpx.AsyncClient for headers/auth
-        http_client = httpx.AsyncClient(
-            headers=self._custom_headers if self._custom_headers else None,
-            auth=self._httpx_auth
-        )
+        http_client = httpx.AsyncClient(headers=self._custom_headers if self._custom_headers else None,
+                                        auth=self._httpx_auth)
 
         try:
             async with http_client:
-                async with streamable_http_client(
-                    url=self._url,
-                    http_client=http_client
-                ) as (read, write, get_session_id):
+                async with streamable_http_client(url=self._url,
+                                                  http_client=http_client) as (read, write, get_session_id):
                     # Store the session ID callback for later retrieval
                     self._get_mcp_session_id = get_session_id
                     async with ClientSession(read, write) as session:

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
@@ -32,7 +32,7 @@ from mcp import ClientSession
 from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters
 from mcp.client.stdio import stdio_client
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 from mcp.types import TextContent
 from nat.authentication.interfaces import AuthenticatedContext
 from nat.authentication.interfaces import AuthFlowType
@@ -599,18 +599,24 @@ class MCPStreamableHTTPClient(MCPBaseClient):
         """
         Establish a session with an MCP server via streamable-http within an async context
         """
+        # Create httpx client with custom headers and auth
+        # streamable_http_client expects a pre-configured httpx.AsyncClient for headers/auth
+        http_client = httpx.AsyncClient(
+            headers=self._custom_headers if self._custom_headers else None,
+            auth=self._httpx_auth
+        )
+
         try:
-            # Use httpx.Auth for authentication and headers for custom business context
-            async with streamablehttp_client(
-                url=self._url,
-                headers=self._custom_headers if self._custom_headers else None,
-                auth=self._httpx_auth
-            ) as (read, write, get_session_id):
-                # Store the session ID callback for later retrieval
-                self._get_mcp_session_id = get_session_id
-                async with ClientSession(read, write) as session:
-                    await session.initialize()
-                    yield session
+            async with http_client:
+                async with streamable_http_client(
+                    url=self._url,
+                    http_client=http_client
+                ) as (read, write, get_session_id):
+                    # Store the session ID callback for later retrieval
+                    self._get_mcp_session_id = get_session_id
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        yield session
         finally:
             # Clear the session ID callback when disconnected
             self._get_mcp_session_id = None

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_config.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_config.py
@@ -52,6 +52,13 @@ class MCPServerConfig(BaseModel):
     auth_provider: str | AuthenticationRef | None = Field(default=None,
                                                           description="Reference to authentication provider")
 
+    # Custom headers for streamable-http transport
+    custom_headers: dict[str, str] | None = Field(
+        default=None,
+        description="Custom HTTP headers to include in requests to the MCP server. "
+                    "Only supported for streamable-http transport. "
+                    "Useful for passing business context or correlation IDs to the MCP server.")
+
     @model_validator(mode="after")
     def validate_model(self):
         """Validate that stdio and SSE/Streamable HTTP properties are mutually exclusive."""
@@ -63,6 +70,9 @@ class MCPServerConfig(BaseModel):
             # Auth is not supported for stdio transport
             if self.auth_provider is not None:
                 raise ValueError("Authentication is not supported for stdio transport")
+            # Custom headers not supported for stdio transport
+            if self.custom_headers is not None:
+                raise ValueError("custom_headers is not supported for stdio transport")
         elif self.transport == "sse":
             if self.command is not None or self.args is not None or self.env is not None:
                 raise ValueError("command, args, and env should not be set when using sse transport")
@@ -71,6 +81,9 @@ class MCPServerConfig(BaseModel):
             # Auth is not supported for SSE transport
             if self.auth_provider is not None:
                 raise ValueError("Authentication is not supported for SSE transport.")
+            # Custom headers not supported for SSE transport
+            if self.custom_headers is not None:
+                raise ValueError("custom_headers is not supported for SSE transport")
         elif self.transport == "streamable-http":
             if self.command is not None or self.args is not None or self.env is not None:
                 raise ValueError("command, args, and env should not be set when using streamable-http transport")

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_config.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_config.py
@@ -56,8 +56,8 @@ class MCPServerConfig(BaseModel):
     custom_headers: dict[str, str] | None = Field(
         default=None,
         description="Custom HTTP headers to include in requests to the MCP server. "
-                    "Only supported for streamable-http transport. "
-                    "Useful for passing business context or correlation IDs to the MCP server.")
+        "Only supported for streamable-http transport. "
+        "Useful for passing business context or correlation IDs to the MCP server.")
 
     @model_validator(mode="after")
     def validate_model(self):

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_impl.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_impl.py
@@ -390,6 +390,7 @@ class MCPFunctionGroup(FunctionGroup):
                 str(config.server.url),
                 auth_provider=self._shared_auth_provider,
                 user_id=session_id,  # Pass session_id as user_id for cache isolation
+                custom_headers=config.server.custom_headers,
                 tool_call_timeout=config.tool_call_timeout,
                 auth_flow_timeout=config.auth_flow_timeout,
                 reconnect_enabled=config.reconnect_enabled,
@@ -557,6 +558,7 @@ async def mcp_client_function_group(config: MCPClientConfig, _builder: Builder):
         client = MCPStreamableHTTPClient(str(config.server.url),
                                          auth_provider=auth_provider,
                                          user_id=base_user_id,
+                                         custom_headers=config.server.custom_headers,
                                          tool_call_timeout=config.tool_call_timeout,
                                          auth_flow_timeout=config.auth_flow_timeout,
                                          reconnect_enabled=config.reconnect_enabled,
@@ -689,6 +691,7 @@ async def per_user_mcp_client_function_group(config: PerUserMCPClientConfig, _bu
         client = MCPStreamableHTTPClient(str(config.server.url),
                                          auth_provider=auth_provider,
                                          user_id=user_id,
+                                         custom_headers=config.server.custom_headers,
                                          tool_call_timeout=config.tool_call_timeout,
                                          auth_flow_timeout=config.auth_flow_timeout,
                                          reconnect_enabled=config.reconnect_enabled,

--- a/tests/nat/mcp/client/test_mcp_client_base.py
+++ b/tests/nat/mcp/client/test_mcp_client_base.py
@@ -15,6 +15,7 @@
 import argparse
 import asyncio
 import os
+from contextlib import asynccontextmanager
 from datetime import timedelta
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
@@ -597,6 +598,191 @@ class TestMCPToolClient:
         # Should raise RuntimeError when parent_client is None
         with pytest.raises(RuntimeError, match="MCPToolClient initialized without a parent client"):
             MCPToolClient(session=mock_session, parent_client=None, tool_name="test_tool", tool_description="Test tool")
+
+
+class TestMCPStreamableHTTPClientSessionIdAndHeaders:
+    """Test MCP session ID exposure and custom headers functionality."""
+
+    def test_custom_headers_initialization(self):
+        """Test that custom headers are properly stored during initialization."""
+        custom_headers = {"X-Business-Context": "test-value", "X-Correlation-ID": "12345"}
+        client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp", custom_headers=custom_headers)
+
+        assert client.custom_headers == custom_headers
+
+    def test_custom_headers_default_empty(self):
+        """Test that custom headers default to empty dict when not provided."""
+        client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp")
+
+        assert client.custom_headers == {}
+
+    def test_custom_headers_none_becomes_empty_dict(self):
+        """Test that None custom headers become empty dict."""
+        client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp", custom_headers=None)
+
+        assert client.custom_headers == {}
+
+    def test_mcp_session_id_before_connection(self):
+        """Test that mcp_session_id returns None before connection is established."""
+        client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp")
+
+        assert client.mcp_session_id is None
+
+    def test_mcp_session_id_with_callback(self):
+        """Test that mcp_session_id returns value from callback when set."""
+        client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp")
+
+        # Simulate what happens during connection - the callback gets set
+        expected_session_id = "test-session-id-12345"
+        client._get_mcp_session_id = lambda: expected_session_id
+
+        assert client.mcp_session_id == expected_session_id
+
+    def test_mcp_session_id_callback_returns_none(self):
+        """Test that mcp_session_id handles callback returning None."""
+        client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp")
+
+        # Callback can return None if session ID hasn't been assigned yet
+        client._get_mcp_session_id = lambda: None
+
+        assert client.mcp_session_id is None
+
+    async def test_mcp_session_id_cleared_after_disconnect(self):
+        """Test that mcp_session_id callback is cleared after disconnection."""
+        client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp")
+
+        # Simulate connection
+        client._get_mcp_session_id = lambda: "session-123"
+        assert client.mcp_session_id == "session-123"
+
+        # Simulate disconnection by clearing the callback (as done in connect_to_server finally block)
+        client._get_mcp_session_id = None
+        assert client.mcp_session_id is None
+
+    async def test_connect_to_server_sets_session_id_callback(self):
+        """Test that connect_to_server properly captures the session ID callback."""
+        from unittest.mock import AsyncMock
+
+        client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp")
+
+        # Mock the streamablehttp_client
+        mock_session_id_callback = MagicMock(return_value="mock-session-id")
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+
+        # Create a mock context manager
+        @asynccontextmanager
+        async def mock_streamable_client(*args, **kwargs):
+            yield (AsyncMock(), AsyncMock(), mock_session_id_callback)
+
+        with patch('nat.plugins.mcp.client.client_base.streamablehttp_client', mock_streamable_client):
+            with patch('nat.plugins.mcp.client.client_base.ClientSession') as MockClientSession:
+                mock_session_cm = AsyncMock()
+                mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+                mock_session_cm.__aexit__ = AsyncMock(return_value=None)
+                MockClientSession.return_value = mock_session_cm
+
+                async with client.connect_to_server():
+                    # During connection, the callback should be set
+                    assert client._get_mcp_session_id is mock_session_id_callback
+                    assert client.mcp_session_id == "mock-session-id"
+
+        # After exiting, callback should be cleared
+        assert client._get_mcp_session_id is None
+
+    async def test_connect_to_server_passes_custom_headers(self):
+        """Test that connect_to_server passes custom headers to streamablehttp_client."""
+        from unittest.mock import AsyncMock
+
+        custom_headers = {"X-Custom-Header": "custom-value"}
+        client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp", custom_headers=custom_headers)
+
+        captured_kwargs = {}
+
+        @asynccontextmanager
+        async def mock_streamable_client(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield (AsyncMock(), AsyncMock(), MagicMock(return_value=None))
+
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+
+        with patch('nat.plugins.mcp.client.client_base.streamablehttp_client', mock_streamable_client):
+            with patch('nat.plugins.mcp.client.client_base.ClientSession') as MockClientSession:
+                mock_session_cm = AsyncMock()
+                mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+                mock_session_cm.__aexit__ = AsyncMock(return_value=None)
+                MockClientSession.return_value = mock_session_cm
+
+                async with client.connect_to_server():
+                    pass
+
+        # Verify custom headers were passed
+        assert captured_kwargs.get('headers') == custom_headers
+
+    async def test_connect_to_server_no_headers_when_empty(self):
+        """Test that connect_to_server passes None for headers when no custom headers configured."""
+        from unittest.mock import AsyncMock
+
+        client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp")
+
+        captured_kwargs = {}
+
+        @asynccontextmanager
+        async def mock_streamable_client(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            yield (AsyncMock(), AsyncMock(), MagicMock(return_value=None))
+
+        mock_session = AsyncMock()
+        mock_session.initialize = AsyncMock()
+
+        with patch('nat.plugins.mcp.client.client_base.streamablehttp_client', mock_streamable_client):
+            with patch('nat.plugins.mcp.client.client_base.ClientSession') as MockClientSession:
+                mock_session_cm = AsyncMock()
+                mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
+                mock_session_cm.__aexit__ = AsyncMock(return_value=None)
+                MockClientSession.return_value = mock_session_cm
+
+                async with client.connect_to_server():
+                    pass
+
+        # Verify headers is None when no custom headers configured
+        assert captured_kwargs.get('headers') is None
+
+
+class TestMCPServerConfigCustomHeaders:
+    """Test MCPServerConfig custom headers validation."""
+
+    def test_custom_headers_valid_for_streamable_http(self):
+        """Test that custom headers are allowed for streamable-http transport."""
+        from nat.plugins.mcp.client.client_config import MCPServerConfig
+
+        config = MCPServerConfig(
+            transport="streamable-http", url="http://localhost:8080/mcp", custom_headers={"X-Header": "value"})
+
+        assert config.custom_headers == {"X-Header": "value"}
+
+    def test_custom_headers_rejected_for_stdio(self):
+        """Test that custom headers raise error for stdio transport."""
+        from nat.plugins.mcp.client.client_config import MCPServerConfig
+
+        with pytest.raises(ValueError, match="custom_headers is not supported for stdio transport"):
+            MCPServerConfig(transport="stdio", command="python", custom_headers={"X-Header": "value"})
+
+    def test_custom_headers_rejected_for_sse(self):
+        """Test that custom headers raise error for SSE transport."""
+        from nat.plugins.mcp.client.client_config import MCPServerConfig
+
+        with pytest.raises(ValueError, match="custom_headers is not supported for SSE transport"):
+            MCPServerConfig(transport="sse", url="http://localhost:8080/sse", custom_headers={"X-Header": "value"})
+
+    def test_custom_headers_default_none(self):
+        """Test that custom headers default to None."""
+        from nat.plugins.mcp.client.client_config import MCPServerConfig
+
+        config = MCPServerConfig(transport="streamable-http", url="http://localhost:8080/mcp")
+
+        assert config.custom_headers is None
 
 
 if __name__ == "__main__":

--- a/tests/nat/mcp/client/test_mcp_client_base.py
+++ b/tests/nat/mcp/client/test_mcp_client_base.py
@@ -665,7 +665,7 @@ class TestMCPStreamableHTTPClientSessionIdAndHeaders:
 
         client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp")
 
-        # Mock the streamablehttp_client
+        # Mock the streamable_http_client
         mock_session_id_callback = MagicMock(return_value="mock-session-id")
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
@@ -675,7 +675,7 @@ class TestMCPStreamableHTTPClientSessionIdAndHeaders:
         async def mock_streamable_client(*args, **kwargs):
             yield (AsyncMock(), AsyncMock(), mock_session_id_callback)
 
-        with patch('nat.plugins.mcp.client.client_base.streamablehttp_client', mock_streamable_client):
+        with patch('nat.plugins.mcp.client.client_base.streamable_http_client', mock_streamable_client):
             with patch('nat.plugins.mcp.client.client_base.ClientSession') as MockClientSession:
                 mock_session_cm = AsyncMock()
                 mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
@@ -691,23 +691,24 @@ class TestMCPStreamableHTTPClientSessionIdAndHeaders:
         assert client._get_mcp_session_id is None
 
     async def test_connect_to_server_passes_custom_headers(self):
-        """Test that connect_to_server passes custom headers to streamablehttp_client."""
+        """Test that connect_to_server configures httpx client with custom headers."""
         from unittest.mock import AsyncMock
 
         custom_headers = {"X-Custom-Header": "custom-value"}
         client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp", custom_headers=custom_headers)
 
-        captured_kwargs = {}
+        captured_http_client = None
 
         @asynccontextmanager
         async def mock_streamable_client(*args, **kwargs):
-            captured_kwargs.update(kwargs)
+            nonlocal captured_http_client
+            captured_http_client = kwargs.get('http_client')
             yield (AsyncMock(), AsyncMock(), MagicMock(return_value=None))
 
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
 
-        with patch('nat.plugins.mcp.client.client_base.streamablehttp_client', mock_streamable_client):
+        with patch('nat.plugins.mcp.client.client_base.streamable_http_client', mock_streamable_client):
             with patch('nat.plugins.mcp.client.client_base.ClientSession') as MockClientSession:
                 mock_session_cm = AsyncMock()
                 mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
@@ -717,26 +718,28 @@ class TestMCPStreamableHTTPClientSessionIdAndHeaders:
                 async with client.connect_to_server():
                     pass
 
-        # Verify custom headers were passed
-        assert captured_kwargs.get('headers') == custom_headers
+        # Verify http_client was passed and has custom headers
+        assert captured_http_client is not None
+        assert captured_http_client.headers.get("X-Custom-Header") == "custom-value"
 
     async def test_connect_to_server_no_headers_when_empty(self):
-        """Test that connect_to_server passes None for headers when no custom headers configured."""
+        """Test that connect_to_server creates httpx client without headers when none configured."""
         from unittest.mock import AsyncMock
 
         client = MCPStreamableHTTPClient(url="http://localhost:8080/mcp")
 
-        captured_kwargs = {}
+        captured_http_client = None
 
         @asynccontextmanager
         async def mock_streamable_client(*args, **kwargs):
-            captured_kwargs.update(kwargs)
+            nonlocal captured_http_client
+            captured_http_client = kwargs.get('http_client')
             yield (AsyncMock(), AsyncMock(), MagicMock(return_value=None))
 
         mock_session = AsyncMock()
         mock_session.initialize = AsyncMock()
 
-        with patch('nat.plugins.mcp.client.client_base.streamablehttp_client', mock_streamable_client):
+        with patch('nat.plugins.mcp.client.client_base.streamable_http_client', mock_streamable_client):
             with patch('nat.plugins.mcp.client.client_base.ClientSession') as MockClientSession:
                 mock_session_cm = AsyncMock()
                 mock_session_cm.__aenter__ = AsyncMock(return_value=mock_session)
@@ -746,8 +749,8 @@ class TestMCPStreamableHTTPClientSessionIdAndHeaders:
                 async with client.connect_to_server():
                     pass
 
-        # Verify headers is None when no custom headers configured
-        assert captured_kwargs.get('headers') is None
+        # Verify http_client was passed (even without custom headers, we still create one for auth support)
+        assert captured_http_client is not None
 
 
 class TestMCPServerConfigCustomHeaders:

--- a/tests/nat/mcp/client/test_mcp_client_base.py
+++ b/tests/nat/mcp/client/test_mcp_client_base.py
@@ -760,8 +760,9 @@ class TestMCPServerConfigCustomHeaders:
         """Test that custom headers are allowed for streamable-http transport."""
         from nat.plugins.mcp.client.client_config import MCPServerConfig
 
-        config = MCPServerConfig(
-            transport="streamable-http", url="http://localhost:8080/mcp", custom_headers={"X-Header": "value"})
+        config = MCPServerConfig(transport="streamable-http",
+                                 url="http://localhost:8080/mcp",
+                                 custom_headers={"X-Header": "value"})
 
         assert config.custom_headers == {"X-Header": "value"}
 

--- a/tests/nat/mcp/client/test_mcp_session_management.py
+++ b/tests/nat/mcp/client/test_mcp_session_management.py
@@ -92,6 +92,7 @@ class TestMCPSessionManagement:
         """Create a mock base MCP client for testing."""
         client = AsyncMock()
         client.server_name = "test-server"
+        client.custom_headers = {}
         client.__aenter__ = AsyncMock(return_value=client)
         client.__aexit__ = AsyncMock(return_value=None)
         return client
@@ -122,6 +123,7 @@ class TestMCPSessionManagement:
 
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_client_class.return_value = mock_session_client
 
@@ -142,6 +144,7 @@ class TestMCPSessionManagement:
 
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_client_class.return_value = mock_session_client
 
@@ -163,6 +166,7 @@ class TestMCPSessionManagement:
 
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_client_class.return_value = mock_session_client
 
@@ -191,6 +195,7 @@ class TestMCPSessionManagement:
 
             with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
                 mock_session_client = AsyncMock()
+                mock_session_client.custom_headers = {}
                 mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
                 mock_client_class.return_value = mock_session_client
 
@@ -199,6 +204,7 @@ class TestMCPSessionManagement:
         # Try to create one more session - should raise RuntimeError
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_client_class.return_value = mock_session_client
 
@@ -214,6 +220,7 @@ class TestMCPSessionManagement:
 
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_session_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_session_client
@@ -238,6 +245,7 @@ class TestMCPSessionManagement:
 
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_client_class.return_value = mock_session_client
 
@@ -267,6 +275,7 @@ class TestMCPSessionManagement:
         # Create a session first
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_client_class.return_value = mock_session_client
 
@@ -298,6 +307,7 @@ class TestMCPSessionManagement:
         # Create sessions first
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_client_class.return_value = mock_session_client
 
@@ -331,6 +341,7 @@ class TestMCPSessionManagement:
 
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_session_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_session_client
@@ -354,6 +365,7 @@ class TestMCPSessionManagement:
 
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_client_class.return_value = mock_session_client
 
@@ -379,6 +391,7 @@ class TestMCPSessionManagement:
 
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_session_client.__aexit__ = AsyncMock(side_effect=Exception("Close error"))
             mock_client_class.return_value = mock_session_client
@@ -403,6 +416,7 @@ class TestMCPSessionManagement:
 
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_client_class.return_value = mock_session_client
 
@@ -429,6 +443,7 @@ class TestMCPSessionManagement:
 
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_client_class.return_value = mock_session_client
 
@@ -472,6 +487,7 @@ class TestMCPSessionManagement:
         # Create multiple sessions
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_session_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_session_client
@@ -507,6 +523,7 @@ class TestMCPSessionManagement:
         # Create session
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_session_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_session_client
@@ -534,6 +551,7 @@ class TestMCPSessionManagement:
         # Create sessions
         with patch('nat.plugins.mcp.client.client_base.MCPStreamableHTTPClient') as mock_client_class:
             mock_session_client = AsyncMock()
+            mock_session_client.custom_headers = {}
             mock_session_client.__aenter__ = AsyncMock(return_value=mock_session_client)
             mock_session_client.__aexit__ = AsyncMock(return_value=None)
             mock_client_class.return_value = mock_session_client
@@ -565,6 +583,7 @@ class TestMCPSessionManagement:
         """Test that lifetime task properly manages client lifecycle on success."""
         session_id = "test-session-123"
         mock_client = AsyncMock()
+        mock_client.custom_headers = {}
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
@@ -593,6 +612,7 @@ class TestMCPSessionManagement:
         """Test that lifetime task properly handles __aenter__ failure."""
         session_id = "test-session-456"
         mock_client = AsyncMock()
+        mock_client.custom_headers = {}
         mock_client.__aenter__ = AsyncMock(side_effect=RuntimeError("Connection failed"))
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
@@ -604,6 +624,7 @@ class TestMCPSessionManagement:
         """Test that lifetime task times out if initialization hangs."""
         session_id = "test-session-timeout"
         mock_client = AsyncMock()
+        mock_client.custom_headers = {}
 
         mock_config.tool_call_timeout = timedelta(seconds=2)
         fg = MCPFunctionGroup(config=mock_config)
@@ -627,6 +648,7 @@ class TestMCPSessionManagement:
         """Test that lifetime task properly exits when stop_event is set."""
         session_id = "test-session-cleanup"
         mock_client = AsyncMock()
+        mock_client.custom_headers = {}
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
@@ -650,6 +672,7 @@ class TestMCPSessionManagement:
         """Test that cancel scope is entered and exited in the same task."""
         session_id = "test-session-scope"
         mock_client = AsyncMock()
+        mock_client.custom_headers = {}
         enter_task_id = None
         exit_task_id = None
 
@@ -694,6 +717,7 @@ class TestMCPSessionManagement:
         """Test that cleanup properly signals the lifetime task."""
         session_id = "test-cleanup-session"
         mock_client = AsyncMock()
+        mock_client.custom_headers = {}
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
@@ -723,6 +747,7 @@ class TestMCPSessionManagement:
         """Test that cleanup skips sessions with ref_count > 0 using lifetime tasks."""
         session_id = "test-active-session"
         mock_client = AsyncMock()
+        mock_client.custom_headers = {}
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
@@ -757,6 +782,7 @@ class TestMCPSessionManagement:
         """Test that cleanup handles tasks that are already done."""
         session_id = "test-done-session"
         mock_client = AsyncMock()
+        mock_client.custom_headers = {}
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
@@ -787,6 +813,7 @@ class TestMCPSessionManagement:
         """Test complete session lifecycle with lifetime tasks."""
         session_id = "test-full-session"
         mock_client = AsyncMock()
+        mock_client.custom_headers = {}
         mock_client.__aenter__ = AsyncMock(return_value=mock_client)
         mock_client.__aexit__ = AsyncMock(return_value=None)
 
@@ -823,10 +850,12 @@ class TestMCPSessionManagement:
         session2_id = "session-2"
 
         mock_client1 = AsyncMock()
+        mock_client1.custom_headers = {}
         mock_client1.__aenter__ = AsyncMock(return_value=mock_client1)
         mock_client1.__aexit__ = AsyncMock(return_value=None)
 
         mock_client2 = AsyncMock()
+        mock_client2.custom_headers = {}
         mock_client2.__aenter__ = AsyncMock(return_value=mock_client2)
         mock_client2.__aexit__ = AsyncMock(return_value=None)
 

--- a/tests/nat/mcp/client/test_mcp_session_management.py
+++ b/tests/nat/mcp/client/test_mcp_session_management.py
@@ -60,6 +60,7 @@ class TestMCPSessionManagement:
         config.server = MagicMock(spec=MCPServerConfig)
         config.server.transport = "streamable-http"
         config.server.url = "http://localhost:8080/mcp"
+        config.server.custom_headers = {}  # Pydantic fields need explicit setting with spec=
 
         # Mock timeouts
         config.tool_call_timeout = timedelta(seconds=60)


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Summary

- Add `mcp_session_id` property to expose the MCP transport-level session ID for backend correlation
- Add `custom_headers` configuration to pass business context to MCP servers
- Migrate from deprecated `streamablehttp_client` to `streamable_http_client`

Motivation

- Users implementing per-user MCP session isolation need to:
- Correlate backend sessions with MCP server sessions for caching purposes
- Pass business context (correlation IDs, metadata) to MCP servers via HTTP headers

Previously, the get_session_id callback from the MCP SDK was discarded, and there was no mechanism to inject custom headers from workflow configuration.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-session custom HTTP headers for streamable MCP connections.
  * Exposed transport session ID accessible after connection.
  * Config validation: custom headers only allowed for supported transports.

* **Bug Fixes**
  * Clears transport session ID callback on disconnect to avoid stale state.

* **Tests**
  * Expanded tests covering header handling, session ID exposure, connection lifecycle, and config validation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->