### PR TITLE
Refactor latency sensitivity to use integers instead of enums.

### DIFF
--- a/packages/nvidia_nat_core/src/nat/builder/context.py
+++ b/packages/nvidia_nat_core/src/nat/builder/context.py
@@ -35,7 +35,6 @@ from nat.data_models.intermediate_step import StreamEventData
 from nat.data_models.intermediate_step import TraceMetadata
 from nat.data_models.invocation_node import InvocationNode
 from nat.data_models.runtime_enum import RuntimeTypeEnum
-from nat.profiler.decorators.latency import LatencySensitivity
 from nat.runtime.user_metadata import RequestAttributes
 from nat.utils.reactive.subject import Subject
 
@@ -83,8 +82,8 @@ class ContextState(metaclass=Singleton):
         self._active_function: ContextVar[InvocationNode | None] = ContextVar("active_function", default=None)
         self._active_span_id_stack: ContextVar[list[str] | None] = ContextVar("active_span_id_stack", default=None)
         self._function_path_stack: ContextVar[list[str] | None] = ContextVar("function_path_stack", default=None)
-        self._latency_sensitivity_stack: ContextVar[list[LatencySensitivity] | None] = ContextVar(
-            "latency_sensitivity_stack", default=None)
+        self._latency_sensitivity_stack: ContextVar[list[int] | None] = ContextVar("latency_sensitivity_stack",
+                                                                                   default=None)
 
         # Default is a lambda no-op which returns NoneType
         self.user_input_callback: ContextVar[Callable[[InteractionPrompt], Awaitable[HumanResponse | None]]
@@ -126,10 +125,10 @@ class ContextState(metaclass=Singleton):
         return typing.cast(ContextVar[list[str]], self._function_path_stack)
 
     @property
-    def latency_sensitivity_stack(self) -> ContextVar[list[LatencySensitivity]]:
+    def latency_sensitivity_stack(self) -> ContextVar[list[int]]:
         if self._latency_sensitivity_stack.get() is None:
-            self._latency_sensitivity_stack.set([LatencySensitivity.MEDIUM])
-        return typing.cast(ContextVar[list[LatencySensitivity]], self._latency_sensitivity_stack)
+            self._latency_sensitivity_stack.set([2])
+        return typing.cast(ContextVar[list[int]], self._latency_sensitivity_stack)
 
     @staticmethod
     def get() -> "ContextState":
@@ -373,38 +372,37 @@ class Context:
         return self._context_state.runtime_type.get() == RuntimeTypeEnum.EVALUATE
 
     @property
-    def latency_sensitivity(self) -> LatencySensitivity:
+    def latency_sensitivity(self) -> int:
         """
         Returns the current latency sensitivity level.
 
         When multiple sensitivity levels are pushed onto the stack,
-        returns the one with highest priority (HIGH > MEDIUM > LOW).
+        returns the maximum value (higher integers mean higher sensitivity).
 
         Returns:
-            LatencySensitivity: The current effective latency sensitivity.
+            int: The current effective latency sensitivity.
         """
         stack = self._context_state.latency_sensitivity_stack.get()
-        # Return the sensitivity with the highest priority
-        return max(stack, key=lambda s: s.priority)
+        return max(stack)
 
     @contextmanager
-    def push_latency_sensitivity(self, sensitivity: LatencySensitivity):
+    def push_latency_sensitivity(self, sensitivity: int):
         """
         Push a latency sensitivity level onto the stack.
 
-        The effective sensitivity is the maximum priority across all
+        The effective sensitivity is the maximum value across all
         pushed levels. When the context exits, the pushed level is removed.
 
         Args:
-            sensitivity: The latency sensitivity level to push.
+            sensitivity: The latency sensitivity level to push (integer).
 
         Yields:
             None
 
         Example:
             >>> ctx = Context.get()
-            >>> with ctx.push_latency_sensitivity(LatencySensitivity.HIGH):
-            ...     # Inside this block, sensitivity is at least HIGH
+            >>> with ctx.push_latency_sensitivity(3):
+            ...     # Inside this block, sensitivity is at least 3
             ...     pass
         """
         stack = self._context_state.latency_sensitivity_stack.get()

--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -476,13 +476,12 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         # Get prefix ID from context (supports depth-awareness and overrides)
         prefix_id = DynamoPrefixContext.get()
 
-        # Get latency sensitivity from context (defaults to MEDIUM)
+        # Get latency sensitivity from context (defaults to 2)
         try:
             ctx = Context.get()
-            latency_sensitivity = str(ctx.latency_sensitivity.value)
+            latency_sensitivity = ctx.latency_sensitivity
         except Exception:
-            # If context not available or latency_sensitivity not implemented yet, default to MEDIUM
-            latency_sensitivity = "MEDIUM"
+            latency_sensitivity = 2
 
         # Initialize with static config values (always integers)
         total_requests = self._total_requests
@@ -547,7 +546,7 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
             headers[f"{LLMHeaderPrefix.DYNAMO}-total-requests"] = str(total_requests)
             headers[f"{LLMHeaderPrefix.DYNAMO}-osl"] = str(osl_value)
             headers[f"{LLMHeaderPrefix.DYNAMO}-iat"] = str(iat_value)
-            headers[f"{LLMHeaderPrefix.DYNAMO}-latency-sensitivity"] = latency_sensitivity
+            headers[f"{LLMHeaderPrefix.DYNAMO}-latency-sensitivity"] = str(latency_sensitivity)
 
         # Modify body to inject nvext.agent_hints (if JSON POST request)
         content = request.content
@@ -561,7 +560,7 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
                         "total_requests": total_requests,
                         "osl": osl_value,
                         "iat": iat_value,
-                        "latency_sensitivity": latency_sensitivity,
+                        "latency_sensitivity": float(latency_sensitivity),
                     }
 
                     # Add/merge nvext.agent_hints

