### PR TITLE
Add type converters for langgraph wrapper `nat serve` endpoints

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
@@ -21,7 +21,6 @@ import uuid
 from collections.abc import AsyncGenerator
 from collections.abc import Callable
 from pathlib import Path
-from types import NoneType
 from typing import Any
 
 from dotenv import load_dotenv
@@ -42,6 +41,10 @@ from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function import Function
 from nat.cli.register_workflow import register_function
+from nat.data_models.api_server import ChatRequest
+from nat.data_models.api_server import ChatResponse
+from nat.data_models.api_server import ChatResponseChunk
+from nat.data_models.api_server import Usage
 from nat.data_models.function import FunctionBaseConfig
 
 GraphDefType = Callable[[RunnableConfig], CompiledStateGraph | StateGraph] | CompiledStateGraph
@@ -76,7 +79,7 @@ class LanggraphWrapperConfig(FunctionBaseConfig, name="langgraph_wrapper"):
     env: FilePath | dict[str, str] | None = None
 
 
-class LanggraphWrapperFunction(Function[LanggraphWrapperInput, NoneType, LanggraphWrapperOutput]):
+class LanggraphWrapperFunction(Function[LanggraphWrapperInput, LanggraphWrapperOutput, LanggraphWrapperOutput]):
     """Function for the LangGraph wrapper."""
 
     def __init__(self, *, config: LanggraphWrapperConfig, description: str | None = None, graph: CompiledStateGraph):
