### PR TITLE
fix(ci): ensure packaging works in GitLab CI

### DIFF
--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -106,6 +106,28 @@ function get_num_proc() {
    echo "${NUM_PROC}"
 }
 
+function set_versions() {
+   # Set the version for the wheels based on GIT_TAG / SCM
+
+   if [[ "${CI_CRON_NIGHTLY}" == "1" || "${IS_TAGGED}" == "1" ]]; then
+      # For tagged releases and nightly builds, use the git tag as the version as-is
+      NAT_VERSION="${GIT_TAG}"
+   else
+      set +e
+      NAT_VERSION=$(python -m setuptools_scm)
+      local SETUPTOOLS_SCM_RESULT=$?
+      set -e
+
+      if [[ ${SETUPTOOLS_SCM_RESULT} -ne 0 ]]; then
+         rapids-logger "Error, setuptools_scm failed to determine the version: ${NAT_VERSION}"
+         exit ${SETUPTOOLS_SCM_RESULT}
+      fi
+   fi
+
+   export SETUPTOOLS_SCM_PRETEND_VERSION="${NAT_VERSION}"
+   export USE_FULL_VERSION="1"
+}
+
 function build_wheel() {
     rapids-logger "Building Wheel for $1"
     uv build --wheel --no-progress --out-dir "${WHEELS_DIR}/$2" --directory $1

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -40,6 +40,9 @@ for NAT_EXAMPLE in ${NAT_EXAMPLES[@]}; do
     build_wheel ${NAT_EXAMPLE} "examples"
 done
 
+rapids-logger "Removing built examples wheels"
+rm -rf "${WHEELS_BASE_DIR}/examples"
+
 # Flatten out the wheels into a single directory for upload
 BUILT_WHEELS=$(find "${WHEELS_BASE_DIR}"/**/ -type f -name "*.whl")
 MOVED_WHEELS=()

--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -25,9 +25,16 @@ IS_TAGGED=$(is_current_commit_release_tagged)
 rapids-logger "Git Version: ${GIT_TAG} - Is Tagged: ${IS_TAGGED}"
 
 if [[ "${CI_COMMIT_BRANCH}" == "${CI_DEFAULT_BRANCH}" && "${IS_TAGGED}" == "0" ]]; then
-    # We should create a nightly tag that matches the git tag
-    git tag ${GIT_TAG}
+    # If the commit is not tagged, we should create a nightly version that matches ${GIT_TAG/-dev/aYYYYMMDD}
+    NAT_VERSION="${GIT_TAG/-dev/a$(date +"%Y%m%d")}"
+else
+    # If the commit is tagged, we should use the tag as the version
+    NAT_VERSION="${GIT_TAG}"
 fi
+
+# We need to set these variables to ensure that the version is set correctly in the wheel
+export SETUPTOOLS_SCM_PRETEND_VERSION="${NAT_VERSION}"
+export USE_FULL_VERSION="1"
 
 create_env
 

--- a/ci/scripts/gitlab/build_wheel.sh
+++ b/ci/scripts/gitlab/build_wheel.sh
@@ -24,19 +24,10 @@ GIT_TAG=$(get_git_tag)
 IS_TAGGED=$(is_current_commit_release_tagged)
 rapids-logger "Git Version: ${GIT_TAG} - Is Tagged: ${IS_TAGGED}"
 
-if [[ "${CI_COMMIT_BRANCH}" == "${CI_DEFAULT_BRANCH}" && "${IS_TAGGED}" == "0" ]]; then
-    # If the commit is not tagged, we should create a nightly version that matches ${GIT_TAG/-dev/aYYYYMMDD}
-    NAT_VERSION="${GIT_TAG/-dev/a$(date +"%Y%m%d")}"
-else
-    # If the commit is tagged, we should use the tag as the version
-    NAT_VERSION="${GIT_TAG}"
-fi
-
-# We need to set these variables to ensure that the version is set correctly in the wheel
-export SETUPTOOLS_SCM_PRETEND_VERSION="${NAT_VERSION}"
-export USE_FULL_VERSION="1"
-
 create_env
+
+# Set the version for the wheels based on GIT_TAG / SCM
+set_versions
 
 WHEELS_BASE_DIR="${CI_PROJECT_DIR}/.tmp/wheels"
 WHEELS_DIR="${WHEELS_BASE_DIR}/nvidia-nat"


### PR DESCRIPTION
## Description

Ensure that packaging works in GitLab CI by being more cautious about tagging (a.k.a. don't)

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now cleans up intermediate example build artifacts after wheel creation, keeping build outputs tidy.
  * Build process now uses an explicit version-determination step for wheels, ensuring consistent embedded package versions instead of generating transient tags during non-tagged runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->