### PR TITLE
fix: update openpipe-art accuracy reward logic

### DIFF
--- a/examples/finetuning/rl_with_openpipe_art/src/rl_with_openpipe_art/accuracy_evaluator.py
+++ b/examples/finetuning/rl_with_openpipe_art/src/rl_with_openpipe_art/accuracy_evaluator.py
@@ -42,6 +42,11 @@ class AccuracyEvaluator(BaseEvaluator):
         gamma_base: float = 0.8,
         delta_bonus: float = 0.95,
     ) -> float:
+        if not (0.0 < gamma_base <= 1.0):
+            raise ValueError(f"gamma_base must be in (0, 1], got {gamma_base}")
+        if not (0.0 < delta_bonus <= 1.0):
+            raise ValueError(f"delta_bonus must be in (0, 1], got {delta_bonus}")
+
         s = np.asarray(state_values, dtype=float)
         T = len(s) - 1
         assert T >= 0
@@ -51,7 +56,9 @@ class AccuracyEvaluator(BaseEvaluator):
         bonus = np.maximum(s - 1.0, 0.0)
 
         # 2) Reverse-discounted base in [0,1]
-        exponents = np.arange(T, -1, -1)  # T, T-1, ..., 0
+        #    exponents = [0, 1, ..., T] so that earlier steps (index 0) get
+        #    weight gamma^0 = 1 (largest) and later steps get gamma^T (smallest).
+        exponents = np.arange(0, T + 1)  # 0, 1, ..., T
         w = gamma_base**exponents
         w = w / w.sum()
         R_base = float(np.dot(w, base))  # in [0,1]


### PR DESCRIPTION
## Description
Fixes a bug in the episode_value_from_states method where the time-decay exponents were computed in reverse order, causing earlier steps to receive less weight instead of more.

### Changes

- Fixed exponent order: Changed `np.arange(T, -1, -1)` to `np.arange(0, T + 1)` so that earlier steps (index 0) get weight γ⁰ = 1 (largest) and later steps get weight γᵀ (smallest)
- Added parameter validation: Added bounds checking for `gamma_base` and `delta_bonus` to ensure they fall within valid ranges (0, 1]

Closes #1613

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Implemented parameter validation to ensure reinforcement learning configuration values remain within valid ranges, raising errors for invalid inputs.

* **Refactor**
  * Modified reward weighting calculation methodology to use forward exponential decay instead of reverse decay, affecting how historical rewards contribute to final episode values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->