### PR TITLE
Refactor call index tracking for prefix predictions

### DIFF
--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -471,6 +471,9 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         self._prediction_lookup = prediction_lookup
         self._use_raw_values = use_raw_values
         self._disable_headers = disable_headers
+        # Per-prefix call counter so call_index advances across requests
+        # for the same prefix_id (keyed by prefix_id string).
+        self._call_counts: dict[str, int] = {}
 
     async def handle_async_request(self, request: "httpx.Request") -> "httpx.Response":
         # Get prefix ID from context (supports depth-awareness and overrides)
@@ -491,17 +494,13 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         # Check for prediction override
         if self._prediction_lookup is not None:
             try:
-                from nat.llm.prediction_context import get_call_tracker
-
                 ctx = Context.get()
                 path = ctx.function_path
 
-                # Get call index for current parent function
-                call_index = 1
-                active_fn = ctx.active_function
-                if active_fn and active_fn.function_id != "root":
-                    tracker = get_call_tracker()
-                    call_index = tracker.counts.get(active_fn.function_id, 1)
+                # Increment per-prefix call counter to advance through trie predictions.
+                # This is self-contained — no dependency on intermediate_step_manager.
+                self._call_counts[prefix_id] = self._call_counts.get(prefix_id, 0) + 1
+                call_index = self._call_counts[prefix_id]
 
                 # Look up prediction
                 prediction = self._prediction_lookup.find(path, call_index)

--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -71,6 +71,7 @@ prefix_total_requests
 
 import json
 import logging
+import threading
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
@@ -474,6 +475,7 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         # Per-prefix call counter so call_index advances across requests
         # for the same prefix_id (keyed by prefix_id string).
         self._call_counts: dict[str, int] = {}
+        self._call_counts_lock = threading.Lock()
 
     async def handle_async_request(self, request: "httpx.Request") -> "httpx.Response":
         # Get prefix ID from context (supports depth-awareness and overrides)

--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -499,8 +499,9 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
 
                 # Increment per-prefix call counter to advance through trie predictions.
                 # This is self-contained — no dependency on intermediate_step_manager.
-                self._call_counts[prefix_id] = self._call_counts.get(prefix_id, 0) + 1
-                call_index = self._call_counts[prefix_id]
+                with self._call_counts_lock:
+                    call_index = self._call_counts.get(prefix_id, 0) + 1
+                    self._call_counts[prefix_id] = call_index
 
                 # Look up prediction
                 prediction = self._prediction_lookup.find(path, call_index)


### PR DESCRIPTION

## Description
Replaced external call tracker logic with an internal per-prefix call counter for managing call indices. This simplifies dependency management by removing reliance on intermediate_step_manager and ensures increment logic remains self-contained within the class.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal per-prefix call tracking and concurrency handling to provide more consistent call indexing and safer concurrent behavior; no changes to public APIs or visible behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->