### PR TITLE
chore(pre-commit): update versions in pre-commit; add root-level `uv.lock` check

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args: ["-i", "--style", "./pyproject.toml"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.0
+    rev: v0.14.14
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,7 @@ repos:
         args: ["-i", "--style", "./pyproject.toml"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.14
+    rev: v0.15.0
     hooks:
       # Run the linter.
       - id: ruff-check

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,15 +21,16 @@ repos:
         args: ["-i", "--style", "./pyproject.toml"]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.9
+    rev: v0.15.0
     hooks:
       # Run the linter.
       - id: ruff-check
         args: [ --fix ]
 
   - repo: https://github.com/astral-sh/uv-pre-commit
-    rev: 0.6.2
+    rev: 0.9.28
     hooks:
+      - { id: uv-lock, name: "uv-lock", files: "pyproject.toml" }
       - { id: uv-lock, name: "uv-lock-a2a", args: [--project, packages/nvidia_nat_a2a], files: "packages/nvidia_nat_a2a/pyproject.toml" }
       - { id: uv-lock, name: "uv-lock-adk", args: [--project, packages/nvidia_nat_adk], files: "packages/nvidia_nat_adk/pyproject.toml" }
       - { id: uv-lock, name: "uv-lock-agno", args: [--project, packages/nvidia_nat_agno], files: "packages/nvidia_nat_agno/pyproject.toml" }
@@ -64,7 +65,7 @@ repos:
         language: unsupported_script
 
   - repo: https://github.com/tcort/markdown-link-check
-    rev: v3.14.1
+    rev: v3.14.2
     hooks:
       - id: markdown-link-check
         args: ["-q", "--config", "ci/markdown-link-check-config.json"]

--- a/ci/scripts/license_diff.py
+++ b/ci/scripts/license_diff.py
@@ -135,10 +135,7 @@ def main(base_branch: str) -> None:
             else:
                 print(f"- {pkg} {base_version} -> {head_version}")
         except KeyError:
-            if not printed_header:
-                print("Changed packages:")
-                printed_header = True
-            print(f"- {pkg} (source)")
+            pass
 
 
 if __name__ == "__main__":

--- a/packages/nvidia_nat_core/src/nat/builder/framework_enum.py
+++ b/packages/nvidia_nat_core/src/nat/builder/framework_enum.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
+from enum import StrEnum
 
 
-class LLMFrameworkEnum(str, Enum):
+class LLMFrameworkEnum(StrEnum):
     LANGCHAIN = "langchain"
     LLAMA_INDEX = "llama_index"
     CREWAI = "crewai"

--- a/packages/nvidia_nat_core/src/nat/data_models/api_server.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/api_server.py
@@ -18,7 +18,7 @@ import datetime
 import typing
 import uuid
 from abc import abstractmethod
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
@@ -37,7 +37,7 @@ from nat.utils.type_converter import GlobalTypeConverter
 FINISH_REASONS = frozenset({'stop', 'length', 'tool_calls', 'content_filter', 'function_call'})
 
 
-class UserMessageContentRoleType(str, Enum):
+class UserMessageContentRoleType(StrEnum):
     """
     Enum representing chat message roles in API requests and responses.
     """
@@ -67,7 +67,7 @@ class Request(BaseModel):
         default=None, description="Cookies sent with the request, stored in a dictionary-like object.")
 
 
-class ChatContentType(str, Enum):
+class ChatContentType(StrEnum):
     """
     ChatContentType is an Enum that represents the type of Chat content.
     """
@@ -528,7 +528,7 @@ class GenerateResponse(BaseModel):
     value: str | None = "default"
 
 
-class WebSocketMessageType(str, Enum):
+class WebSocketMessageType(StrEnum):
     """
     WebSocketMessageType is an Enum that represents WebSocket Message types.
     """
@@ -541,7 +541,7 @@ class WebSocketMessageType(str, Enum):
     ERROR_MESSAGE = "error_message"
 
 
-class WorkflowSchemaType(str, Enum):
+class WorkflowSchemaType(StrEnum):
     """
     WorkflowSchemaType is an Enum that represents Workkflow response types.
     """
@@ -551,7 +551,7 @@ class WorkflowSchemaType(str, Enum):
     CHAT = "chat"
 
 
-class WebSocketMessageStatus(str, Enum):
+class WebSocketMessageStatus(StrEnum):
     """
     WebSocketMessageStatus is an Enum that represents the status of a WebSocket message.
     """
@@ -578,7 +578,7 @@ class User(BaseModel):
     email: str = "default"
 
 
-class ErrorTypes(str, Enum):
+class ErrorTypes(StrEnum):
     UNKNOWN_ERROR = "unknown_error"
     INVALID_MESSAGE = "invalid_message"
     INVALID_MESSAGE_TYPE = "invalid_message_type"

--- a/packages/nvidia_nat_core/src/nat/data_models/authentication.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/authentication.py
@@ -16,7 +16,7 @@
 import typing
 from datetime import UTC
 from datetime import datetime
-from enum import Enum
+from enum import StrEnum
 
 import httpx
 from pydantic import BaseModel
@@ -40,7 +40,7 @@ class AuthProviderBaseConfig(TypedBaseModel, BaseModelRegistryTag):
 AuthProviderBaseConfigT = typing.TypeVar("AuthProviderBaseConfigT", bound=AuthProviderBaseConfig)
 
 
-class CredentialLocation(str, Enum):
+class CredentialLocation(StrEnum):
     """
     Enum representing the location of credentials in an HTTP request.
     """
@@ -50,7 +50,7 @@ class CredentialLocation(str, Enum):
     BODY = "body"
 
 
-class AuthFlowType(str, Enum):
+class AuthFlowType(StrEnum):
     """
     Enum representing different types of authentication flows.
     """
@@ -77,7 +77,7 @@ class AuthenticatedContext(BaseModel):
     metadata: dict[str, typing.Any] | None = Field(default=None, description="Additional metadata for the request.")
 
 
-class HeaderAuthScheme(str, Enum):
+class HeaderAuthScheme(StrEnum):
     """
     Enum representing different header authentication schemes.
     """
@@ -87,7 +87,7 @@ class HeaderAuthScheme(str, Enum):
     CUSTOM = "Custom"
 
 
-class HTTPMethod(str, Enum):
+class HTTPMethod(StrEnum):
     """
     Enum representing HTTP methods used in requests.
     """
@@ -100,7 +100,7 @@ class HTTPMethod(str, Enum):
     OPTIONS = "OPTIONS"
 
 
-class CredentialKind(str, Enum):
+class CredentialKind(StrEnum):
     """
     Enum representing different kinds of credentials used for authentication.
     """

--- a/packages/nvidia_nat_core/src/nat/data_models/discovery_metadata.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/discovery_metadata.py
@@ -17,7 +17,7 @@ import importlib.metadata
 import inspect
 import logging
 import typing
-from enum import Enum
+from enum import StrEnum
 from functools import lru_cache
 from types import ModuleType
 from typing import TYPE_CHECKING
@@ -36,12 +36,12 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class DiscoveryStatusEnum(str, Enum):
+class DiscoveryStatusEnum(StrEnum):
     SUCCESS = "success"
     FAILURE = "failure"
 
 
-class DiscoveryContractFieldsEnum(str, Enum):
+class DiscoveryContractFieldsEnum(StrEnum):
     PACKAGE = "package"
     VERSION = "version"
     COMPONENT_TYPE = "component_type"

--- a/packages/nvidia_nat_core/src/nat/data_models/evaluate.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/evaluate.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import typing
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 
 from pydantic import BaseModel
@@ -30,7 +30,7 @@ from nat.data_models.intermediate_step import IntermediateStepType
 from nat.data_models.profiler import ProfilerConfig
 
 
-class JobEvictionPolicy(str, Enum):
+class JobEvictionPolicy(StrEnum):
     """Policy for evicting old jobs when max_jobs is exceeded."""
     TIME_CREATED = "time_created"
     TIME_MODIFIED = "time_modified"

--- a/packages/nvidia_nat_core/src/nat/data_models/finetuning.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/finetuning.py
@@ -15,7 +15,7 @@
 
 import logging
 import typing
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -74,7 +74,7 @@ class TrainingJobRef(BaseModel):
     metadata: dict | None = Field(description="Any additional metadata for the training job.", default=None)
 
 
-class TrainingStatusEnum(str, Enum):
+class TrainingStatusEnum(StrEnum):
     PENDING = "pending"
     RUNNING = "running"
     COMPLETED = "completed"
@@ -96,7 +96,7 @@ class TrainingJobStatus(BaseModel):
     metadata: dict | None = Field(description="Any additional metadata for the training job.", default=None)
 
 
-class EpisodeItemRole(str, Enum):
+class EpisodeItemRole(StrEnum):
     USER = "user"
     ASSISTANT = "assistant"
     SYSTEM = "system"

--- a/packages/nvidia_nat_core/src/nat/data_models/interactive.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/interactive.py
@@ -15,7 +15,7 @@
 
 import re
 import typing
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel
 from pydantic import Discriminator
@@ -23,7 +23,7 @@ from pydantic import Field
 from pydantic import field_validator
 
 
-class HumanPromptModelType(str, Enum):
+class HumanPromptModelType(StrEnum):
     """
     Represents the type of an interaction model.
     """
@@ -36,7 +36,7 @@ class HumanPromptModelType(str, Enum):
     OAUTH_CONSENT = "oauth_consent"
 
 
-class BinaryChoiceOptionsType(str, Enum):
+class BinaryChoiceOptionsType(StrEnum):
     """
     Represents the types of system interaction binary choice content
     """
@@ -44,7 +44,7 @@ class BinaryChoiceOptionsType(str, Enum):
     CANCEL = "cancel"
 
 
-class MultipleChoiceOptionType(str, Enum):
+class MultipleChoiceOptionType(StrEnum):
     """
     Represents the types of system interaction multiple choice content
     """
@@ -203,7 +203,7 @@ HumanPrompt = typing.Annotated[HumanPromptText | HumanPromptNotification | Human
                                Discriminator("input_type")]
 
 
-class InteractionStatus(str, Enum):
+class InteractionStatus(StrEnum):
     """
     Represents the status of an interaction.
     """

--- a/packages/nvidia_nat_core/src/nat/data_models/intermediate_step.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/intermediate_step.py
@@ -16,7 +16,7 @@
 import time
 import typing
 import uuid
-from enum import Enum
+from enum import StrEnum
 from typing import Literal
 
 from pydantic import BaseModel
@@ -30,7 +30,7 @@ from nat.data_models.invocation_node import InvocationNode
 from nat.profiler.callbacks.token_usage_base_model import TokenUsageBaseModel
 
 
-class IntermediateStepCategory(str, Enum):
+class IntermediateStepCategory(StrEnum):
     LLM = "LLM"
     TOOL = "TOOL"
     WORKFLOW = "WORKFLOW"
@@ -41,7 +41,7 @@ class IntermediateStepCategory(str, Enum):
     TTC = "TTC"
 
 
-class IntermediateStepType(str, Enum):
+class IntermediateStepType(StrEnum):
     LLM_START = "LLM_START"
     LLM_END = "LLM_END"
     LLM_NEW_TOKEN = "LLM_NEW_TOKEN"
@@ -62,7 +62,7 @@ class IntermediateStepType(str, Enum):
     SPAN_END = "SPAN_END"
 
 
-class IntermediateStepState(str, Enum):
+class IntermediateStepState(StrEnum):
     START = "START"
     CHUNK = "CHUNK"
     END = "END"

--- a/packages/nvidia_nat_core/src/nat/data_models/llm.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/llm.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import typing
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import Field
 
@@ -22,7 +22,7 @@ from .common import BaseModelRegistryTag
 from .common import TypedBaseModel
 
 
-class APITypeEnum(str, Enum):
+class APITypeEnum(StrEnum):
     CHAT_COMPLETION = "chat_completion"
     RESPONSES = "responses"
 

--- a/packages/nvidia_nat_core/src/nat/data_models/openai_mcp.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/openai_mcp.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel
 from pydantic import ConfigDict
 from pydantic import Field
 
 
-class MCPApprovalRequiredEnum(str, Enum):
+class MCPApprovalRequiredEnum(StrEnum):
     """
     Enum to specify if approval is required for tool usage in the OpenAI MCP schema.
     """

--- a/packages/nvidia_nat_core/src/nat/data_models/optimizer.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/optimizer.py
@@ -13,7 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
+from enum import StrEnum
 from pathlib import Path
 from typing import Literal
 
@@ -30,7 +30,7 @@ class OptimizerMetric(BaseModel):
     weight: float = Field(description="Weight of the metric in the optimization process.", default=1.0)
 
 
-class SamplerType(str, Enum):
+class SamplerType(StrEnum):
     BAYESIAN = "bayesian"
     GRID = "grid"
 

--- a/packages/nvidia_nat_core/src/nat/data_models/runtime_enum.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/runtime_enum.py
@@ -16,7 +16,7 @@
 import enum
 
 
-class RuntimeTypeEnum(str, enum.Enum):
+class RuntimeTypeEnum(enum.StrEnum):
     """
     Enum representing different runtime types.
     """

--- a/packages/nvidia_nat_core/src/nat/data_models/step_adaptor.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/step_adaptor.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel
 from pydantic import Field
@@ -25,7 +25,7 @@ from nat.data_models.intermediate_step import IntermediateStepType
 logger = logging.getLogger(__name__)
 
 
-class StepAdaptorMode(str, Enum):
+class StepAdaptorMode(StrEnum):
     DEFAULT = "default"
     CUSTOM = "custom"
     OFF = "off"

--- a/packages/nvidia_nat_core/src/nat/eval/red_teaming_evaluator/evaluate.py
+++ b/packages/nvidia_nat_core/src/nat/eval/red_teaming_evaluator/evaluate.py
@@ -15,7 +15,7 @@
 
 import logging
 from collections.abc import Callable
-from enum import Enum
+from enum import StrEnum
 
 from langchain_classic.output_parsers import ResponseSchema
 from langchain_classic.output_parsers import StructuredOutputParser
@@ -36,7 +36,7 @@ logger = logging.getLogger(__name__)
 # flake8: noqa: E501
 
 
-class ReductionStrategy(str, Enum):
+class ReductionStrategy(StrEnum):
     """Reduction strategy for selecting a single intermediate step from filtered steps."""
     FIRST = "first"
     MAX = "max"

--- a/packages/nvidia_nat_core/src/nat/experimental/test_time_compute/models/stage_enums.py
+++ b/packages/nvidia_nat_core/src/nat/experimental/test_time_compute/models/stage_enums.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
+from enum import StrEnum
 
 
-class PipelineTypeEnum(str, Enum):
+class PipelineTypeEnum(StrEnum):
     """
     Enum to represent the type of pipeline used in Inference Time Scaling.
     """
@@ -29,7 +29,7 @@ class PipelineTypeEnum(str, Enum):
         return self.value
 
 
-class StageTypeEnum(str, Enum):
+class StageTypeEnum(StrEnum):
     """
     Enum to represent the type of stage in a pipeline.
     """

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
@@ -663,7 +663,7 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
             except NoSuchKeyError as e:
                 raise HTTPException(status_code=404, detail=str(e)) from e
 
-            filename = file_path.split("/")[-1]
+            filename = file_path.rsplit("/", maxsplit=1)[-1]
 
             async def reader():
                 yield file_data.data

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/job_store.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/job_store.py
@@ -25,7 +25,7 @@ from contextlib import asynccontextmanager
 from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
-from enum import Enum
+from enum import StrEnum
 from uuid import uuid4
 
 from dask.distributed import Future
@@ -54,7 +54,7 @@ if typing.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class JobStatus(str, Enum):
+class JobStatus(StrEnum):
     """
     Enumeration of possible job statuses in the job store.
 

--- a/packages/nvidia_nat_core/src/nat/llm/utils/constants.py
+++ b/packages/nvidia_nat_core/src/nat/llm/utils/constants.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
+from enum import StrEnum
 
 
-class LLMHeaderPrefix(str, Enum):
+class LLMHeaderPrefix(StrEnum):
     """HTTP header prefixes used by LLM clients for metadata and routing."""
 
     PAYLOAD = "X-Payload"  # Custom metadata propagation

--- a/packages/nvidia_nat_core/src/nat/observability/mixin/tagging_config_mixin.py
+++ b/packages/nvidia_nat_core/src/nat/observability/mixin/tagging_config_mixin.py
@@ -15,7 +15,7 @@
 
 import sys
 from collections.abc import Mapping
-from enum import Enum
+from enum import StrEnum
 from typing import Generic
 from typing import TypeVar
 
@@ -35,7 +35,7 @@ class BaseTaggingConfigMixin(BaseModel, Generic[TagMappingT]):
     tags: TagMappingT | None = Field(default=None, description="Tags to add to the span.")
 
 
-class PrivacyLevel(str, Enum):
+class PrivacyLevel(StrEnum):
     """Privacy level for the traces."""
     NONE = "none"
     LOW = "low"

--- a/packages/nvidia_nat_core/src/nat/registry_handlers/package_utils.py
+++ b/packages/nvidia_nat_core/src/nat/registry_handlers/package_utils.py
@@ -72,7 +72,7 @@ def parse_requirement(requirement: str) -> str:
         'requests' from 'requests[security]~=2.28.0')
     """
     # Handle inline comments by splitting on '#' and taking the first part
-    clean_requirement = requirement.split('#')[0].strip()
+    clean_requirement = requirement.split('#', maxsplit=1)[0].strip()
     if not clean_requirement:
         return ""
 
@@ -172,7 +172,7 @@ def extract_dependencies_with_extras_resolved(pyproject_path: str) -> set[str]:
     def _process_dependency(dep_spec: str):
         """Process a single dependency specification and resolve extras."""
         # Handle inline comments
-        clean_req = dep_spec.split('#')[0].strip()
+        clean_req = dep_spec.split('#', maxsplit=1)[0].strip()
         if not clean_req:
             return
 

--- a/packages/nvidia_nat_core/src/nat/registry_handlers/schemas/search.py
+++ b/packages/nvidia_nat_core/src/nat/registry_handlers/schemas/search.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel
 
@@ -24,7 +24,7 @@ from nat.registry_handlers.schemas.status import StatusMessage
 logger = logging.getLogger(__name__)
 
 
-class SearchFields(str, Enum):
+class SearchFields(StrEnum):
     ALL = "all"
     PACKAGE = "package"
     VERSION = "version"
@@ -33,7 +33,7 @@ class SearchFields(str, Enum):
     DEVELOPER_NOTES = "developer_notes"
 
 
-class VisualizeFields(str, Enum):
+class VisualizeFields(StrEnum):
     PACKAGE = "package"
     VERSION = "version"
     COMPONENT_TYPE = "component_type"

--- a/packages/nvidia_nat_core/src/nat/registry_handlers/schemas/status.py
+++ b/packages/nvidia_nat_core/src/nat/registry_handlers/schemas/status.py
@@ -14,21 +14,21 @@
 # limitations under the License.
 
 import logging
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel
 
 logger = logging.getLogger(__name__)
 
 
-class ActionEnum(str, Enum):
+class ActionEnum(StrEnum):
     PUBLISH = "publish"
     PULL = "pull"
     REMOVE = "remove"
     SEARCH = "search"
 
 
-class StatusEnum(str, Enum):
+class StatusEnum(StrEnum):
     SUCCESS = "success"
     ERROR = "error"
 

--- a/packages/nvidia_nat_core/src/nat/tool/code_execution/local_sandbox/local_sandbox_server.py
+++ b/packages/nvidia_nat_core/src/nat/tool/code_execution/local_sandbox/local_sandbox_server.py
@@ -19,7 +19,7 @@ import logging
 import multiprocessing
 import os
 import resource
-from enum import Enum
+from enum import StrEnum
 from io import StringIO
 
 from flask import Flask
@@ -34,7 +34,7 @@ logger = logging.getLogger(__name__)
 logger.setLevel(logging.WARNING)
 
 
-class CodeExecutionStatus(str, Enum):
+class CodeExecutionStatus(StrEnum):
     """
     Status of code execution.
     """

--- a/packages/nvidia_nat_core/src/nat/tool/code_execution/utils.py
+++ b/packages/nvidia_nat_core/src/nat/tool/code_execution/utils.py
@@ -56,7 +56,7 @@ def _extract_between_separators(generation: str, separators: tuple[str, str], ex
         separators = [re.escape(sp) for sp in separators]
         pattern = f'{separators[0]}(.*?){separators[1]}'
         return re.findall(pattern, generation, re.DOTALL)
-    return generation.split(separators[0])[-1].split(separators[1])[0]
+    return generation.rsplit(separators[0], maxsplit=1)[-1].split(separators[1])[0]
 
 
 def extract_code_to_execute(generation: str, code_begin: str, code_end: str, extract_all: bool = False):

--- a/packages/nvidia_nat_core/tests/nat/observability/processor/test_span_tagging_processor.py
+++ b/packages/nvidia_nat_core/tests/nat/observability/processor/test_span_tagging_processor.py
@@ -16,6 +16,7 @@
 import logging
 import os
 from enum import Enum
+from enum import StrEnum
 from typing import cast
 from unittest.mock import patch
 
@@ -26,7 +27,7 @@ from nat.data_models.span import SpanContext
 from nat.observability.processor.span_tagging_processor import SpanTaggingProcessor
 
 
-class SampleEnum(str, Enum):
+class SampleEnum(StrEnum):
     """Sample enum for testing enum value handling."""
     VALUE1 = "test_value_1"
     VALUE2 = "test_value_2"

--- a/packages/nvidia_nat_data_flywheel/src/nat/plugins/data_flywheel/observability/schema/sink/elasticsearch/contract_version.py
+++ b/packages/nvidia_nat_data_flywheel/src/nat/plugins/data_flywheel/observability/schema/sink/elasticsearch/contract_version.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
+from enum import StrEnum
 
 from pydantic import BaseModel
 
 from nat.plugins.data_flywheel.observability.schema.schema_registry import SchemaRegistry
 
 
-class ContractVersion(str, Enum):
+class ContractVersion(StrEnum):
     """The contract version for Elasticsearch schema."""
 
     V1_0 = "1.0"

--- a/packages/nvidia_nat_data_flywheel/src/nat/plugins/data_flywheel/observability/schema/sink/elasticsearch/dfw_es_record.py
+++ b/packages/nvidia_nat_data_flywheel/src/nat/plugins/data_flywheel/observability/schema/sink/elasticsearch/dfw_es_record.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 import logging
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 from typing import Literal
 from typing import Self
@@ -33,7 +33,7 @@ from .contract_version import ContractVersion
 logger = logging.getLogger(__name__)
 
 
-class FinishReason(str, Enum):
+class FinishReason(StrEnum):
     """Finish reason for chat completion responses."""
 
     STOP = "stop"

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/output_parser.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/output_parser.py
@@ -126,7 +126,7 @@ class ReActOutputParser(AgentOutputParser):
             if final_answer_match:
                 answer_text = text[final_answer_match.end():].strip()
                 return AgentFinish({"output": answer_text}, text)
-            return AgentFinish({"output": text.split(FINAL_ANSWER_ACTION)[-1].strip()}, text)
+            return AgentFinish({"output": text.rsplit(FINAL_ANSWER_ACTION, maxsplit=1)[-1].strip()}, text)
 
         # Check for missing components with case-insensitive patterns
         if not re.search(r"action\s*\d*\s*:\s*(.*?)", text, re.DOTALL | re.IGNORECASE):

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/exceptions.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/exceptions.py
@@ -13,10 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from enum import Enum
+from enum import StrEnum
 
 
-class MCPErrorCategory(str, Enum):
+class MCPErrorCategory(StrEnum):
     """Categories of MCP errors for structured handling."""
     CONNECTION = "connection"
     TIMEOUT = "timeout"

--- a/packages/nvidia_nat_vanna/src/nat/plugins/vanna/db_utils.py
+++ b/packages/nvidia_nat_vanna/src/nat/plugins/vanna/db_utils.py
@@ -18,7 +18,7 @@ import json
 import logging
 import re
 import typing
-from enum import Enum
+from enum import StrEnum
 from typing import Any
 
 from pydantic import BaseModel
@@ -38,7 +38,7 @@ def _serialize_secret(v: SecretStr) -> str:
 RequiredSecretStr = typing.Annotated[SecretStr, PlainSerializer(_serialize_secret)]
 
 
-class SupportedDatabase(str, Enum):
+class SupportedDatabase(StrEnum):
     """Supported database types for Vanna text-to-SQL."""
 
     DATABRICKS = "databricks"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -163,13 +163,14 @@ dev = [
   "nbconvert", # Version determined by jupyter
   "pre-commit>=4.0,<5.0",
   "python-docx~=1.1",
-  "ruff~=0.12",
+  "ruff==0.15.0", # align with .pre-commit-config.yaml
   "setuptools >= 64",
   "setuptools_scm>=8",
   "tomlkit>=0.13.2",
   "twine~=6.0",
+  "uv==0.9.28", # align with .pre-commit-config.yaml
   "vale~=3.12",
-  "yapf==0.43.*",
+  "yapf==0.43.0", # align with .pre-commit-config.yaml
   # documentation related dependencies
   "myst-parser~=4.0",
   "nbsphinx~=0.9",

--- a/scripts/web_utils.py
+++ b/scripts/web_utils.py
@@ -116,7 +116,7 @@ def cache_html(input_dict: dict, base_path="."):
 
 
 def _get_short_url(url: str):
-    path = url.split("://")[-1].split("www.")[-1]
+    path = url.rsplit("://", maxsplit=1)[-1].split("www.")[-1]
     path_components = path.split("/")
     domain = path_components[0]
     short_url = "/".join(path_components[1:])

--- a/uv.lock
+++ b/uv.lock
@@ -6331,6 +6331,7 @@ dev = [
     { name = "sphinx-reredirects" },
     { name = "tomlkit" },
     { name = "twine" },
+    { name = "uv" },
     { name = "vale" },
     { name = "werkzeug" },
     { name = "yapf" },
@@ -6450,7 +6451,7 @@ dev = [
     { name = "nvidia-sphinx-theme", specifier = ">=0.0.9" },
     { name = "pre-commit", specifier = ">=4.0,<5.0" },
     { name = "python-docx", specifier = "~=1.1" },
-    { name = "ruff", specifier = "~=0.12" },
+    { name = "ruff", specifier = "==0.15.0" },
     { name = "setuptools", specifier = ">=64" },
     { name = "setuptools-scm", specifier = ">=8" },
     { name = "sphinx", specifier = "~=8.2" },
@@ -6461,9 +6462,10 @@ dev = [
     { name = "sphinx-reredirects", specifier = "~=1.1" },
     { name = "tomlkit", specifier = ">=0.13.2" },
     { name = "twine", specifier = "~=6.0" },
+    { name = "uv", specifier = "==0.9.28" },
     { name = "vale", specifier = "~=3.12" },
     { name = "werkzeug", specifier = ">=3.1.5" },
-    { name = "yapf", specifier = "==0.43.*" },
+    { name = "yapf", specifier = "==0.43.0" },
 ]
 
 [[package]]
@@ -10060,28 +10062,27 @@ sdist = { url = "https://files.pythonhosted.org/packages/f7/5d/c589ccf1b86632d21
 
 [[package]]
 name = "ruff"
-version = "0.14.14"
+version = "0.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/2e/06/f71e3a86b2df0dfa2d2f72195941cd09b44f87711cb7fa5193732cb9a5fc/ruff-0.14.14.tar.gz", hash = "sha256:2d0f819c9a90205f3a867dbbd0be083bee9912e170fd7d9704cc8ae45824896b", size = 4515732, upload-time = "2026-01-22T22:30:17.527Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c8/39/5cee96809fbca590abea6b46c6d1c586b49663d1d2830a751cc8fc42c666/ruff-0.15.0.tar.gz", hash = "sha256:6bdea47cdbea30d40f8f8d7d69c0854ba7c15420ec75a26f463290949d7f7e9a", size = 4524893, upload-time = "2026-02-03T17:53:35.357Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d2/89/20a12e97bc6b9f9f68343952da08a8099c57237aef953a56b82711d55edd/ruff-0.14.14-py3-none-linux_armv6l.whl", hash = "sha256:7cfe36b56e8489dee8fbc777c61959f60ec0f1f11817e8f2415f429552846aed", size = 10467650, upload-time = "2026-01-22T22:30:08.578Z" },
-    { url = "https://files.pythonhosted.org/packages/a3/b1/c5de3fd2d5a831fcae21beda5e3589c0ba67eec8202e992388e4b17a6040/ruff-0.14.14-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:6006a0082336e7920b9573ef8a7f52eec837add1265cc74e04ea8a4368cd704c", size = 10883245, upload-time = "2026-01-22T22:30:04.155Z" },
-    { url = "https://files.pythonhosted.org/packages/b8/7c/3c1db59a10e7490f8f6f8559d1db8636cbb13dccebf18686f4e3c9d7c772/ruff-0.14.14-py3-none-macosx_11_0_arm64.whl", hash = "sha256:026c1d25996818f0bf498636686199d9bd0d9d6341c9c2c3b62e2a0198b758de", size = 10231273, upload-time = "2026-01-22T22:30:34.642Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/6e/5e0e0d9674be0f8581d1f5e0f0a04761203affce3232c1a1189d0e3b4dad/ruff-0.14.14-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f666445819d31210b71e0a6d1c01e24447a20b85458eea25a25fe8142210ae0e", size = 10585753, upload-time = "2026-01-22T22:30:31.781Z" },
-    { url = "https://files.pythonhosted.org/packages/23/09/754ab09f46ff1884d422dc26d59ba18b4e5d355be147721bb2518aa2a014/ruff-0.14.14-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3c0f18b922c6d2ff9a5e6c3ee16259adc513ca775bcf82c67ebab7cbd9da5bc8", size = 10286052, upload-time = "2026-01-22T22:30:24.827Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/cc/e71f88dd2a12afb5f50733851729d6b571a7c3a35bfdb16c3035132675a0/ruff-0.14.14-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1629e67489c2dea43e8658c3dba659edbfd87361624b4040d1df04c9740ae906", size = 11043637, upload-time = "2026-01-22T22:30:13.239Z" },
-    { url = "https://files.pythonhosted.org/packages/67/b2/397245026352494497dac935d7f00f1468c03a23a0c5db6ad8fc49ca3fb2/ruff-0.14.14-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:27493a2131ea0f899057d49d303e4292b2cae2bb57253c1ed1f256fbcd1da480", size = 12194761, upload-time = "2026-01-22T22:30:22.542Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/06/06ef271459f778323112c51b7587ce85230785cd64e91772034ddb88f200/ruff-0.14.14-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:01ff589aab3f5b539e35db38425da31a57521efd1e4ad1ae08fc34dbe30bd7df", size = 12005701, upload-time = "2026-01-22T22:30:20.499Z" },
-    { url = "https://files.pythonhosted.org/packages/41/d6/99364514541cf811ccc5ac44362f88df66373e9fec1b9d1c4cc830593fe7/ruff-0.14.14-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1cc12d74eef0f29f51775f5b755913eb523546b88e2d733e1d701fe65144e89b", size = 11282455, upload-time = "2026-01-22T22:29:59.679Z" },
-    { url = "https://files.pythonhosted.org/packages/ca/71/37daa46f89475f8582b7762ecd2722492df26421714a33e72ccc9a84d7a5/ruff-0.14.14-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb8481604b7a9e75eff53772496201690ce2687067e038b3cc31aaf16aa0b974", size = 11215882, upload-time = "2026-01-22T22:29:57.032Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/10/a31f86169ec91c0705e618443ee74ede0bdd94da0a57b28e72db68b2dbac/ruff-0.14.14-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:14649acb1cf7b5d2d283ebd2f58d56b75836ed8c6f329664fa91cdea19e76e66", size = 11180549, upload-time = "2026-01-22T22:30:27.175Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/1e/c723f20536b5163adf79bdd10c5f093414293cdf567eed9bdb7b83940f3f/ruff-0.14.14-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e8058d2145566510790eab4e2fad186002e288dec5e0d343a92fe7b0bc1b3e13", size = 10543416, upload-time = "2026-01-22T22:30:01.964Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/34/8a84cea7e42c2d94ba5bde1d7a4fae164d6318f13f933d92da6d7c2041ff/ruff-0.14.14-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e651e977a79e4c758eb807f0481d673a67ffe53cfa92209781dfa3a996cf8412", size = 10285491, upload-time = "2026-01-22T22:30:29.51Z" },
-    { url = "https://files.pythonhosted.org/packages/55/ef/b7c5ea0be82518906c978e365e56a77f8de7678c8bb6651ccfbdc178c29f/ruff-0.14.14-py3-none-musllinux_1_2_i686.whl", hash = "sha256:cc8b22da8d9d6fdd844a68ae937e2a0adf9b16514e9a97cc60355e2d4b219fc3", size = 10733525, upload-time = "2026-01-22T22:30:06.499Z" },
-    { url = "https://files.pythonhosted.org/packages/6a/5b/aaf1dfbcc53a2811f6cc0a1759de24e4b03e02ba8762daabd9b6bd8c59e3/ruff-0.14.14-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:16bc890fb4cc9781bb05beb5ab4cd51be9e7cb376bf1dd3580512b24eb3fda2b", size = 11315626, upload-time = "2026-01-22T22:30:36.848Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
-    { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/88/3fd1b0aa4b6330d6aaa63a285bc96c9f71970351579152d231ed90914586/ruff-0.15.0-py3-none-linux_armv6l.whl", hash = "sha256:aac4ebaa612a82b23d45964586f24ae9bc23ca101919f5590bdb368d74ad5455", size = 10354332, upload-time = "2026-02-03T17:52:54.892Z" },
+    { url = "https://files.pythonhosted.org/packages/72/f6/62e173fbb7eb75cc29fe2576a1e20f0a46f671a2587b5f604bfb0eaf5f6f/ruff-0.15.0-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:dcd4be7cc75cfbbca24a98d04d0b9b36a270d0833241f776b788d59f4142b14d", size = 10767189, upload-time = "2026-02-03T17:53:19.778Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e4/968ae17b676d1d2ff101d56dc69cf333e3a4c985e1ec23803df84fc7bf9e/ruff-0.15.0-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d747e3319b2bce179c7c1eaad3d884dc0a199b5f4d5187620530adf9105268ce", size = 10075384, upload-time = "2026-02-03T17:53:29.241Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bf/9843c6044ab9e20af879c751487e61333ca79a2c8c3058b15722386b8cae/ruff-0.15.0-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:650bd9c56ae03102c51a5e4b554d74d825ff3abe4db22b90fd32d816c2e90621", size = 10481363, upload-time = "2026-02-03T17:52:43.332Z" },
+    { url = "https://files.pythonhosted.org/packages/55/d9/4ada5ccf4cd1f532db1c8d44b6f664f2208d3d93acbeec18f82315e15193/ruff-0.15.0-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a6664b7eac559e3048223a2da77769c2f92b43a6dfd4720cef42654299a599c9", size = 10187736, upload-time = "2026-02-03T17:53:00.522Z" },
+    { url = "https://files.pythonhosted.org/packages/86/e2/f25eaecd446af7bb132af0a1d5b135a62971a41f5366ff41d06d25e77a91/ruff-0.15.0-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:6f811f97b0f092b35320d1556f3353bf238763420ade5d9e62ebd2b73f2ff179", size = 10968415, upload-time = "2026-02-03T17:53:15.705Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/dc/f06a8558d06333bf79b497d29a50c3a673d9251214e0d7ec78f90b30aa79/ruff-0.15.0-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:761ec0a66680fab6454236635a39abaf14198818c8cdf691e036f4bc0f406b2d", size = 11809643, upload-time = "2026-02-03T17:53:23.031Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/45/0ece8db2c474ad7df13af3a6d50f76e22a09d078af63078f005057ca59eb/ruff-0.15.0-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:940f11c2604d317e797b289f4f9f3fa5555ffe4fb574b55ed006c3d9b6f0eb78", size = 11234787, upload-time = "2026-02-03T17:52:46.432Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/d9/0e3a81467a120fd265658d127db648e4d3acfe3e4f6f5d4ea79fac47e587/ruff-0.15.0-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bcbca3d40558789126da91d7ef9a7c87772ee107033db7191edefa34e2c7f1b4", size = 11112797, upload-time = "2026-02-03T17:52:49.274Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/cb/8c0b3b0c692683f8ff31351dfb6241047fa873a4481a76df4335a8bff716/ruff-0.15.0-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9a121a96db1d75fa3eb39c4539e607f628920dd72ff1f7c5ee4f1b768ac62d6e", size = 11033133, upload-time = "2026-02-03T17:53:33.105Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/5e/23b87370cf0f9081a8c89a753e69a4e8778805b8802ccfe175cc410e50b9/ruff-0.15.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:5298d518e493061f2eabd4abd067c7e4fb89e2f63291c94332e35631c07c3662", size = 10442646, upload-time = "2026-02-03T17:53:06.278Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/9a/3c94de5ce642830167e6d00b5c75aacd73e6347b4c7fc6828699b150a5ee/ruff-0.15.0-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:afb6e603d6375ff0d6b0cee563fa21ab570fd15e65c852cb24922cef25050cf1", size = 10195750, upload-time = "2026-02-03T17:53:26.084Z" },
+    { url = "https://files.pythonhosted.org/packages/30/15/e396325080d600b436acc970848d69df9c13977942fb62bb8722d729bee8/ruff-0.15.0-py3-none-musllinux_1_2_i686.whl", hash = "sha256:77e515f6b15f828b94dc17d2b4ace334c9ddb7d9468c54b2f9ed2b9c1593ef16", size = 10676120, upload-time = "2026-02-03T17:53:09.363Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/c9/229a23d52a2983de1ad0fb0ee37d36e0257e6f28bfd6b498ee2c76361874/ruff-0.15.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:6f6e80850a01eb13b3e42ee0ebdf6e4497151b48c35051aab51c101266d187a3", size = 11201636, upload-time = "2026-02-03T17:52:57.281Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b0/69adf22f4e24f3677208adb715c578266842e6e6a3cc77483f48dd999ede/ruff-0.15.0-py3-none-win32.whl", hash = "sha256:238a717ef803e501b6d51e0bdd0d2c6e8513fe9eec14002445134d3907cd46c3", size = 10465945, upload-time = "2026-02-03T17:53:12.591Z" },
+    { url = "https://files.pythonhosted.org/packages/51/ad/f813b6e2c97e9b4598be25e94a9147b9af7e60523b0cb5d94d307c15229d/ruff-0.15.0-py3-none-win_amd64.whl", hash = "sha256:dd5e4d3301dc01de614da3cdffc33d4b1b96fb89e45721f1598e5532ccf78b18", size = 11564657, upload-time = "2026-02-03T17:52:51.893Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b0/2d823f6e77ebe560f4e397d078487e8d52c1516b331e3521bc75db4272ca/ruff-0.15.0-py3-none-win_arm64.whl", hash = "sha256:c480d632cc0ca3f0727acac8b7d053542d9e114a462a145d0b00e7cd658c515a", size = 10865753, upload-time = "2026-02-03T17:53:03.014Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3325,7 +3325,7 @@ name = "ipykernel"
 version = "7.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-10-nvidia-nat-crewai' and extra == 'extra-10-nvidia-nat-openpipe-art')" },
+    { name = "appnope", marker = "sys_platform == 'darwin' or (extra == 'extra-10-nvidia-nat-adk' and extra == 'extra-10-nvidia-nat-openpipe-art') or (extra == 'extra-10-nvidia-nat-adk' and extra == 'extra-10-nvidia-nat-ragaai') or (extra == 'extra-10-nvidia-nat-crewai' and extra == 'extra-10-nvidia-nat-openpipe-art') or (extra == 'extra-10-nvidia-nat-most' and extra == 'extra-10-nvidia-nat-openpipe-art') or (extra == 'extra-10-nvidia-nat-most' and extra == 'extra-10-nvidia-nat-ragaai') or (extra == 'extra-10-nvidia-nat-ragaai' and extra == 'extra-10-nvidia-nat-strands')" },
     { name = "comm" },
     { name = "debugpy" },
     { name = "ipython" },
@@ -5412,12 +5412,14 @@ requires-dist = [
 name = "nat-documentation-guides"
 source = { editable = "examples/documentation_guides" }
 dependencies = [
+    { name = "nat-simple-web-query" },
     { name = "nvidia-nat", extra = ["langchain", "test"] },
     { name = "text-file-ingest" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "nat-simple-web-query", editable = "examples/getting_started/simple_web_query" },
     { name = "nvidia-nat", extras = ["langchain", "test"], editable = "." },
     { name = "text-file-ingest", editable = "examples/documentation_guides/workflows/text_file_ingest" },
 ]
@@ -5544,11 +5546,23 @@ requires-dist = [
 name = "nat-notebooks"
 source = { editable = "examples/notebooks" }
 dependencies = [
-    { name = "nvidia-nat", extra = ["test"] },
+    { name = "ipykernel" },
+    { name = "ipython" },
+    { name = "nat-alert-triage-agent" },
+    { name = "nat-simple-calculator" },
+    { name = "nvidia-nat", extra = ["langchain", "llama-index", "mcp", "profiling", "test"] },
+    { name = "python-dotenv", extra = ["cli"] },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "nvidia-nat", extras = ["test"], editable = "." }]
+requires-dist = [
+    { name = "ipykernel" },
+    { name = "ipython", specifier = "~=8.31" },
+    { name = "nat-alert-triage-agent", editable = "examples/advanced_agents/alert_triage_agent" },
+    { name = "nat-simple-calculator", editable = "examples/getting_started/simple_calculator" },
+    { name = "nvidia-nat", extras = ["langchain", "llama-index", "mcp", "profiling", "test"], editable = "." },
+    { name = "python-dotenv", extras = ["cli"], specifier = "~=1.1.1" },
+]
 
 [[package]]
 name = "nat-per-user-workflow"
@@ -5591,16 +5605,16 @@ name = "nat-profiler-agent"
 source = { editable = "examples/advanced_agents/profiler_agent" }
 dependencies = [
     { name = "arize-phoenix-client" },
+    { name = "nat-simple-calculator" },
     { name = "nvidia-nat", extra = ["langchain", "opentelemetry", "phoenix", "profiling", "test", "weave"] },
     { name = "nvidia-nat", extra = ["ragaai"], marker = "extra == 'extra-10-nvidia-nat-ragaai' or (extra == 'extra-10-nvidia-nat-adk' and extra == 'extra-10-nvidia-nat-openpipe-art') or (extra == 'extra-10-nvidia-nat-crewai' and extra == 'extra-10-nvidia-nat-openpipe-art') or (extra == 'extra-10-nvidia-nat-most' and extra == 'extra-10-nvidia-nat-openpipe-art')" },
-    { name = "pydantic" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "arize-phoenix-client", specifier = "~=1.21" },
+    { name = "nat-simple-calculator", editable = "examples/getting_started/simple_calculator" },
     { name = "nvidia-nat", extras = ["langchain", "opentelemetry", "phoenix", "profiling", "ragaai", "test", "weave"], editable = "." },
-    { name = "pydantic" },
 ]
 
 [[package]]
@@ -9476,6 +9490,11 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f6/b0/4bc07ccd3572a2f9df7e6782f52b0c6c90dcbb803ac4a167702d7d0dfe1e/python_dotenv-1.1.1.tar.gz", hash = "sha256:a8a6399716257f45be6a007360200409fce5cda2661e3dec71d23dc15f6189ab", size = 41978, upload-time = "2025-06-24T04:21:07.341Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/ed/539768cf28c661b5b068d66d96a2f155c4971a5d55684a514c1a0e0dec2f/python_dotenv-1.1.1-py3-none-any.whl", hash = "sha256:31f23644fe2602f88ff55e1f5c79ba497e01224ee7737937930c448e4d0e24dc", size = 20556, upload-time = "2025-06-24T04:21:06.073Z" },
+]
+
+[package.optional-dependencies]
+cli = [
+    { name = "click" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

1. Updates versions of the following hooks in `.pre-commit-config.yaml`:
    - ruff-pre-commit
    - uv-pre-commit
    - markdown-link-check
2. Aligns versions in root pyproject.toml with the pre-commit configuration:
    - uv
    - ruff
    - yapf
3. Updates code based on `ruff check` (inheriting from str + Enum -> StrEnum)
4. Fixes a bug with the license_diff script to suppress "changed" source packages

```
Changed packages:
- ruff 0.14.14 -> 0.15.0
```

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit tool versions and pinned dev dependencies for consistency.
  * Expanded lockfile entries across many components for reproducible tooling.

* **New Features**
  * Numerous enums migrated to string-based enum semantics; several enums gain new values.
  * Added a helper to retrieve contract schema classes for the Elasticsearch contract version.

* **Bug Fixes**
  * Improved robustness of path/URL parsing, inline-comment handling, and final-answer extraction.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->