### PR TITLE
Add a new per-user MCP client tool list endpoint

### DIFF
--- a/docs/source/build-workflows/mcp-client.md
+++ b/docs/source/build-workflows/mcp-client.md
@@ -367,7 +367,6 @@ When you serve a workflow that includes an `mcp_client` function group, the NeMo
 - Method: `GET`
 - Purpose: Returns tools configured in each `mcp_client` function group, indicates whether each tool is available on the connected MCP server, and includes metadata about the function group and HTTP session.
 
-
 ### Sample Output
 
 ```json

--- a/docs/source/build-workflows/mcp-client.md
+++ b/docs/source/build-workflows/mcp-client.md
@@ -367,6 +367,7 @@ When you serve a workflow that includes an `mcp_client` function group, the NeMo
 - Method: `GET`
 - Purpose: Returns tools configured in each `mcp_client` function group, indicates whether each tool is available on the connected MCP server, and includes metadata about the function group and HTTP session.
 
+
 ### Sample Output
 
 ```json
@@ -438,6 +439,29 @@ When you serve a workflow that includes an `mcp_client` function group, the NeMo
     }
   ]
 }
+```
+
+### Per-user endpoint
+Use this endpoint with per-user workflows to list tools available to a specific user.
+
+- Path: `/mcp/client/tool/list/per_user`
+- Method: `GET`
+- Query parameter: `user_id`
+
+Example:
+1. Start the MCP server if not already running:
+```bash
+nat mcp serve --config_file examples/getting_started/simple_calculator/configs/config.yml
+```
+
+2. Start per-user workflow:
+```bash
+nat serve --config_file examples/MCP/simple_calculator_mcp/configs/config-per-user-mcp-client.yml
+```
+
+3. Call the endpoint:
+```bash
+curl -s "http://localhost:8000/mcp/client/tool/list/per_user?user_id=alice" | jq
 ```
 
 ## MCP Inspection via UI

--- a/examples/MCP/simple_calculator_mcp/README.md
+++ b/examples/MCP/simple_calculator_mcp/README.md
@@ -99,3 +99,59 @@ This starts an MCP server on port 9901 with endpoint `/mcp` and uses `streamable
 ```bash
 nat run --config_file examples/MCP/simple_calculator_mcp/configs/config-mcp-client.yml --input "Is the product of 2 * 4 greater than the current hour of the day?"
 ```
+
+# Per-user workflow
+The `config-per-user-mcp-client.yml` example demonstrates how to use the `per_user_mcp_client` function group with a per-user workflow.
+Per-user workflows are useful when:
+1. You need to lazy instantiate MCP sessions for each user on first input.
+2. Need complete isolation of workflow instances for each user.
+
+`examples/MCP/simple_calculator_mcp/configs/config-per-user-mcp-client.yml`:
+```yaml
+function_groups:
+  mcp_math:
+    _type: per_user_mcp_client
+    server:
+      transport: streamable-http
+      url: "http://localhost:9901/mcp"
+    include:
+      - calculator__add
+      - calculator__subtract
+      - calculator__multiply
+      - calculator__divide
+```
+
+To run this example:
+
+1. Start the remote MCP server:
+```bash
+nat mcp serve --config_file examples/getting_started/simple_calculator/configs/config.yml
+```
+
+2. Run the workflow:
+```bash
+nat serve --config_file examples/MCP/simple_calculator_mcp/configs/config-per-user-mcp-client.yml
+```
+
+3. Send a message to the workflow for users "Alice" and "Hatter":
+```bash
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -H "Cookie: nat-session=alice" \
+  -d '{"messages": [{"role": "user", "content": "Is the product of 2 * 4 greater than the current hour of the day?"}]}'
+```
+```bash
+curl -X POST http://localhost:8000/generate \
+  -H "Content-Type: application/json" \
+  -H "Cookie: nat-session=Hatter" \
+  -d '{"messages": [{"role": "user", "content": "Is the product of 2 * 4 greater than the current hour of the day?"}]}'
+```
+
+4. You can also list the tools available to each user:
+```bash
+curl -s "http://localhost:8000/mcp/client/tool/list/per_user?user_id=alice" | jq
+```
+
+```bash
+curl -s "http://localhost:8000/mcp/client/tool/list/per_user?user_id=Hatter" | jq
+```

