### PR TITLE
Refactor span attribute serialization to use JSON strings

### DIFF
--- a/packages/nvidia_nat_core/src/nat/observability/exporter/span_exporter.py
+++ b/packages/nvidia_nat_core/src/nat/observability/exporter/span_exporter.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import logging
 import os
 import re
@@ -221,7 +222,7 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
                 sub_span.set_attribute(SpanAttributes.INPUT_VALUE.value, serialized_input)
                 sub_span.set_attribute(SpanAttributes.INPUT_MIME_TYPE.value,
                                        MimeTypes.JSON.value if is_json else MimeTypes.TEXT.value)
-                sub_span.set_attribute("input.value_obj", self._to_dict(event.payload.data.input))
+                sub_span.set_attribute("input.value_obj", self._to_json_string(event.payload.data.input))
 
         # Add metadata to the metadata stack
         start_metadata = event.payload.metadata or {}
@@ -291,7 +292,7 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
             sub_span.set_attribute(SpanAttributes.OUTPUT_VALUE.value, serialized_output)
             sub_span.set_attribute(SpanAttributes.OUTPUT_MIME_TYPE.value,
                                    MimeTypes.JSON.value if is_json else MimeTypes.TEXT.value)
-            sub_span.set_attribute("output.value_obj", self._to_dict(event.payload.data.output))
+            sub_span.set_attribute("output.value_obj", self._to_json_string(event.payload.data.output))
 
         # Merge metadata from start event with end event metadata
         start_metadata = self._metadata_stack.pop(event.UUID)  # type: ignore
@@ -323,20 +324,53 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
         # Export the span with processing pipeline
         self._create_export_task(self._export_with_processing(sub_span))  # type: ignore
 
-    def _to_dict(self, data: typing.Any) -> dict[str, typing.Any] | typing.Any:
-        """Transform serialized payload into a structured dict for span attributes."""
+    def _to_json_string(self, data: typing.Any) -> str:
+        """Transform payload into a JSON string for span attributes.
 
-        if hasattr(data, 'model_dump'):
-            result = data.model_dump(exclude_none=True)
-        elif isinstance(data, dict):
-            result = {k: v for k, v in data.items() if v is not None}
-        else:
-            return data
+        Converts the input data to a JSON string representation that is always
+        compatible with OTLP span attribute encoding. Raw dicts and nested structures
+        can contain types (None, custom objects) that OTLP cannot encode, so the
+        result is serialized to a JSON string for safety.
 
-        if 'value' in result and result['value'] is not None:
-            return result['value']
+        The normalization process:
+        1. Recursively processes nested structures (dicts, lists, tuples)
+        2. Converts Pydantic models via model_dump(exclude_none=True)
+        3. Filters out None values from dicts
+        4. Extracts 'value' key if present in dict and not None
+        5. Falls back to str() for non-serializable objects
 
-        return result
+        Returns:
+            A valid JSON string representation of the data.
+        """
+
+        def _normalize(obj: typing.Any) -> typing.Any:
+            """Recursively normalize objects for JSON serialization."""
+            # Pydantic models: dump and recursively normalize
+            if hasattr(obj, 'model_dump'):
+                dumped = obj.model_dump(exclude_none=True)
+                return _normalize(dumped)
+
+            # Dicts: drop None values, normalize values, optionally extract 'value' key
+            if isinstance(obj, dict):
+                normalized = {k: _normalize(v) for k, v in obj.items() if v is not None}
+                # Extract 'value' key if present and not None
+                if 'value' in normalized and normalized['value'] is not None:
+                    return _normalize(normalized['value'])
+                return normalized
+
+            # Lists/tuples: normalize each element
+            if isinstance(obj, (list, tuple)):
+                return [_normalize(item) for item in obj]
+
+            # Primitives and other objects: return as-is (json.dumps will handle via default=str)
+            return obj
+
+        try:
+            normalized = _normalize(data)
+            return json.dumps(normalized, default=str)
+        except Exception:
+            # Last-resort fallback: str() representation wrapped in JSON
+            return json.dumps(str(data))
 
     @override
     async def _cleanup(self):

--- a/packages/nvidia_nat_core/src/nat/observability/exporter/span_exporter.py
+++ b/packages/nvidia_nat_core/src/nat/observability/exporter/span_exporter.py
@@ -334,7 +334,7 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
 
         The normalization process:
         1. Recursively processes nested structures (dicts, lists, tuples)
-        2. Converts Pydantic models via model_dump(exclude_none=True)
+        2. Converts Pydantic models via model_dump(mode='json', exclude_none=True)
         3. Filters out None values from dicts
         4. Extracts 'value' key if present in dict and not None
         5. Falls back to str() for non-serializable objects
