### PR TITLE
Fix FastMCP example E2E tests

### DIFF
--- a/examples/MCP/simple_calculator_fastmcp/tests/test_simple_calculator_fastmcp.py
+++ b/examples/MCP/simple_calculator_fastmcp/tests/test_simple_calculator_fastmcp.py
@@ -48,10 +48,8 @@ async def simple_calc_fastmcp_process_fixture(
     nat_fastmcp_port: str,
     root_repo_dir: Path,
 ) -> subprocess.Popen:
-    config_file = (
-        root_repo_dir
-        / "examples/getting_started/simple_calculator/src/nat_simple_calculator/configs/config.yml"
-    )
+    config_file = (root_repo_dir /
+                   "examples/getting_started/simple_calculator/src/nat_simple_calculator/configs/config.yml")
 
     env = os.environ.copy()
     env.pop("NAT_LOG_LEVEL", None)

--- a/examples/MCP/simple_calculator_fastmcp/tests/test_simple_calculator_fastmcp.py
+++ b/examples/MCP/simple_calculator_fastmcp/tests/test_simple_calculator_fastmcp.py
@@ -43,11 +43,15 @@ def nat_fastmcp_url_fixture(nat_fastmcp_host: str, nat_fastmcp_port: str) -> str
 
 
 @pytest.fixture(name="simple_calc_fastmcp_process", scope="module")
-async def simple_calc_fastmcp_process_fixture(nat_fastmcp_host: str, nat_fastmcp_port: str) -> subprocess.Popen:
-    from nat.test.utils import locate_example_config
-    from nat_simple_calculator.register import CalculatorToolConfig
-
-    config_file: Path = locate_example_config(CalculatorToolConfig)
+async def simple_calc_fastmcp_process_fixture(
+    nat_fastmcp_host: str,
+    nat_fastmcp_port: str,
+    root_repo_dir: Path,
+) -> subprocess.Popen:
+    config_file = (
+        root_repo_dir
+        / "examples/getting_started/simple_calculator/src/nat_simple_calculator/configs/config.yml"
+    )
 
     env = os.environ.copy()
     env.pop("NAT_LOG_LEVEL", None)

--- a/examples/MCP/simple_calculator_fastmcp_protected/tests/test_simple_calculator_fastmcp_protected.py
+++ b/examples/MCP/simple_calculator_fastmcp_protected/tests/test_simple_calculator_fastmcp_protected.py
@@ -55,8 +55,8 @@ async def fastmcp_protected_process_fixture(
 
     env = os.environ.copy()
     env.pop("NAT_LOG_LEVEL", None)
-    env.setdefault("CALCULATOR_RESOURCE_CLIENT_ID", "nat-mcp-resource-server")
-    env.setdefault("CALCULATOR_RESOURCE_CLIENT_SECRET", "dummy-secret")
+    env.setdefault("NAT_CALCULATOR_RESOURCE_CLIENT_ID", "nat-mcp-resource-server")
+    env.setdefault("NAT_CALCULATOR_RESOURCE_CLIENT_SECRET", "dummy-secret")
 
     cmd = [
         "nat",
@@ -113,5 +113,5 @@ async def fastmcp_protected_ready_fixture(
 @pytest.mark.integration
 @pytest.mark.usefixtures("fastmcp_protected_ready")
 async def test_fastmcp_protected_requires_auth(fastmcp_protected_base_url: str):
-    response = httpx.get(f"{fastmcp_protected_base_url}/debug/tools/list", timeout=5.0)
+    response = httpx.get(f"{fastmcp_protected_base_url}/mcp", timeout=5.0)
     assert response.status_code == 401


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Fix FastMCP example E2E tests by:
- aligning env var names for the protected server auth config
- pointing the FastMCP example test at the correct config file path
- checking auth on the protected /mcp endpoint instead of the public debug route

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Test setup updated to use explicit repository-relative config paths for calculator examples.
  * Standardized environment variable names for calculator resource client credentials.
  * Adjusted protected-test endpoint to align with the expected protected resource routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->