### PR TITLE
Update RL README with OpenAI API key setup and adjust commands

### DIFF
--- a/examples/finetuning/rl_with_openpipe_art/README.md
+++ b/examples/finetuning/rl_with_openpipe_art/README.md
@@ -201,6 +201,8 @@ curl http://localhost:8000/v1/models
 In a **separate terminal** with your NeMo Agent toolkit environment activated:
 
 ```bash
+# This is a dummy key for local vLLM usage
+export OPENAI_API_KEY=default
 # Run the pre-training evaluation
 nat eval --config_file examples/finetuning/rl_with_openpipe_art/configs/config_pre_train.yml --reps 3
 ```
@@ -227,7 +229,7 @@ source art-env/bin/activate
 export HF_TOKEN=<your_huggingface_token>
 
 # Start the ART server
-uv run art --host 0.0.0.0 --port 7623
+art --host 0.0.0.0 --port 7623
 ```
 
 > **Note**: The ART server listens on port `7623` for training commands and starts vLLM internally on port `8000` for inference.
@@ -318,6 +320,8 @@ finetuning:
 In your **NeMo Agent toolkit environment**:
 
 ```bash
+# This is a dummy key for local vLLM usage
+export OPENAI_API_KEY=default
 nat finetune --config_file examples/finetuning/rl_with_openpipe_art/configs/config.yml
 ```
 
@@ -571,6 +575,8 @@ The ART server continues serving the finetuned model weights. Do not restart it,
 ### 6.2 Run Post-Training Evaluation
 
 ```bash
+# This is a dummy key for local vLLM usage
+export OPENAI_API_KEY=default
 nat eval --config_file examples/finetuning/rl_with_openpipe_art/configs/config_post_train.yml --reps 3
 ```
 


### PR DESCRIPTION


## Description
Added instructions to export a dummy OpenAI API key for local vLLM usage. Simplified the command to start the ART server by removing the `uv` prefix for clarity. These changes improve usability and ensure proper environment setup for users.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions for the RL with OpenPipe ART example.
  * Simplified server startup command for easier local testing.
  * Clarified API key configuration requirements for local development.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->