### PR TITLE
Remove the task_timeout from the a2a sample config files

### DIFF
--- a/examples/A2A/currency_agent_a2a/configs/config.yml
+++ b/examples/A2A/currency_agent_a2a/configs/config.yml
@@ -30,7 +30,6 @@ function_groups:
   currency_agent:
     _type: a2a_client
     url: http://localhost:11000
-    task_timeout: 60
 
 llms:
   nim_llm:

--- a/examples/A2A/math_assistant_a2a/src/nat_math_assistant_a2a/configs/config.yml
+++ b/examples/A2A/math_assistant_a2a/src/nat_math_assistant_a2a/configs/config.yml
@@ -18,7 +18,6 @@ function_groups:
   calculator_a2a:
     _type: a2a_client
     url: http://localhost:10000
-    task_timeout: 60
     include_skills_in_description: true
 
   # Local MCP server for time and date operations

--- a/examples/A2A/math_assistant_a2a_protected/configs/config-client.yml
+++ b/examples/A2A/math_assistant_a2a_protected/configs/config-client.yml
@@ -19,7 +19,6 @@ function_groups:
     _type: a2a_client
     url: http://localhost:10000
     auth_provider: calculator_oauth
-    task_timeout: 60
     include_skills_in_description: true
 
   # Local MCP server for time and date operations


### PR DESCRIPTION
The default a2a task timeout is 300s. The sample config was unnecessarily lowering it to 60s resulting in timeouts for slower agents.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified timeout configurations by removing explicit settings to rely on default system behavior across agent examples.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->