### PR TITLE
feat(observability): Cross-Workflow Observability

### DIFF
--- a/docs/source/run-workflows/observe/observe.md
+++ b/docs/source/run-workflows/observe/observe.md
@@ -26,13 +26,6 @@ The NeMo Agent Toolkit uses a flexible, plugin-based observability system that p
 
 These features enable developers to test their workflows locally and integrate observability seamlessly with their preferred monitoring stack.
 
-
-### Compatibility with Previous Versions
-As of v1.2, the span exporter exports attributes names prefixed with `nat` by default. In prior releases the attribute names were prefixed with `aiq`, to retain compatibility the `NAT_SPAN_PREFIX` environment variable can be set to `aiq`:
-```bash
-export NAT_SPAN_PREFIX=aiq
-```
-
 ## Installation
 
 The core observability features (console and file logging) are included by default. For advanced telemetry features like OpenTelemetry and Phoenix tracing, you need to install the optional telemetry extras.
@@ -247,3 +240,60 @@ For complete information about developing and integrating custom telemetry expor
 
 ::::
 
+## Cross-Workflow Observability
+
+When one workflow invokes another (for example, by calling a remote workflow over HTTP or by running a child workflow programmatically), you can link the child workflow's trace to the parent so that observability backends show a single, connected tree instead of separate traces.
+
+### Specifying Parent When Running a Workflow Programmatically
+
+If you run a workflow from code using a session, pass `parent_id` and `parent_name` into `session.run()`. The toolkit uses these to set the root of the child workflow's intermediate steps so the first step has the correct parent.
+
+```python
+async with session_manager.session() as session:
+    async with session.run(
+        prompt,
+        parent_id="parent-step-uuid",
+        parent_name="Caller Workflow",
+    ) as runner:
+        result = await runner.result(to_type=str)
+```
+
+- **`parent_id`**: The step ID of the parent (for example, the current workflow step or span that is invoking the child). The root workflow step of the child run is emitted with this as its parent.
+- **`parent_name`**: Optional display name for the parent (for example, the workflow or function name). The root's function ancestry uses this as the parent name for observability.
+
+### HTTP Headers When Triggering a Workflow
+
+When a workflow is triggered over HTTP (such as a POST to `/generate/full`), the server reads request headers to set the parent for that run. If present, they are applied before the workflow starts so the root step has the correct parent.
+
+| Header | Description |
+| ------ | ----------- |
+| `workflow-parent-id` | Step ID of the parent. The root workflow step is emitted with this as its parent. |
+| `workflow-parent-name` | Optional display name for the parent (workflow or function name). |
+
+Example with curl:
+
+```bash
+curl -X POST http://localhost:8000/generate/full \
+  -H "workflow-parent-id: <parent-step-id>" \
+  -H "workflow-parent-name: Parent Workflow Name" \
+  -H "Content-Type: application/json" \
+  -d '{"input_message": "..."}'
+```
+
+Use these headers when the caller (orchestrator, API gateway, or another workflow) has a step or span ID and wants the child workflow to appear under that step in traces.
+
+### Replaying Intermediate Steps from a Remote Workflow
+
+When your workflow calls a remote workflow (for example, by calling its `/generate/full` endpoint) and receives intermediate step data in the response, you can push those steps into the current run's observability stream. That way, the remote workflow's steps appear as part of the same trace tree.
+
+Use the {py:meth}`~nat.builder.intermediate_step_manager.IntermediateStepManager.push_intermediate_steps` method from any code that runs inside the current workflow context. Pass the list of intermediate steps (for example, parsed from the remote response); they are injected into the current run's event stream. The parent of the replayed root step is determined by how the remote was invoked: set `workflow-parent-id` and `workflow-parent-name` headers when calling the remote, or use `session.run(parent_id=..., parent_name=...)` when running a child workflow programmatically, so the trace tree links correctly.
+
+```python
+from nat.builder.context import Context
+
+# After calling a remote workflow (for example, /generate/full) and parsing
+# the response into a list of IntermediateStep:
+Context.get().intermediate_step_manager.push_intermediate_steps(remote_intermediate_steps)
+```
+
+This is useful when you call a remote workflow and want its steps to appear under the current workflow's trace in your observability backend, so you get one connected tree for the full request.

--- a/docs/source/run-workflows/observe/observe.md
+++ b/docs/source/run-workflows/observe/observe.md
@@ -242,11 +242,11 @@ For complete information about developing and integrating custom telemetry expor
 
 ## Cross-Workflow Observability
 
-When one workflow invokes another (for example, by calling a remote workflow over HTTP or by running a child workflow programmatically), you can link the child workflow's trace to the parent so that observability backends show a single, connected tree instead of separate traces.
+When one workflow invokes another (for example, by calling a remote workflow over HTTP or by running a child workflow programmatically), you can link the trace of the child workflow to the parent so that observability backends show a single, connected tree instead of separate traces.
 
 ### Specifying Parent When Running a Workflow Programmatically
 