--- a/packages/nvidia_nat_core/src/nat/profiler/decorators/latency.py
+++ b/packages/nvidia_nat_core/src/nat/profiler/decorators/latency.py
@@ -16,8 +16,8 @@
 Latency sensitivity decorator for marking functions with latency requirements.
 
 This module provides the @latency_sensitive decorator that allows marking functions
-with latency sensitivity levels (LOW, MEDIUM, HIGH). The sensitivity propagates through
-the call stack with priority-based merging, where higher sensitivity takes precedence.
+with integer latency sensitivity levels. The sensitivity propagates through
+the call stack with max-based merging, where higher values take precedence.
 
 Use cases:
 - LLM routing: Direct high-sensitivity requests to low-latency backends
@@ -25,17 +25,17 @@ Use cases:
 - Observability: Track which parts of workflows have strict latency requirements
 
 Example:
-    Basic usage with enum::
+    Basic usage with integers::
 
-        from nat.profiler.decorators.latency import LatencySensitivity, latency_sensitive
+        from nat.profiler.decorators.latency import latency_sensitive
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def critical_llm_call():
             return await llm.generate()
 
-    Using string form::
+    Using integer values::
 
-        @latency_sensitive("low")
+        @latency_sensitive(1)
         def background_task():
             pass
 
@@ -45,7 +45,7 @@ Example:
 
         def my_function():
             sensitivity = Context.get().latency_sensitivity
-            if sensitivity == LatencySensitivity.HIGH:
+            if sensitivity >= 3:
                 # Use fast path
                 pass
 """
@@ -53,114 +53,45 @@ Example:
 import functools
 import inspect
 from collections.abc import Callable
-from enum import StrEnum
 from typing import Any
 from typing import TypeVar
-
-
-class LatencySensitivity(StrEnum):
-    """
-    Latency sensitivity levels for function execution.
-
-    The sensitivity level indicates how time-critical a function's execution is.
-    Higher sensitivity values take precedence when contexts are nested.
-
-    Attributes:
-        LOW: Low latency sensitivity (priority=1). Suitable for background tasks
-            or non-time-critical operations.
-        MEDIUM: Medium latency sensitivity (priority=2). Default level for most
-            operations. Suitable for typical user interactions.
-        HIGH: High latency sensitivity (priority=3). Suitable for critical user-facing
-            operations requiring immediate response.
-    """
-
-    LOW = "LOW"
-    MEDIUM = "MEDIUM"
-    HIGH = "HIGH"
-
-    @property
-    def priority(self) -> int:
-        """
-        Return numeric priority for this sensitivity level.
-
-        Higher priority values indicate higher sensitivity. Used for comparing
-        sensitivities when nesting contexts.
-
-        Returns:
-            int: Priority value (LOW=1, MEDIUM=2, HIGH=3)
-        """
-        return {"LOW": 1, "MEDIUM": 2, "HIGH": 3}[self.value]
-
-    @classmethod
-    def parse(cls, value: "LatencySensitivity | str") -> "LatencySensitivity":
-        """
-        Parse string or enum to LatencySensitivity.
-
-        Accepts either a LatencySensitivity enum value or a string representation.
-        String parsing is case-insensitive.
-
-        Args:
-            value: Either a LatencySensitivity enum or string like "high", "MEDIUM", "Low"
-
-        Returns:
-            LatencySensitivity: Parsed enum value
-
-        Raises:
-            ValueError: If value is not a valid sensitivity level
-
-        Example:
-            >>> LatencySensitivity.parse("high")
-            <LatencySensitivity.HIGH: 'HIGH'>
-            >>> LatencySensitivity.parse(LatencySensitivity.LOW)
-            <LatencySensitivity.LOW: 'LOW'>
-        """
-        if isinstance(value, cls):
-            return value
-
-        if isinstance(value, str):
-            normalized = value.upper()
-            if normalized in {"LOW", "MEDIUM", "HIGH"}:
-                return cls(normalized)
-
-        raise ValueError(f"Invalid latency sensitivity: {value!r}. "
-                         f"Must be 'LOW', 'MEDIUM', 'HIGH', or LatencySensitivity enum.")
-
 
 # Type variable for preserving function signature
 F = TypeVar("F", bound=Callable[..., Any])
 
 
-def latency_sensitive(sensitivity: LatencySensitivity | str) -> Callable[[F], F]:
+def latency_sensitive(sensitivity: int) -> Callable[[F], F]:
     """
     Decorator to mark a function with a latency sensitivity level.
 
     The sensitivity is pushed onto the context stack for the duration of the
-    function execution. The effective sensitivity is the maximum priority across
+    function execution. The effective sensitivity is the maximum value across
     all pushed levels.
 
     Args:
-        sensitivity: Latency sensitivity level (enum or string like "high", "LOW")
+        sensitivity: Latency sensitivity level as an integer (e.g. 1=low, 2=medium, 3=high)
 
     Returns:
         Decorated function that pushes sensitivity onto context stack
 
     Raises:
-        ValueError: If sensitivity is not a valid level
+        TypeError: If sensitivity is not an int
 
     Example:
-        >>> from nat.profiler.decorators.latency import latency_sensitive, LatencySensitivity
+        >>> from nat.profiler.decorators.latency import latency_sensitive
         >>> from nat.builder.context import Context
         >>>
-        >>> @latency_sensitive(LatencySensitivity.HIGH)
+        >>> @latency_sensitive(3)
         ... def critical_function():
         ...     return Context.get().latency_sensitivity
         >>>
