### PR TITLE
Add max_sensitivity for latency-based prioritization

### DIFF
--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -114,6 +114,10 @@ _OSL_CATEGORY_TO_INT: dict[str, int] = {"LOW": 128, "MEDIUM": 512, "HIGH": 2048}
 # HIGH: 750ms (midpoint of 500-1000ms range)
 _IAT_CATEGORY_TO_INT: dict[str, int] = {"LOW": 50, "MEDIUM": 250, "HIGH": 750}
 
+# Fallback when Context is unavailable (e.g. outside a workflow run).
+# Mid-range default on the [0, max_sensitivity] scale.
+_DEFAULT_LATENCY_SENSITIVITY: int = 2
+
 
 class CachePinType(StrEnum):
     """Cache pinning strategy for KV cache entries.
@@ -430,11 +434,17 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
 
     @field_validator("prefix_iat", mode="before")
     @classmethod
-    def _coerce_prefix_iat(cls, v: object) -> object:
+    def _coerce_prefix_iat(cls, v: object) -> int:
         """Convert categorical IAT strings (LOW/MEDIUM/HIGH) to representative millisecond values."""
-        if isinstance(v, str) and v.upper() in _IAT_CATEGORY_TO_INT:
-            return _IAT_CATEGORY_TO_INT[v.upper()]
-        return v
+        if isinstance(v, int):
+            return v
+        if isinstance(v, str):
+            upper = v.upper()
+            if upper in _IAT_CATEGORY_TO_INT:
+                return _IAT_CATEGORY_TO_INT[upper]
+            raise ValueError(f"Invalid IAT value '{v}'. Must be an integer >= 1 "
+                             f"or one of: {', '.join(_IAT_CATEGORY_TO_INT.keys())}")
+        raise TypeError(f"prefix_iat must be int or str, got {type(v)}")
 
     # =========================================================================
     # UTILITY METHODS
@@ -519,12 +529,14 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         # Get prefix ID from context (supports depth-awareness and overrides)
         prefix_id = DynamoPrefixContext.get()
 
-        # Get latency sensitivity from context (defaults to 2)
+        # Get latency sensitivity from context.
+        # Context.latency_sensitivity is typed as int; coerce
+        # defensively in case a subclass or mock returns a float.
         try:
             ctx = Context.get()
-            latency_sensitivity = ctx.latency_sensitivity
+            latency_sensitivity = int(ctx.latency_sensitivity)
         except Exception:
-            latency_sensitivity = 2
+            latency_sensitivity = _DEFAULT_LATENCY_SENSITIVITY
 
         # Initialize with static config values (always integers)
         total_requests = self._total_requests
@@ -594,18 +606,13 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
             try:
                 body = json.loads(content.decode("utf-8", errors="replace"))
                 if isinstance(body, dict):
-                    # Build agent_hints dict (int or str depending on raw mode)
                     # Priority is the integer complement of latency_sensitivity:
                     # lower priority value = higher priority request.
+                    if latency_sensitivity > self._max_sensitivity:
+                        raise ValueError(f"latency_sensitivity ({latency_sensitivity}) exceeds "
+                                         f"max_sensitivity ({self._max_sensitivity}). "
+                                         f"Increase max_sensitivity or lower latency_sensitivity.")
                     priority = self._max_sensitivity - latency_sensitivity
-                    if priority < 0:
-                        logger.warning(
-                            "latency_sensitivity (%s) exceeds max_sensitivity (%s); "
-                            "clamping priority to 0",
-                            latency_sensitivity,
-                            self._max_sensitivity,
-                        )
-                        priority = 0
                     agent_hints = {
                         "prefix_id": prefix_id,
                         "total_requests": total_requests,

--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -403,6 +403,14 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
         "Set to null/None to disable cache control hints.",
     )
 
+    max_sensitivity: int = Field(
+        default=1000,
+        ge=1,
+        description="Maximum latency sensitivity value used to compute request priority. "
+        "Priority is the integer complement: priority = max_sensitivity - latency_sensitivity. "
+        "Lower priority values indicate higher priority requests.",
+    )
+
     # =========================================================================
     # VALIDATORS (backward compatibility: categorical strings -> integers)
     # =========================================================================
@@ -460,6 +468,7 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
             "prediction_trie_path",
             "disable_headers",
             "cache_pin_type",
+            "max_sensitivity",
         })
 
 
@@ -490,6 +499,7 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         use_raw_values: bool = True,
         disable_headers: bool = True,
         cache_pin_type: CachePinType | None = CachePinType.EPHEMERAL,
+        max_sensitivity: int = 1000,
     ):
         self._transport = transport
         self._total_requests = total_requests
@@ -499,6 +509,7 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         self._use_raw_values = use_raw_values
         self._disable_headers = disable_headers
         self._cache_pin_type = cache_pin_type
+        self._max_sensitivity = max_sensitivity
         # Per-prefix call counter so call_index advances across requests
         # for the same prefix_id (keyed by prefix_id string).
         self._call_counts: dict[str, int] = {}
@@ -584,12 +595,24 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
                 body = json.loads(content.decode("utf-8", errors="replace"))
                 if isinstance(body, dict):
                     # Build agent_hints dict (int or str depending on raw mode)
+                    # Priority is the integer complement of latency_sensitivity:
+                    # lower priority value = higher priority request.
+                    priority = self._max_sensitivity - latency_sensitivity
+                    if priority < 0:
+                        logger.warning(
+                            "latency_sensitivity (%s) exceeds max_sensitivity (%s); "
+                            "clamping priority to 0",
+                            latency_sensitivity,
+                            self._max_sensitivity,
+                        )
+                        priority = 0
                     agent_hints = {
                         "prefix_id": prefix_id,
                         "total_requests": total_requests,
                         "osl": osl_value,
                         "iat": iat_value,
                         "latency_sensitivity": float(latency_sensitivity),
+                        "priority": priority,
                     }
 
                     # Add/merge nvext.agent_hints
@@ -671,6 +694,7 @@ def create_httpx_client_with_dynamo_hooks(
     use_raw_values: bool = True,
     disable_headers: bool = True,
     cache_pin_type: CachePinType | None = CachePinType.EPHEMERAL,
+    max_sensitivity: int = 1000,
 ) -> "httpx.AsyncClient":
     """
     Create an httpx.AsyncClient with Dynamo hint injection via custom transport.
