### PR TITLE
Populate full connection attributes and payload for HTTP and WebSocket sessions

### DIFF
--- a/packages/nvidia_nat_core/src/nat/data_models/api_server.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/api_server.py
@@ -48,7 +48,7 @@ class UserMessageContentRoleType(StrEnum):
 
 class Request(BaseModel):
     """
-    Request is a data model that represents HTTP request attributes.
+    Request is a data model that represents HTTP request and WebSocket attributes.
     """
     model_config = ConfigDict(extra="forbid")
 
@@ -65,6 +65,8 @@ class Request(BaseModel):
     client_port: int | None = Field(default=None, description="Client port number from which the request originated.")
     cookies: dict[str, str] | None = Field(
         default=None, description="Cookies sent with the request, stored in a dictionary-like object.")
+    payload: dict[str, typing.Any] | None = Field(default=None,
+                                                  description="Request payload from the incoming request.")
 
 
 class ChatContentType(StrEnum):

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
@@ -119,6 +119,7 @@ class WebSocketMessageHandler:
         self._message_parent_id = message.id
         self._workflow_schema_type = message.schema_type
         self._conversation_id = message.conversation_id
+        self._user_message_payload: dict[str, Any] = message.model_dump(exclude={"security"})
         if self._conversation_id:
             self._worker.set_conversation_handler(self._conversation_id, self)
 
@@ -406,7 +407,7 @@ class WebSocketMessageHandler:
                                                      http_connection=self._socket,
                                                      user_input_callback=self.human_interaction_callback,
                                                      user_authentication_callback=auth_callback) as session:
-
+                self._session_manager._context.metadata._request.payload = self._user_message_payload
                 async for value in generate_streaming_response(payload,
                                                                session=session,
                                                                streaming=True,

--- a/packages/nvidia_nat_core/src/nat/runtime/session.py
+++ b/packages/nvidia_nat_core/src/nat/runtime/session.py
@@ -471,7 +471,7 @@ class SessionManager:
                                              pre_parsed_cookies=cookies_dict)
 
         if isinstance(http_connection, Request):
-            self.set_metadata_from_http_request(http_connection)
+            await self.set_metadata_from_http_request(http_connection)
 
         builder_info: PerUserBuilderInfo | None = None
         request_start_time: float | None = None
@@ -582,7 +582,7 @@ class SessionManager:
                         logger.exception(f"Error cleaning up builder for user {user_id}")
                 self._per_user_builders.clear()
 
-    def set_metadata_from_http_request(self, request: Request) -> None:
+    async def set_metadata_from_http_request(self, request: Request) -> None:
         """
         Extracts and sets user metadata request attributes from a HTTP request.
         If request is None, no attributes are set.
@@ -597,6 +597,10 @@ class SessionManager:
         self._context.metadata._request.client_host = request.client.host
         self._context.metadata._request.client_port = request.client.port
         self._context.metadata._request.cookies = request.cookies
+        try:
+            self._context.metadata._request.payload = await request.json()
+        except Exception:
+            self._context.metadata._request.payload = None
 
         if request.headers.get("conversation-id"):
             self._context_state.conversation_id.set(request.headers["conversation-id"])
@@ -641,6 +645,17 @@ class SessionManager:
         If pre_parsed_cookies is provided (e.g. from get_auth_and_cookies_from_connection),
         uses it instead of parsing scope headers again.
         """
+        self._context.metadata._request.url_path = websocket.url.path
+        self._context.metadata._request.url_port = websocket.url.port
+        self._context.metadata._request.url_scheme = websocket.url.scheme
+        self._context.metadata._request.headers = websocket.headers
+        self._context.metadata._request.query_params = websocket.query_params
+        self._context.metadata._request.path_params = websocket.path_params
+        host = websocket.client[0] if websocket.client else None
+        port = websocket.client[1] if websocket.client else None
+        self._context.metadata._request.client_host = host
+        self._context.metadata._request.client_port = port
+
         if websocket and hasattr(websocket, 'scope') and 'headers' in websocket.scope:
             if pre_parsed_cookies is not None:
                 cookies = pre_parsed_cookies

--- a/packages/nvidia_nat_core/src/nat/runtime/user_metadata.py
+++ b/packages/nvidia_nat_core/src/nat/runtime/user_metadata.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import typing
+
 from starlette.datastructures import Headers
 from starlette.datastructures import QueryParams
 
@@ -128,6 +130,11 @@ class RequestAttributes:
             dict[str, str] | None
         """
         return self._request.cookies
+
+    @property
+    def payload(self) -> dict[str, typing.Any] | None:
+        """Request payload parsed as a dictionary."""
+        return self._request.payload
 
     def to_dict(self) -> dict[str, object]:
         """

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_session_traceparent.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_session_traceparent.py
@@ -111,7 +111,6 @@ TRACE_ID_CASES: list[tuple[list[tuple[bytes, bytes]], int | None]] = [
     "headers,expected_trace_id",
     TRACE_ID_CASES,
 )