@@ -88,21 +91,17 @@ class LanggraphWrapperFunction(Function[LanggraphWrapperInput, NoneType, Langgra
             graph: The graph to wrap.
         """
 
-        super().__init__(config=config, description=description, converters=[LanggraphWrapperFunction.convert_to_str])
+        super().__init__(config=config,
+                         description=description,
+                         converters=[
+                             LanggraphWrapperFunction.convert_to_str,
+                             LanggraphWrapperFunction.convert_chat_request,
+                             LanggraphWrapperFunction.convert_str,
+                             LanggraphWrapperFunction.convert_to_chat_response,
+                             LanggraphWrapperFunction.convert_to_chat_response_chunk,
+                         ])
 
         self._graph = graph
-
-    def _convert_input(self, value: Any) -> LanggraphWrapperInput:
-
-        # If the value is not a list, wrap it in a list to be compatible with the graph input and use the normal
-        # conversion logic
-        if (not isinstance(value, list)):
-            value = [value]
-
-        # Convert the value to message format using LangChain utils. Ensures is compatible with the message format
-        messages = convert_to_messages(value)
-
-        return LanggraphWrapperInput(messages=messages)
 
     async def _ainvoke(self, value: LanggraphWrapperInput) -> LanggraphWrapperOutput:
 
@@ -125,12 +124,23 @@ class LanggraphWrapperFunction(Function[LanggraphWrapperInput, NoneType, Langgra
                 logger.info("Graph is an async context manager")
                 async with self._graph as graph:
                     async for output in graph.astream(value.model_dump()):
-                        yield LanggraphWrapperOutput.model_validate(output)
+                        yield self._parse_stream_output(output)
             else:
                 async for output in self._graph.astream(value.model_dump()):
-                    yield LanggraphWrapperOutput.model_validate(output)
+                    yield self._parse_stream_output(output)
         except Exception as e:
             raise RuntimeError(f"Error in LangGraph workflow: {e}") from e
+
+    @staticmethod
+    def _parse_stream_output(output: dict) -> LanggraphWrapperOutput:
+        """Unwrap node-keyed dicts that LangGraph astream() yields."""
+        try:
+            return LanggraphWrapperOutput.model_validate(output)
+        except Exception:
+            if len(output) == 1:
+                node_output = next(iter(output.values()))
+                return LanggraphWrapperOutput.model_validate(node_output)
+            raise
 
     @staticmethod
     def convert_to_str(value: LanggraphWrapperOutput) -> str:
@@ -139,6 +149,29 @@ class LanggraphWrapperFunction(Function[LanggraphWrapperInput, NoneType, Langgra
             return ""
 
         return value.messages[-1].text
+
+    @staticmethod
+    def convert_chat_request(value: ChatRequest) -> LanggraphWrapperInput:
+        """Convert a ChatRequest to LanggraphWrapperInput."""
+        message_dicts: list[dict[str, Any]] = [m.model_dump() for m in value.messages]
+        return LanggraphWrapperInput(messages=convert_to_messages(message_dicts))
+
+    @staticmethod
+    def convert_str(value: str) -> LanggraphWrapperInput:
+        """Convert a plain text string to LanggraphWrapperInput."""
+        return LanggraphWrapperInput(messages=convert_to_messages([value]))
+
+    @staticmethod
+    def convert_to_chat_response(value: LanggraphWrapperOutput) -> ChatResponse:
+        """Convert LanggraphWrapperOutput to ChatResponse."""
+        text: str = value.messages[-1].text if value.messages else ""
+        return ChatResponse.from_string(text, usage=Usage())
+
+    @staticmethod
+    def convert_to_chat_response_chunk(value: LanggraphWrapperOutput) -> ChatResponseChunk:
+        """Convert LanggraphWrapperOutput to ChatResponseChunk."""
+        text: str = value.messages[-1].text if value.messages else ""
+        return ChatResponseChunk.from_string(text)
 
 
 @register_function(config_type=LanggraphWrapperConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])

--- a/packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py
+++ b/packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py
@@ -1,0 +1,203 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.messages import HumanMessage
+from langchain_core.messages import SystemMessage
+
+from nat.data_models.api_server import ChatRequest
+from nat.data_models.api_server import ChatResponse
+from nat.data_models.api_server import ChatResponseChunk
+from nat.data_models.api_server import Message
+from nat.data_models.api_server import UserMessageContentRoleType
+from nat.plugins.langchain.langgraph_workflow import LanggraphWrapperFunction
+from nat.plugins.langchain.langgraph_workflow import LanggraphWrapperInput
+from nat.plugins.langchain.langgraph_workflow import LanggraphWrapperOutput
+
+
+class TestConvertChatRequest:
+    """Tests for LanggraphWrapperFunction.convert_chat_request: ChatRequest → LanggraphWrapperInput."""
+
+    def test_single_user_message(self):
+        """Test converting a single user message."""
+        chat_req = ChatRequest(messages=[Message(content="hello", role=UserMessageContentRoleType.USER)])
+        result = LanggraphWrapperFunction.convert_chat_request(chat_req)
+
+        assert isinstance(result, LanggraphWrapperInput)
+        assert len(result.messages) == 1
+        assert isinstance(result.messages[0], HumanMessage)
+        assert result.messages[0].content == "hello"
+
+    def test_multi_turn(self):
+        """Test converting a multi-turn conversation."""
+        chat_req = ChatRequest(messages=[
+            Message(content="hello", role=UserMessageContentRoleType.USER),
+            Message(content="hi there", role=UserMessageContentRoleType.ASSISTANT),
+            Message(content="how are you?", role=UserMessageContentRoleType.USER),
+        ])
+        result = LanggraphWrapperFunction.convert_chat_request(chat_req)
+
+        assert isinstance(result, LanggraphWrapperInput)
+        assert len(result.messages) == 3
+        assert isinstance(result.messages[0], HumanMessage)
+        assert isinstance(result.messages[1], AIMessage)
+        assert isinstance(result.messages[2], HumanMessage)
+        assert result.messages[2].content == "how are you?"
+
+    def test_system_message(self):
+        """Test converting a system message."""
+        chat_req = ChatRequest(messages=[
+            Message(content="You are helpful.", role=UserMessageContentRoleType.SYSTEM),
+            Message(content="hello", role=UserMessageContentRoleType.USER),
+        ])
+        result = LanggraphWrapperFunction.convert_chat_request(chat_req)
+
+        assert len(result.messages) == 2
+        assert isinstance(result.messages[0], SystemMessage)
+        assert result.messages[0].content == "You are helpful."
+        assert isinstance(result.messages[1], HumanMessage)
+
+
+class TestConvertStr:
+    """Tests for LanggraphWrapperFunction.convert_str: str → LanggraphWrapperInput."""
+
+    def test_plain_text(self):
+        """Test converting a plain text string."""
+        result = LanggraphWrapperFunction.convert_str("hello")
+
+        assert isinstance(result, LanggraphWrapperInput)
+        assert len(result.messages) == 1
+        assert isinstance(result.messages[0], HumanMessage)
+        assert result.messages[0].content == "hello"
+
+    def test_empty_string(self):
+        """Test converting an empty string."""
+        result = LanggraphWrapperFunction.convert_str("")
+
+        assert isinstance(result, LanggraphWrapperInput)
+        assert len(result.messages) == 1
+        assert result.messages[0].content == ""
+
+
+class TestConvertOutputToChatResponse:
+    """Tests for LanggraphWrapperFunction.convert_to_chat_response: LanggraphWrapperOutput → ChatResponse."""
+
+    def test_single_ai_message(self):
+        """Test converting output with a single AI message."""
+        output = LanggraphWrapperOutput(messages=[AIMessage(content="Echo: hello")])
+        result = LanggraphWrapperFunction.convert_to_chat_response(output)
+
+        assert isinstance(result, ChatResponse)
+        assert result.choices[0].message.content == "Echo: hello"
+        assert result.object == "chat.completion"
+
+    def test_empty_messages(self):
+        """Test converting output with no messages."""
+        output = LanggraphWrapperOutput(messages=[])
+        result = LanggraphWrapperFunction.convert_to_chat_response(output)
+
+        assert isinstance(result, ChatResponse)
+        assert result.choices[0].message.content == ""
+
+    def test_multi_message_uses_last(self):
+        """Test that the last message content is used."""
+        output = LanggraphWrapperOutput(messages=[AIMessage(content="first"), AIMessage(content="second")])
+        result = LanggraphWrapperFunction.convert_to_chat_response(output)
+
+        assert result.choices[0].message.content == "second"
+
+
+class TestConvertOutputToChatResponseChunk:
+    """Tests for LanggraphWrapperFunction.convert_to_chat_response_chunk: LanggraphWrapperOutput → ChatResponseChunk."""
+
+    def test_single_ai_message(self):
+        """Test converting output with a single AI message."""
+        output = LanggraphWrapperOutput(messages=[AIMessage(content="Echo: hello")])
+        result = LanggraphWrapperFunction.convert_to_chat_response_chunk(output)
+
+        assert isinstance(result, ChatResponseChunk)
+        assert result.choices[0].delta.content == "Echo: hello"
+        assert result.object == "chat.completion.chunk"
+
+    def test_empty_messages(self):
+        """Test converting output with no messages."""
+        output = LanggraphWrapperOutput(messages=[])
+        result = LanggraphWrapperFunction.convert_to_chat_response_chunk(output)
+
+        assert isinstance(result, ChatResponseChunk)
+        assert result.choices[0].delta.content == ""
+
+    def test_multi_message_uses_last(self):
+        """Test that the last message content is used."""
+        output = LanggraphWrapperOutput(messages=[AIMessage(content="first"), AIMessage(content="second")])
+        result = LanggraphWrapperFunction.convert_to_chat_response_chunk(output)
+
+        assert result.choices[0].delta.content == "second"
+
+
+class TestConvertToStr:
+    """Tests for LanggraphWrapperFunction.convert_to_str: LanggraphWrapperOutput → str."""
+
+    def test_single_ai_message(self):
+        """Test extracting content from a single AI message."""
+        output = LanggraphWrapperOutput(messages=[AIMessage(content="Echo: hello")])
+        result = LanggraphWrapperFunction.convert_to_str(output)
+        assert result == "Echo: hello"
+
+    def test_empty_messages(self):
+        """Test extracting content when no messages are present."""
+        output = LanggraphWrapperOutput(messages=[])
+        result = LanggraphWrapperFunction.convert_to_str(output)
+        assert result == ""
+
+    def test_multi_message_returns_last(self):
+        """Test that the last message content is returned."""
+        output = LanggraphWrapperOutput(messages=[AIMessage(content="first"), AIMessage(content="second")])
+        result = LanggraphWrapperFunction.convert_to_str(output)
+        assert result == "second"
+
+
+class TestParseStreamOutput:
+    """Tests for LanggraphWrapperFunction._parse_stream_output."""
+
+    def test_flat_dict(self):
+        """Test parsing a flat messages dict."""
+        raw = {"messages": [AIMessage(content="hi")]}
+        result = LanggraphWrapperFunction._parse_stream_output(raw)
+
+        assert isinstance(result, LanggraphWrapperOutput)
+        assert result.messages[0].content == "hi"
+
+    def test_node_keyed_dict(self):
+        """Test parsing a single-node-keyed dict from LangGraph astream."""
+        raw = {"echo": {"messages": [AIMessage(content="hi")]}}
+        result = LanggraphWrapperFunction._parse_stream_output(raw)
+
+        assert isinstance(result, LanggraphWrapperOutput)
+        assert result.messages[0].content == "hi"
+
+    def test_multi_key_dict_raises(self):
+        """Test that multiple node keys raises an error."""
+        raw = {
+            "node_a": {
+                "messages": [AIMessage(content="a")]
+            },
+            "node_b": {
+                "messages": [AIMessage(content="b")]
+            },
+        }
+        with pytest.raises(Exception):
+            LanggraphWrapperFunction._parse_stream_output(raw)


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

When serving a `langgraph_wrapper` workflow via `nat serve`, multiple endpoints failed:
- `/generate` and `/generate/stream` failed because the old `_convert_input` override passed the pre-validated `LanggraphWrapperInput` object directly into `convert_to_messages`, which didn't know how to handle it
- `/chat`, `/chat/stream`, and `/v1/chat/completions` failed because there was no `ChatRequest → LanggraphWrapperInput` converter, causing `convert_to_messages` to receive a `ChatRequest` object it couldn't handle
- All streaming endpoints failed because `StreamingOutputT` was declared as `NoneType`, so the framework rejected the actual `LanggraphWrapperOutput` during output conversion
- `/chat` output failed because there was no `LanggraphWrapperOutput → ChatResponse` converter

Closes #1600 

### Changes

**`langgraph_workflow.py`:**
- Fix generic params: `Function[LanggraphWrapperInput, LanggraphWrapperOutput, LanggraphWrapperOutput]`
- Replace `_convert_input` override with registered static method converters:
  - `convert_chat_request`: `ChatRequest → LanggraphWrapperInput`
  - `convert_str`: `str → LanggraphWrapperInput`
  - `convert_to_chat_response`: `LanggraphWrapperOutput → ChatResponse`
  - `convert_to_chat_response_chunk`: `LanggraphWrapperOutput → ChatResponseChunk`
- Add `_parse_stream_output` for unwrapping node-keyed streaming dicts from LangGraph `astream()`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Broader input/output conversion: accepts chat requests and plain text, and produces full responses and response chunks.
  * Updated function interface for clearer input/output handling and more predictable response typing.

* **Reliability**
  * Improved streaming output parsing to handle varied stream formats and surface stream errors reliably.

* **Tests**
  * Added comprehensive tests covering conversions, multi-turn and system messages, streaming scenarios, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->