@@ -692,6 +716,7 @@ def create_httpx_client_with_dynamo_hooks(
         use_raw_values: When True send raw integers; when False convert to LOW/MEDIUM/HIGH
         disable_headers: If True, do not inject hints as HTTP headers (still injects nvext.agent_hints)
         cache_pin_type: Cache pinning strategy. When set, injects nvext.cache_control with TTL. Set to None to disable.
+        max_sensitivity: Maximum latency sensitivity for computing priority
 
     Returns:
         An httpx.AsyncClient configured with Dynamo hint injection.
@@ -713,6 +738,7 @@ def create_httpx_client_with_dynamo_hooks(
         use_raw_values=use_raw_values,
         disable_headers=disable_headers,
         cache_pin_type=cache_pin_type,
+        max_sensitivity=max_sensitivity,
     )
 
     return httpx.AsyncClient(

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
@@ -46,6 +46,7 @@ class TestDynamoModelConfig:
         assert config.disable_headers is True
         assert config.request_timeout == 600.0
         assert config.cache_pin_type == CachePinType.EPHEMERAL
+        assert config.max_sensitivity == 1000
 
     def test_custom_prefix_values(self):
         """Test custom prefix parameter values."""
@@ -180,6 +181,7 @@ class TestDynamoModelConfig:
             "prediction_trie_path",
             "disable_headers",
             "cache_pin_type",
+            "max_sensitivity",
         })
 
         assert field_names == expected
@@ -500,6 +502,8 @@ class TestDynamoTransport:
         assert agent_hints["total_requests"] == 10
         assert agent_hints["osl"] == 512
         assert agent_hints["iat"] == 750
+        # Default latency_sensitivity=2, max_sensitivity=1000 -> priority=998
+        assert agent_hints["priority"] == 998
 
         # Cleanup
         DynamoPrefixContext.clear()
@@ -755,6 +759,7 @@ class TestDynamoTransport:
         assert agent_hints["total_requests"] == 10
         assert agent_hints["osl"] == 512
         assert agent_hints["iat"] == 250
+        assert agent_hints["priority"] == 998  # 1000 - 2
 
         DynamoPrefixContext.clear()
 
@@ -849,6 +854,8 @@ class TestDynamoTransport:
         assert "agent_hints" in body["nvext"]
         agent_hints = body["nvext"]["agent_hints"]
         assert agent_hints["latency_sensitivity"] == 2.0
+        # priority = max_sensitivity(1000) - latency_sensitivity(2) = 998
+        assert agent_hints["priority"] == 998
 
         # Cleanup
         DynamoPrefixContext.clear()
@@ -1036,6 +1043,44 @@ class TestDynamoTransport:
         cache_control = body["nvext"]["cache_control"]
         assert cache_control["type"] == "ephemeral"
         assert cache_control["ttl"] == "2s"  # 25 * 50 = 1250ms -> ceil = 2s