@@ -345,9 +345,9 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
 
         def _normalize(obj: typing.Any) -> typing.Any:
             """Recursively normalize objects for JSON serialization."""
-            # Pydantic models: dump and recursively normalize
+            # Pydantic models: dump with JSON mode and recursively normalize
             if hasattr(obj, 'model_dump'):
-                dumped = obj.model_dump(exclude_none=True)
+                dumped = obj.model_dump(mode='json', exclude_none=True)
                 return _normalize(dumped)
 
             # Dicts: drop None values, normalize values, optionally extract 'value' key
@@ -368,8 +368,9 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
         try:
             normalized = _normalize(data)
             return json.dumps(normalized, default=str)
-        except Exception:
+        except Exception as e:
             # Last-resort fallback: str() representation wrapped in JSON
+            logger.debug("Span attribute serialization failed, using str fallback: %s", e)
             return json.dumps(str(data))
 
     @override

--- a/packages/nvidia_nat_core/tests/nat/observability/exporter/test_span_exporter.py
+++ b/packages/nvidia_nat_core/tests/nat/observability/exporter/test_span_exporter.py
@@ -13,12 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 import os
 import uuid
 from datetime import datetime
 from unittest.mock import patch
 
 import pytest
+from pydantic import BaseModel
 
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.data_models.intermediate_step import IntermediateStep
@@ -574,52 +576,185 @@ class TestSpanExporterFunctionality:
             assert len(span_exporter._outstanding_spans) == 0
             assert len(span_exporter.exported_spans) == 1
 
-    def test_span_name_uses_display_name_from_metadata(self, span_exporter):
-        """Test that span name uses display_name from trace metadata when available.
-        """
-        # Create event with internal name and display_name in trace metadata
-        event_with_display_name = create_intermediate_step(
-            event_type=IntermediateStepType.WORKFLOW_START,
-            framework=LLMFrameworkEnum.LANGCHAIN,
-            name="<workflow>",  # Internal name for filters/middleware
-            event_timestamp=datetime.now().timestamp(),
-            data=StreamEventData(input="Test input"),
-            metadata=TraceMetadata(provided_metadata={"display_name": "My Custom Agent"}))
 
-        span_exporter.export(event_with_display_name)
-        span = span_exporter._outstanding_spans[event_with_display_name.payload.UUID]
+class TestToJsonStringSerialization:
+    """Tests for _to_json_string ensuring OTLP-compatible serialization."""
 
-        # Span name should use display_name, not the internal name
-        assert span.name == "My Custom Agent"
+    @pytest.fixture(name="exporter")
+    def fixture_exporter(self):
+        return ConcreteSpanExporter()
 
-    def test_span_name_falls_back_to_payload_name(self, span_exporter):
-        """Test that span name falls back to payload name when display_name is not set."""
-        # Create event without display_name
-        event_without_display_name = create_intermediate_step(event_type=IntermediateStepType.WORKFLOW_START,
-                                                              framework=LLMFrameworkEnum.LANGCHAIN,
-                                                              name="<workflow>",
-                                                              event_timestamp=datetime.now().timestamp(),
-                                                              data=StreamEventData(input="Test input"),
-                                                              metadata=None)
+    def test_string_input(self, exporter):
+        """String input is returned as-is via str()."""
+        result = exporter._to_json_string("hello")
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed == "hello"
 
-        span_exporter.export(event_without_display_name)
-        span = span_exporter._outstanding_spans[event_without_display_name.payload.UUID]
+    def test_dict_input(self, exporter):
+        """Dict input is JSON-serialized."""
+        data = {"key": "value", "number": 42}
+        result = exporter._to_json_string(data)
+        assert isinstance(result, str)
+        assert json.loads(result) == {"key": "value", "number": 42}
 
-        # Span name should fall back to payload name
-        assert span.name == "<workflow>"
+    def test_dict_filters_none_values(self, exporter):
+        """Dict input has None values filtered out before serialization."""
+        data = {"key": "value", "empty": None, "number": 0}
+        result = exporter._to_json_string(data)
+        parsed = json.loads(result)
+        assert "empty" not in parsed
+        assert parsed == {"key": "value", "number": 0}
 
