### PR TITLE
fix(testing): guard huggingface integration test with importorskip

### DIFF
--- a/tests/nat/llm_providers/test_langchain_agents.py
+++ b/tests/nat/llm_providers/test_langchain_agents.py
@@ -26,6 +26,7 @@ from nat.llm.azure_openai_llm import AzureOpenAIModelConfig
 from nat.llm.nim_llm import NIMModelConfig
 from nat.llm.openai_llm import OpenAIModelConfig
 
+
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key")
 async def test_nim_langchain_agent():

--- a/tests/nat/llm_providers/test_langchain_agents.py
+++ b/tests/nat/llm_providers/test_langchain_agents.py
@@ -26,13 +26,6 @@ from nat.llm.azure_openai_llm import AzureOpenAIModelConfig
 from nat.llm.nim_llm import NIMModelConfig
 from nat.llm.openai_llm import OpenAIModelConfig
 
-try:
-    from nat.llm.huggingface_llm import HuggingFaceConfig  # noqa: F401
-    HAS_HUGGINGFACE = True
-except ImportError:
-    HAS_HUGGINGFACE = False
-
-
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key")
 async def test_nim_langchain_agent():
@@ -148,14 +141,14 @@ async def test_azure_openai_react_e2e(test_data_dir: str):
 
 
 @pytest.mark.integration
-@pytest.mark.skipif(not HAS_HUGGINGFACE, reason="HuggingFace dependencies (transformers, torch) not installed")
 async def test_huggingface_langchain_agent():
     """
     Test HuggingFace LLM with LangChain/LangGraph agent.
     Requires transformers and torch to be installed (optional dependencies).
     """
-    from nat.llm.huggingface_llm import HuggingFaceConfig
+    pytest.importorskip("torch", reason="HuggingFace dependencies (transformers, torch) not installed")
 
+    from nat.llm.huggingface_llm import HuggingFaceConfig
     prompt = ChatPromptTemplate.from_messages([("system", "You are a helpful AI assistant."), ("human", "{input}")])
 
     # Use a small, fast model for testing

--- a/tests/nat/llm_providers/test_langchain_agents.py
+++ b/tests/nat/llm_providers/test_langchain_agents.py
@@ -148,6 +148,7 @@ async def test_huggingface_langchain_agent():
     Requires transformers and torch to be installed (optional dependencies).
     """
     pytest.importorskip("torch", reason="HuggingFace dependencies (transformers, torch) not installed")
+    pytest.importorskip("transformers", reason="HuggingFace dependencies (transformers, torch) not installed")
 
     from nat.llm.huggingface_llm import HuggingFaceConfig
     prompt = ChatPromptTemplate.from_messages([("system", "You are a helpful AI assistant."), ("human", "{input}")])


### PR DESCRIPTION
## Description

Extended nightly run incorrectly tested for huggingface support.

Fix this by directly attempting to import torch

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Simplified dependency handling by removing module-level import guards and using runtime checks that skip tests when optional ML libraries are unavailable.
  * Deferred importing of optional config/components until after runtime checks to prevent import errors and maintain consistent test behavior when dependencies are present.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->