### PR TITLE
fix(mcp-client): ensure tools are only invoked when available

### DIFF
--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
@@ -217,6 +217,11 @@ class MCPBaseClient(ABC):
         self._tools = None
 
     @property
+    def is_connected(self) -> bool:
+        """Whether the client has an active, initialized connection."""
+        return self._exit_stack is not None and self._connection_established
+
+    @property
     def server_name(self):
         """
         Provide server name for logging

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_impl.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_impl.py
@@ -494,6 +494,24 @@ def mcp_session_tool_function(tool, function_group: MCPFunctionGroup):
     def _convert_from_str(input_str: str) -> tool.input_schema:
         return tool.input_schema.model_validate_json(input_str)
 
+    async def _invoke_tool(session_tool, tool_input: BaseModel | None, kwargs: dict) -> str:
+        """Invoke the resolved MCP tool with the given arguments."""
+        if tool_input:
+            args = tool_input.model_dump(exclude_none=True, mode='json')
+            return await session_tool.acall(args)
+
+        # kwargs arrives with all optional fields set to None because NAT's framework
+        # converts the input dict to a Pydantic model (filling in all Field(default=None)),
+        # then dumps it back to a dict. We need to strip out these None values because
+        # many MCP servers (e.g., Kaggle) reject requests with excessive null fields.
+        # We re-validate here (yes, redundant) to leverage Pydantic's exclude_none with
+        # mode='json' for recursive None removal in nested models.
+        # Reference: function_info.py:_convert_input_pydantic
+        validated_input = session_tool.input_schema.model_validate(
+            _drop_invalid_none_values(kwargs, session_tool.input_schema))
+        args = validated_input.model_dump(exclude_none=True, mode='json')
+        return await session_tool.acall(args)
+
     async def _response_fn(tool_input: BaseModel | None = None, **kwargs) -> str:
         """Response function for the session-aware tool."""
         try:
@@ -508,34 +526,21 @@ def mcp_session_tool_function(tool, function_group: MCPFunctionGroup):
             if (not function_group._shared_auth_provider or session_id == function_group._default_user_id):
                 # Use base client directly for default user
                 client = function_group.mcp_client
-                if client is None:
+                if client is None or not client.is_connected:
                     return "Tool temporarily unavailable. Try again."
                 session_tool = await client.get_tool(tool.name)
-            else:
-                # Use session usage context to prevent cleanup during tool execution
-                if session_id is None:
+                return await _invoke_tool(session_tool, tool_input, kwargs)
+
+            # Use session usage context to keep ref_count elevated for the
+            # entire tool invocation, preventing cleanup from closing the
+            # underlying session mid-call.
+            if session_id is None:
+                return "Tool temporarily unavailable. Try again."
+            async with function_group._session_usage_context(session_id) as client:
+                if client is None or not client.is_connected:
                     return "Tool temporarily unavailable. Try again."
-                async with function_group._session_usage_context(session_id) as client:
-                    if client is None:
-                        return "Tool temporarily unavailable. Try again."
-                    session_tool = await client.get_tool(tool.name)
-
-            # Preserve original calling convention
-            if tool_input:
-                args = tool_input.model_dump(exclude_none=True, mode='json')
-                return await session_tool.acall(args)
-
-            # kwargs arrives with all optional fields set to None because NAT's framework
-            # converts the input dict to a Pydantic model (filling in all Field(default=None)),
-            # then dumps it back to a dict. We need to strip out these None values because
-            # many MCP servers (e.g., Kaggle) reject requests with excessive null fields.
-            # We re-validate here (yes, redundant) to leverage Pydantic's exclude_none with
-            # mode='json' for recursive None removal in nested models.
-            # Reference: function_info.py:_convert_input_pydantic
-            validated_input = session_tool.input_schema.model_validate(
-                _drop_invalid_none_values(kwargs, session_tool.input_schema))
-            args = validated_input.model_dump(exclude_none=True, mode='json')
-            return await session_tool.acall(args)
+                session_tool = await client.get_tool(tool.name)
+                return await _invoke_tool(session_tool, tool_input, kwargs)
         except Exception as e:
             logger.warning("Error calling tool %s", tool.name, exc_info=True)
             return str(e)

--- a/packages/nvidia_nat_mcp/tests/client/test_mcp_client_base.py
+++ b/packages/nvidia_nat_mcp/tests/client/test_mcp_client_base.py
@@ -529,6 +529,43 @@ async def test_connection_established_flag():
     assert client._connection_established is False
 
 
+async def test_is_connected_lifecycle():
+    """Test that is_connected reflects the full client lifecycle."""
+    client = MockMCPClient(transport="streamable-http")
+
+    assert client.is_connected is False
+
+    async with client:
+        assert client.is_connected is True
+
+    assert client.is_connected is False
+
+
+async def test_is_connected_false_after_reconnect_failure():
+    """Test that is_connected is False when reconnect exhausts all attempts."""
+    client = MockMCPClient(
+        transport="streamable-http",
+        reconnect_enabled=True,
+        reconnect_max_attempts=1,
+        reconnect_initial_backoff=0.01,
+        reconnect_max_backoff=0.02,
+    )
+
+    client.connect_should_fail = True
+    client.connect_failure_count = 2
+
+    async def always_fail():
+        raise ConnectionError("Always fails")
+
+    client.list_tools_side_effect = always_fail
+
+    async with client:
+        assert client.is_connected is True
+        with pytest.raises(MCPConnectionError):
+            await client.get_tools()
+        assert client.is_connected is False
+
+
 class TestMCPToolClient:
     """Test the MCPToolClient basic functionality."""
 

--- a/packages/nvidia_nat_mcp/tests/client/test_mcp_client_impl.py
+++ b/packages/nvidia_nat_mcp/tests/client/test_mcp_client_impl.py
@@ -18,6 +18,7 @@ from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import pytest
 from pydantic import BaseModel
 
 from nat.builder.function import FunctionGroup
@@ -26,8 +27,10 @@ from nat.plugins.mcp.client.client_base import MCPBaseClient
 from nat.plugins.mcp.client.client_config import MCPClientConfig
 from nat.plugins.mcp.client.client_config import MCPServerConfig
 from nat.plugins.mcp.client.client_config import MCPToolOverrideConfig
+from nat.plugins.mcp.client.client_impl import MCPFunctionGroup
 from nat.plugins.mcp.client.client_impl import mcp_apply_tool_alias_and_description
 from nat.plugins.mcp.client.client_impl import mcp_client_function_group
+from nat.plugins.mcp.client.client_impl import mcp_session_tool_function
 
 
 class _InputSchema(BaseModel):
@@ -160,3 +163,160 @@ async def test_mcp_client_function_group_no_include_exposes_all():
             accessible = await group.get_accessible_functions()
             sep = FunctionGroup.SEPARATOR
             assert set(accessible.keys()) == {f"mcp_client{sep}a", f"mcp_client{sep}b"}
+
+
+def _make_group(server_cfg=None, client_cfg=None):
+    """Create an MCPFunctionGroup with sensible defaults for unit tests."""
+    if server_cfg is None:
+        server_cfg = MCPServerConfig(transport="stdio", command="python", args=["server.py"])
+    if client_cfg is None:
+        client_cfg = MCPClientConfig(server=server_cfg)
+    return MCPFunctionGroup(config=client_cfg)
+
+
+class TestSessionToolDefaultUserPath:
+    """Tests for mcp_session_tool_function when routed through the default-user (base-client) path."""
+
+    async def test_returns_unavailable_when_base_client_is_none(self):
+        """mcp_client is None -> graceful unavailable message."""
+        tool = _FakeTool("health")
+        group = _make_group()
+        group.mcp_client = None
+
+        fn_info = mcp_session_tool_function(tool, group)
+        result = await fn_info.single_fn(_InputSchema(param="x"))
+
+        assert result == "Tool temporarily unavailable. Try again."
+
+    async def test_returns_unavailable_when_base_client_disconnected(self):
+        """mcp_client exists but is_connected is False -> graceful unavailable message.
+
+        This is the scenario from the original bug: the client object is non-None
+        but _exit_stack is None (e.g. after __aexit__ during shutdown).
+        """
+        tool = _FakeTool("health")
+        group = _make_group()
+
+        fake_client = _FakeMCPClient(tools={"health": _FakeTool("health")})
+        group.mcp_client = fake_client
+        assert not fake_client.is_connected
+
+        fn_info = mcp_session_tool_function(tool, group)
+        result = await fn_info.single_fn(_InputSchema(param="x"))
+
+        assert result == "Tool temporarily unavailable. Try again."
+
+    async def test_invokes_tool_when_connected(self):
+        """Connected base client -> tool is invoked and result returned."""
+        tool = _FakeTool("health")
+        group = _make_group()
+
+        fake_client = _FakeMCPClient(tools={"health": _FakeTool("health")})
+        async with fake_client:
+            group.mcp_client = fake_client
+            assert fake_client.is_connected
+
+            fn_info = mcp_session_tool_function(tool, group)
+            result = await fn_info.single_fn(_InputSchema(param="ping"))
+
+            assert result == "ok ping"
+
+
+class TestSessionToolSessionPath:
+    """Tests for mcp_session_tool_function when routed through the per-session path."""
+
+    @pytest.fixture
+    def session_group(self):
+        """Create a group configured for the session path (auth provider present)."""
+        group = _make_group()
+        group._shared_auth_provider = MagicMock()
+        group._default_user_id = "default-user"
+        group._client_config = MagicMock()
+        group._client_config.session_aware_tools = False
+        return group
+
+    async def test_returns_unavailable_when_session_client_is_none(self, session_group):
+        """Session context yields None -> graceful unavailable message."""
+        tool = _FakeTool("health")
+
+        @asynccontextmanager
+        async def fake_ctx(session_id):
+            yield None
+
+        with patch.object(session_group, '_get_session_id_from_context', return_value="sess-1"):
+            with patch.object(session_group, '_session_usage_context', fake_ctx):
+                fn_info = mcp_session_tool_function(tool, session_group)
+                result = await fn_info.single_fn(_InputSchema(param="x"))
+
+        assert result == "Tool temporarily unavailable. Try again."
+
+    async def test_returns_unavailable_when_session_client_disconnected(self, session_group):
+        """Session client exists but is_connected is False -> graceful unavailable message."""
+        tool = _FakeTool("health")
+        disconnected_client = _FakeMCPClient(tools={})
+
+        @asynccontextmanager
+        async def fake_ctx(session_id):
+            yield disconnected_client
+
+        with patch.object(session_group, '_get_session_id_from_context', return_value="sess-1"):
+            with patch.object(session_group, '_session_usage_context', fake_ctx):
+                fn_info = mcp_session_tool_function(tool, session_group)
+                result = await fn_info.single_fn(_InputSchema(param="x"))
+
+        assert result == "Tool temporarily unavailable. Try again."
+
+    async def test_invokes_tool_when_connected(self, session_group):
+        """Connected session client -> tool is invoked and result returned."""
+        tool = _FakeTool("health")
+        fake_client = _FakeMCPClient(tools={"health": _FakeTool("health")})
+
+        @asynccontextmanager
+        async def fake_ctx(session_id):
+            async with fake_client:
+                yield fake_client
+
+        with patch.object(session_group, '_get_session_id_from_context', return_value="sess-1"):
+            with patch.object(session_group, '_session_usage_context', fake_ctx):
+                fn_info = mcp_session_tool_function(tool, session_group)
+                result = await fn_info.single_fn(_InputSchema(param="ping"))
+
+        assert result == "ok ping"
+
+    async def test_tool_call_executes_inside_session_context(self, session_group):
+        """Verify acall runs while the session usage context is still active.
+
+        This guards against the original scoping bug where session_tool.acall()
+        was invoked after the context manager had already decremented ref_count.
+        """
+        tool = _FakeTool("health")
+        context_active = False
+        acall_was_inside_context = None
+
+        class _TrackingTool:
+            name = "health"
+            description = "desc"
+            input_schema = _InputSchema
+
+            async def acall(self, args):
+                nonlocal acall_was_inside_context
+                acall_was_inside_context = context_active
+                return f"ok {args['param']}"
+
+        fake_client = _FakeMCPClient(tools={"health": _TrackingTool()})
+
+        @asynccontextmanager
+        async def tracking_ctx(session_id):
+            nonlocal context_active
+            async with fake_client:
+                context_active = True
+                yield fake_client
+            context_active = False
+
+        with patch.object(session_group, '_get_session_id_from_context', return_value="sess-1"):
+            with patch.object(session_group, '_session_usage_context', tracking_ctx):
+                fn_info = mcp_session_tool_function(tool, session_group)
+                result = await fn_info.single_fn(_InputSchema(param="ping"))
+
+        assert result == "ok ping"
+        assert acall_was_inside_context is True


### PR DESCRIPTION
## Description
During MCP client reauth, we do not ensure there is a new, valid connection. Guard this in the following way:
- Add a new `is_connected` property
- Extend the lifetime of a tool while in use (`get_tool` + `acall`)

Adds exhaustive testing for scenarios.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `is_connected` property to check if an active connection is established

* **Improvements**
  * Enhanced tool invocation with improved session-aware routing and stricter connectivity validation before execution
  * Improved session context handling for per-session tool calls

<!-- end of auto-generated comment: release notes by coderabbit.ai -->