-        >>> @latency_sensitive("low")
+        >>> @latency_sensitive(1)
         ... async def background_task():
         ...     return await do_work()
     """
-    # Parse and validate at decoration time
-    parsed_sensitivity = LatencySensitivity.parse(sensitivity)
+    # Validate at decoration time
+    if not isinstance(sensitivity, int):
+        raise TypeError(f"sensitivity must be an int, got {type(sensitivity).__name__}")
 
     def decorator(func: F) -> F:
         # Import here to avoid circular dependency
@@ -171,7 +102,7 @@ def latency_sensitive(sensitivity: LatencySensitivity | str) -> Callable[[F], F]
             @functools.wraps(func)
             async def async_gen_wrapper(*args: Any, **kwargs: Any):
                 ctx = Context.get()
-                with ctx.push_latency_sensitivity(parsed_sensitivity):
+                with ctx.push_latency_sensitivity(sensitivity):
                     async for item in func(*args, **kwargs):
                         yield item
 
@@ -182,7 +113,7 @@ def latency_sensitive(sensitivity: LatencySensitivity | str) -> Callable[[F], F]
             @functools.wraps(func)
             async def async_wrapper(*args: Any, **kwargs: Any) -> Any:
                 ctx = Context.get()
-                with ctx.push_latency_sensitivity(parsed_sensitivity):
+                with ctx.push_latency_sensitivity(sensitivity):
                     return await func(*args, **kwargs)
 
             return async_wrapper  # type: ignore
@@ -192,7 +123,7 @@ def latency_sensitive(sensitivity: LatencySensitivity | str) -> Callable[[F], F]
             @functools.wraps(func)
             def generator_wrapper(*args: Any, **kwargs: Any):
                 ctx = Context.get()
-                with ctx.push_latency_sensitivity(parsed_sensitivity):
+                with ctx.push_latency_sensitivity(sensitivity):
                     yield from func(*args, **kwargs)
 
             return generator_wrapper  # type: ignore
@@ -202,7 +133,7 @@ def latency_sensitive(sensitivity: LatencySensitivity | str) -> Callable[[F], F]
             @functools.wraps(func)
             def sync_wrapper(*args: Any, **kwargs: Any) -> Any:
                 ctx = Context.get()
-                with ctx.push_latency_sensitivity(parsed_sensitivity):
+                with ctx.push_latency_sensitivity(sensitivity):
                     return func(*args, **kwargs)
 
             return sync_wrapper  # type: ignore

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
@@ -760,7 +760,7 @@ class TestDynamoTransport:
 
         # Verify latency-sensitivity header was injected with default MEDIUM
         prefix = f"{LLMHeaderPrefix.DYNAMO}"
-        assert modified_request.headers[f"{prefix}-latency-sensitivity"] == "MEDIUM"
+        assert modified_request.headers[f"{prefix}-latency-sensitivity"] == "2"
 
         # Cleanup
         DynamoPrefixContext.clear()
@@ -814,7 +814,7 @@ class TestDynamoTransport:
         assert "nvext" in body
         assert "agent_hints" in body["nvext"]
         agent_hints = body["nvext"]["agent_hints"]
-        assert agent_hints["latency_sensitivity"] == "MEDIUM"
+        assert agent_hints["latency_sensitivity"] == 2.0
 
         # Cleanup
         DynamoPrefixContext.clear()

--- a/packages/nvidia_nat_core/tests/nat/profiler/decorators/test_latency.py
+++ b/packages/nvidia_nat_core/tests/nat/profiler/decorators/test_latency.py
@@ -18,215 +18,235 @@ import asyncio
 import pytest
 
 from nat.builder.context import Context
-from nat.profiler.decorators.latency import LatencySensitivity
 from nat.profiler.decorators.latency import latency_sensitive
 
 
-class TestLatencySensitivity:
-    """Tests for LatencySensitivity enum."""
+class TestLatencySensitiveValidation:
+    """Tests for latency_sensitive decorator input validation."""
 
-    def test_enum_values_exist(self):
-        """Test that all three sensitivity levels exist."""
-        assert LatencySensitivity.LOW
-        assert LatencySensitivity.MEDIUM
-        assert LatencySensitivity.HIGH
+    def test_accepts_int(self):
+        """Test that @latency_sensitive accepts an integer."""
 
-    def test_enum_string_values(self):
-        """Test that enum values are correct strings."""
-        assert LatencySensitivity.LOW.value == "LOW"
-        assert LatencySensitivity.MEDIUM.value == "MEDIUM"
-        assert LatencySensitivity.HIGH.value == "HIGH"
+        @latency_sensitive(3)
+        def sync_func():
+            return Context.get().latency_sensitivity
 
-    def test_priority_values(self):
-        """Test that priority property returns correct numeric values."""
-        assert LatencySensitivity.LOW.priority == 1
-        assert LatencySensitivity.MEDIUM.priority == 2
-        assert LatencySensitivity.HIGH.priority == 3
+        result = sync_func()
+        assert result == 3
 
-    def test_parse_enum_value(self):
-        """Test that parse accepts enum values directly."""
-        result = LatencySensitivity.parse(LatencySensitivity.HIGH)
-        assert result == LatencySensitivity.HIGH
+    def test_rejects_string(self):
+        """Test that @latency_sensitive rejects a string."""
+        with pytest.raises(TypeError):
 
-    def test_parse_uppercase_string(self):
-        """Test that parse accepts uppercase strings."""
-        assert LatencySensitivity.parse("LOW") == LatencySensitivity.LOW
-        assert LatencySensitivity.parse("MEDIUM") == LatencySensitivity.MEDIUM
-        assert LatencySensitivity.parse("HIGH") == LatencySensitivity.HIGH
+            @latency_sensitive("high")
+            def sync_func():
+                pass
 
-    def test_parse_lowercase_string(self):
-        """Test that parse accepts lowercase strings (case-insensitive)."""
-        assert LatencySensitivity.parse("low") == LatencySensitivity.LOW
-        assert LatencySensitivity.parse("medium") == LatencySensitivity.MEDIUM
-        assert LatencySensitivity.parse("high") == LatencySensitivity.HIGH
+    def test_rejects_float(self):
+        """Test that @latency_sensitive rejects a float."""
+        with pytest.raises(TypeError):
 
-    def test_parse_mixed_case_string(self):
-        """Test that parse accepts mixed-case strings."""
-        assert LatencySensitivity.parse("Low") == LatencySensitivity.LOW
-        assert LatencySensitivity.parse("MeDiUm") == LatencySensitivity.MEDIUM
-        assert LatencySensitivity.parse("HiGh") == LatencySensitivity.HIGH
+            @latency_sensitive(3.0)
+            def sync_func():
+                pass
 
-    def test_parse_invalid_string(self):
-        """Test that parse raises ValueError for invalid strings."""
-        with pytest.raises(ValueError, match="Invalid latency sensitivity"):
-            LatencySensitivity.parse("INVALID")
+    def test_rejects_none(self):
+        """Test that @latency_sensitive rejects None."""
+        with pytest.raises(TypeError):
 
-    def test_parse_invalid_type(self):
-        """Test that parse raises ValueError for invalid types."""
-        with pytest.raises(ValueError, match="Invalid latency sensitivity"):
-            LatencySensitivity.parse(123)
+            @latency_sensitive(None)
+            def sync_func():
+                pass
 
-    def test_parse_empty_string(self):
-        """Test that parse raises ValueError for empty string."""
-        with pytest.raises(ValueError, match="Invalid latency sensitivity"):
-            LatencySensitivity.parse("")
+    def test_accepts_zero(self):
+        """Test that @latency_sensitive accepts zero."""
+
+        @latency_sensitive(0)
+        def sync_func():
+            return Context.get().latency_sensitivity
+
+        # 0 < default 2, so default wins
+        result = sync_func()
+        assert result == 2
+
+    def test_accepts_negative(self):
+        """Test that @latency_sensitive accepts a negative integer."""
+
+        @latency_sensitive(-1)
+        def sync_func():
+            return Context.get().latency_sensitivity
+
+        # -1 < default 2, so default wins
+        result = sync_func()
+        assert result == 2
+
+    def test_accepts_large_int(self):
+        """Test that @latency_sensitive accepts a large integer."""
+
+        @latency_sensitive(100)
+        def sync_func():
+            return Context.get().latency_sensitivity
+
+        result = sync_func()
+        assert result == 100
+
+    def test_accepts_arbitrary_int(self):
+        """Test that @latency_sensitive accepts an arbitrary integer like 42."""
+
+        @latency_sensitive(42)
+        def sync_func():
+            return Context.get().latency_sensitivity
+
+        result = sync_func()
+        # 42 > default 2, so 42 wins
+        assert result == 42
 
 
 class TestContextIntegration:
     """Tests for Context integration with latency sensitivity."""
 
     def test_default_sensitivity_is_medium(self):
-        """Test that default latency sensitivity is MEDIUM."""
+        """Test that default latency sensitivity is 2 (MEDIUM)."""
         ctx = Context.get()
         sensitivity = ctx.latency_sensitivity
-        assert sensitivity == LatencySensitivity.MEDIUM
+        assert sensitivity == 2
 
     def test_push_higher_priority_changes_sensitivity(self):
         """Test that pushing higher priority changes current sensitivity."""
         ctx = Context.get()
 
-        # Default is MEDIUM
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # Default is 2
+        assert ctx.latency_sensitivity == 2
 
-        # Push HIGH (higher priority)
-        with ctx.push_latency_sensitivity(LatencySensitivity.HIGH):
-            assert ctx.latency_sensitivity == LatencySensitivity.HIGH
+        # Push 3 (HIGH, higher priority)
+        with ctx.push_latency_sensitivity(3):
+            assert ctx.latency_sensitivity == 3
 
-        # Reverts to MEDIUM
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # Reverts to 2
+        assert ctx.latency_sensitivity == 2
 
     def test_push_lower_priority_keeps_current(self):
         """Test that pushing lower priority keeps current sensitivity."""
         ctx = Context.get()
 
-        # Push HIGH first
-        with ctx.push_latency_sensitivity(LatencySensitivity.HIGH):
-            assert ctx.latency_sensitivity == LatencySensitivity.HIGH
+        # Push 3 (HIGH) first
+        with ctx.push_latency_sensitivity(3):
+            assert ctx.latency_sensitivity == 3
 
-            # Try to push LOW (lower priority) - should stay HIGH
-            with ctx.push_latency_sensitivity(LatencySensitivity.LOW):
-                assert ctx.latency_sensitivity == LatencySensitivity.HIGH
+            # Try to push 1 (LOW, lower priority) - should stay 3
+            with ctx.push_latency_sensitivity(1):
+                assert ctx.latency_sensitivity == 3
 
-            # Still HIGH after inner context exits
-            assert ctx.latency_sensitivity == LatencySensitivity.HIGH
+            # Still 3 after inner context exits
+            assert ctx.latency_sensitivity == 3
 
-        # Reverts to MEDIUM
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # Reverts to 2
+        assert ctx.latency_sensitivity == 2
 
     def test_deep_nesting_maintains_priority(self):
         """Test that deep nesting correctly maintains highest priority."""
         ctx = Context.get()
 
-        # MEDIUM (default)
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # 2 (default)
+        assert ctx.latency_sensitivity == 2
 
-        with ctx.push_latency_sensitivity(LatencySensitivity.LOW):
-            # LOW < MEDIUM, stays MEDIUM
-            assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        with ctx.push_latency_sensitivity(1):
+            # 1 < 2, stays 2
+            assert ctx.latency_sensitivity == 2
 
-            with ctx.push_latency_sensitivity(LatencySensitivity.HIGH):
-                # HIGH > MEDIUM, becomes HIGH
-                assert ctx.latency_sensitivity == LatencySensitivity.HIGH
+            with ctx.push_latency_sensitivity(3):
+                # 3 > 2, becomes 3
+                assert ctx.latency_sensitivity == 3
 
-                with ctx.push_latency_sensitivity(LatencySensitivity.MEDIUM):
-                    # MEDIUM < HIGH, stays HIGH
-                    assert ctx.latency_sensitivity == LatencySensitivity.HIGH
+                with ctx.push_latency_sensitivity(2):
+                    # 2 < 3, stays 3
+                    assert ctx.latency_sensitivity == 3
 
-                    with ctx.push_latency_sensitivity(LatencySensitivity.LOW):
-                        # LOW < HIGH, stays HIGH
-                        assert ctx.latency_sensitivity == LatencySensitivity.HIGH
+                    with ctx.push_latency_sensitivity(1):
+                        # 1 < 3, stays 3
+                        assert ctx.latency_sensitivity == 3
 
-                    # Still HIGH
-                    assert ctx.latency_sensitivity == LatencySensitivity.HIGH
+                    # Still 3
+                    assert ctx.latency_sensitivity == 3
 
-                # Still HIGH
-                assert ctx.latency_sensitivity == LatencySensitivity.HIGH
+                # Still 3
+                assert ctx.latency_sensitivity == 3
 
-            # Back to MEDIUM
-            assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+            # Back to 2
+            assert ctx.latency_sensitivity == 2
 
-        # Back to MEDIUM
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # Back to 2
+        assert ctx.latency_sensitivity == 2
 
     def test_exception_in_context_still_pops(self):
         """Test that exceptions don't break stack management."""
         ctx = Context.get()
 
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        assert ctx.latency_sensitivity == 2
 
         try:
