### PR TITLE
Fix typo in documentation for uv sync command 

### DIFF
--- a/docs/source/resources/contributing/index.md
+++ b/docs/source/resources/contributing/index.md
@@ -81,7 +81,7 @@ NeMo Agent Toolkit is a Python library that doesn’t require a GPU to run the w
     uv venv --seed .venv
     source .venv/bin/activate
     # most contains almost all packages within the NeMo Agent Toolkit.
-    uv sync --all-groups --extras most
+    uv sync --all-groups --extra most
     ```
    :::{note}
    You may encounter `Too many open files (os error 24)`. This error occurs when your system’s file descriptor limit is too low.


### PR DESCRIPTION
## Description
Development environment setup instructions show `extras` flag instead of `extra`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected command syntax in the contributing documentation to ensure developers follow accurate setup instructions when configuring their development environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->