-If you run a workflow from code using a session, pass `parent_id` and `parent_name` into `session.run()`. The toolkit uses these to set the root of the child workflow's intermediate steps so the first step has the correct parent.
+If you run a workflow from code using a session, pass `parent_id` and `parent_name` into `session.run()`. The toolkit uses these to set the root of the intermediate steps of the child workflow so the first step has the correct parent.
 
 ```python
 async with session_manager.session() as session:
@@ -259,7 +259,7 @@ async with session_manager.session() as session:
 ```
 
 - **`parent_id`**: The step ID of the parent (for example, the current workflow step or span that is invoking the child). The root workflow step of the child run is emitted with this as its parent.
-- **`parent_name`**: Optional display name for the parent (for example, the workflow or function name). The root's function ancestry uses this as the parent name for observability.
+- **`parent_name`**: Optional display name for the parent (for example, the workflow or function name). The function ancestry of the root uses this as the parent name for observability.
 
 ### HTTP Headers When Triggering a Workflow
 
@@ -284,9 +284,9 @@ Use these headers when the caller (orchestrator, API gateway, or another workflo
 
 ### Replaying Intermediate Steps from a Remote Workflow
 
-When your workflow calls a remote workflow (for example, by calling its `/generate/full` endpoint) and receives intermediate step data in the response, you can push those steps into the current run's observability stream. That way, the remote workflow's steps appear as part of the same trace tree.
+When your workflow calls a remote workflow (for example, by calling its `/generate/full` endpoint) and receives intermediate step data in the response, you can push those steps into the observability stream of the current run. That way, the steps of the remote workflow appear as part of the same trace tree.
 
-Use the {py:meth}`~nat.builder.intermediate_step_manager.IntermediateStepManager.push_intermediate_steps` method from any code that runs inside the current workflow context. Pass the list of intermediate steps (for example, parsed from the remote response); they are injected into the current run's event stream. The parent of the replayed root step is determined by how the remote was invoked: set `workflow-parent-id` and `workflow-parent-name` headers when calling the remote, or use `session.run(parent_id=..., parent_name=...)` when running a child workflow programmatically, so the trace tree links correctly.
+Use the {py:meth}`~nat.builder.intermediate_step_manager.IntermediateStepManager.push_intermediate_steps` method from any code that runs inside the current workflow context. Pass the list of intermediate steps (for example, parsed from the remote response); they are injected into the event stream of the current run. The parent of the replayed root step is determined by how the remote was invoked: set `workflow-parent-id` and `workflow-parent-name` headers when calling the remote, or use `session.run(parent_id=..., parent_name=...)` when running a child workflow programmatically, so the trace tree links correctly.
 
 ```python
 from nat.builder.context import Context
@@ -296,4 +296,4 @@ from nat.builder.context import Context
 Context.get().intermediate_step_manager.push_intermediate_steps(remote_intermediate_steps)
 ```
 
-This is useful when you call a remote workflow and want its steps to appear under the current workflow's trace in your observability backend, so you get one connected tree for the full request.
+This is useful when you call a remote workflow and want its steps to appear under the trace of the current workflow in your observability backend, so you get one connected tree for the full request.

--- a/packages/nvidia_nat_core/src/nat/builder/context.py
+++ b/packages/nvidia_nat_core/src/nat/builder/context.py
@@ -86,6 +86,10 @@ class ContextState(metaclass=Singleton):
         self._latency_sensitivity_stack: ContextVar[list[LatencySensitivity] | None] = ContextVar(
             "latency_sensitivity_stack", default=None)
 
+        # Cross-workflow observability: parent step id/name for the root of this workflow run
+        self.workflow_parent_id: ContextVar[str | None] = ContextVar("workflow_parent_id", default=None)
+        self.workflow_parent_name: ContextVar[str | None] = ContextVar("workflow_parent_name", default=None)
+
         # Default is a lambda no-op which returns NoneType
         self.user_input_callback: ContextVar[Callable[[InteractionPrompt], Awaitable[HumanResponse | None]]
                                              | None] = ContextVar(

--- a/packages/nvidia_nat_core/src/nat/builder/intermediate_step_manager.py
+++ b/packages/nvidia_nat_core/src/nat/builder/intermediate_step_manager.py
@@ -189,6 +189,27 @@ class IntermediateStepManager:
 
         self._context_state.event_stream.get().on_next(intermediate_step)
 
+    def push_intermediate_steps(self, steps: list[IntermediateStep]) -> None:
+        """
+        Inject a sequence of intermediate steps into the event stream without updating
+        the step manager's internal stack. Used to replay steps from a remote workflow
+        (for example, from a /generate/full response) into the current workflow's
+        observability stream so the full tree is visible.
+
+        When replaying steps from a remote workflow, ensure the remote was invoked
+        with the appropriate workflow-parent-id and workflow-parent-name (HTTP
+        headers or session.run(parent_id=..., parent_name=...)) so the root step
+        in the replayed list has the correct parent in the trace tree.
+
+        Parameters
+        ----------
+        steps : list[IntermediateStep]
+            Steps to inject (for example, parsed from a remote workflow response).
+        """
+        stream = self._context_state.event_stream.get()
+        for step in steps:
+            stream.on_next(step)
+
     def subscribe(self,
                   on_next: OnNext[IntermediateStep],
                   on_error: OnError = None,

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
@@ -888,9 +888,11 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
             Stream raw intermediate steps without any step adaptor translations.
             """
 
-            async def post_stream(payload: request_type, filter_steps: str | None = None):
+            async def post_stream(request: Request, payload: request_type, filter_steps: str | None = None):
 
-                async with session_manager.session(http_connection=None) as session:
+                async with session_manager.session(
+                        http_connection=request,
+                        user_authentication_callback=self._http_flow_handler.authenticate) as session:
                     return StreamingResponse(headers={"Content-Type": "text/event-stream; charset=utf-8"},
                                              content=generate_streaming_response_full_as_str(payload,
                                                                                              session=session,

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_plugin_worker.py
@@ -817,9 +817,11 @@ class FastApiFrontEndPluginWorker(FastApiFrontEndPluginWorkerBase):
 
         def get_streaming_raw_endpoint(streaming: bool, result_type: type | None, output_type: type | None):
 
-            async def get_stream(filter_steps: str | None = None):
+            async def get_stream(request: Request, filter_steps: str | None = None):
 
-                async with session_manager.session(http_connection=None) as session:
+                async with session_manager.session(
+                        http_connection=request,
+                        user_authentication_callback=self._http_flow_handler.authenticate) as session:
                     return StreamingResponse(headers={"Content-Type": "text/event-stream; charset=utf-8"},
                                              content=generate_streaming_response_full_as_str(None,
                                                                                              session=session,

--- a/packages/nvidia_nat_core/src/nat/runtime/runner.py
+++ b/packages/nvidia_nat_core/src/nat/runtime/runner.py
@@ -117,10 +117,20 @@ class Runner:
 
         # Create reactive event stream
         self._context_state.event_stream.set(Subject())
-        self._context_state.active_function.set(InvocationNode(
-            function_name="root",
-            function_id="root",
-        ))
+
+        # Cross-workflow observability: use parent_id/parent_name when this workflow is a child
+        workflow_parent_id = self._context_state.workflow_parent_id.get()
+        workflow_parent_name = self._context_state.workflow_parent_name.get()
+        root_parent_id = workflow_parent_id if workflow_parent_id else "root"
+        self._context_state.active_function.set(
+            InvocationNode(
+                function_name="root",
+                function_id="root",
+                parent_id=workflow_parent_id,
+                parent_name=workflow_parent_name,
+            ))
+        # So the root workflow step's parent_id is workflow_parent_id when provided
+        self._context_state.active_span_id_stack.set([root_parent_id])
 
         self._runtime_type_token = self._context_state.runtime_type.set(self._runtime_type)
 

--- a/packages/nvidia_nat_core/src/nat/runtime/session.py
+++ b/packages/nvidia_nat_core/src/nat/runtime/session.py
@@ -609,7 +609,7 @@ class SessionManager:
 
         Sets request attributes (method, path, headers, and so on), plus optional
         headers:
-        
+
         - conversation-id
         - user-message-id
         - traceparent

--- a/packages/nvidia_nat_core/src/nat/runtime/session.py
+++ b/packages/nvidia_nat_core/src/nat/runtime/session.py
@@ -138,12 +138,16 @@ class Session:
         Start a workflow run using this session's workflow.
 
         Args:
-            message: Input message for the workflow
-            runtime_type: Runtime type (defaults to SessionManager's runtime_type)
-            parent_id: Optional parent step ID for cross-workflow observability. When set,
-                the root workflow step is emitted with this as its parent.
-            parent_name: Optional parent step name for cross-workflow observability. When set,
-                the root workflow's function ancestry uses this as the parent name.
+            message
+                Input message for the workflow
+            runtime_type : RuntimeTypeEnum
+                Runtime type (defaults to SessionManager's runtime_type)
+            parent_id : str | None, optional
+                Optional parent step ID for cross-workflow observability.
+                When set, the root workflow step is emitted with this as its parent.
+            parent_name : str | None, optional
+                Optional parent step name for cross-workflow observability.
+                When set, the root workflow's function ancestry uses this as the parent name.
 
         Yields:
             Runner instance for the workflow execution
@@ -607,9 +611,7 @@ class SessionManager:
         """
         Extracts and sets user metadata from an HTTP request.
 
-        Sets request attributes (method, path, headers, and so on), plus optional
-        headers:
-
+        Sets request attributes (method, path, headers), plus optional headers:
         - conversation-id
         - user-message-id
         - traceparent
@@ -617,6 +619,7 @@ class SessionManager:
         - workflow-run-id
         - workflow-parent-id (for cross-workflow observability)
         - workflow-parent-name (for cross-workflow observability)
+
         """
         self._context.metadata._request.method = getattr(request, "method", None)
         self._context.metadata._request.url_path = request.url.path

--- a/packages/nvidia_nat_core/src/nat/runtime/session.py
+++ b/packages/nvidia_nat_core/src/nat/runtime/session.py
@@ -499,7 +499,8 @@ class SessionManager:
         token_workflow_parent_id = None
         token_workflow_parent_name = None
         if isinstance(http_connection, Request):
-            token_workflow_parent_id, token_workflow_parent_name = await self.set_metadata_from_http_request(http_connection)
+            token_workflow_parent_id, token_workflow_parent_name = \
+                await self.set_metadata_from_http_request(http_connection)
 
         builder_info: PerUserBuilderInfo | None = None
         request_start_time: float | None = None

--- a/packages/nvidia_nat_core/src/nat/runtime/session.py
+++ b/packages/nvidia_nat_core/src/nat/runtime/session.py
@@ -129,20 +129,41 @@ class Session:
         return self._session_manager
 
     @asynccontextmanager
-    async def run(self, message, runtime_type: RuntimeTypeEnum = RuntimeTypeEnum.RUN_OR_SERVE):
+    async def run(self,
+                  message,
+                  runtime_type: RuntimeTypeEnum = RuntimeTypeEnum.RUN_OR_SERVE,
+                  parent_id: str | None = None,
+                  parent_name: str | None = None):
         """
         Start a workflow run using this session's workflow.
 
         Args:
             message: Input message for the workflow
             runtime_type: Runtime type (defaults to SessionManager's runtime_type)
+            parent_id: Optional parent step ID for cross-workflow observability. When set,
+                the root workflow step is emitted with this as its parent.
+            parent_name: Optional parent step name for cross-workflow observability. When set,
+                the root workflow's function ancestry uses this as the parent name.
 
         Yields:
             Runner instance for the workflow execution
         """
-        async with self._semaphore:
-            async with self._workflow.run(message, runtime_type=runtime_type) as runner:
-                yield runner
+        context_state = self._session_manager._context_state
+        token_parent_id = None
+        token_parent_name = None
+        if parent_id is not None:
+            token_parent_id = context_state.workflow_parent_id.set(parent_id)
+        if parent_name is not None:
+            token_parent_name = context_state.workflow_parent_name.set(parent_name)
+        try:
+            async with self._semaphore:
+                async with self._workflow.run(message, runtime_type=runtime_type) as runner:
+                    yield runner
+        finally:
+            if token_parent_id is not None:
+                context_state.workflow_parent_id.reset(token_parent_id)
+            if token_parent_name is not None:
+                context_state.workflow_parent_name.reset(token_parent_name)
 
 
 class SessionManager:
@@ -584,8 +605,18 @@ class SessionManager:
 
     def set_metadata_from_http_request(self, request: Request) -> None:
         """
-        Extracts and sets user metadata request attributes from a HTTP request.
-        If request is None, no attributes are set.
+        Extracts and sets user metadata from an HTTP request.
+
+        Sets request attributes (method, path, headers, and so on), plus optional
+        headers:
+        
+        - conversation-id
+        - user-message-id
+        - traceparent
+        - workflow-trace-id
+        - workflow-run-id
+        - workflow-parent-id (for cross-workflow observability)
+        - workflow-parent-name (for cross-workflow observability)
         """
         self._context.metadata._request.method = getattr(request, "method", None)
         self._context.metadata._request.url_path = request.url.path
@@ -630,6 +661,14 @@ class SessionManager:
         workflow_run_id = request.headers.get("workflow-run-id")
         if workflow_run_id:
             self._context_state.workflow_run_id.set(workflow_run_id)
+
+        # Cross-workflow observability: parent step id/name for the root of this workflow
+        workflow_parent_id = request.headers.get("workflow-parent-id")
+        if workflow_parent_id:
+            self._context_state.workflow_parent_id.set(workflow_parent_id)
+        workflow_parent_name = request.headers.get("workflow-parent-name")
+        if workflow_parent_name:
+            self._context_state.workflow_parent_name.set(workflow_parent_name)
 
     def set_metadata_from_websocket(self,
                                     websocket: WebSocket,

--- a/packages/nvidia_nat_core/src/nat/runtime/session.py
+++ b/packages/nvidia_nat_core/src/nat/runtime/session.py
@@ -495,8 +495,10 @@ class SessionManager:
                                              conversation_id,
                                              pre_parsed_cookies=cookies_dict)
 
+        token_workflow_parent_id = None
+        token_workflow_parent_name = None
         if isinstance(http_connection, Request):
-            self.set_metadata_from_http_request(http_connection)
+            token_workflow_parent_id, token_workflow_parent_name = self.set_metadata_from_http_request(http_connection)
 
         builder_info: PerUserBuilderInfo | None = None
         request_start_time: float | None = None
@@ -556,6 +558,10 @@ class SessionManager:
                         latency_ms = (time.perf_counter() - request_start_time) * 1000
                         builder_info.record_request(latency_ms, request_success)
 
+            if token_workflow_parent_name is not None:
+                self._context_state.workflow_parent_name.reset(token_workflow_parent_name)
+            if token_workflow_parent_id is not None:
+                self._context_state.workflow_parent_id.reset(token_workflow_parent_id)
             if token_user_id is not None:
                 self._context_state.user_id.reset(token_user_id)
             if token_user_id_builder is not None:
@@ -607,7 +613,7 @@ class SessionManager:
                         logger.exception(f"Error cleaning up builder for user {user_id}")
                 self._per_user_builders.clear()
 
-    def set_metadata_from_http_request(self, request: Request) -> None:
+    def set_metadata_from_http_request(self, request: Request) -> tuple:
         """
         Extracts and sets user metadata from an HTTP request.
 
@@ -620,6 +626,11 @@ class SessionManager:
         - workflow-parent-id (for cross-workflow observability)
         - workflow-parent-name (for cross-workflow observability)
 
+        Returns:
+            A tuple of (workflow_parent_id_token, workflow_parent_name_token).
+            Each element is a contextvars.Token if the corresponding header was
+            present, or None otherwise.  Callers must reset these tokens when the
+            request scope ends to avoid context-variable leaks.
         """
         self._context.metadata._request.method = getattr(request, "method", None)
         self._context.metadata._request.url_path = request.url.path
@@ -666,12 +677,16 @@ class SessionManager:
             self._context_state.workflow_run_id.set(workflow_run_id)
 
         # Cross-workflow observability: parent step id/name for the root of this workflow
+        workflow_parent_id_token = None
         workflow_parent_id = request.headers.get("workflow-parent-id")
         if workflow_parent_id:
-            self._context_state.workflow_parent_id.set(workflow_parent_id)
+            workflow_parent_id_token = self._context_state.workflow_parent_id.set(workflow_parent_id)
+        workflow_parent_name_token = None
         workflow_parent_name = request.headers.get("workflow-parent-name")
         if workflow_parent_name:
-            self._context_state.workflow_parent_name.set(workflow_parent_name)
+            workflow_parent_name_token = self._context_state.workflow_parent_name.set(workflow_parent_name)
+
+        return workflow_parent_id_token, workflow_parent_name_token
 
     def set_metadata_from_websocket(self,
                                     websocket: WebSocket,

--- a/packages/nvidia_nat_core/tests/nat/builder/test_intermediate_step_manager.py
+++ b/packages/nvidia_nat_core/tests/nat/builder/test_intermediate_step_manager.py
@@ -321,3 +321,71 @@ async def test_async_with_task_end(mgr: IntermediateStepManager, output_steps: l
         assert child == actual.name
         assert parent is None or parent == actual.parent_id
         assert etype == actual.event_type
+
+
+# --------------------------------------------------------------------------- #
+# push_intermediate_steps (cross-workflow observability)
+# --------------------------------------------------------------------------- #
+
+
+def test_push_intermediate_steps_injects_steps_into_stream_without_updating_stack(
+    ctx_state: ContextState,
+    output_steps: list,
+):
+    """Test push_intermediate_steps injects steps into the event stream and does not update internal stack."""
+    # Ensure event stream exists so subscription and on_next work
+    from nat.utils.reactive.subject import Subject
+    ctx_state.event_stream.set(Subject())
+
+    mgr = IntermediateStepManager(context_state=ctx_state)
+
+    def on_next(step: IntermediateStep):
+        output_steps.append(step)
+
+    mgr.subscribe(on_next)
+
+    payload1 = IntermediateStepPayload(
+        UUID="remote-step-1",
+        name="remote_workflow",
+        event_type=IntermediateStepType.WORKFLOW_START,
+    )
+    payload2 = IntermediateStepPayload(
+        UUID="remote-step-1",
+        name="remote_workflow",
+        event_type=IntermediateStepType.WORKFLOW_END,
+    )
+    step1 = IntermediateStep(
+        parent_id="root",
+        function_ancestry=InvocationNode(function_id="root", function_name="root"),
+        payload=payload1,
+    )
+    step2 = IntermediateStep(
+        parent_id="root",
+        function_ancestry=InvocationNode(function_id="root", function_name="root"),
+        payload=payload2,
+    )
+    steps_to_inject = [step1, step2]
+
+    assert len(mgr._outstanding_start_steps) == 0
+    mgr.push_intermediate_steps(steps_to_inject)
+
+    assert len(output_steps) == 2
+    assert output_steps[0].UUID == "remote-step-1"
+    assert output_steps[0].event_type == IntermediateStepType.WORKFLOW_START
+    assert output_steps[1].UUID == "remote-step-1"
+    assert output_steps[1].event_type == IntermediateStepType.WORKFLOW_END
+    # push_intermediate_steps does not update the internal stack
+    assert len(mgr._outstanding_start_steps) == 0
+
+
+def test_push_intermediate_steps_empty_list_no_op(ctx_state: ContextState, output_steps: list):
+    """Test push_intermediate_steps with empty list is a no-op."""
+    from nat.utils.reactive.subject import Subject
+    ctx_state.event_stream.set(Subject())
+
+    mgr = IntermediateStepManager(context_state=ctx_state)
+    mgr.subscribe(lambda step: output_steps.append(step))
+
+    mgr.push_intermediate_steps([])
+
+    assert len(output_steps) == 0

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_runner_trace_ids.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_runner_trace_ids.py
@@ -180,7 +180,8 @@ async def test_runner_workflow_name_resolution(
     ("parent-step-1", "Parent Workflow"),
     ("parent-step-2", None),
     (None, None),
-], ids=["both_set", "parent_id_only", "neither_set"])
+],
+                         ids=["both_set", "parent_id_only", "neither_set"])
 async def test_runner_uses_workflow_parent_id_and_name_for_root(
     parent_id: str | None,
     parent_name: str | None,

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_runner_trace_ids.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_runner_trace_ids.py
@@ -174,3 +174,59 @@ async def test_runner_workflow_name_resolution(
             await runner.result()
 
     assert captured_workflow_name == expected_workflow_name
+
+
+@pytest.mark.parametrize("parent_id,parent_name", [
+    ("parent-step-1", "Parent Workflow"),
+    ("parent-step-2", None),
+    (None, None),
+], ids=["both_set", "parent_id_only", "neither_set"])
+async def test_runner_uses_workflow_parent_id_and_name_for_root(
+    parent_id: str | None,
+    parent_name: str | None,
+):
+    """Test Runner sets active_function and active_span_id_stack from workflow_parent_id/name."""
+
+    class _TestFunction:
+        has_single_output = True
+        has_streaming_output = False
+        config = _DummyConfig()
+        instance_name = "workflow"
+        display_name = "workflow"
+
+        def convert(self, v, to_type):
+            return v
+
+        async def ainvoke(self, _message, to_type=None):
+            ctx_state = ContextState.get()
+            active_fn = ctx_state.active_function.get()
+            stack = ctx_state.active_span_id_stack.get()
+            # Root should have parent_id/parent_name when provided
+            assert active_fn is not None
+            assert active_fn.function_id == "root"
+            assert active_fn.function_name == "root"
+            assert active_fn.parent_id == parent_id
+            assert active_fn.parent_name == parent_name
+            # Stack root should be parent_id or "root"
+            expected_root = parent_id if parent_id else "root"
+            assert stack is not None and len(stack) >= 1
+            assert stack[0] == expected_root
+            return {"ok": True}
+
+    ctx_state = ContextState.get()
+    tkn_parent_id = ctx_state.workflow_parent_id.set(parent_id) if parent_id else None
+    tkn_parent_name = ctx_state.workflow_parent_name.set(parent_name) if parent_name else None
+    try:
+        runner = Runner(
+            "msg",
+            typing.cast(Function, _TestFunction()),
+            ctx_state,
+            typing.cast(ExporterManager, _DummyExporterManager()),
+        )
+        async with runner:
+            await runner.result()
+    finally:
+        if tkn_parent_id is not None:
+            ctx_state.workflow_parent_id.reset(tkn_parent_id)
+        if tkn_parent_name is not None:
+            ctx_state.workflow_parent_name.reset(tkn_parent_name)

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
@@ -568,7 +568,7 @@ class TestSessionManagerSetMetadataFromHttpRequest:
     """Tests for set_metadata_from_http_request (including cross-workflow headers)."""
 
     @patch('nat.cli.type_registry.GlobalTypeRegistry')
-    def test_set_metadata_from_http_request_sets_workflow_parent_headers(self, mock_registry):
+    async def test_set_metadata_from_http_request_sets_workflow_parent_headers(self, mock_registry):
         """Test workflow-parent-id and workflow-parent-name headers are set on context."""
         mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(is_per_user=False)
 
@@ -594,14 +594,14 @@ class TestSessionManagerSetMetadataFromHttpRequest:
         request.client.port = 12345
         request.cookies = {}
 
-        sm.set_metadata_from_http_request(request)
+        await sm.set_metadata_from_http_request(request)
 
         ctx_state = ContextState.get()
         assert ctx_state.workflow_parent_id.get() == "parent-uuid-456"
         assert ctx_state.workflow_parent_name.get() == "Parent Workflow Name"
 
     @patch('nat.cli.type_registry.GlobalTypeRegistry')
-    def test_set_metadata_from_http_request_workflow_parent_optional(self, mock_registry):
+    async def test_set_metadata_from_http_request_workflow_parent_optional(self, mock_registry):
         """Test workflow runs without parent headers when they are not sent."""
         mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(is_per_user=False)
 
@@ -625,7 +625,7 @@ class TestSessionManagerSetMetadataFromHttpRequest:
         request.client.port = 12345
         request.cookies = {}
 
-        sm.set_metadata_from_http_request(request)
+        await sm.set_metadata_from_http_request(request)
 
         ctx_state = ContextState.get()
         assert ctx_state.workflow_parent_id.get() is None

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
@@ -522,8 +522,7 @@ class TestSessionRunCrossWorkflowObservability:
     @patch('nat.cli.type_registry.GlobalTypeRegistry')
     async def test_session_run_sets_and_resets_workflow_parent_context(self, mock_registry):
         """Test run(parent_id=..., parent_name=...) sets context vars during run and resets on exit."""
-        mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(
-            is_per_user=False)
+        mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(is_per_user=False)
 
         ctx_state = ContextState.get()
         sm = SessionManager(config=create_mock_config(),
@@ -538,9 +537,7 @@ class TestSessionRunCrossWorkflowObservability:
 
             values_during_run = []
 
-            async with session.run("hello",
-                                  parent_id="parent-step-123",
-                                  parent_name="Caller Workflow") as _:
+            async with session.run("hello", parent_id="parent-step-123", parent_name="Caller Workflow") as _:
                 values_during_run.append(ctx_state.workflow_parent_id.get())
                 values_during_run.append(ctx_state.workflow_parent_name.get())
 
@@ -553,8 +550,7 @@ class TestSessionRunCrossWorkflowObservability:
     @patch('nat.cli.type_registry.GlobalTypeRegistry')
     async def test_session_run_without_parent_leaves_context_unset(self, mock_registry):
         """Test run() without parent_id/parent_name leaves workflow_parent context vars unset."""
-        mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(
-            is_per_user=False)
+        mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(is_per_user=False)
 
         ctx_state = ContextState.get()
         sm = SessionManager(config=create_mock_config(),

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
@@ -520,7 +520,6 @@ class TestSessionRunCrossWorkflowObservability:
     """Tests for Session.run() with parent_id/parent_name (cross-workflow observability)."""
 
     @patch('nat.cli.type_registry.GlobalTypeRegistry')
-    @pytest.mark.asyncio
     async def test_session_run_sets_and_resets_workflow_parent_context(self, mock_registry):
         """Test run(parent_id=..., parent_name=...) sets context vars during run and resets on exit."""
         mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(
@@ -541,7 +540,7 @@ class TestSessionRunCrossWorkflowObservability:
 
             async with session.run("hello",
                                   parent_id="parent-step-123",
-                                  parent_name="Caller Workflow") as runner:
+                                  parent_name="Caller Workflow") as _:
                 values_during_run.append(ctx_state.workflow_parent_id.get())
                 values_during_run.append(ctx_state.workflow_parent_name.get())
 
@@ -552,7 +551,6 @@ class TestSessionRunCrossWorkflowObservability:
         assert values_during_run == ["parent-step-123", "Caller Workflow"]
 
     @patch('nat.cli.type_registry.GlobalTypeRegistry')
-    @pytest.mark.asyncio
     async def test_session_run_without_parent_leaves_context_unset(self, mock_registry):
         """Test run() without parent_id/parent_name leaves workflow_parent context vars unset."""
         mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(
@@ -565,7 +563,7 @@ class TestSessionRunCrossWorkflowObservability:
                             shared_workflow=MockWorkflow())
 
         async with sm.session() as session:
-            async with session.run("hello") as runner:
+            async with session.run("hello") as _:
                 assert ctx_state.workflow_parent_id.get() is None
                 assert ctx_state.workflow_parent_name.get() is None
 

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
@@ -130,6 +130,24 @@ def create_mock_function_registration(is_per_user: bool = False):
     return registration
 
 
+def _reset_workflow_parent_context() -> None:
+    """Reset cross-workflow observability context vars (ContextState is a singleton)."""
+    ctx_state = ContextState.get()
+    ctx_state.workflow_parent_id.set(None)
+    ctx_state.workflow_parent_name.set(None)
+
+
+@pytest.fixture(autouse=True)
+def reset_workflow_parent_context():
+    """
+    Reset workflow_parent_id and workflow_parent_name before and after each test
+    so tests do not leak state via the singleton ContextState.
+    """
+    _reset_workflow_parent_context()
+    yield
+    _reset_workflow_parent_context()
+
+
 class TestPerUserBuilderInfo:
     """Tests for PerUserBuilderInfo Pydantic model."""
 
@@ -496,6 +514,128 @@ class TestSessionManagerCleanup:
             cleaned = await sm._cleanup_inactive_per_user_builders()
             assert cleaned == 0
             assert "user123" in sm._per_user_builders
+
+
+class TestSessionRunCrossWorkflowObservability:
+    """Tests for Session.run() with parent_id/parent_name (cross-workflow observability)."""
+
+    @patch('nat.cli.type_registry.GlobalTypeRegistry')
+    @pytest.mark.asyncio
+    async def test_session_run_sets_and_resets_workflow_parent_context(self, mock_registry):
+        """Test run(parent_id=..., parent_name=...) sets context vars during run and resets on exit."""
+        mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(
+            is_per_user=False)
+
+        ctx_state = ContextState.get()
+        sm = SessionManager(config=create_mock_config(),
+                            shared_builder=MockWorkflowBuilder(),
+                            entry_function=None,
+                            shared_workflow=MockWorkflow())
+
+        async with sm.session() as session:
+            # Before run, parent context should be unset
+            assert ctx_state.workflow_parent_id.get() is None
+            assert ctx_state.workflow_parent_name.get() is None
+
+            values_during_run = []
+
+            async with session.run("hello",
+                                  parent_id="parent-step-123",
+                                  parent_name="Caller Workflow") as runner:
+                values_during_run.append(ctx_state.workflow_parent_id.get())
+                values_during_run.append(ctx_state.workflow_parent_name.get())
+
+            # After exiting run(), context should be reset
+            assert ctx_state.workflow_parent_id.get() is None
+            assert ctx_state.workflow_parent_name.get() is None
+
+        assert values_during_run == ["parent-step-123", "Caller Workflow"]
+
+    @patch('nat.cli.type_registry.GlobalTypeRegistry')
+    @pytest.mark.asyncio
+    async def test_session_run_without_parent_leaves_context_unset(self, mock_registry):
+        """Test run() without parent_id/parent_name leaves workflow_parent context vars unset."""
+        mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(
+            is_per_user=False)
+
+        ctx_state = ContextState.get()
+        sm = SessionManager(config=create_mock_config(),
+                            shared_builder=MockWorkflowBuilder(),
+                            entry_function=None,
+                            shared_workflow=MockWorkflow())
+
+        async with sm.session() as session:
+            async with session.run("hello") as runner:
+                assert ctx_state.workflow_parent_id.get() is None
+                assert ctx_state.workflow_parent_name.get() is None
+
+
+class TestSessionManagerSetMetadataFromHttpRequest:
+    """Tests for set_metadata_from_http_request (including cross-workflow headers)."""
+
+    @patch('nat.cli.type_registry.GlobalTypeRegistry')
+    def test_set_metadata_from_http_request_sets_workflow_parent_headers(self, mock_registry):
+        """Test workflow-parent-id and workflow-parent-name headers are set on context."""
+        mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(is_per_user=False)
+
+        sm = SessionManager(config=create_mock_config(),
+                            shared_builder=MockWorkflowBuilder(),
+                            entry_function=None,
+                            shared_workflow=MockWorkflow())
+
+        request = MagicMock()
+        request.method = "POST"
+        request.url = MagicMock()
+        request.url.path = "/generate/full"
+        request.url.port = 8000
+        request.url.scheme = "http"
+        request.headers = MagicMock()
+        request.headers.get.side_effect = lambda k, default=None: {
+            "workflow-parent-id": "parent-uuid-456",
+            "workflow-parent-name": "Parent Workflow Name", }.get(k, default)
+        request.query_params = {}
+        request.path_params = {}
+        request.client = MagicMock()
+        request.client.host = "127.0.0.1"
+        request.client.port = 12345
+        request.cookies = {}
+
+        sm.set_metadata_from_http_request(request)
+
+        ctx_state = ContextState.get()
+        assert ctx_state.workflow_parent_id.get() == "parent-uuid-456"
+        assert ctx_state.workflow_parent_name.get() == "Parent Workflow Name"
+
+    @patch('nat.cli.type_registry.GlobalTypeRegistry')
+    def test_set_metadata_from_http_request_workflow_parent_optional(self, mock_registry):
+        """Test workflow runs without parent headers when they are not sent."""
+        mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(is_per_user=False)
+
+        sm = SessionManager(config=create_mock_config(),
+                            shared_builder=MockWorkflowBuilder(),
+                            entry_function=None,
+                            shared_workflow=MockWorkflow())
+
+        request = MagicMock()
+        request.method = "POST"
+        request.url = MagicMock()
+        request.url.path = "/generate/full"
+        request.url.port = 8000
+        request.url.scheme = "http"
+        request.headers = MagicMock()
+        request.headers.get.return_value = None
+        request.query_params = {}
+        request.path_params = {}
+        request.client = MagicMock()
+        request.client.host = "127.0.0.1"
+        request.client.port = 12345
+        request.cookies = {}
+
+        sm.set_metadata_from_http_request(request)
+
+        ctx_state = ContextState.get()
+        assert ctx_state.workflow_parent_id.get() is None
+        assert ctx_state.workflow_parent_name.get() is None
 
 
 class TestSessionManagerContextExtraction:


### PR DESCRIPTION
## Description

Add support for linking child workflow runs to a parent so observability backends can show a single trace tree when one workflow invokes another (programmatically or via HTTP).

### Changes
1. Programmatic runs – parent context

    - `Session.run(message, parent_id=..., parent_name=...)` Optional parent_id and parent_name set context for the run and are reset when the run context exits.
    - `ContextState`: New context vars: workflow_parent_id, workflow_parent_name.
    - `Runner`: On enter, uses those vars to set the root InvocationNode’s parent_id/parent_name and the initial active_span_id_stack, so the first emitted workflow step has the correct parent.

2. HTTP-triggered runs – headers
    - **Request headers**: `set_metadata_from_http_request()` reads workflow-parent-id and workflow-parent-name and sets the same context vars.
    - **`POST /generate/full`**:  Endpoint now receives the Request and passes it into `session_manager.session(http_connection=request)` so these headers (and auth) are applied.

3. Replaying remote workflow steps
    - `IntermediateStepManager.push_intermediate_steps(steps)` Injects a list of IntermediateStep into the current run’s event stream without updating the manager’s internal stack. Used to replay steps from a remote workflow (e.g. /generate/full response) so they appear in the same trace tree. Callers use `Context.get().intermediate_step_manager.push_intermediate_steps(remote_steps)` from code that has the current context.

4. Documentation
    - `docs/source/run-workflows/observe/observe.md` New “Cross-Workflow Observability” section: specifying parent when running programmatically, HTTP headers, and replaying intermediate steps from a remote workflow.

5. Tests
    - **Session:** `run(parent_id=..., parent_name=...)` sets/resets context; run without parent leaves vars unset.
    - **SessionManager:** `set_metadata_from_http_request` sets workflow-parent headers; optional test verifies no headers → vars stay unset.
    - **Runner:** parametrized test that root active_function and active_span_id_stack reflect workflow_parent_id / workflow_parent_name (both set, only parent_id, or neither).
    - **IntermediateStepManager:** push_intermediate_steps injects steps into the stream without updating _outstanding_start_steps; empty list is a no-op.
    - Autouse fixture in `test_session_manager.py` resets workflow_parent_id and workflow_parent_name before/after each test to avoid leaking state via the singleton ContextState.

Closes #760

Closes #829


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cross-workflow observability: link child workflows to parent workflows via API parameters and HTTP headers (workflow-parent-id, workflow-parent-name).
  * Replay remote intermediate steps into a running workflow’s observability stream.
  * Raw streaming now requires authenticated HTTP requests.

* **Documentation**
  * Added guide with examples for cross-workflow linking, header usage, and replaying intermediate steps.
  * Removed legacy “Compatibility with Previous Versions” note.

* **Tests**
  * New tests validating parent propagation, header extraction, replay behavior, and context cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->