-            with ctx.push_latency_sensitivity(LatencySensitivity.HIGH):
-                assert ctx.latency_sensitivity == LatencySensitivity.HIGH
+            with ctx.push_latency_sensitivity(3):
+                assert ctx.latency_sensitivity == 3
                 raise ValueError("test error")
         except ValueError:
             pass
 
-        # Should revert to MEDIUM despite exception
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # Should revert to 2 despite exception
+        assert ctx.latency_sensitivity == 2
 
 
 class TestDecoratorSyncFunctions:
     """Tests for @latency_sensitive decorator on sync functions."""
 
-    def test_sync_function_with_enum(self):
-        """Test decorator on sync function with enum value."""
+    def test_sync_function_with_int(self):
+        """Test decorator on sync function with integer value."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def sync_func():
             return Context.get().latency_sensitivity
 
-        # Outside decorator, should be MEDIUM
-        assert Context.get().latency_sensitivity == LatencySensitivity.MEDIUM
+        # Outside decorator, should be 2
+        assert Context.get().latency_sensitivity == 2
 
-        # Inside decorator, should be HIGH
+        # Inside decorator, should be 3
         result = sync_func()
-        assert result == LatencySensitivity.HIGH
+        assert result == 3
 
-        # After decorator, back to MEDIUM
-        assert Context.get().latency_sensitivity == LatencySensitivity.MEDIUM
+        # After decorator, back to 2
+        assert Context.get().latency_sensitivity == 2
 
-    def test_sync_function_with_string(self):
-        """Test decorator on sync function with string value."""
+    def test_sync_function_with_lower_int(self):
+        """Test decorator on sync function with lower integer value."""
 
-        @latency_sensitive("low")
+        @latency_sensitive(1)
         def sync_func():
             return Context.get().latency_sensitivity
 
         result = sync_func()
-        # LOW is in stack, but MEDIUM default has higher priority
-        assert result == LatencySensitivity.MEDIUM
+        # 1 is in stack, but default 2 has higher priority
+        assert result == 2
 
     def test_sync_function_priority_nesting(self):
         """Test priority-based nesting with sync functions."""
 
-        @latency_sensitive(LatencySensitivity.LOW)
+        @latency_sensitive(1)
         def low_func():
             return Context.get().latency_sensitivity
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def high_func():
             inner = low_func()
             return Context.get().latency_sensitivity, inner
 
         outer, inner = high_func()
-        # Both should be HIGH due to priority
-        assert outer == LatencySensitivity.HIGH
-        assert inner == LatencySensitivity.HIGH
+        # Both should be 3 due to priority
+        assert outer == 3
+        assert inner == 3
 
     def test_sync_function_with_return_value(self):
         """Test that decorator preserves return values."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def func_with_return(x, y):
             return x + y
 