-    def test_span_name_falls_back_to_event_type(self, span_exporter):
-        """Test that span name falls back to event type when neither display_name nor name is available."""
-        # Create event without name or display_name
-        event_without_name = create_intermediate_step(event_type=IntermediateStepType.WORKFLOW_START,
-                                                      framework=LLMFrameworkEnum.LANGCHAIN,
-                                                      name=None,
-                                                      event_timestamp=datetime.now().timestamp(),
-                                                      data=StreamEventData(input="Test input"),
-                                                      metadata=None)
+    def test_dict_with_value_key(self, exporter):
+        """Dict with a 'value' key extracts and serializes just the value."""
+        data = {"value": "extracted", "other": "ignored"}
+        result = exporter._to_json_string(data)
+        parsed = json.loads(result)
+        assert parsed == "extracted"
 
-        span_exporter.export(event_without_name)
-        span = span_exporter._outstanding_spans[event_without_name.payload.UUID]
+    def test_dict_with_none_value_key(self, exporter):
+        """Dict with value=None does not extract the value field."""
+        data = {"value": None, "other": "kept"}
+        result = exporter._to_json_string(data)
+        parsed = json.loads(result)
+        assert parsed == {"other": "kept"}
 
-        # Span name should fall back to event type string
-        assert span.name == str(IntermediateStepType.WORKFLOW_START)
+    def test_pydantic_model(self, exporter):
+        """Pydantic model is serialized via model_dump then JSON."""
+
+        class SampleModel(BaseModel):
+            content: str
+            score: float
+            optional_field: str | None = None
+
+        model = SampleModel(content="test message", score=0.95)
+        result = exporter._to_json_string(model)
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed == {"content": "test message", "score": 0.95}
+
+    def test_pydantic_model_with_value_key(self, exporter):
+        """Pydantic model with a 'value' field extracts just that field."""
+
+        class WrappedModel(BaseModel):
+            value: str
+            metadata: str | None = None
+
+        model = WrappedModel(value="unwrapped content")
+        result = exporter._to_json_string(model)
+        parsed = json.loads(result)
+        assert parsed == "unwrapped content"
+
+    def test_list_of_pydantic_models(self, exporter):
+        """List of Pydantic models is serialized."""
+
+        class MockMessage(BaseModel):
+            content: str
+            role: str
+            extra: str | None = None
+
+        messages = [MockMessage(content="Hello", role="human"), MockMessage(content="Hi there", role="assistant")]
+        result = exporter._to_json_string(messages)
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert len(parsed) == 2
+        assert parsed[0] == {"content": "Hello", "role": "human"}
+        assert parsed[1] == {"content": "Hi there", "role": "assistant"}
+
+    def test_list_of_mixed_types(self, exporter):
+        """List with mixed types (models and primitives) is serialized."""
+
+        class Item(BaseModel):
+            name: str
+
+        data = [Item(name="first"), "plain string", 42]
+        result = exporter._to_json_string(data)
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed == [{"name": "first"}, "plain string", 42]
+
+    def test_dict_with_nested_none_values(self, exporter):
+        """Dict with deeply nested None values does not cause errors."""
+        data = {
+            "level1": {
+                "level2": [{
+                    "key": "value", "empty": None
+                }, {
+                    "nested_none": None, "data": "present"
+                }]
+            },
+            "top_none": None,
+        }
+        result = exporter._to_json_string(data)
+        assert isinstance(result, str)
+        # Should be valid JSON regardless of nested Nones
+        parsed = json.loads(result)
+        assert "top_none" not in parsed
+        assert parsed["level1"]["level2"][0]["key"] == "value"
+
+    def test_arbitrary_object_falls_back_to_str(self, exporter):
+        """Non-serializable objects fall back to str() representation."""
+
+        class CustomObj:
+
+            def __str__(self):
+                return "custom_string_repr"
+
+        result = exporter._to_json_string(CustomObj())
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed == "custom_string_repr"
+
+    def test_exception_during_serialization_falls_back_to_str(self, exporter):
+        """If JSON serialization fails, falls back to str()."""
+
+        class BrokenModel:
+            """Object with model_dump that returns non-serializable data."""
+
+            def model_dump(self, **kwargs):
+                raise RuntimeError("serialization broken")
+
+            def __str__(self):
+                return "broken_model_str"
+
+        result = exporter._to_json_string(BrokenModel())
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed == "broken_model_str"
+
+    def test_integer_input(self, exporter):
+        """Integer input is converted to string."""
+        result = exporter._to_json_string(42)
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed == 42
+
+    def test_none_input(self, exporter):
+        """None input is converted to JSON null."""
+        result = exporter._to_json_string(None)
+        assert isinstance(result, str)
+        parsed = json.loads(result)
+        assert parsed is None
+
+    def test_result_is_always_a_string(self, exporter):
+        """Every code path returns a string - key invariant for OTLP."""
+        test_cases = [
+            "text",
+            42,
+            3.14,
+            True,
+            None,
+            {
+                "a": 1
+            },
+            [1, 2, 3],
+            {
+                "value": "extracted"
+            },
+        ]
+        for data in test_cases:
+            result = exporter._to_json_string(data)
+            msg = (f"_to_json_string({data!r}) returned "
+                   f"{type(result).__name__}, expected str")
+            assert isinstance(result, str), msg

