### PR TITLE
Resolve user ID from configurable HTTP header

### DIFF
--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_config.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_config.py
@@ -142,6 +142,8 @@ class MCPClientConfig(MCPClientBaseConfig, name="mcp_client"):
     """
     session_aware_tools: bool = Field(default=True,
                                       description="Session-aware tools are created if True. Defaults to True.")
+    auth_token_header: str | None = Field(
+        default=None, description="HTTP header name containing a token used for user identification.")
     max_sessions: int = Field(default=100,
                               ge=1,
                               description="Maximum number of concurrent session clients. Defaults to 100.")

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_impl.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_impl.py
@@ -253,6 +253,32 @@ class MCPFunctionGroup(FunctionGroup):
         except Exception:
             return None
 
+    def _resolve_user_id_from_auth_header(self) -> str | None:
+        """Extract a JWT from the configured HTTP header and resolve the user ID from its claims."""
+        if not self._client_config or not self._client_config.auth_token_header:
+            return None
+
+        from nat.builder.context import Context as _Ctx
+        from nat.runtime.connection_auth import resolve_user_id
+
+        headers = getattr(_Ctx.get().metadata, "headers", None)
+        if headers is None:
+            return None
+
+        user_auth_header: str | None = headers.get(self._client_config.auth_token_header)
+        if not user_auth_header:
+            return None
+
+        user_id: str | None = resolve_user_id(user_auth_header, {})
+        if not user_id:
+            logger.warning("Could not resolve user ID from header '%s'", self._client_config.auth_token_header)
+            return None
+
+        logger.debug("Resolved user_id '%s' from header '%s'",
+                     truncate_session_id(user_id),
+                     self._client_config.auth_token_header)
+        return user_id
+
     async def cleanup_sessions(self, max_age: timedelta | None = None) -> int:
         """
         Manually trigger cleanup of inactive sessions.
@@ -516,7 +542,10 @@ def mcp_session_tool_function(tool, function_group: MCPFunctionGroup):
         """Response function for the session-aware tool."""
         try:
             # Route to the appropriate session client
-            session_id = function_group._get_session_id_from_context()
+            if (function_group._client_config and function_group._client_config.auth_token_header):
+                session_id = function_group._resolve_user_id_from_auth_header()
+            else:
+                session_id = function_group._get_session_id_from_context()
 
             # If no session is available and default-user fallback is disabled, deny the call
             if function_group._shared_auth_provider and session_id is None:

--- a/packages/nvidia_nat_mcp/tests/client/test_mcp_client_impl.py
+++ b/packages/nvidia_nat_mcp/tests/client/test_mcp_client_impl.py
@@ -18,6 +18,7 @@ from typing import Any
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import jwt
 import pytest
 from pydantic import BaseModel
 
@@ -174,6 +175,22 @@ def _make_group(server_cfg=None, client_cfg=None):
     return MCPFunctionGroup(config=client_cfg)
 
 
+@patch("nat.builder.context.Context")
+def test_resolve_user_id_from_auth_header(mock_context_cls):
+    """When auth_token_header is configured, user ID is resolved from JWT claims."""
+    token: str = jwt.encode({"name": "Alice", "sub": "alice-123"}, "a" * 32, algorithm="HS256")
+    ctx = MagicMock()
+    ctx.metadata.headers = {"Authorization": f"Bearer {token}"}
+    mock_context_cls.get.return_value = ctx
+
+    server_cfg = MCPServerConfig(transport="streamable-http", url="http://localhost:9901/mcp")
+    client_cfg = MCPClientConfig(server=server_cfg, auth_token_header="Authorization")
+    group = MCPFunctionGroup(config=client_cfg)
+    group._client_config = client_cfg
+
+    assert group._resolve_user_id_from_auth_header() == "Alice"
+
+
 class TestSessionToolDefaultUserPath:
     """Tests for mcp_session_tool_function when routed through the default-user (base-client) path."""
 
@@ -233,6 +250,7 @@ class TestSessionToolSessionPath:
         group._default_user_id = "default-user"
         group._client_config = MagicMock()
         group._client_config.session_aware_tools = False
+        group._client_config.auth_token_header = None
         return group
 
     async def test_returns_unavailable_when_session_client_is_none(self, session_group):


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
Adds `auth_token_header` config field to `MCPClientConfig` that specifies an HTTP header containing a JWT for user identification. When set, the user ID is extracted from JWT claims and used as the per-user session key, as an alternative to the `nat-session` cookie. Authentication with the MCP server still proceeds through the normal OAuth flow.

This supports deployments where an upstream service sends the user's identity as a JWT in an HTTP header (e.g., `Authorization`) rather than a session cookie, such as HTTP streaming scenarios.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for HTTP header–based authentication using JWTs to improve user identification and session routing
  * New configuration option to specify which HTTP header contains authentication tokens for routing decisions

* **Tests**
  * Added test coverage for JWT-based authentication header resolution
<!-- end of auto-generated comment: release notes by coderabbit.ai -->