@@ -236,7 +256,7 @@ class TestDecoratorSyncFunctions:
     def test_sync_function_with_args_kwargs(self):
         """Test that decorator preserves arguments."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def func_with_args(*args, **kwargs):
             return (args, kwargs)
 
@@ -246,22 +266,22 @@ class TestDecoratorSyncFunctions:
     def test_sync_function_exception_propagates(self):
         """Test that exceptions propagate and stack still pops."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def failing_func():
             raise ValueError("test error")
 
         ctx = Context.get()
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        assert ctx.latency_sensitivity == 2
 
         with pytest.raises(ValueError, match="test error"):
             failing_func()
 
-        # Should revert to MEDIUM despite exception
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # Should revert to 2 despite exception
+        assert ctx.latency_sensitivity == 2
 
     def test_invalid_sensitivity_at_decoration_time(self):
-        """Test that invalid sensitivity raises ValueError at decoration time."""
-        with pytest.raises(ValueError, match="Invalid latency sensitivity"):
+        """Test that invalid sensitivity raises TypeError at decoration time."""
+        with pytest.raises(TypeError):
 
             @latency_sensitive("INVALID")
             def func():
@@ -271,55 +291,55 @@ class TestDecoratorSyncFunctions:
 class TestDecoratorAsyncFunctions:
     """Tests for @latency_sensitive decorator on async functions."""
 