--- a/examples/MCP/simple_calculator_mcp/configs/config-per-user-mcp-client.yml
+++ b/examples/MCP/simple_calculator_mcp/configs/config-per-user-mcp-client.yml
@@ -1,0 +1,68 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This config file shows how to use the MCP server to get the current date and time.
+# Here the workflow acts as a MCP client and connects to the MCP server running
+# on the specified URL. streamable-http is the recommended transport for HTTP-based
+# connections, but sse is also supported for backwards compatibility.
+
+# This config file shows -
+# 1. how to use a local MCP server to get the current date and time using stdio transport.
+# 2. how to access a remote MCP server using streamable-http transport for math operations.
+#
+# As the mcp_server_time is running locally ensure that the package "mcp_server_time" is installed
+# on your local machine. For example, if you are using pip, you can install it with:
+# uv pip install mcp-server-time
+
+function_groups:
+  mcp_time:
+    _type: mcp_client
+    server:
+      transport: stdio
+      command: "python"
+      args: ["-m", "mcp_server_time", "--local-timezone=America/Los_Angeles"]
+    tool_overrides:
+      # Optionally override the tool name and description from the MCP server
+      get_current_time:
+        alias: get_current_time_mcp_tool
+        description: "Returns the current date and time"
+
+  mcp_math:
+    _type: per_user_mcp_client
+    server:
+      transport: streamable-http
+      url: "http://localhost:9901/mcp"
+    include:
+      - calculator__add
+      - calculator__subtract
+      - calculator__multiply
+      - calculator__divide
+
+llms:
+  nim_llm:
+    _type: nim
+    model_name: meta/llama-3.1-70b-instruct
+    temperature: 0.0
+    max_tokens: 1024
+
+workflow:
+  _type: per_user_react_agent
+  tool_names:
+    - mcp_time
+    - mcp_math
+  llm_name: nim_llm
+  verbose: true
+  retry_parsing_errors: true
+  max_retries: 3

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
@@ -1320,8 +1320,8 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                                     override_configs[override.alias] = override
                                 else:
                                     override_configs[orig_name] = override
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.exception("Error processing tool overrides for MCP client group %s: %s", group_name, e)
 
                     # Create tool info list (always return configured tools; mark availability)
                     tools_info: list[dict[str, Any]] = []
@@ -1369,7 +1369,7 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                     })
 
                 except Exception as e:
-                    logger.error(f"Error processing MCP client {group_name}: {e}")
+                    logger.exception("Error processing MCP client %s", group_name)
                     mcp_clients_info.append({
                         "function_group": group_name,
                         "server": "unknown",
@@ -1379,7 +1379,7 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                         "error": str(e),
                         "tools": [],
                         "total_tools": 0,
-                        "workflow_tools": 0
+                        "available_tools": 0
                     })
 
             return mcp_clients_info
@@ -1418,9 +1418,9 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                     mcp_clients_info = await _collect_mcp_client_tool_list(session.workflow.function_groups)
                     return MCPClientToolListResponse(mcp_clients=mcp_clients_info)
             except Exception as e:
