### PR TITLE
fix(ci): Fix build_wheels and slack notifications for nightlies

### DIFF
--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -24,6 +24,11 @@ GIT_TAG=$(get_git_tag)
 IS_TAGGED=$(is_current_commit_release_tagged)
 rapids-logger "Git Version: ${GIT_TAG} - Is Tagged: ${IS_TAGGED}"
 
+if [[ "${CI_COMMIT_BRANCH}" == "${CI_DEFAULT_BRANCH}" && "${IS_TAGGED}" == "0" ]]; then
+    # We should create a nightly tag that matches the git tag
+    git tag ${GIT_TAG}
+fi
+
 create_env
 
 WHEELS_BASE_DIR="${CI_PROJECT_DIR}/.tmp/wheels"

--- a/ci/scripts/gitlab/report_test_results.py
+++ b/ci/scripts/gitlab/report_test_results.py
@@ -106,6 +106,10 @@ def add_text(text: str, blocks: list[dict], plain_text: list[str]) -> None:
     plain_text.append(text)
 
 
+def chunk_items(items: list[typing.Any], chunk_size: int) -> list[list[typing.Any]]:
+    return [items[index:index + chunk_size] for index in range(0, len(items), chunk_size)]
+
+
 def build_messages(junit_data: dict[str, typing.Any], coverage_data: str) -> ReportMessages:
     branch_name = os.environ.get("CI_COMMIT_BRANCH", "unknown")
     num_errors = junit_data['num_errors']
@@ -199,14 +203,25 @@ def main():
                                        text="\n".join(report_messages.plain_text),
                                        blocks=report_messages.blocks,
                                        link_names=report_messages.failure_text is not None)
+    SLACK_BLOCK_LIMIT = 40
 
     if report_messages.failure_text is not None:
         # Since potentially a large number of failures could occur, we will post them in a thread to the original
         # message to avoid spamming the channel.
-        client.chat_postMessage(channel=slack_channel,
-                                text="\n".join(report_messages.failure_text),
-                                blocks=report_messages.failure_blocks,
-                                thread_ts=response["ts"])
+        failure_blocks = report_messages.failure_blocks or []
+        failure_text = report_messages.failure_text or []
+        if len(failure_blocks) > SLACK_BLOCK_LIMIT:
+            blocks_chunks = chunk_items(failure_blocks, SLACK_BLOCK_LIMIT)
+            text_chunks = chunk_items(failure_text, SLACK_BLOCK_LIMIT)
+        else:
+            blocks_chunks = [failure_blocks]
+            text_chunks = [failure_text]
+
+        for blocks_chunk, text_chunk in zip(blocks_chunks, text_chunks):
+            client.chat_postMessage(channel=slack_channel,
+                                    text="\n".join(text_chunk),
+                                    blocks=blocks_chunk,
+                                    thread_ts=response["ts"])
 
     return return_code
 

--- a/ci/scripts/gitlab/report_test_results.py
+++ b/ci/scripts/gitlab/report_test_results.py
@@ -25,6 +25,7 @@ from datetime import date
 from slack_sdk import WebClient
 
 MAX_TEXT_LENGTH = 3000  # Slack message text limit
+BLOCK_LIMIT = 20  # Slack block limit -- actual limit is 50, but we will use a smaller limit to be safe
 
 logger = logging.getLogger()
 
@@ -203,20 +204,12 @@ def main():
                                        text="\n".join(report_messages.plain_text),
                                        blocks=report_messages.blocks,
                                        link_names=report_messages.failure_text is not None)
-    # The actual limit is 50 blocks, but we will use a smaller limit to be safe and to stay under character limit, too.
-    SLACK_BLOCK_LIMIT = 20
 
     if report_messages.failure_text is not None:
         # Since potentially a large number of failures could occur, we will post them in a thread to the original
         # message to avoid spamming the channel.
-        failure_blocks = report_messages.failure_blocks or []
-        failure_text = report_messages.failure_text or []
-        if len(failure_blocks) > SLACK_BLOCK_LIMIT:
-            blocks_chunks = chunk_items(failure_blocks, SLACK_BLOCK_LIMIT)
-            text_chunks = chunk_items(failure_text, SLACK_BLOCK_LIMIT)
-        else:
-            blocks_chunks = [failure_blocks]
-            text_chunks = [failure_text]
+        blocks_chunks = chunk_items(report_messages.failure_blocks or [], BLOCK_LIMIT)
+        text_chunks = chunk_items(report_messages.failure_text or [], BLOCK_LIMIT)
 
         for blocks_chunk, text_chunk in zip(blocks_chunks, text_chunks):
             client.chat_postMessage(channel=slack_channel,

--- a/ci/scripts/gitlab/report_test_results.py
+++ b/ci/scripts/gitlab/report_test_results.py
@@ -203,7 +203,8 @@ def main():
                                        text="\n".join(report_messages.plain_text),
                                        blocks=report_messages.blocks,
                                        link_names=report_messages.failure_text is not None)
-    SLACK_BLOCK_LIMIT = 40
+    # The actual limit is 50 blocks, but we will use a smaller limit to be safe and to stay under character limit, too.
+    SLACK_BLOCK_LIMIT = 20
 
     if report_messages.failure_text is not None:
         # Since potentially a large number of failures could occur, we will post them in a thread to the original


### PR DESCRIPTION
## Description

After streamlining the wheels build, I forgot to ensure that an appropriate tag was used.

1. Always create a tag that matches GIT_TAG if doing a build on `develop`
2. When we have lots of errors, Slack gets angry (>=50). Chunk messages by 40 to err on the side of caution.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic nightly tag creation for untagged commits on the default branch.
  * Improved Slack test-failure reporting: large failure reports are split into multiple threaded messages to avoid size limits.

* **Chores**
  * Build and CI pipeline improvements to support nightly tagging and chunked reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->