-    async def test_async_function_with_enum(self):
-        """Test decorator on async function with enum value."""
+    async def test_async_function_with_int(self):
+        """Test decorator on async function with integer value."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def async_func():
             return Context.get().latency_sensitivity
 
-        # Outside decorator, should be MEDIUM
-        assert Context.get().latency_sensitivity == LatencySensitivity.MEDIUM
+        # Outside decorator, should be 2
+        assert Context.get().latency_sensitivity == 2
 
-        # Inside decorator, should be HIGH
+        # Inside decorator, should be 3
         result = await async_func()
-        assert result == LatencySensitivity.HIGH
+        assert result == 3
 
-        # After decorator, back to MEDIUM
-        assert Context.get().latency_sensitivity == LatencySensitivity.MEDIUM
+        # After decorator, back to 2
+        assert Context.get().latency_sensitivity == 2
 
-    async def test_async_function_with_string(self):
-        """Test decorator on async function with string value."""
+    async def test_async_function_with_lower_int(self):
+        """Test decorator on async function with lower integer value."""
 
-        @latency_sensitive("low")
+        @latency_sensitive(1)
         async def async_func():
             return Context.get().latency_sensitivity
 
         result = await async_func()
-        # LOW is in stack, but MEDIUM default has higher priority
-        assert result == LatencySensitivity.MEDIUM
+        # 1 is in stack, but default 2 has higher priority
+        assert result == 2
 
     async def test_async_function_priority_nesting(self):
         """Test priority-based nesting with async functions."""
 
-        @latency_sensitive(LatencySensitivity.LOW)
+        @latency_sensitive(1)
         async def low_func():
             return Context.get().latency_sensitivity
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def high_func():
             inner = await low_func()
             return Context.get().latency_sensitivity, inner
 
         outer, inner = await high_func()
-        # Both should be HIGH due to priority
-        assert outer == LatencySensitivity.HIGH
-        assert inner == LatencySensitivity.HIGH
+        # Both should be 3 due to priority
+        assert outer == 3
+        assert inner == 3
 
     async def test_async_function_with_return_value(self):
         """Test that decorator preserves return values."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def func_with_return(x, y):
             await asyncio.sleep(0)  # Make it actually async
             return x + y
@@ -330,7 +350,7 @@ class TestDecoratorAsyncFunctions:
     async def test_async_function_with_args_kwargs(self):
         """Test that decorator preserves arguments."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def func_with_args(*args, **kwargs):
             await asyncio.sleep(0)
             return (args, kwargs)
@@ -341,95 +361,95 @@ class TestDecoratorAsyncFunctions:
     async def test_async_function_exception_propagates(self):
         """Test that exceptions propagate and stack still pops."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def failing_func():
             raise ValueError("test error")
 
         ctx = Context.get()
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        assert ctx.latency_sensitivity == 2
 
         with pytest.raises(ValueError, match="test error"):
             await failing_func()
 
-        # Should revert to MEDIUM despite exception
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # Should revert to 2 despite exception
+        assert ctx.latency_sensitivity == 2
 
     async def test_mixed_sync_async_nesting(self):
         """Test that sync and async functions can nest together."""
 
-        @latency_sensitive(LatencySensitivity.LOW)
+        @latency_sensitive(1)
         def sync_func():
             return Context.get().latency_sensitivity
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def async_func():
-            # HIGH takes precedence
+            # 3 takes precedence
             sync_result = sync_func()
             async_result = Context.get().latency_sensitivity
             return sync_result, async_result
 
         sync_result, async_result = await async_func()
-        assert sync_result == LatencySensitivity.HIGH
-        assert async_result == LatencySensitivity.HIGH
+        assert sync_result == 3
+        assert async_result == 3
 
 
 class TestDecoratorGeneratorFunctions:
     """Tests for @latency_sensitive decorator on generator functions."""
 
-    def test_generator_function_with_enum(self):
-        """Test decorator on generator function with enum value."""
+    def test_generator_function_with_int(self):
+        """Test decorator on generator function with integer value."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def gen_func():
             for i in range(3):
                 yield (i, Context.get().latency_sensitivity)
 
-        # Outside decorator, should be MEDIUM
-        assert Context.get().latency_sensitivity == LatencySensitivity.MEDIUM
+        # Outside decorator, should be 2
+        assert Context.get().latency_sensitivity == 2
 
-        # Inside decorator, should be HIGH
+        # Inside decorator, should be 3
         results = list(gen_func())
         assert len(results) == 3
         for i, sensitivity in results:
-            assert sensitivity == LatencySensitivity.HIGH
+            assert sensitivity == 3
 
-        # After decorator, back to MEDIUM
-        assert Context.get().latency_sensitivity == LatencySensitivity.MEDIUM
+        # After decorator, back to 2
+        assert Context.get().latency_sensitivity == 2
 
-    def test_generator_function_with_string(self):
-        """Test decorator on generator function with string value."""
+    def test_generator_function_with_lower_int(self):
+        """Test decorator on generator function with lower integer value."""
 
-        @latency_sensitive("low")
+        @latency_sensitive(1)
         def gen_func():
             for i in range(2):
                 yield Context.get().latency_sensitivity
 
         results = list(gen_func())
-        # LOW is in stack, but MEDIUM default has higher priority
-        assert all(s == LatencySensitivity.MEDIUM for s in results)
+        # 1 is in stack, but default 2 has higher priority
+        assert all(s == 2 for s in results)
 
     def test_generator_function_priority_nesting(self):
         """Test priority-based nesting with generator functions."""
 
-        @latency_sensitive(LatencySensitivity.LOW)
+        @latency_sensitive(1)
         def low_gen():
             yield Context.get().latency_sensitivity
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def high_gen():
-            # Get first value from low_gen while in HIGH context
+            # Get first value from low_gen while in 3 context
             low_result = next(low_gen())
             yield Context.get().latency_sensitivity, low_result
 
         outer, inner = next(high_gen())
-        # Both should be HIGH due to priority
-        assert outer == LatencySensitivity.HIGH
-        assert inner == LatencySensitivity.HIGH
+        # Both should be 3 due to priority
+        assert outer == 3
+        assert inner == 3
 
     def test_generator_function_yields_values(self):
         """Test that decorator preserves yielded values."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def gen_with_values(n):
             for i in range(n):
                 yield i * 2