-                logger.error(f"Error in per-user MCP client tool list endpoint: {e}")
+                logger.exception("Error in per-user MCP client tool list endpoint: %s", e)
                 raise HTTPException(status_code=500,
-                                    detail=f"Failed to retrieve per-user MCP client information: {str(e)}")
+                                    detail=f"Failed to retrieve per-user MCP client information: {str(e)}") from e
 
         # Add the route to the FastAPI app
         app.add_api_route(

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
@@ -1263,146 +1263,164 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
         class MCPClientToolListResponse(BaseModel):
             mcp_clients: list[dict[str, Any]]
 
+        async def _collect_mcp_client_tool_list(function_groups: dict[str, FunctionGroup]) -> list[dict[str, Any]]:
+            mcp_clients_info = []
+
+            for group_name, group_instance in function_groups.items():
+                config = group_instance.get_config()
+                if config.type not in {"mcp_client", "per_user_mcp_client"}:
+                    continue
+
+                client = getattr(group_instance, "mcp_client", None)
+                if client is None:
+                    raise RuntimeError(f"MCP client not found for group {group_name}")
+
+                try:
+                    session_healthy = False
+                    server_tools: dict[str, Any] = {}
+
+                    try:
+                        server_tools = await client.get_tools()
+                        session_healthy = True
+                    except Exception as e:
+                        logger.exception(f"Failed to connect to MCP server {client.server_name}: {e}")
+                        session_healthy = False
+
+                    # Get workflow function group configuration (configured client-side tools)
+                    configured_short_names: list[str] = []
+                    configured_full_to_fn: dict[str, Function] = {}
+                    try:
+                        # Pass a no-op filter function to bypass any default filtering that might check
+                        # health status, preventing potential infinite recursion during health status checks.
+                        async def pass_through_filter(fn):
+                            return fn
+
+                        accessible_functions = await group_instance.get_accessible_functions(
+                            filter_fn=pass_through_filter)
+                        configured_full_to_fn = accessible_functions
+                        configured_short_names = []
+                        for name in accessible_functions.keys():
+                            if FunctionGroup.SEPARATOR in name:
+                                configured_short_names.append(name.split(FunctionGroup.SEPARATOR, 1)[1])
+                            elif FunctionGroup.LEGACY_SEPARATOR in name:
+                                configured_short_names.append(name.split(FunctionGroup.LEGACY_SEPARATOR, 1)[1])
+                            else:
+                                configured_short_names.append(name)
+                    except Exception as e:
+                        logger.exception(f"Failed to get accessible functions for group {group_name}: {e}")
+
+                    # Build alias->original mapping and override configs from overrides
+                    alias_to_original: dict[str, str] = {}
+                    override_configs: dict[str, Any] = {}
+                    try:
+                        if config.tool_overrides is not None:
+                            for orig_name, override in config.tool_overrides.items():
+                                if override.alias is not None:
+                                    alias_to_original[override.alias] = orig_name
+                                    override_configs[override.alias] = override
+                                else:
+                                    override_configs[orig_name] = override
+                    except Exception:
+                        pass
+
+                    # Create tool info list (always return configured tools; mark availability)
+                    tools_info: list[dict[str, Any]] = []
+                    available_count = 0
+                    for full_name, wf_fn in configured_full_to_fn.items():
+                        if FunctionGroup.SEPARATOR in full_name:
+                            fn_short = full_name.split(FunctionGroup.SEPARATOR, 1)[1]
+                        elif FunctionGroup.LEGACY_SEPARATOR in full_name:
+                            fn_short = full_name.split(FunctionGroup.LEGACY_SEPARATOR, 1)[1]
+                        else:
+                            fn_short = full_name
+                        orig_name = alias_to_original.get(fn_short, fn_short)
+                        available = session_healthy and (orig_name in server_tools)
+                        if available:
+                            available_count += 1
+
+                        # Prefer tool override description, then workflow function description,
+                        # then server description
+                        description = ""
+                        if fn_short in override_configs and override_configs[fn_short].description:
+                            description = override_configs[fn_short].description
+                        elif wf_fn.description:
+                            description = wf_fn.description
+                        elif available and orig_name in server_tools:
+                            description = server_tools[orig_name].description or ""
+
+                        tools_info.append(
+                            MCPToolInfo(name=fn_short,
+                                        description=description or "",
+                                        server=client.server_name,
+                                        available=available).model_dump())
+
+                    # Sort tools_info by name to maintain consistent ordering
+                    tools_info.sort(key=lambda x: x['name'])
+
+                    mcp_clients_info.append({
+                        "function_group": group_name,
+                        "server": client.server_name,
+                        "transport": config.server.transport,
+                        "session_healthy": session_healthy,
+                        "protected": True if config.server.auth_provider is not None else False,
+                        "tools": tools_info,
+                        "total_tools": len(configured_short_names),
+                        "available_tools": available_count
+                    })
+
+                except Exception as e:
+                    logger.error(f"Error processing MCP client {group_name}: {e}")
+                    mcp_clients_info.append({
+                        "function_group": group_name,
+                        "server": "unknown",
+                        "transport": config.server.transport if config.server else "unknown",
+                        "session_healthy": False,
+                        "protected": False,
+                        "error": str(e),
+                        "tools": [],
+                        "total_tools": 0,
+                        "workflow_tools": 0
+                    })
+
+            return mcp_clients_info
+
         async def get_mcp_client_tool_list() -> MCPClientToolListResponse:
             """
             Get the list of MCP tools from all MCP clients in the workflow configuration.
             Checks session health and compares with workflow function group configuration.
             """
-            mcp_clients_info = []
-
             try:
                 # Get all function groups from the builder
-                function_groups = builder._function_groups
-
-                # Find MCP client function groups
-                for group_name, configured_group in function_groups.items():
-                    if configured_group.config.type != "mcp_client":
-                        continue
-
-                    from nat.plugins.mcp.client.client_config import MCPClientConfig
-
-                    config = configured_group.config
-                    assert isinstance(config, MCPClientConfig)
-
-                    # Reuse the existing MCP client session stored on the function group instance
-                    group_instance = configured_group.instance
-
-                    client = group_instance.mcp_client
-                    if client is None:
-                        raise RuntimeError(f"MCP client not found for group {group_name}")
-
-                    try:
-                        session_healthy = False
-                        server_tools: dict[str, Any] = {}
-
-                        try:
-                            server_tools = await client.get_tools()
-                            session_healthy = True
-                        except Exception as e:
-                            logger.exception(f"Failed to connect to MCP server {client.server_name}: {e}")
-                            session_healthy = False
-
-                        # Get workflow function group configuration (configured client-side tools)
-                        configured_short_names: list[str] = []
-                        configured_full_to_fn: dict[str, Function] = {}
-                        try:
-                            # Pass a no-op filter function to bypass any default filtering that might check
-                            # health status, preventing potential infinite recursion during health status checks.
-                            async def pass_through_filter(fn):
-                                return fn
-
-                            accessible_functions = await group_instance.get_accessible_functions(
-                                filter_fn=pass_through_filter)
-                            configured_full_to_fn = accessible_functions
-                            configured_short_names = []
-                            for name in accessible_functions.keys():
-                                if FunctionGroup.SEPARATOR in name:
-                                    configured_short_names.append(name.split(FunctionGroup.SEPARATOR, 1)[1])
-                                elif FunctionGroup.LEGACY_SEPARATOR in name:
-                                    configured_short_names.append(name.split(FunctionGroup.LEGACY_SEPARATOR, 1)[1])
-                                else:
-                                    configured_short_names.append(name)
-                        except Exception as e:
-                            logger.exception(f"Failed to get accessible functions for group {group_name}: {e}")
-
-                        # Build alias->original mapping and override configs from overrides
-                        alias_to_original: dict[str, str] = {}
-                        override_configs: dict[str, Any] = {}
-                        try:
-                            if config.tool_overrides is not None:
-                                for orig_name, override in config.tool_overrides.items():
-                                    if override.alias is not None:
-                                        alias_to_original[override.alias] = orig_name
-                                        override_configs[override.alias] = override
-                                    else:
-                                        override_configs[orig_name] = override
-                        except Exception:
-                            pass
-
-                        # Create tool info list (always return configured tools; mark availability)
-                        tools_info: list[dict[str, Any]] = []
-                        available_count = 0
-                        for full_name, wf_fn in configured_full_to_fn.items():
-                            if FunctionGroup.SEPARATOR in full_name:
-                                fn_short = full_name.split(FunctionGroup.SEPARATOR, 1)[1]
-                            elif FunctionGroup.LEGACY_SEPARATOR in full_name:
-                                fn_short = full_name.split(FunctionGroup.LEGACY_SEPARATOR, 1)[1]
-                            else:
-                                fn_short = full_name
-                            orig_name = alias_to_original.get(fn_short, fn_short)
-                            available = session_healthy and (orig_name in server_tools)
-                            if available:
-                                available_count += 1
-
-                            # Prefer tool override description, then workflow function description,
-                            # then server description
-                            description = ""
-                            if fn_short in override_configs and override_configs[fn_short].description:
-                                description = override_configs[fn_short].description
-                            elif wf_fn.description:
-                                description = wf_fn.description
-                            elif available and orig_name in server_tools:
-                                description = server_tools[orig_name].description or ""
-
-                            tools_info.append(
-                                MCPToolInfo(name=fn_short,
-                                            description=description or "",
-                                            server=client.server_name,
-                                            available=available).model_dump())
-
-                        # Sort tools_info by name to maintain consistent ordering
-                        tools_info.sort(key=lambda x: x['name'])
-
-                        mcp_clients_info.append({
-                            "function_group": group_name,
-                            "server": client.server_name,
-                            "transport": config.server.transport,
-                            "session_healthy": session_healthy,
-                            "protected": True if config.server.auth_provider is not None else False,
-                            "tools": tools_info,
-                            "total_tools": len(configured_short_names),
-                            "available_tools": available_count
-                        })
-
-                    except Exception as e:
-                        logger.error(f"Error processing MCP client {group_name}: {e}")
-                        mcp_clients_info.append({
-                            "function_group": group_name,
-                            "server": "unknown",
-                            "transport": config.server.transport if config.server else "unknown",
-                            "session_healthy": False,
-                            "protected": False,
-                            "error": str(e),
-                            "tools": [],
-                            "total_tools": 0,
-                            "workflow_tools": 0
-                        })
-
+                function_groups = {name: cfg.instance for name, cfg in builder._function_groups.items()}
+                mcp_clients_info = await _collect_mcp_client_tool_list(function_groups)
                 return MCPClientToolListResponse(mcp_clients=mcp_clients_info)
 
             except Exception as e:
                 logger.error(f"Error in MCP client tool list endpoint: {e}")
                 raise HTTPException(status_code=500, detail=f"Failed to retrieve MCP client information: {str(e)}")
+
+        async def get_per_user_mcp_client_tool_list(
+            request: Request,
+            user_id: str | None = None,
+        ) -> MCPClientToolListResponse:
+            """
+            Get the list of MCP tools for a specific user in per-user workflows.
+
+            Uses the per-user workflow builder to resolve function groups and
+            applies the same MCP client inspection logic as the shared endpoint.
+            """
+            per_user_manager = next((sm for sm in self._session_managers if sm.is_workflow_per_user), None)
+            if per_user_manager is None:
+                raise HTTPException(status_code=400, detail="No per-user workflow is configured.")
+
+            try:
+                async with per_user_manager.session(user_id=user_id, http_connection=request) as session:
+                    mcp_clients_info = await _collect_mcp_client_tool_list(session.workflow.function_groups)
+                    return MCPClientToolListResponse(mcp_clients=mcp_clients_info)
+            except Exception as e:
+                logger.error(f"Error in per-user MCP client tool list endpoint: {e}")
+                raise HTTPException(status_code=500,
+                                    detail=f"Failed to retrieve per-user MCP client information: {str(e)}")
 
         # Add the route to the FastAPI app
         app.add_api_route(
@@ -1440,6 +1458,23 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
                     "description": "Internal Server Error"
                 }
             })
