### PR TITLE
fix(serve): backport event loop fix for Python 3.11 compatibility

### DIFF
--- a/src/nat/cli/commands/start.py
+++ b/src/nat/cli/commands/start.py
@@ -235,6 +235,10 @@ class StartCommandGroup(click.Group):
 
             return asyncio.run(run_plugin())
 
+        except KeyboardInterrupt:
+            logger.info("Interrupted by user.")
+            return None
+
         except Exception as e:
             logger.error("Failed to initialize workflow")
             raise click.ClickException(str(e)) from e

--- a/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
+++ b/src/nat/front_ends/fastapi/fastapi_front_end_plugin.py
@@ -198,16 +198,23 @@ class FastApiFrontEndPlugin(DaskClientMixin, FrontEndBase[FastApiFrontEndConfig]
                     formatter["fmt"] = f"%(asctime)s - {formatter['fmt']}"
                     formatter["datefmt"] = LOG_DATE_FORMAT
 
-                uvicorn.run("nat.front_ends.fastapi.main:get_app",
-                            host=self.front_end_config.host,
-                            port=self.front_end_config.port,
-                            workers=self.front_end_config.workers,
-                            reload=self.front_end_config.reload,
-                            factory=True,
-                            reload_excludes=reload_excludes,
-                            loop=event_loop_policy,
-                            log_level=log_level,
-                            log_config=log_config)
+                config = uvicorn.Config(
+                    "nat.front_ends.fastapi.main:get_app",
+                    host=self.front_end_config.host,
+                    port=self.front_end_config.port,
+                    workers=self.front_end_config.workers,
+                    reload=self.front_end_config.reload,
+                    factory=True,
+                    reload_excludes=reload_excludes,
+                    loop=event_loop_policy,
+                    log_level=log_level,
+                    log_config=log_config,
+                )
+                server = uvicorn.Server(config)
+                try:
+                    await server.serve()
+                except KeyboardInterrupt:
+                    logger.info("Received interrupt, shutting down FastAPI server.")
 
             else:
                 app = get_app()


### PR DESCRIPTION
## Description

This PR backports the Python 3.11 event loop fix from PR #1528 (develop branch) to the release/1.4 branch.

## Problem

Users running `nat serve` with Python 3.11 encounter this error:

```
Error: Runner.run() cannot be called from a running event loop
```

This occurs because Python 3.11 enforces stricter event loop rules. The original code calls `uvicorn.run()` which tries to create a new event loop, but one already exists from `asyncio.run()` in the startup code.

## Solution

The fix changes how we start the uvicorn server:

1. **Replace `uvicorn.run()` with manual server setup**: Create a `uvicorn.Config` and `uvicorn.Server` instance, then `await server.serve()`
2. **Add KeyboardInterrupt handling**: Catch Ctrl+C cleanly in both the startup command and the server itself

These changes ensure a single event loop is used throughout the application lifecycle.

## Changes

- `src/nat/cli/commands/start.py`: Add KeyboardInterrupt exception handler
- `src/nat/front_ends/fastapi/fastapi_front_end_plugin.py`: Replace `uvicorn.run()` with `uvicorn.Server` pattern

## Testing

This is a clean backport of commit 2d1230bf from develop. The fix was already tested and merged in PR #1528.

The changes are identical to the develop branch version - no modifications were made during the backport.

## Impact

- Fixes Python 3.11 compatibility for `nat serve`
- No behavior changes for Python 3.12+
- Maintains clean shutdown behavior

Closes #1554
Related: #1528

## By Submitting this PR I confirm:
- I am familiar with the Contributing Guidelines
- All commits are signed-off (git commit -s)
- This is a backport of tested code from develop

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved graceful shutdown handling when users interrupt the application. The application now logs a shutdown message and exits cleanly instead of displaying error traces when interrupted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->