--- a/packages/nvidia_nat_core/tests/nat/observability/exporter/test_span_exporter.py
+++ b/packages/nvidia_nat_core/tests/nat/observability/exporter/test_span_exporter.py
@@ -622,6 +622,8 @@ class TestSpanExporterFunctionality:
 
         span_exporter.export(event_without_name)
         span = span_exporter._outstanding_spans[event_without_name.payload.UUID]
+        # Span name should fall back to event type string
+        assert span.name == str(IntermediateStepType.WORKFLOW_START)
 
 
 class TestToJsonStringSerialization:

--- a/packages/nvidia_nat_core/tests/nat/observability/exporter/test_span_exporter.py
+++ b/packages/nvidia_nat_core/tests/nat/observability/exporter/test_span_exporter.py
@@ -576,6 +576,53 @@ class TestSpanExporterFunctionality:
             assert len(span_exporter._outstanding_spans) == 0
             assert len(span_exporter.exported_spans) == 1
 
+    def test_span_name_uses_display_name_from_metadata(self, span_exporter):
+        """Test that span name uses display_name from trace metadata when available.
+        """
+        # Create event with internal name and display_name in trace metadata
+        event_with_display_name = create_intermediate_step(
+            event_type=IntermediateStepType.WORKFLOW_START,
+            framework=LLMFrameworkEnum.LANGCHAIN,
+            name="<workflow>",  # Internal name for filters/middleware
+            event_timestamp=datetime.now().timestamp(),
+            data=StreamEventData(input="Test input"),
+            metadata=TraceMetadata(provided_metadata={"display_name": "My Custom Agent"}))
+
+        span_exporter.export(event_with_display_name)
+        span = span_exporter._outstanding_spans[event_with_display_name.payload.UUID]
+
+        # Span name should use display_name, not the internal name
+        assert span.name == "My Custom Agent"
+
+    def test_span_name_falls_back_to_payload_name(self, span_exporter):
+        """Test that span name falls back to payload name when display_name is not set."""
+        # Create event without display_name
+        event_without_display_name = create_intermediate_step(event_type=IntermediateStepType.WORKFLOW_START,
+                                                              framework=LLMFrameworkEnum.LANGCHAIN,
+                                                              name="<workflow>",
+                                                              event_timestamp=datetime.now().timestamp(),
+                                                              data=StreamEventData(input="Test input"),
+                                                              metadata=None)
+
+        span_exporter.export(event_without_display_name)
+        span = span_exporter._outstanding_spans[event_without_display_name.payload.UUID]
+
+        # Span name should fall back to payload name
+        assert span.name == "<workflow>"
+
+    def test_span_name_falls_back_to_event_type(self, span_exporter):
+        """Test that span name falls back to event type when neither display_name nor name is available."""
+        # Create event without name or display_name
+        event_without_name = create_intermediate_step(event_type=IntermediateStepType.WORKFLOW_START,
+                                                      framework=LLMFrameworkEnum.LANGCHAIN,
+                                                      name=None,
+                                                      event_timestamp=datetime.now().timestamp(),
+                                                      data=StreamEventData(input="Test input"),
+                                                      metadata=None)
+
+        span_exporter.export(event_without_name)
+        span = span_exporter._outstanding_spans[event_without_name.payload.UUID]
+
 
 class TestToJsonStringSerialization:
     """Tests for _to_json_string ensuring OTLP-compatible serialization."""


### PR DESCRIPTION
## Description
Replaced _to_dict with _to_json_string for safer, OTLP-compatible span attribute serialization. Added robust handling for nested structures, Pydantic models, and edge cases. Introduced comprehensive tests to validate serialization behavior and ensure stability.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Span input/output payloads are now serialized and stored as JSON strings for OTLP compatibility, including recursive normalization, extraction of top-level value fields, filtering of None entries, and safe fallbacks for non-serializable data; internal documentation for the transformation was added.

* **Tests**
  * Expanded test coverage for JSON serialization edge cases: strings, dicts/lists, model types, value-field extraction, None filtering, mixed types, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->