### PR TITLE
fix(milvus): Fix vector_field config mapping and document_id type

### DIFF
--- a/packages/nvidia_nat_core/src/nat/retriever/milvus/register.py
+++ b/packages/nvidia_nat_core/src/nat/retriever/milvus/register.py
@@ -84,6 +84,10 @@ async def milvus_retriever_client(config: MilvusRetrieverConfig, builder: Builde
     model_dict = config.model_dump()
     optional_args = {field: model_dict[field] for field in optional_fields if model_dict[field] is not None}
 
+    # Map vector_field config to vector_field_name parameter expected by retriever
+    if "vector_field" in optional_args:
+        optional_args["vector_field_name"] = optional_args.pop("vector_field")
+
     retriever.bind(**optional_args)
 
     yield retriever

--- a/packages/nvidia_nat_core/src/nat/retriever/milvus/retriever.py
+++ b/packages/nvidia_nat_core/src/nat/retriever/milvus/retriever.py
@@ -282,9 +282,9 @@ def _wrap_milvus_single_results(res: Hit | dict, content_field: str) -> Document
     if isinstance(res, Hit):
         metadata = {k: v for k, v in res.fields.items() if k != content_field}
         metadata.update({"distance": res.distance})
-        return Document(page_content=res.fields[content_field], metadata=metadata, document_id=res.id)
+        return Document(page_content=res.fields[content_field], metadata=metadata, document_id=str(res.id))
 
     fields = res["entity"]
     metadata = {k: v for k, v in fields.items() if k != content_field}
     metadata.update({"distance": res.get("distance")})
-    return Document(page_content=fields.get(content_field), metadata=metadata, document_id=res["id"])
+    return Document(page_content=fields.get(content_field), metadata=metadata, document_id=str(res["id"]))

--- a/packages/nvidia_nat_core/tests/nat/retriever/test_retrievers.py
+++ b/packages/nvidia_nat_core/tests/nat/retriever/test_retrievers.py
@@ -31,7 +31,7 @@ class CustomMilvusClient:
         self.__dict__.update(kwargs)
 
     def list_collections(self):
-        return ["collection1", "collection2"]
+        return ["collection1", "collection2", "collection_custom_vector", "collection_int_ids"]
 
     def describe_collection(self, collection_name: str):
         collection_descriptions = {
@@ -54,6 +54,40 @@ class CustomMilvusClient:
             },
             "collection2": {
                 "collection_name": "collection1",
+                "fields": [
+                    {
+                        "name": "text"
+                    },
+                    {
+                        "name": "author"
+                    },
+                    {
+                        "name": "title"
+                    },
+                    {
+                        "name": "vector"
+                    },
+                ]
+            },
+            "collection_custom_vector": {
+                "collection_name": "collection_custom_vector",
+                "fields": [
+                    {
+                        "name": "text"
+                    },
+                    {
+                        "name": "author"
+                    },
+                    {
+                        "name": "title"
+                    },
+                    {
+                        "name": "embeddings"
+                    },
+                ]
+            },
+            "collection_int_ids": {
+                "collection_name": "collection_int_ids",
                 "fields": [
                     {
                         "name": "text"
@@ -109,18 +143,29 @@ class CustomMilvusClient:
         assert isinstance(anns_field, str)
         to_return = min(limit, 4)
 
+        # Use integer IDs for collection_int_ids to test ID type casting
+        use_int_ids = collection_name == "collection_int_ids"
+
         return [[
             {
-                'id': '1234', 'distance': 0.45, 'entity': self._get_entity_from_fields(output_fields, num=1)
+                'id': 1234 if use_int_ids else '1234',
+                'distance': 0.45,
+                'entity': self._get_entity_from_fields(output_fields, num=1)
             },
             {
-                'id': '5678', 'distance': 0.55, 'entity': self._get_entity_from_fields(output_fields, num=2)
+                'id': 5678 if use_int_ids else '5678',
+                'distance': 0.55,
+                'entity': self._get_entity_from_fields(output_fields, num=2)
             },
             {
-                'id': '2468', 'distance': 0.70, 'entity': self._get_entity_from_fields(output_fields, num=3)
+                'id': 2468 if use_int_ids else '2468',
+                'distance': 0.70,
+                'entity': self._get_entity_from_fields(output_fields, num=3)
             },
             {
-                'id': '1357', 'distance': 0.85, 'entity': self._get_entity_from_fields(output_fields, num=4)
+                'id': 1357 if use_int_ids else '1357',
+                'distance': 0.85,
+                'entity': self._get_entity_from_fields(output_fields, num=4)
             },
         ][:to_return]]
 
@@ -177,7 +222,7 @@ class CustomAsyncMilvusClient:
         self.__dict__.update(kwargs)
 
     async def list_collections(self):
-        return ["collection1", "collection2"]
+        return ["collection1", "collection2", "collection_custom_vector", "collection_int_ids"]
 
     async def describe_collection(self, collection_name: str):
         collection_descriptions = {
@@ -200,6 +245,40 @@ class CustomAsyncMilvusClient:
             },
             "collection2": {
                 "collection_name": "collection1",
+                "fields": [
+                    {
+                        "name": "text"
+                    },
+                    {
+                        "name": "author"
+                    },
+                    {
+                        "name": "title"
+                    },
+                    {
+                        "name": "vector"
+                    },
+                ]
+            },
+            "collection_custom_vector": {
+                "collection_name": "collection_custom_vector",
+                "fields": [
+                    {
+                        "name": "text"
+                    },
+                    {
+                        "name": "author"
+                    },
+                    {
+                        "name": "title"
+                    },
+                    {
+                        "name": "embeddings"
+                    },
+                ]
+            },
+            "collection_int_ids": {
+                "collection_name": "collection_int_ids",
                 "fields": [
                     {
                         "name": "text"
@@ -255,18 +334,29 @@ class CustomAsyncMilvusClient:
         assert isinstance(anns_field, str)
         to_return = min(limit, 4)
 
+        # Use integer IDs for collection_int_ids to test ID type casting
+        use_int_ids = collection_name == "collection_int_ids"
+
         return [[
             {
-                'id': '1234', 'distance': 0.45, 'entity': self._get_entity_from_fields(output_fields, num=1)
+                'id': 1234 if use_int_ids else '1234',
+                'distance': 0.45,
+                'entity': self._get_entity_from_fields(output_fields, num=1)
             },
             {
-                'id': '5678', 'distance': 0.55, 'entity': self._get_entity_from_fields(output_fields, num=2)
+                'id': 5678 if use_int_ids else '5678',
+                'distance': 0.55,
+                'entity': self._get_entity_from_fields(output_fields, num=2)
             },
             {
-                'id': '2468', 'distance': 0.70, 'entity': self._get_entity_from_fields(output_fields, num=3)
+                'id': 2468 if use_int_ids else '2468',
+                'distance': 0.70,
+                'entity': self._get_entity_from_fields(output_fields, num=3)
             },
             {
-                'id': '1357', 'distance': 0.85, 'entity': self._get_entity_from_fields(output_fields, num=4)
+                'id': 1357 if use_int_ids else '1357',
+                'distance': 0.85,
+                'entity': self._get_entity_from_fields(output_fields, num=4)
             },
         ][:to_return]]
 
@@ -572,3 +662,124 @@ async def test_async_milvus_validation(async_milvus_retriever):
     async_milvus_retriever.content_field = "c"
     with pytest.raises(ValueError):
         _ = await async_milvus_retriever.search(query="Test query", collection_name="collection1", top_k=2)
+
+
+# Tests for custom vector field names and integer primary keys
+
+
+@pytest.fixture(name="milvus_retriever_fresh")
+def _get_milvus_retriever_fresh():
+    """Fresh retriever instance for tests that need unbound state."""
+    test_client = CustomMilvusClient()
+    return MilvusRetriever(
+        client=test_client,
+        embedder=TestEmbeddings(),
+    )
+
+
+@pytest.fixture(name="async_milvus_retriever_fresh")
+def _get_async_milvus_retriever_fresh():
+    """Fresh async retriever instance for tests that need unbound state."""
+    test_client = CustomAsyncMilvusClient()
+    return MilvusRetriever(
+        client=test_client,
+        embedder=TestEmbeddings(),
+    )
+
+
+async def test_milvus_custom_vector_field(milvus_retriever_fresh):
+    """Test that custom vector field names work correctly.
+
+    This tests the fix for the vector_field config mapping issue where
+    the retriever's _search method expects 'vector_field_name' parameter.
+    """
+    # Search with custom vector field name should work
+    res = await milvus_retriever_fresh.search(
+        query="Test query?",
+        collection_name="collection_custom_vector",
+        top_k=2,
+        vector_field_name="embeddings",
+    )
+    assert isinstance(res, RetrieverOutput)
+    assert len(res) == 2
+
+    # Using the default "vector" field should fail since the collection uses "embeddings"
+    with pytest.raises(ValueError, match="vector.*not part of the schema"):
+        _ = await milvus_retriever_fresh.search(
+            query="Test query?",
+            collection_name="collection_custom_vector",
+            top_k=2,
+        )
+
+
+async def test_milvus_integer_primary_keys(milvus_retriever_fresh):
+    """Test that integer primary keys are handled correctly.
+
+    This tests the fix for document_id type casting where Milvus returns
+    integer IDs but the Document model expects string IDs.
+    """
+    res = await milvus_retriever_fresh.search(
+        query="Test query?",
+        collection_name="collection_int_ids",
+        top_k=2,
+    )
+    assert isinstance(res, RetrieverOutput)
+    assert len(res) == 2
+
+    # Verify document_id is a string even though Milvus returned an integer
+    doc = res.results[0]
+    assert isinstance(doc.document_id, str)
+    assert doc.document_id == "1234"
+
+
+async def test_async_milvus_custom_vector_field(async_milvus_retriever_fresh):
+    """Test that custom vector field names work correctly with async client."""
+    res = await async_milvus_retriever_fresh.search(
+        query="Test query?",
+        collection_name="collection_custom_vector",
+        top_k=2,
+        vector_field_name="embeddings",
+    )
+    assert isinstance(res, RetrieverOutput)
+    assert len(res) == 2
+
+    # Using the default "vector" field should fail since the collection uses "embeddings"
+    with pytest.raises(ValueError, match="vector.*not part of the schema"):
+        _ = await async_milvus_retriever_fresh.search(
+            query="Test query?",
+            collection_name="collection_custom_vector",
+            top_k=2,
+        )
+
+
+async def test_async_milvus_integer_primary_keys(async_milvus_retriever_fresh):
+    """Test that integer primary keys are handled correctly with async client."""
+    res = await async_milvus_retriever_fresh.search(
+        query="Test query?",
+        collection_name="collection_int_ids",
+        top_k=2,
+    )
+    assert isinstance(res, RetrieverOutput)
+    assert len(res) == 2
+
+    # Verify document_id is a string even though Milvus returned an integer
+    doc = res.results[0]
+    assert isinstance(doc.document_id, str)
+    assert doc.document_id == "1234"
+
+
+async def test_milvus_bind_custom_vector_field(milvus_retriever_fresh):
+    """Test that binding vector_field_name works correctly.
+
+    This tests that the vector_field can be bound via bind() and used
+    in subsequent searches without passing it explicitly.
+    """
+    milvus_retriever_fresh.bind(
+        collection_name="collection_custom_vector",
+        top_k=2,
+        vector_field_name="embeddings",
+    )
+
+    res = await milvus_retriever_fresh.search(query="Test query?")
+    assert isinstance(res, RetrieverOutput)
+    assert len(res) == 2


### PR DESCRIPTION
## Summary

Two bug fixes for the Milvus retriever:

- **Fix vector_field config mapping**: The config uses `vector_field` but the retriever's `_search` method expects `vector_field_name` as the parameter name. Without this mapping, the vector field from config was being ignored and the default "vector" was always used.

- **Fix document_id type casting**: Milvus returns integer IDs but the `Document` model expects `document_id: str | None` (see `models.py` line 33). This caused Pydantic validation errors when using collections with integer primary keys.

## Test plan

- [ ] Existing unit tests in `tests/nat/retriever/test_retrievers.py` continue to pass
- [ ] Manual testing with a Milvus collection that has:
  - A custom vector field name (not "vector")
  - Integer primary keys

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Fixed Milvus retriever configuration parameter mapping to ensure proper binding of optional settings during initialization
- Standardized document identifiers in retrieval results to consistently return strings across all result formats and types, improving data consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->