### PR TITLE
fix: Langchain agents should reuse runnable config

### DIFF
--- a/examples/agents/data/rewoo.json
+++ b/examples/agents/data/rewoo.json
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:7912597c8ec3a2758218f1da2a0f78ba039d510cd4fe184151732b2bb4453b5d
-size 858
+oid sha256:09839abfa575926352b95bae91d08ef70c072e6db30d99481b3decc22bf1bef2
+size 863

--- a/examples/agents/tests/conftest.py
+++ b/examples/agents/tests/conftest.py
@@ -1,0 +1,104 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import json
+import os
+from pathlib import Path
+
+import pytest
+
+from nat.runtime.loader import load_config
+from nat.runtime.loader import load_workflow
+from nat.test.utils import build_nat_client
+
+AGENT_CONFIGS = [
+    "mixture_of_agents/configs/config.yml",
+    "react/configs/config.yml",
+    "react/configs/config-reasoning.yml",
+    "tool_calling/configs/config.yml",
+    "tool_calling/configs/config-reasoning.yml",
+]
+AGENT_IDS = ["mixture_of_agents", "react", "react-reasoning", "tool_calling", "tool_calling-reasoning"]
+
+
+@pytest.fixture(name="agents_dir", scope="session")
+def fixture_agents_dir(examples_dir: Path) -> Path:
+    return examples_dir / "agents"
+
+
+@pytest.fixture(name="question", scope="session")
+def fixture_question() -> str:
+    return "What are LLMs"
+
+
+@pytest.fixture(name="answer", scope="session")
+def fixture_answer() -> str:
+    return "large language model"
+
+
+@pytest.fixture(name="rewoo_data", scope="session")
+def fixture_rewoo_data(agents_dir: Path) -> list[dict]:
+    data_path = agents_dir / "data/rewoo.json"
+    assert data_path.exists(), f"Data file {data_path} does not exist"
+    with open(data_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+@pytest.fixture(name="rewoo_session_manager", scope="class")
+async def fixture_rewoo_session_manager(agents_dir: Path):
+    """Build the ReWOO workflow once, share across all tests in the class."""
+    async with load_workflow(agents_dir / "rewoo/configs/config.yml") as session_manager:
+        yield session_manager
+
+
+@pytest.fixture(name="rewoo_nat_client", scope="class")
+async def fixture_rewoo_nat_client(agents_dir: Path):
+    """Build the ReWOO ASGI client once, share across all tests in the class."""
+    config_path = agents_dir / "rewoo/configs/config.yml"
+    config = load_config(config_path)
+    old_val = os.environ.get("NAT_CONFIG_FILE")
+    os.environ["NAT_CONFIG_FILE"] = str(config_path.absolute())
+    try:
+        async with build_nat_client(config) as client:
+            yield client
+    finally:
+        if old_val is None:
+            os.environ.pop("NAT_CONFIG_FILE", None)
+        else:
+            os.environ["NAT_CONFIG_FILE"] = old_val
+
+
+@pytest.fixture(name="agent_session_manager", scope="class", params=AGENT_CONFIGS, ids=AGENT_IDS)
+async def fixture_agent_session_manager(request: pytest.FixtureRequest, agents_dir: Path):
+    """Build each agent workflow once per config, share across all tests in the class."""
+    async with load_workflow(agents_dir / request.param) as session_manager:
+        yield session_manager
+
+
+@pytest.fixture(name="agent_nat_client", scope="class", params=AGENT_CONFIGS, ids=AGENT_IDS)
+async def fixture_agent_nat_client(request: pytest.FixtureRequest, agents_dir: Path):
+    """Build each agent ASGI client once per config, share across all tests in the class."""
+    config_path = agents_dir / request.param
+    config = load_config(config_path)
+    old_val = os.environ.get("NAT_CONFIG_FILE")
+    os.environ["NAT_CONFIG_FILE"] = str(config_path.absolute())
+    try:
+        async with build_nat_client(config) as client:
+            yield client
+    finally:
+        if old_val is None:
+            os.environ.pop("NAT_CONFIG_FILE", None)
+        else:
+            os.environ["NAT_CONFIG_FILE"] = old_val

--- a/examples/agents/tests/test_agents.py
+++ b/examples/agents/tests/test_agents.py
@@ -13,83 +13,95 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import json
 import re
 from pathlib import Path
 
 import pytest
 
 from nat.test.utils import run_workflow
-from nat.test.utils import serve_workflow
 
 
-@pytest.fixture(name="agents_dir", scope="session")
-def agents_dir_fixture(examples_dir: Path) -> Path:
-    return examples_dir / "agents"
+def _extract_serve_response_text(response_json: dict) -> str:
+    """Extract the answer text from a nat serve response payload.
+
+    Handles both simple string responses and OpenAI-style chat completion responses.
+    """
+    response_value = response_json.get('value', {})
+    if isinstance(response_value, str):
+        return response_value
+    combined = []
+    for choice in response_value.get('choices', []):
+        combined.append(choice.get('message', {}).get('content', ''))
+    return "\n".join(combined)
 
 
-@pytest.fixture(name="question", scope="module")
-def question_fixture() -> str:
-    return "What are LLMs"
+def _assert_expected_answer(result: str, expected_answer: str) -> None:
+    """Assert that the expected answer appears in the result, normalizing whitespace and case."""
+    normalized = ' '.join(result.split())
+    assert expected_answer.lower() in normalized.lower(), f"Expected '{expected_answer}' in '{result}'"
 
 
-@pytest.fixture(name="answer", scope="module")
-def answer_fixture() -> str:
-    return "large language model"
+# ---------------------------------------------------------------------------
+# ReWOO agent tests -- one workflow build shared across all 5 questions
+# ---------------------------------------------------------------------------
 
 
-@pytest.fixture(name="rewoo_data", scope="module")
-def rewoo_data_fixture(agents_dir: Path) -> list[dict]:
-    data_path = agents_dir / "data/rewoo.json"
-    assert data_path.exists(), f"Data file {data_path} does not exist"
-    with open(data_path, encoding="utf-8") as f:
-        return json.load(f)
-
-
-@pytest.fixture(name="rewoo_question")
-def rewoo_question_fixture(request: pytest.FixtureRequest, rewoo_data: list[dict]) -> str:
-    return rewoo_data[request.param]["question"]
-
-
-@pytest.fixture(name="rewoo_answer")
-def rewoo_answer_fixture(request: pytest.FixtureRequest, rewoo_data: list[dict]) -> str:
-    return rewoo_data[request.param]["answer"].lower()
-
-
-@pytest.mark.usefixtures("nvidia_api_key", "tavily_api_key")
 @pytest.mark.integration
-@pytest.mark.parametrize("use_rest_api", [False, True], ids=["nat_run", "nat_serve"])
-@pytest.mark.parametrize("rewoo_question, rewoo_answer", [(i, i) for i in range(5)],
-                         ids=[f"qa_{i+1}" for i in range(5)],
-                         indirect=True)
-async def test_rewoo_full_workflow(agents_dir: Path, use_rest_api: bool, rewoo_question: str, rewoo_answer: str):
-    config_file = agents_dir / "rewoo/configs/config.yml"
-    if use_rest_api:
-        await serve_workflow(config_path=config_file, question=rewoo_question, expected_answer=rewoo_answer)
-    else:
-        await run_workflow(config_file=config_file, question=rewoo_question, expected_answer=rewoo_answer)
+@pytest.mark.usefixtures("nvidia_api_key", "tavily_api_key")
+class TestReWOONatRun:
+
+    @pytest.mark.parametrize("qa_idx", range(5), ids=[f"qa_{i+1}" for i in range(5)])
+    async def test_question(self, rewoo_session_manager, rewoo_data: list[dict], qa_idx: int):
+        qa = rewoo_data[qa_idx]
+        async with rewoo_session_manager.session() as session:
+            async with session.run(qa["question"]) as runner:
+                result = await runner.result(to_type=str)
+                _assert_expected_answer(result, qa["answer"])
+
+
+@pytest.mark.integration
+@pytest.mark.usefixtures("nvidia_api_key", "tavily_api_key")
+class TestReWOONatServe:
+
+    @pytest.mark.parametrize("qa_idx", range(5), ids=[f"qa_{i+1}" for i in range(5)])
+    async def test_question(self, rewoo_nat_client, rewoo_data: list[dict], qa_idx: int):
+        qa = rewoo_data[qa_idx]
+        resp = await rewoo_nat_client.post("/generate",
+                                           json={"messages": [{
+                                               "role": "user", "content": qa["question"]
+                                           }]})
+        resp.raise_for_status()
+        response_text = _extract_serve_response_text(resp.json())
+        _assert_expected_answer(response_text, qa["answer"])
+
+
+# ---------------------------------------------------------------------------
+# Other agent tests -- fixture parametrized by config (class-scoped)
+# ---------------------------------------------------------------------------
 
 
 @pytest.mark.slow
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key")
-@pytest.mark.parametrize("use_rest_api", [False, True], ids=["nat_run", "nat_serve"])
-@pytest.mark.parametrize(
-    "config_file",
-    [
-        # These are all expected to be relative to the agents_dir
-        "mixture_of_agents/configs/config.yml",
-        "react/configs/config.yml",
-        "react/configs/config-reasoning.yml",
-        "tool_calling/configs/config.yml",
-        "tool_calling/configs/config-reasoning.yml",
-    ],
-    ids=["mixture_of_agents", "react", "react-reasoning", "tool_calling", "tool_calling-reasoning"])
-async def test_agent_full_workflow(agents_dir: Path, config_file: str, use_rest_api: bool, question: str, answer: str):
-    if use_rest_api:
-        await serve_workflow(config_path=agents_dir / config_file, question=question, expected_answer=answer)
-    else:
-        await run_workflow(config_file=agents_dir / config_file, question=question, expected_answer=answer)
+class TestAgentNatRun:
+
+    async def test_question(self, agent_session_manager, question: str, answer: str):
+        async with agent_session_manager.session() as session:
+            async with session.run(question) as runner:
+                result = await runner.result(to_type=str)
+                _assert_expected_answer(result, answer)
+
+
+@pytest.mark.slow
+@pytest.mark.integration
+@pytest.mark.usefixtures("nvidia_api_key")
+class TestAgentNatServe:
+
+    async def test_question(self, agent_nat_client, question: str, answer: str):
+        resp = await agent_nat_client.post("/generate", json={"messages": [{"role": "user", "content": question}]})
+        resp.raise_for_status()
+        response_text = _extract_serve_response_text(resp.json())
+        _assert_expected_answer(response_text, answer)
 
 
 # Code examples from `docs/source/resources/running-tests.md`

--- a/examples/documentation_guides/tests/test_text_file_ingest.py
+++ b/examples/documentation_guides/tests/test_text_file_ingest.py
@@ -62,6 +62,7 @@ def add_src_dir_to_path_fixture(src_dir: Path) -> Generator[str]:
 async def test_text_file_ingest_full_workflow():
     from text_file_ingest.text_file_ingest_function import TextFileIngestFunctionConfig
     config_file = locate_example_config(TextFileIngestFunctionConfig)
-    await run_workflow(config_file=config_file,
-                       question="What does DOCA GPUNetIO do to remove the CPU from the critical path?",
-                       expected_answer="without CPU")
+    result = await run_workflow(config_file=config_file,
+                                question="What does DOCA GPUNetIO do to remove the CPU from the critical path?")
+    assert result is not None
+    assert any(phrase in result.lower() for phrase in ["without cpu", "without the cpu", "gpudirect", "gdakin"])

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/base.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/base.py
@@ -31,6 +31,7 @@ from langchain_core.runnables import Runnable
 from langchain_core.runnables import RunnableConfig
 from langchain_core.tools import BaseTool
 from langgraph.graph.state import CompiledStateGraph
+from langgraph.runtime import DEFAULT_RUNTIME
 
 logger = logging.getLogger(__name__)
 
@@ -80,11 +81,10 @@ class BaseAgent(ABC):
         self.detailed_logs = detailed_logs
         self.log_response_max_chars = log_response_max_chars
         self.graph = None
+        self._runnable_config = RunnableConfig(callbacks=self.callbacks,
+                                               configurable={"__pregel_runtime": DEFAULT_RUNTIME})
 
-    async def _stream_llm(self,
-                          runnable: Any,
-                          inputs: dict[str, Any],
-                          config: RunnableConfig | None = None) -> AIMessage:
+    async def _stream_llm(self, runnable: Any, inputs: dict[str, Any]) -> AIMessage:
         """
         Stream from LLM runnable. Retry logic is handled automatically by the underlying LLM client.
 
@@ -94,8 +94,6 @@ class BaseAgent(ABC):
             The LLM runnable (prompt | llm or similar)
         inputs : Dict[str, Any]
             The inputs to pass to the runnable
-        config : RunnableConfig | None
-            The config to pass to the runnable (should include callbacks)
 
         Returns
         -------
@@ -103,12 +101,12 @@ class BaseAgent(ABC):
             The LLM response
         """
         output_message = []
-        async for event in runnable.astream(inputs, config=config):
+        async for event in runnable.astream(inputs, config=self._runnable_config):
             output_message.append(event.content)
 
         return AIMessage(content="".join(output_message))
 
-    async def _call_llm(self, llm: Runnable, inputs: dict[str, Any], config: RunnableConfig | None = None) -> AIMessage:
+    async def _call_llm(self, llm: Runnable, inputs: dict[str, Any]) -> AIMessage:
         """
         Call the LLM directly. Retry logic is handled automatically by the underlying LLM client.
 
@@ -118,22 +116,16 @@ class BaseAgent(ABC):
             The LLM runnable (prompt | llm or similar)
         inputs : dict[str, Any]
             The inputs to pass to the runnable
-        config : RunnableConfig | None
-            The config to pass to the runnable (should include callbacks)
 
         Returns
         -------
         AIMessage
             The LLM response
         """
-        response = await llm.ainvoke(inputs, config=config)
+        response = await llm.ainvoke(inputs, config=self._runnable_config)
         return AIMessage(content=str(response.content))
 
-    async def _call_tool(self,
-                         tool: BaseTool,
-                         tool_input: dict[str, Any] | str,
-                         config: RunnableConfig | None = None,
-                         max_retries: int = 3) -> ToolMessage:
+    async def _call_tool(self, tool: BaseTool, tool_input: dict[str, Any] | str, max_retries: int = 3) -> ToolMessage:
         """
         Call a tool with retry logic and error handling.
 
@@ -143,8 +135,6 @@ class BaseAgent(ABC):
             The tool to call
         tool_input : Union[Dict[str, Any], str]
             The input to pass to the tool
-        config : RunnableConfig | None
-            The config to pass to the tool
         max_retries : int
             Maximum number of retry attempts (default: 3)
 
@@ -157,7 +147,7 @@ class BaseAgent(ABC):
 
         for attempt in range(1, max_retries + 1):
             try:
-                response = await tool.ainvoke(tool_input, config=config)
+                response = await tool.ainvoke(tool_input, config=self._runnable_config)
 
                 # Handle empty responses
                 if response is None or (isinstance(response, str) and response == ""):

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
@@ -31,9 +31,7 @@ from langchain_core.messages.tool import ToolMessage
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.prompts import MessagesPlaceholder
 from langchain_core.runnables import Runnable
-from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import BaseTool
-from langgraph.runtime import DEFAULT_RUNTIME
 from pydantic import BaseModel
 from pydantic import Field
 
@@ -177,14 +175,9 @@ class ReActAgentGraph(DualNodeAgent):
                     question = content
                     logger.debug("%s Querying agent, attempt: %s", AGENT_LOG_PREFIX, attempt)
                     chat_history = self._get_chat_history(state.messages)
-                    output_message = await self._stream_llm(
-                        self.agent,
-                        {
-                            "question": question, "chat_history": chat_history
-                        },
-                        RunnableConfig(callbacks=self.callbacks,
-                                       configurable={"__pregel_runtime": DEFAULT_RUNTIME})  # type: ignore
-                    )
+                    output_message = await self._stream_llm(self.agent, {
+                        "question": question, "chat_history": chat_history
+                    })  # type: ignore
 
                     if self.detailed_logs:
                         logger.info(AGENT_CALL_LOG_MESSAGE, question, output_message.content)
@@ -205,13 +198,9 @@ class ReActAgentGraph(DualNodeAgent):
                     logger.debug("%s Querying agent, attempt: %s", AGENT_LOG_PREFIX, attempt)
 
                     output_message = await self._stream_llm(
-                        self.agent,
-                        {
+                        self.agent, {
                             "question": question, "agent_scratchpad": agent_scratchpad, "chat_history": chat_history
-                        },
-                        RunnableConfig(callbacks=self.callbacks,
-                                       configurable={"__pregel_runtime": DEFAULT_RUNTIME})  # type: ignore
-                    )
+                        })  # type: ignore
 
                     if self.detailed_logs:
                         logger.info(AGENT_CALL_LOG_MESSAGE, question, output_message.content)
@@ -373,12 +362,7 @@ class ReActAgentGraph(DualNodeAgent):
                 tool_input = tool_input_str
 
         # Call tool once with the determined input (either parsed dict or raw string)
-        tool_response = await self._call_tool(
-            requested_tool,
-            tool_input,
-            RunnableConfig(callbacks=self.callbacks,
-                           configurable={"__pregel_runtime": DEFAULT_RUNTIME}),  # type: ignore
-            max_retries=self.tool_call_max_retries)
+        tool_response = await self._call_tool(requested_tool, tool_input, max_retries=self.tool_call_max_retries)
 
         if self.detailed_logs:
             self._log_tool_response(requested_tool.name, tool_input, str(tool_response.content))

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/output_parser.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/output_parser.py
@@ -60,16 +60,15 @@ class ReActOutputParserException(ValueError, LangChainException):
                  missing_action_input: bool = False,
                  final_answer_and_action: bool = False,
                  llm_output: str | None = None):
-        super(ValueError).__init__(
-            self,
-            "ReActOutputParserException: " + f"observation={self.observation}, " +
-            f"missing_action={self.missing_action}, " + f"missing_action_input={self.missing_action_input}, " +
-            f"final_answer_and_action={self.final_answer_and_action}, " + f"llm_output={self.llm_output}")
         self.observation = observation
         self.missing_action = missing_action
         self.missing_action_input = missing_action_input
         self.final_answer_and_action = final_answer_and_action
         self.llm_output = llm_output
+        super().__init__("ReActOutputParserException: " + f"observation={self.observation}, " +
+                         f"missing_action={self.missing_action}, " +
+                         f"missing_action_input={self.missing_action_input}, " +
+                         f"final_answer_and_action={self.final_answer_and_action}, " + f"llm_output={self.llm_output}")
 
     def __repr__(self) -> str:
         return (f"ReActOutputParserException(observation={self.observation}, " +

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/output_parser.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/output_parser.py
@@ -45,25 +45,41 @@ class ReActAgentParsingFailedError(RuntimeError):
 
     def __init__(self, observation: str, llm_output: str, attempts: int):
         self.observation = observation
-        self.llm_output = llm_output
+        self.llm_output = llm_output if len(llm_output) <= 200 else llm_output[:200] + "..."
         self.attempts = attempts
-        super().__init__(f"Failed to parse agent output after {attempts} attempts. "
-                         f"Error: {observation}. LLM output: {llm_output[:200]}..." if len(llm_output) >
-                         200 else f"Failed to parse agent output after {attempts} attempts. "
-                         f"Error: {observation}. LLM output: {llm_output}")
+        super().__init__("ReActAgentParsingFailedError: " +
+                         f"Failed to parse agent output after {self.attempts} attempts. " +
+                         f"Error: {self.observation}. LLM output: '{self.llm_output}'")
 
 
 class ReActOutputParserException(ValueError, LangChainException):
 
     def __init__(self,
-                 observation=None,
-                 missing_action=False,
-                 missing_action_input=False,
-                 final_answer_and_action=False):
+                 observation: str | None = None,
+                 missing_action: bool = False,
+                 missing_action_input: bool = False,
+                 final_answer_and_action: bool = False,
+                 llm_output: str | None = None):
+        super(ValueError).__init__(
+            self,
+            "ReActOutputParserException: " + f"observation={self.observation}, " +
+            f"missing_action={self.missing_action}, " + f"missing_action_input={self.missing_action_input}, " +
+            f"final_answer_and_action={self.final_answer_and_action}, " + f"llm_output={self.llm_output}")
         self.observation = observation
         self.missing_action = missing_action
         self.missing_action_input = missing_action_input
         self.final_answer_and_action = final_answer_and_action
+        self.llm_output = llm_output
+
+    def __repr__(self) -> str:
+        return (f"ReActOutputParserException(observation={self.observation}, " +
+                f"missing_action={self.missing_action}, missing_action_input={self.missing_action_input}, " +
+                f"final_answer_and_action={self.final_answer_and_action}, llm_output={self.llm_output})")
+
+    def __str__(self) -> str:
+        return (f"ReActOutputParserException(observation={self.observation}, " +
+                f"missing_action={self.missing_action}, missing_action_input={self.missing_action_input}, " +
+                f"final_answer_and_action={self.final_answer_and_action}, llm_output={self.llm_output})")
 
 
 class ReActOutputParser(AgentOutputParser):
@@ -110,9 +126,9 @@ class ReActOutputParser(AgentOutputParser):
         action_match = re.search(regex_primary, text, re.DOTALL | re.IGNORECASE)
         if action_match:
             if includes_answer:
-                raise ReActOutputParserException(
-                    final_answer_and_action=True,
-                    observation=f"{FINAL_ANSWER_AND_PARSABLE_ACTION_ERROR_MESSAGE}: {text}")
+                raise ReActOutputParserException(observation=FINAL_ANSWER_AND_PARSABLE_ACTION_ERROR_MESSAGE,
+                                                 final_answer_and_action=True,
+                                                 llm_output=text)
             action = action_match.group(1).strip()
             action_input = action_match.group(2)
             tool_input = action_input.strip(" ")
@@ -131,11 +147,13 @@ class ReActOutputParser(AgentOutputParser):
         # Check for missing components with case-insensitive patterns
         if not re.search(r"action\s*\d*\s*:\s*(.*?)", text, re.DOTALL | re.IGNORECASE):
             raise ReActOutputParserException(observation=MISSING_ACTION_AFTER_THOUGHT_ERROR_MESSAGE,
-                                             missing_action=True)
+                                             missing_action=True,
+                                             llm_output=text)
         if not re.search(r"[\s]*(?:action\s*\d*\s*)?input\s*\d*\s*:\s*(.*)", text, re.DOTALL | re.IGNORECASE):
             raise ReActOutputParserException(observation=MISSING_ACTION_INPUT_AFTER_ACTION_ERROR_MESSAGE,
-                                             missing_action_input=True)
-        raise ReActOutputParserException(f"Could not parse LLM output: `{text}`")
+                                             missing_action_input=True,
+                                             llm_output=text)
+        raise ReActOutputParserException("Could not parse LLM output", llm_output=text)
 
     @property
     def _type(self) -> str:

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/rewoo_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/rewoo_agent/agent.py
@@ -27,11 +27,9 @@ from langchain_core.messages.base import BaseMessage
 from langchain_core.messages.human import HumanMessage
 from langchain_core.messages.tool import ToolMessage
 from langchain_core.prompts.chat import ChatPromptTemplate
-from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import BaseTool
 from langgraph.graph import StateGraph
 from langgraph.graph.state import CompiledStateGraph
-from langgraph.runtime import DEFAULT_RUNTIME
 from pydantic import BaseModel
 from pydantic import Field
 
@@ -276,8 +274,6 @@ class ReWOOAgentGraph(BaseAgent):
                 {
                     "task": task, "chat_history": chat_history
                 },
-                RunnableConfig(callbacks=self.callbacks,
-                               configurable={"__pregel_runtime": DEFAULT_RUNTIME})  # type: ignore
             )
 
             steps = self._parse_planner_output(str(plan.content))
@@ -432,12 +428,7 @@ class ReWOOAgentGraph(BaseAgent):
 
         # Parse and execute the tool
         tool_input_parsed = self._parse_tool_input(tool_input)
-        tool_response = await self._call_tool(
-            requested_tool,
-            tool_input_parsed,
-            RunnableConfig(callbacks=self.callbacks,
-                           configurable={"__pregel_runtime": DEFAULT_RUNTIME}),  # type: ignore
-            max_retries=self.tool_call_max_retries)
+        tool_response = await self._call_tool(requested_tool, tool_input_parsed, max_retries=self.tool_call_max_retries)
 
         if self.detailed_logs:
             self._log_tool_response(requested_tool.name, tool_input_parsed, str(tool_response))
@@ -488,10 +479,7 @@ class ReWOOAgentGraph(BaseAgent):
             solver_prompt = self.solver_prompt.partial(plan=plan)
             solver = solver_prompt | self.llm
 
-            output_message = await self._stream_llm(solver, {"task": task},
-                                                    RunnableConfig(callbacks=self.callbacks,
-                                                                   configurable={"__pregel_runtime": DEFAULT_RUNTIME})
-                                                    )  # type: ignore
+            output_message = await self._stream_llm(solver, {"task": task})
 
             if self.detailed_logs:
                 solver_output_log_message = AGENT_CALL_LOG_MESSAGE % (task, str(output_message.content))

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/agent.py
@@ -22,12 +22,10 @@ from langchain_core.messages import SystemMessage
 from langchain_core.messages import ToolMessage
 from langchain_core.messages.base import BaseMessage
 from langchain_core.runnables import RunnableLambda
-from langchain_core.runnables.config import RunnableConfig
 from langchain_core.tools import BaseTool
 from langgraph.graph import StateGraph
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.prebuilt import ToolNode
-from langgraph.runtime import DEFAULT_RUNTIME
 from pydantic import BaseModel
 from pydantic import Field
 
@@ -102,7 +100,7 @@ class ToolCallAgentGraph(DualNodeAgent):
                 raise RuntimeError('No input received in state: "messages"')
             response = await self.agent.ainvoke(
                 {"messages": state.messages},
-                config=RunnableConfig(callbacks=self.callbacks, configurable={"__pregel_runtime": DEFAULT_RUNTIME}),
+                config=self._runnable_config,
             )
             if self.detailed_logs:
                 agent_input = "\n".join(str(message.content) for message in state.messages)
@@ -138,7 +136,7 @@ class ToolCallAgentGraph(DualNodeAgent):
             tool_input = state.messages[-1]
             tool_response = await self.tool_caller.ainvoke(
                 input={"messages": [tool_input]},
-                config=RunnableConfig(callbacks=self.callbacks, configurable={"__pregel_runtime": DEFAULT_RUNTIME}),
+                config=self._runnable_config,
             )
             # configurable with __pregel_runtime is needed when invoking ToolNode outside graph context
 

--- a/packages/nvidia_nat_langchain/tests/agent/test_base.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_base.py
@@ -24,7 +24,6 @@ from langchain_core.messages import HumanMessage
 from langchain_core.messages import ToolMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.graph.state import CompiledStateGraph
-from langgraph.runtime import DEFAULT_RUNTIME
 
 from nat.plugins.langchain.agent.base import BaseAgent
 
@@ -41,6 +40,7 @@ class MockBaseAgent(BaseAgent):
         self.callbacks = []
         self.detailed_logs = detailed_logs
         self.log_response_max_chars = log_response_max_chars
+        self._runnable_config = RunnableConfig()
 
     async def _build_graph(self, state_schema: type) -> CompiledStateGraph:
         """Mock implementation."""
@@ -70,16 +70,14 @@ class TestStreamLLM:
         mock_event2 = Mock()
         mock_event2.content = "world!"
 
-        async def mock_astream(inputs, config=None):
+        async def mock_astream(inputs, **kwargs):
             for event in [mock_event1, mock_event2]:
                 yield event
 
         mock_runnable.astream = mock_astream
 
         inputs = {"messages": [HumanMessage(content="test")]}
-        config = RunnableConfig(callbacks=[], configurable={"__pregel_runtime": DEFAULT_RUNTIME})
-
-        result = await base_agent._stream_llm(mock_runnable, inputs, config)
+        result = await base_agent._stream_llm(mock_runnable, inputs)
 
         assert isinstance(result, AIMessage)
         assert result.content == "Hello world!"
@@ -88,7 +86,7 @@ class TestStreamLLM:
         """Test that streaming errors are propagated to the automatic retry system."""
         mock_runnable = Mock()
 
-        async def mock_astream(inputs, config=None):
+        async def mock_astream(inputs, **kwargs):
             raise Exception("Network error")
             yield  # Never executed but makes this an async generator
 
@@ -106,7 +104,7 @@ class TestStreamLLM:
         mock_event = Mock()
         mock_event.content = ""
 
-        async def mock_astream(inputs, config=None):
+        async def mock_astream(inputs, **kwargs):
             yield mock_event
 
         mock_runnable.astream = mock_astream
@@ -133,7 +131,7 @@ class TestCallLLM:
 
         assert isinstance(result, AIMessage)
         assert result.content == "Response content"
-        base_agent.llm.ainvoke.assert_called_once_with(inputs, config=None)
+        base_agent.llm.ainvoke.assert_called_once_with(inputs, config=base_agent._runnable_config)
 
     async def test_llm_call_error_propagation(self, base_agent):
         """Test that LLM call errors are propagated to the automatic retry system."""
@@ -167,28 +165,25 @@ class TestCallTool:
         """Test successful tool call."""
         tool = base_agent.tools[0]  # Tool A
         tool_input = {"query": "test"}
-        config = RunnableConfig(callbacks=[], configurable={"__pregel_runtime": DEFAULT_RUNTIME})
-
         tool.ainvoke = AsyncMock(return_value="Tool response")
 
-        result = await base_agent._call_tool(tool, tool_input, config)
+        result = await base_agent._call_tool(tool, tool_input)
 
         assert isinstance(result, ToolMessage)
         assert result.content == "Tool response"
         assert result.name == tool.name
         assert result.tool_call_id == tool.name
-        tool.ainvoke.assert_called_once_with(tool_input, config=config)
+        tool.ainvoke.assert_called_once_with(tool_input, config=base_agent._runnable_config)
 
     async def test_tool_call_with_retries_success_on_second_attempt(self, base_agent):
         """Test that tool call succeeds on second attempt with retry logic."""
         tool = base_agent.tools[0]  # Tool A
         tool_input = {"query": "test"}
-        config = RunnableConfig(callbacks=[], configurable={"__pregel_runtime": DEFAULT_RUNTIME})
 
         tool.ainvoke = AsyncMock(side_effect=[Exception("Network error"), "Tool response"])
 
         with patch('asyncio.sleep', new_callable=AsyncMock) as mock_sleep:
-            result = await base_agent._call_tool(tool, tool_input, config, max_retries=2)
+            result = await base_agent._call_tool(tool, tool_input, max_retries=2)
 
         assert isinstance(result, ToolMessage)
         assert result.content == "Tool response"

--- a/packages/nvidia_nat_test/src/nat/test/utils.py
+++ b/packages/nvidia_nat_test/src/nat/test/utils.py
@@ -74,7 +74,7 @@ async def run_workflow(*,
                        config: "Config | None" = None,
                        config_file: "StrPath | None" = None,
                        question: str,
-                       expected_answer: str,
+                       expected_answer: str | None = None,
                        assert_expected_answer: bool = True,
                        **kwargs) -> str:
     """
@@ -85,7 +85,7 @@ async def run_workflow(*,
 
     result = await nat_run_workflow(config=config, config_file=config_file, prompt=question, to_type=str, **kwargs)
 
-    if assert_expected_answer:
+    if expected_answer is not None and assert_expected_answer:
         # sometimes LLMs use fancy unicode space characters like \u202f, normalize before comparing
         normalized_result = ' '.join(result.split())
         assert expected_answer.lower() in normalized_result.lower(), f"Expected '{expected_answer}' in '{result}'"
@@ -96,7 +96,7 @@ async def run_workflow(*,
 async def serve_workflow(*,
                          config_path: Path,
                          question: str,
-                         expected_answer: str,
+                         expected_answer: str | None = None,
                          assert_expected_answer: bool = True,
                          port: int = 8000,
                          pipeline_timeout: int = 60,
@@ -139,7 +139,7 @@ async def serve_workflow(*,
 
             response_text = "\n".join(combined_response)
 
-        if assert_expected_answer:
+        if expected_answer is not None and assert_expected_answer:
             assert expected_answer.lower() in response_text.lower(), \
                 f"Unexpected response: {response.text}"
     finally:


### PR DESCRIPTION
## Description

When we bumped langchain/langgraph to 1.*, we augmented the public API of BaseAgent and DualNodeAgent. This should not have been done. Switch to preferring a hidden class member.

Additionally, this PR speeds up the execution of ReWOO tests by having `nat run`/`nat serve` being done once as a class fixture, then having each test input reuse the fixture. E2E tests of `examples/agents` now consistently take less than 4 minutes.

Note: there is still some flakiness with the agent e2e tests -- this PR should reduce the flakiness, but it can still occurr.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved agent error reporting to include relevant model output for easier troubleshooting.

* **Refactor**
  * Simplified runtime configuration handling across agents for more consistent behavior.
  * Test utilities updated to allow optional expected answers.

* **Examples**
  * Example dataset pointer updated (Q&A content refreshed for local experimentation).

* **Tests**
  * Expanded integration-style agent tests covering multiple QA scenarios.
  * Added reusable test fixtures to streamline test setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->