-@pytest.mark.asyncio
 async def test_session_trace_id_from_headers_parameterized(headers: list[tuple[bytes, bytes]],
                                                            expected_trace_id: int | None):
     scope = {
@@ -132,7 +131,7 @@ async def test_session_trace_id_from_headers_parameterized(headers: list[tuple[b
         with patch("nat.cli.type_registry.GlobalTypeRegistry") as mock_registry:
             mock_registry.get.return_value.get_function.return_value = _create_mock_function_registration()
             sm = SessionManager(config=_create_mock_config(), shared_builder=_MockWorkflowBuilder(), max_concurrency=0)
-            sm.set_metadata_from_http_request(request)
+            await sm.set_metadata_from_http_request(request)
             assert ctx_state.workflow_trace_id.get() == expected_trace_id
     finally:
         ctx_state.workflow_trace_id.reset(token)
@@ -160,7 +159,6 @@ METADATA_CASES: list[tuple[list[tuple[bytes, bytes]], str | None, str | None, st
     "headers,expected_conv,expected_msg,expected_run",
     METADATA_CASES,
 )
-@pytest.mark.asyncio
 async def test_session_metadata_headers_parameterized(headers: list[tuple[bytes, bytes]],
                                                       expected_conv: str | None,
                                                       expected_msg: str | None,
@@ -186,7 +184,7 @@ async def test_session_metadata_headers_parameterized(headers: list[tuple[bytes,
         with patch("nat.cli.type_registry.GlobalTypeRegistry") as mock_registry:
             mock_registry.get.return_value.get_function.return_value = _create_mock_function_registration()
             sm = SessionManager(config=_create_mock_config(), shared_builder=_MockWorkflowBuilder(), max_concurrency=0)
-            sm.set_metadata_from_http_request(request)
+            await sm.set_metadata_from_http_request(request)
             assert ctx_state.conversation_id.get() == expected_conv
             assert ctx_state.user_message_id.get() == expected_msg
             assert ctx_state.workflow_run_id.get() == expected_run

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_user_metadata.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_user_metadata.py
@@ -28,3 +28,4 @@ def test_request_attributes_defaults():
     assert ra.client_host is None
     assert ra.client_port is None
     assert ra.cookies is None
+    assert ra.payload is None

--- a/packages/nvidia_nat_core/tests/nat/server/test_unified_api_server.py
+++ b/packages/nvidia_nat_core/tests/nat/server/test_unified_api_server.py
@@ -18,7 +18,6 @@ import datetime
 import json
 import os
 import re
-from collections.abc import Mapping
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
@@ -470,43 +469,115 @@ async def test_chat_stream_endpoint_observability_trace_id_integration(client: h
 
 
 @pytest.mark.integration
-async def test_user_attributes_from_http_request(client: httpx.AsyncClient, config: Config):
-    """Tests setting user attributes from HTTP request."""
-    input_message = {"message": f"{config.app.input}"}
-    headers = {"Header-Test": "application/json"}
-    query_params = {"param1": "value1"}
+async def test_metadata_from_http_request_populates_all_request_attributes(client: httpx.AsyncClient,
+                                                                           config: Config) -> None:
+    captured: list = []
 
-    # Capture the metadata that gets set during the request
-    actual_headers: list[Mapping[str, str] | None] = [None]
-    actual_query_params: list[Mapping[str, str] | None] = [None]
+    original = SessionManager.set_metadata_from_http_request
 
-    # Store reference to original method before patching
-    original_method = SessionManager.set_metadata_from_http_request
+    async def capture_metadata(self, request) -> None:
+        await original(self, request)
+        meta = Context.get().metadata
+        captured.append({
+            "method": meta.method,
+            "url_path": meta.url_path,
+            "url_scheme": meta.url_scheme,
+            "url_port": meta.url_port,
+            "client_host": meta.client_host,
+            "client_port": meta.client_port,
+            "headers": meta.headers,
+            "query_params": meta.query_params,
+            "path_params": meta.path_params,
+            "cookies": meta.cookies,
+            "payload": meta.payload,
+        })
 
-    def mock_set_metadata_from_http_request(self, request):
-        """Mock the metadata setting to capture what would be set."""
-        original_method(self, request)
-        actual_headers[0] = Context.get().metadata.headers
-        actual_query_params[0] = Context.get().metadata.query_params
-
-    # Patch the method to capture metadata
-    with patch("nat.runtime.session.SessionManager.set_metadata_from_http_request",
-               mock_set_metadata_from_http_request):
+    with patch(
+            "nat.runtime.session.SessionManager.set_metadata_from_http_request",
+            capture_metadata,
+    ):
         response = await client.post(
-            f"{config.endpoint.generate}",
-            json=input_message,
-            headers=headers,
-            params=query_params,
+            f"{config.endpoint.generate}?tenant_id=abc&env=test",
+            json={"message": config.app.input},
+            headers={
+                "x-custom": "custom-value", "cookie": "session=xyz123; foo=bar"
+            },
         )
 
     assert response.status_code == 200
+    assert len(captured) == 1
+    meta = captured[0]
+    assert meta["method"] == "POST"
+    assert config.endpoint.generate in meta["url_path"]
+    assert meta["url_scheme"] == "http"
+    assert meta["url_port"] == 8000
+    assert meta["client_host"] is not None
+    assert meta["client_port"] is not None
+    assert meta["headers"] is not None
+    assert meta["headers"].get("x-custom") == "custom-value"
+    assert meta["query_params"] is not None
+    assert meta["query_params"].get("tenant_id") == "abc"
+    assert meta["query_params"].get("env") == "test"
+    assert meta["path_params"] is not None
+    assert meta["cookies"] is not None
+    assert meta["cookies"].get("session") == "xyz123"
+    assert meta["cookies"].get("foo") == "bar"
+    assert meta["payload"] is not None
 
-    # Verify the metadata was captured correctly
-    assert actual_headers[0] is not None
-    assert actual_query_params[0] is not None
 
-    assert actual_headers[0]["header-test"] == headers["Header-Test"]
-    assert actual_query_params[0]["param1"] == query_params["param1"]
+def test_metadata_from_websocket_populates_all_request_attributes() -> None:
+    """Unit test: set_metadata_from_websocket populates context metadata from a mock websocket."""
+    from unittest.mock import MagicMock
+
+    from nat.builder.context import ContextState
+    from nat.runtime.session import SessionManager
+    from nat.runtime.user_metadata import RequestAttributes
+
+    # Reset the ContextVar so we start with a fresh RequestAttributes,
+    # avoiding stale state from previous tests sharing the session-scoped event loop.
+    ContextState.get()._metadata.set(RequestAttributes())
+
+    mock_config = MagicMock()
+    mock_config.workflow = EchoFunctionConfig()
+    mock_builder = MagicMock()
+    sm = SessionManager(config=mock_config, shared_builder=mock_builder, entry_function=None)
+
+    mock_ws = MagicMock()
+    mock_ws.url.path = "/websocket"
+    mock_ws.url.port = 443
+    mock_ws.url.scheme = "ws"
+    mock_ws.headers = {"x-custom": "custom-value"}
+    mock_ws.query_params = {"tenant_id": "abc", "env": "test"}
+    mock_ws.path_params = {}
+    mock_ws.client = ("192.168.1.1", 12345)
+    mock_ws.cookies = {"session": "xyz123", "foo": "bar"}
+    mock_ws.scope = {"headers": []}
+
+    sm.set_metadata_from_websocket(
+        mock_ws,
+        user_message_id="msg-1",
+        conversation_id="conv-1",
+        pre_parsed_cookies={
+            "session": "xyz123", "foo": "bar"
+        },
+    )
+
+    meta = ContextState.get().metadata.get()
+    assert meta.url_path == "/websocket"
+    assert meta.url_scheme == "ws"
+    assert meta.url_port == 443
+    assert meta.client_host == "192.168.1.1"
+    assert meta.client_port == 12345
+    assert meta.headers is not None
+    assert meta.headers.get("x-custom") == "custom-value"
+    assert meta.query_params is not None
+    assert meta.query_params.get("tenant_id") == "abc"
+    assert meta.query_params.get("env") == "test"
+    assert meta.path_params is not None
+    assert meta.cookies is not None
+    assert meta.payload is None
+    assert meta.cookies.get("session") == "xyz123"
+    assert meta.cookies.get("foo") == "bar"
 
 
 async def test_valid_user_message():


### PR DESCRIPTION
## Description

Closes Issue #1578 

Populate all connection attributes (URL, scheme, port, headers, query params, path params, cookies, client info) in `set_metadata_from_websocket` to achieve parity with HTTP metadata extraction. Add a `payload` field to `RequestAttributes` that stores the parsed HTTP request body and the full WebSocket user message dict (excluding the `security` field). Make `set_metadata_from_http_request` async to support `await request.json()`.

**Changes:**
- **`api_server.py`** — Add `payload: dict[str, Any] | None` field to the `Request` model.
- **`user_metadata.py`** — Add `payload` property to `RequestAttributes`.
- **`session.py`** — Populate all WebSocket connection attributes (url, scheme, headers, query params, path params, client host/port) in `set_metadata_from_websocket`. Make `set_metadata_from_http_request` async and read the parsed JSON body into `payload`.
- **`message_handler.py`** — Store `message.model_dump(exclude={"security"})` as the WebSocket payload and set it on the session metadata in `_run_workflow`.
- **Tests** — Replace the former `test_user_attributes_from_http_request` with comprehensive `test_metadata_from_http_request_populates_all_request_attributes` (integration) and `test_metadata_from_websocket_populates_all_request_attributes` (unit) tests that assert every request attribute field for both transport types. Update `test_session_traceparent.py` to `await` the now-async `set_metadata_from_http_request`. Add `payload` assertion to `test_request_attributes_defaults`.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Request payloads from HTTP and WebSocket connections are now captured and exposed in request metadata for downstream workflows.

* **Chores**
  * Metadata collection for HTTP requests was updated to support extracting the request payload.

* **Tests**
  * Tests expanded and updated to validate that metadata (including payload, headers, query params, cookies, and client info) is populated for HTTP and WebSocket flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->