### PR TITLE
fix(gitlab-ci): ensure gitlab artifact upload is configured correctly

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -288,12 +288,11 @@ package:wheel:
     - ./ci/scripts/gitlab/build_wheel.sh
   artifacts:
     paths:
-      # match - .tmp/wheels/nvidia-nat/<version>/*.whl, .tmp/wheels/nvidia-nat/nvidia-nat-crewai/<version>/*.whl etc.
-      - .tmp/wheels/nvidia-nat/*/*/*.whl
-      # Match the example wheels
-      - .tmp/wheels/nvidia-nat/examples/*.whl
-      # Match  the transitional wheels
-      - .tmp/wheels/nat/*/*/*.whl
+      # match the following wheels:
+      # - root metapackage: .tmp/wheels/nvidia-nat/nvidia-nat/nvidia_nat-<VERSION>-py3-none-any.whl
+      # - subpackages: .tmp/wheels/nvidia-nat/nvidia_nat_<PACKAGE>/nvidia_nat_<PACKAGE>-<VERSION>-py3-none-any.whl
+      # - example wheels: .tmp/wheels/nvidia-nat/examples/*.whl
+      - .tmp/wheels/nvidia-nat/*/*.whl
     expire_in: 1 week
   rules:
     - if: $CI_CRON_NIGHTLY == "1"


### PR DESCRIPTION
## Description

With the new package structure, some directories have changed.

This meant that successfully built wheels were never being uploaded as artifacts.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined CI/CD artifact collection configuration with improved documentation for clarity and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->