@@ -440,7 +460,7 @@ class TestDecoratorGeneratorFunctions:
     def test_generator_function_with_args_kwargs(self):
         """Test that decorator preserves arguments."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def gen_with_args(*args, **kwargs):
             yield args
             yield kwargs
@@ -452,13 +472,13 @@ class TestDecoratorGeneratorFunctions:
     def test_generator_function_exception_propagates(self):
         """Test that exceptions propagate and stack still pops."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def failing_gen():
             yield 1
             raise ValueError("test error")
 
         ctx = Context.get()
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        assert ctx.latency_sensitivity == 2
 
         gen = failing_gen()
         assert next(gen) == 1
@@ -466,18 +486,18 @@ class TestDecoratorGeneratorFunctions:
         with pytest.raises(ValueError, match="test error"):
             next(gen)
 
-        # Should revert to MEDIUM despite exception
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # Should revert to 2 despite exception
+        assert ctx.latency_sensitivity == 2
 
     def test_generator_function_early_exit(self):
         """Test that early exit from generator still pops stack."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         def gen_func():
             yield from range(10)
 
         ctx = Context.get()
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        assert ctx.latency_sensitivity == 2
 
         # Only consume first 3 values
         gen = gen_func()
@@ -489,68 +509,68 @@ class TestDecoratorGeneratorFunctions:
 
         # Should still be able to access context after early exit
         # Note: Stack will pop when generator is garbage collected
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        assert ctx.latency_sensitivity == 2
 
 
 class TestDecoratorAsyncGeneratorFunctions:
     """Tests for @latency_sensitive decorator on async generator functions."""
 
-    async def test_async_generator_function_with_enum(self):
-        """Test decorator on async generator function with enum value."""
+    async def test_async_generator_function_with_int(self):
+        """Test decorator on async generator function with integer value."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def async_gen_func():
             for i in range(3):
                 yield (i, Context.get().latency_sensitivity)
 
-        # Outside decorator, should be MEDIUM
-        assert Context.get().latency_sensitivity == LatencySensitivity.MEDIUM
+        # Outside decorator, should be 2
+        assert Context.get().latency_sensitivity == 2
 
-        # Inside decorator, should be HIGH
+        # Inside decorator, should be 3
         results = [item async for item in async_gen_func()]
         assert len(results) == 3
         for i, sensitivity in results:
-            assert sensitivity == LatencySensitivity.HIGH
+            assert sensitivity == 3
 
-        # After decorator, back to MEDIUM
-        assert Context.get().latency_sensitivity == LatencySensitivity.MEDIUM
+        # After decorator, back to 2
+        assert Context.get().latency_sensitivity == 2
 
-    async def test_async_generator_function_with_string(self):
-        """Test decorator on async generator function with string value."""
+    async def test_async_generator_function_with_lower_int(self):
+        """Test decorator on async generator function with lower integer value."""
 
-        @latency_sensitive("low")
+        @latency_sensitive(1)
         async def async_gen_func():
             for i in range(2):
                 yield Context.get().latency_sensitivity
 
         results = [item async for item in async_gen_func()]
-        # LOW is in stack, but MEDIUM default has higher priority
-        assert all(s == LatencySensitivity.MEDIUM for s in results)
+        # 1 is in stack, but default 2 has higher priority
+        assert all(s == 2 for s in results)
 
     async def test_async_generator_function_priority_nesting(self):
         """Test priority-based nesting with async generator functions."""
 
-        @latency_sensitive(LatencySensitivity.LOW)
+        @latency_sensitive(1)
         async def low_async_gen():
             yield Context.get().latency_sensitivity
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def high_async_gen():
-            # Get first value from low_async_gen while in HIGH context
+            # Get first value from low_async_gen while in 3 context
             async for val in low_async_gen():
                 low_result = val
                 break
             yield Context.get().latency_sensitivity, low_result
 
         async for outer, inner in high_async_gen():
-            # Both should be HIGH due to priority
-            assert outer == LatencySensitivity.HIGH
-            assert inner == LatencySensitivity.HIGH
+            # Both should be 3 due to priority
+            assert outer == 3
+            assert inner == 3
 
     async def test_async_generator_function_yields_values(self):
         """Test that decorator preserves yielded values."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def async_gen_with_values(n):
             for i in range(n):
                 yield i * 2
@@ -561,7 +581,7 @@ class TestDecoratorAsyncGeneratorFunctions:
     async def test_async_generator_function_with_args_kwargs(self):
         """Test that decorator preserves arguments."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def async_gen_with_args(*args, **kwargs):
             yield args
             yield kwargs
