### PR TITLE
fix(serve): ensure a single event loop for python 3.11

### DIFF
--- a/src/nat/cli/commands/start.py
+++ b/src/nat/cli/commands/start.py
@@ -235,6 +235,10 @@ class StartCommandGroup(click.Group):
 
             return asyncio.run(run_plugin())
 
+        except KeyboardInterrupt:
+            logger.info("Interrupted by user.")
+            return None
+
         except Exception as e:
             logger.error("Failed to initialize workflow")
             raise click.ClickException(str(e)) from e

--- a/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
@@ -198,16 +198,23 @@ class FastApiFrontEndPlugin(DaskClientMixin, FrontEndBase[FastApiFrontEndConfig]
                     formatter["fmt"] = f"%(asctime)s - {formatter['fmt']}"
                     formatter["datefmt"] = LOG_DATE_FORMAT
 
-                uvicorn.run("nat.front_ends.fastapi.main:get_app",
-                            host=self.front_end_config.host,
-                            port=self.front_end_config.port,
-                            workers=self.front_end_config.workers,
-                            reload=self.front_end_config.reload,
-                            factory=True,
-                            reload_excludes=reload_excludes,
-                            loop=event_loop_policy,
-                            log_level=log_level,
-                            log_config=log_config)
+                config = uvicorn.Config(
+                    "nat.front_ends.fastapi.main:get_app",
+                    host=self.front_end_config.host,
+                    port=self.front_end_config.port,
+                    workers=self.front_end_config.workers,
+                    reload=self.front_end_config.reload,
+                    factory=True,
+                    reload_excludes=reload_excludes,
+                    loop=event_loop_policy,
+                    log_level=log_level,
+                    log_config=log_config,
+                )
+                server = uvicorn.Server(config)
+                try:
+                    await server.serve()
+                except KeyboardInterrupt:
+                    logger.info("Received interrupt, shutting down FastAPI server.")
 
             else:
                 app = get_app()


### PR DESCRIPTION
This is a backport to the release/1.4 branch for a PR that fixes `nat serve` with Python 3.11

This PR ensures that a single event loop is in use at all times when issuing `nat serve`

- catch KeyboardInterrupt cleanly to reduce error propagation
- manually start the server rather than call `uvicorn.run()`

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.



## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown handling across startup paths to properly catch interrupts, log the interruption, and ensure clean termination of the application and web front-end.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

Authors:
  - Will Killian (https://github.com/willkill07)

Approvers:
  - Yuchen Zhang (https://github.com/yczhang-nv)

URL: https://github.com/NVIDIA/NeMo-Agent-Toolkit/pull/1528

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced interrupt handling with improved logging and graceful shutdown when users stop the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->