+
+        app.add_api_route(path="/mcp/client/tool/list/per_user",
+                          endpoint=get_per_user_mcp_client_tool_list,
+                          methods=["GET"],
+                          response_model=MCPClientToolListResponse,
+                          description="Get list of MCP client tools for per-user workflows",
+                          responses={
+                              200: {
+                                  "description": "Successfully retrieved per-user MCP client tool information"
+                              },
+                              400: {
+                                  "description": "Per-user workflow not configured"
+                              },
+                              500: {
+                                  "description": "Internal Server Error"
+                              }
+                          })
 
     async def add_monitor_route(self, app: FastAPI):
         """Add the per-user monitoring endpoint to the FastAPI app.

--- a/packages/nvidia_nat_mcp/tests/server/test_mcp_client_endpoint.py
+++ b/packages/nvidia_nat_mcp/tests/server/test_mcp_client_endpoint.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from contextlib import asynccontextmanager
+
 import pytest
 import pytest_asyncio
 from fastapi import FastAPI
@@ -50,10 +52,14 @@ class _FnStub:
 
 class _GroupInstanceStub:
 
-    def __init__(self, client: _ClientStub, functions_map: dict[str, _FnStub]):
+    def __init__(self, config, client: _ClientStub, functions_map: dict[str, _FnStub]):
+        self._config = config
         # Reuse the pre-established client session on the group, like runtime
         self.mcp_client = client
         self._functions_map = functions_map
+
+    def get_config(self):
+        return self._config
 
     async def get_accessible_functions(self, filter_fn=None) -> dict[str, _FnStub]:
         return self._functions_map
@@ -71,6 +77,34 @@ class _BuilderStub:
     def __init__(self, groups: dict[str, _ConfiguredGroupStub]):
         # FastAPI worker inspects this internal mapping
         self._function_groups = groups
+
+
+class _WorkflowStub:
+
+    def __init__(self, function_groups: dict[str, _GroupInstanceStub]):
+        self.function_groups = function_groups
+
+
+class _SessionStub:
+
+    def __init__(self, workflow: _WorkflowStub):
+        self.workflow = workflow
+
+
+class _PerUserSessionManagerStub:
+
+    def __init__(self, workflow: _WorkflowStub):
+        self._workflow = workflow
+        self._user_ids: list[str | None] = []
+
+    @property
+    def is_workflow_per_user(self) -> bool:
+        return True
+
+    @asynccontextmanager
+    async def session(self, user_id=None, http_connection=None):
+        self._user_ids.append(user_id)
+        yield _SessionStub(self._workflow)
 
 
 @pytest_asyncio.fixture(name="app_worker")
@@ -102,7 +136,7 @@ async def test_mcp_client_tool_list_success_with_alias(app_worker):
     # Workflow configured function uses the alias name
     group_name = "mcp_group"
     group_instance = _GroupInstanceStub(
-        client, {f"{group_name}{FunctionGroup.SEPARATOR}alias_tool": _FnStub("Overridden desc")})
+        cfg, client, {f"{group_name}{FunctionGroup.SEPARATOR}alias_tool": _FnStub("Overridden desc")})
     configured_group = _ConfiguredGroupStub(cfg, group_instance)
     builder = _BuilderStub({group_name: configured_group})
 
@@ -143,7 +177,8 @@ async def test_mcp_client_tool_list_unhealthy_marks_unavailable(app_worker):
     client = _ClientStub("streamable-http:http://localhost:9901/mcp", {}, raise_on_get=True)
 
     group_name = "mcp_math"
-    group_instance = _GroupInstanceStub(client,
+    group_instance = _GroupInstanceStub(cfg,
+                                        client,
                                         {
                                             f"{group_name}.calculator__add": _FnStub("Add"),
                                             f"{group_name}.calculator__subtract": _FnStub("Subtract"),
@@ -164,3 +199,52 @@ async def test_mcp_client_tool_list_unhealthy_marks_unavailable(app_worker):
         assert group["available_tools"] == 0
         assert len(group["tools"]) == 2
         assert all(t["available"] is False for t in group["tools"])
+
+
+async def test_mcp_client_tool_list_per_user_success(app_worker):
+    app, worker = app_worker
+
+    from nat.plugins.mcp.client.client_config import MCPClientConfig
+    from nat.plugins.mcp.client.client_config import MCPServerConfig
+    from nat.plugins.mcp.client.client_config import MCPToolOverrideConfig
+
+    server_cfg = MCPServerConfig(transport="streamable-http", url="http://localhost:9901/mcp")
+    cfg = MCPClientConfig(
+        server=server_cfg,
+        tool_overrides={"orig_tool": MCPToolOverrideConfig(alias="alias_tool", description="Overridden desc")})
+
+    client = _ClientStub("streamable-http:http://localhost:9901/mcp", {"orig_tool": _ToolStub("Server Desc")})
+
+    group_name = "mcp_group"
+    group_instance = _GroupInstanceStub(
+        cfg, client, {f"{group_name}{FunctionGroup.SEPARATOR}alias_tool": _FnStub("Overridden desc")})
+
+    workflow = _WorkflowStub({group_name: group_instance})
+    per_user_manager = _PerUserSessionManagerStub(workflow)
+    worker._session_managers.append(per_user_manager)
+
+    builder = _BuilderStub({})
+    await worker.add_mcp_client_tool_list_route(app, builder)
+
+    with TestClient(app) as client_http:
+        resp = client_http.get("/mcp/client/tool/list/per_user?user_id=alice")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "mcp_clients" in data
+        group = data["mcp_clients"][0]
+        assert group["function_group"] == group_name
+        assert group["session_healthy"] is True
+        assert group["total_tools"] == 1
+        assert group["available_tools"] == 1
+        assert group["tools"][0]["name"] == "alias_tool"
+        assert per_user_manager._user_ids == ["alice"]
+
+
+async def test_mcp_client_tool_list_per_user_missing_config(app_worker):
+    app, worker = app_worker
+    builder = _BuilderStub({})
+    await worker.add_mcp_client_tool_list_route(app, builder)
+
+    with TestClient(app) as client_http:
+        resp = client_http.get("/mcp/client/tool/list/per_user?user_id=alice")
+        assert resp.status_code == 400


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes #1543 
Add a mechanism to query the list of tools accessible by a per-user workflow.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-user MCP client HTTP endpoint to list tools with user-specific session context.

* **Documentation**
  * Added docs and examples for per-user MCP workflows, including a YAML config and step-by-step run instructions.

* **Bug Fixes**
  * Improved error handling and health reporting for MCP client tool listing.

* **Tests**
  * Added tests covering per-user session behavior and endpoint error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->