@@ -573,13 +593,13 @@ class TestDecoratorAsyncGeneratorFunctions:
     async def test_async_generator_function_exception_propagates(self):
         """Test that exceptions propagate and stack still pops."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def failing_async_gen():
             yield 1
             raise ValueError("test error")
 
         ctx = Context.get()
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        assert ctx.latency_sensitivity == 2
 
         agen = failing_async_gen()
         assert await agen.__anext__() == 1
@@ -587,19 +607,19 @@ class TestDecoratorAsyncGeneratorFunctions:
         with pytest.raises(ValueError, match="test error"):
             await agen.__anext__()
 
-        # Should revert to MEDIUM despite exception
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # Should revert to 2 despite exception
+        assert ctx.latency_sensitivity == 2
 
     async def test_async_generator_function_early_exit(self):
         """Test that early exit from async generator still pops stack."""
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def async_gen_func():
             for i in range(10):
                 yield i
 
         ctx = Context.get()
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        assert ctx.latency_sensitivity == 2
 
         # Only consume first 3 values
         agen = async_gen_func()
@@ -611,23 +631,23 @@ class TestDecoratorAsyncGeneratorFunctions:
         # Close async generator early
         await agen.aclose()
 
-        # Should revert to MEDIUM after close
-        assert ctx.latency_sensitivity == LatencySensitivity.MEDIUM
+        # Should revert to 2 after close
+        assert ctx.latency_sensitivity == 2
 
     async def test_mixed_async_and_async_gen_nesting(self):
         """Test that async functions and async generators can nest together."""
 
-        @latency_sensitive(LatencySensitivity.LOW)
+        @latency_sensitive(1)
         async def async_func():
             return Context.get().latency_sensitivity
 
-        @latency_sensitive(LatencySensitivity.HIGH)
+        @latency_sensitive(3)
         async def high_async_gen():
-            # HIGH takes precedence
+            # 3 takes precedence
             async_result = await async_func()
             gen_result = Context.get().latency_sensitivity
             yield async_result, gen_result
 
         async for async_result, gen_result in high_async_gen():
-            assert async_result == LatencySensitivity.HIGH
-            assert gen_result == LatencySensitivity.HIGH
+            assert async_result == 3
+            assert gen_result == 3


### PR DESCRIPTION
Replaces the `LatencySensitivity` enum (`LOW`/`MEDIUM`/`HIGH`) with a plain `int`, giving users full control over latency sensitivity values instead of being locked to three predefined levels. The default value is `2` (preserving current MEDIUM behavior).

### Motivation

The three-level enum was unnecessarily restrictive. Users working with custom Dynamo routing setups need to express finer-grained priority — for example, distinguishing between "slightly above normal" (3) and "critical real-time" (10). An integer value maps naturally to the downstream transport:

- **HTTP headers**: sent as `str(int)` (e.g. `"2"`, `"5"`)
- **nvext.agent_hints**: sent as `float(int)` (e.g. `2.0`, `5.0`)

No backwards compatibility shim is needed — the enum was internal and not yet part of any public/stable API.

### Changes (6 files, net -51 lines)

| File | Change |
|------|--------|
| `nat/profiler/decorators/latency.py` | Deleted `LatencySensitivity` enum and `StrEnum` import. Decorator accepts `int`, validates with `isinstance`, raises `TypeError` on misuse. |
| `nat/builder/context.py` | Stack type `list[int]`, default `[2]`. Property returns `int` via plain `max(stack)`. |
| `nat/llm/dynamo_llm.py` | Header: `str(latency_sensitivity)`. Body: `float(latency_sensitivity)`. Fallback: `2`. |
| `tests/.../test_latency.py` | Rewrote enum tests as integer validation tests (accepts int, rejects str/float/None, accepts 0/negative/large/arbitrary). All 42 tests use plain ints. |
| `tests/.../test_dynamo_llm.py` | Two assertion updates: header `"MEDIUM"` → `"2"`, agent_hints `"MEDIUM"` → `2.0`. |
| `examples/.../graph_nodes.py` | Removed enum import, replaced 7 `LatencySensitivity.HIGH` → `3`. |

### Usage

```python
from nat.profiler.decorators.latency import latency_sensitive
from nat.builder.context import Context

@latency_sensitive(3)
async def critical_llm_call():
    return await llm.generate()

@latency_sensitive(1)
def background_task():
    pass

# Read current effective sensitivity (max across the call stack)
sensitivity = Context.get().latency_sensitivity  # returns int
```

### Prior art: APIs that use integer priority

| System | Field | Type | Range | Notes |
|--------|-------|------|-------|-------|
| HTTP/2 | Stream weight | `uint8` | 1–256 | RFC 7540 §5.3 — higher weight = more resources |
| HTTP/3 | Urgency | `int` | 0–7 | RFC 9218 Extensible Priorities — lower = more urgent |
| POSIX / Linux | `nice` value | `int` | -20 to 19 | Lower = higher scheduling priority |
| Kubernetes | Pod `priority` | `int32` | unbounded | Higher = more important; preempts lower-priority pods |
| RabbitMQ | Message priority | `uint8` | 0–255 | Higher = delivered first from priority queues |
| NATS JetStream | Consumer priority | `int` | 0+ | Lower = preferred consumer for message delivery |
| Python `asyncio` | `Task` (3.12+) | — | — | PEP discussion for integer-based task priority |
| gRPC | Retry priority | `int` | impl-defined | Controls retry/hedging order |
| CUDA Streams | Stream priority | `int` | device-range | Lower numerical value = higher priority |

The common pattern is: an unbounded or wide-range integer is more flexible than a fixed enum, and the interpretation (higher-is-more-urgent vs lower-is-more-urgent) is defined by convention, not type.

### Test plan

- [x] `pytest tests/nat/profiler/decorators/test_latency.py -v` — 42/42 passed
- [x] `pytest tests/nat/llm/test_dynamo_llm.py -v -k latency` — 2/2 passed
- [x] `grep -r "LatencySensitivity" packages/nvidia_nat_core/src/` — no matches


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated latency sensitivity handling to use numeric values instead of enum-based representation. Applications specifying latency sensitivity now use integer values rather than predefined constants, maintaining consistent functionality across prediction headers and context management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->