### PR TITLE
fix(ci): coverage reports should only be for `nat` code and examples

### DIFF
--- a/ci/scripts/run_tests.py
+++ b/ci/scripts/run_tests.py
@@ -139,7 +139,12 @@ def run_one(
     if enable_junit:
         cmd.append(f"--junitxml={junit}")
     if enable_coverage:
-        cmd.append("--cov=.")
+        # always include nat module in the coverage report
+        cmd.append("--cov=nat")
+        # if the project has a src directory, include it in the coverage report
+        source_dir = project_dir / "src"
+        if source_dir.exists():
+            cmd.append(f"--cov={str(source_dir)}")
         cmd.append("--cov-report=")
 
     if rc := sh(cmd, env=env):


### PR DESCRIPTION
## Description

With the merge of #1512 the coverage flags were just copied over.

Looking at [a recent report](https://app.codecov.io/gh/NVIDIA/NeMo-Agent-Toolkit/commit/24b6ad76405e6b744d181c9462203cdd43f5c108/tree?dropdown=coverage), coverage of test files were also included, which increases the coverage number.

This PR does two things:
1. restricts coverage to be done only on code that lives within the `nat.` module
2. _if_ a `src` directory exists under the package under test, also add that directory to be covered

With (2) it now means that code that we ship with examples is also now under coverage, which explains the drop to ~70%

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage tracking during continuous integration to automatically include the nat module and project source directories, improving coverage analysis accuracy while maintaining existing reporting functionality.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->