### PR TITLE
fix: flaky batching processor test

### DIFF
--- a/tests/nat/observability/processor/test_batching_processor.py
+++ b/tests/nat/observability/processor/test_batching_processor.py
@@ -639,9 +639,12 @@ class TestBatchingProcessorIntegration:
         processor = BatchingProcessor[str](batch_size=3, flush_interval=0.1)
 
         callback_batches = []
+        flush_event = asyncio.Event()
 
         async def capture_callback(batch):
             callback_batches.append(batch)
+            if len(callback_batches) == 1:
+                flush_event.set()
 
         processor.set_done_callback(capture_callback)
 
@@ -653,7 +656,7 @@ class TestBatchingProcessorIntegration:
         # Time-based batch
         await processor.process("4")
         await processor.process("5")
-        await asyncio.sleep(0.2)  # Wait for time-based flush
+        await asyncio.wait_for(flush_event.wait(), timeout=1.0)
 
         # Add more items before shutdown to ensure shutdown batch is created
         await processor.process("6")


### PR DESCRIPTION
## Description

Add an event for time-based batch rather than sleep.

Closes #1419

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test reliability by replacing time-based waits with proper event-based synchronization, ensuring more consistent test execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->