### PR TITLE
fix(ci): ensure stale action has required permissions

### DIFF
--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -21,6 +21,10 @@ on:
 jobs:
   stale:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      issues: write
+      pull-requests: write
     steps:
       - uses: actions/stale@v10
         with:
@@ -34,3 +38,4 @@ jobs:
           days-before-pr-close: 14
           exempt-issue-labels: 'Needs Triage'
           exempt-pr-labels: 'Under Review'
+          operations-per-run: 100


### PR DESCRIPTION
## Description

The newly added stale action needed permissions to run.

This PR adds the required permissions. I also tested this locally and it ran (with messages being posted under my user).

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized internal workflow processes and automation efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->