+
+        DynamoPrefixContext.clear()
+
+    async def test_transport_clamps_priority_when_exceeding_max(self):
+        """Test that priority is clamped to 0 when latency_sensitivity exceeds max_sensitivity."""
+        import json
+
+        import httpx
+
+        from nat.llm.dynamo_llm import _DynamoTransport
+
+        mock_response = httpx.Response(200, json={"result": "ok"})
+        mock_transport = MagicMock()
+        mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
+
+        # max_sensitivity=5, default latency_sensitivity=2 -> priority would be 5-2=3
+        # But we want to test when latency_sensitivity > max_sensitivity.
+        # Default latency_sensitivity from Context fallback is 2, max_sensitivity=1 -> 1-2=-1 -> clamped to 0
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+            max_sensitivity=1,
+        )
+
+        DynamoPrefixContext.set("clamp-test")
+
+        request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test", "messages": []})
+        await transport.handle_async_request(request)
+
+        modified_request = mock_transport.handle_async_request.call_args[0][0]
+        body = json.loads(modified_request.content.decode("utf-8"))
+        agent_hints = body["nvext"]["agent_hints"]
+
+        # Priority should be clamped to 0, not negative
+        assert agent_hints["priority"] == 0
 
         DynamoPrefixContext.clear()
 

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
@@ -108,6 +108,9 @@ class TestDynamoModelConfig:
         with pytest.raises(ValueError):
             DynamoModelConfig(model_name="test-model", prefix_osl="INVALID")
 
+        with pytest.raises(ValueError):
+            DynamoModelConfig(model_name="test-model", prefix_iat="INVALID")
+
     def test_backward_compat_categorical_strings(self):
         """Test that categorical string values (LOW/MEDIUM/HIGH) are coerced to integers."""
         config = DynamoModelConfig(model_name="test-model", prefix_osl="LOW", prefix_iat="LOW")
@@ -1046,10 +1049,8 @@ class TestDynamoTransport:
 
         DynamoPrefixContext.clear()
 
-    async def test_transport_clamps_priority_when_exceeding_max(self):
-        """Test that priority is clamped to 0 when latency_sensitivity exceeds max_sensitivity."""
-        import json
-
+    async def test_transport_raises_when_latency_exceeds_max(self):
+        """Test that ValueError is raised when latency_sensitivity exceeds max_sensitivity."""
         import httpx
 
         from nat.llm.dynamo_llm import _DynamoTransport
@@ -1058,9 +1059,7 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        # max_sensitivity=5, default latency_sensitivity=2 -> priority would be 5-2=3
-        # But we want to test when latency_sensitivity > max_sensitivity.
-        # Default latency_sensitivity from Context fallback is 2, max_sensitivity=1 -> 1-2=-1 -> clamped to 0
+        # Default latency_sensitivity fallback is 2, max_sensitivity=1 -> 2 > 1 -> ValueError
         transport = _DynamoTransport(
             transport=mock_transport,
             total_requests=10,
@@ -1070,17 +1069,18 @@ class TestDynamoTransport:
             max_sensitivity=1,
         )
 
-        DynamoPrefixContext.set("clamp-test")
+        DynamoPrefixContext.set("overflow-test")
 
-        request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test", "messages": []})
-        await transport.handle_async_request(request)
+        request = httpx.Request(
+            "POST",
+            "https://api.example.com/chat",
+            json={
+                "model": "test", "messages": []
+            },
+        )
 
-        modified_request = mock_transport.handle_async_request.call_args[0][0]
-        body = json.loads(modified_request.content.decode("utf-8"))
-        agent_hints = body["nvext"]["agent_hints"]
-
-        # Priority should be clamped to 0, not negative
-        assert agent_hints["priority"] == 0
+        with pytest.raises(ValueError, match="latency_sensitivity.*exceeds.*max_sensitivity"):
+            await transport.handle_async_request(request)
 
         DynamoPrefixContext.clear()
 

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -275,6 +275,7 @@ async def dynamo_langchain(llm_config: DynamoModelConfig, _builder: Builder):
                 use_raw_values=llm_config.prefix_use_raw_values,
                 disable_headers=llm_config.disable_headers,
                 cache_pin_type=llm_config.cache_pin_type,
+                max_sensitivity=llm_config.max_sensitivity,
             )
             config_dict["http_async_client"] = http_async_client
             logger.info(

--- a/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
+++ b/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
@@ -246,6 +246,7 @@ class TestDynamoLangChain:
                 use_raw_values=True,
                 disable_headers=True,
                 cache_pin_type=CachePinType.EPHEMERAL,
+                max_sensitivity=1000,
             )
 
             # Verify ChatOpenAI was called with the custom httpx client


### PR DESCRIPTION
## Description
Introduced `max_sensitivity` to compute request priorities based on latency sensitivity, with clamping to prevent negative values. Updated relevant methods, tests, and documentation to ensure alignment with this enhanced prioritization logic.

Dynamo treats latency sensitivity and priority independently, so we need to supply both.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `max_sensitivity` configuration parameter for Dynamo LLM models to control request priority computation.
  * Implemented priority-based request handling: priority is calculated as `max_sensitivity - latency_sensitivity`, with automatic clamping to 0 on overflow.

* **Tests**
  * Added tests validating priority clamping behavior when latency sensitivity exceeds configured maximum.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->