### PR TITLE
fix: Pass request_timeout through to OpenAI/Azure LLM clients

### DIFF
--- a/docs/source/build-workflows/llms/index.md
+++ b/docs/source/build-workflows/llms/index.md
@@ -97,6 +97,7 @@ The OpenAI LLM provider is defined by the {py:class}`~nat.llm.openai_llm.OpenAIM
 * `api_key` - The API key to use for the model
 * `base_url` - The base URL to use for the model
 * `max_retries` - The maximum number of retries for the request
+* `request_timeout` - HTTP request timeout in seconds
 
 :::{note}
 `temperature` and `top_p` are model-gated fields and may not be supported by all models. If unsupported and explicitly set, validation will fail. See [Gated Fields](../../extend/custom-components/gated-fields.md) for details.
@@ -133,6 +134,7 @@ The Azure OpenAI LLM provider is defined by the {py:class}`~nat.llm.azure_openai
 * `top_p` - The top-p value to use for the model
 * `seed` - The seed to use for the model
 * `max_retries` - The maximum number of retries for the request
+* `request_timeout` - HTTP request timeout in seconds
 
 :::{note}
 `temperature` is model-gated and may not be supported by all models. See [Gated Fields](../../extend/custom-components/gated-fields.md) for details.

--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/llm.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/llm.py
@@ -43,7 +43,15 @@ async def azure_openai_adk(config: AzureOpenAIModelConfig, _builder: Builder):
 
     config_dict = config.model_dump(
         exclude={
-            "type", "max_retries", "thinking", "azure_endpoint", "azure_deployment", "model_name", "model", "api_type"
+            "type",
+            "max_retries",
+            "thinking",
+            "azure_endpoint",
+            "azure_deployment",
+            "model_name",
+            "model",
+            "api_type",
+            "request_timeout"
         },
         by_alias=True,
         exclude_none=True,
@@ -51,6 +59,8 @@ async def azure_openai_adk(config: AzureOpenAIModelConfig, _builder: Builder):
     )
     if config.azure_endpoint:
         config_dict["api_base"] = config.azure_endpoint
+    if config.request_timeout is not None:
+        config_dict["timeout"] = config.request_timeout
 
     config_dict["api_version"] = config.api_version
 
@@ -116,7 +126,7 @@ async def openai_adk(config: OpenAIModelConfig, _builder: Builder):
     validate_no_responses_api(config, LLMFrameworkEnum.ADK)
 
     config_dict = config.model_dump(
-        exclude={"type", "max_retries", "thinking", "model_name", "model", "base_url", "api_type"},
+        exclude={"type", "max_retries", "thinking", "model_name", "model", "base_url", "api_type", "request_timeout"},
         by_alias=True,
         exclude_none=True,
         exclude_unset=True,
@@ -126,6 +136,8 @@ async def openai_adk(config: OpenAIModelConfig, _builder: Builder):
         config_dict["api_key"] = api_key
     if (base_url := config.base_url or os.getenv("OPENAI_BASE_URL")):
         config_dict["api_base"] = base_url
+    if config.request_timeout is not None:
+        config_dict["timeout"] = config.request_timeout
 
     yield LiteLlm(config.model_name, **config_dict)
 

--- a/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
+++ b/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
@@ -108,7 +108,7 @@ async def openai_agno(llm_config: OpenAIModelConfig, _builder: Builder):
 
     config_obj = {
         **llm_config.model_dump(
-            exclude={"type", "model_name", "thinking", "api_type", "api_key", "base_url"},
+            exclude={"type", "model_name", "thinking", "api_type", "api_key", "base_url", "request_timeout"},
             by_alias=True,
             exclude_none=True,
             exclude_unset=True,
@@ -119,6 +119,8 @@ async def openai_agno(llm_config: OpenAIModelConfig, _builder: Builder):
         config_obj["api_key"] = api_key
     if (base_url := llm_config.base_url or os.getenv("OPENAI_BASE_URL")):
         config_obj["base_url"] = base_url
+    if llm_config.request_timeout is not None:
+        config_obj["timeout"] = llm_config.request_timeout
 
     if llm_config.api_type == APITypeEnum.RESPONSES:
         client = OpenAIResponses(**config_obj, id=llm_config.model_name)

--- a/packages/nvidia_nat_autogen/src/nat/plugins/autogen/llm.py
+++ b/packages/nvidia_nat_autogen/src/nat/plugins/autogen/llm.py
@@ -147,7 +147,7 @@ async def openai_autogen(llm_config: OpenAIModelConfig, _builder: Builder) -> As
     # Extract AutoGen-compatible configuration
     config_obj = {
         **llm_config.model_dump(
-            exclude={"type", "model_name", "thinking", "api_key", "base_url"},
+            exclude={"type", "model_name", "thinking", "api_key", "base_url", "request_timeout"},
             by_alias=True,
             exclude_none=True,
         ),
@@ -157,6 +157,8 @@ async def openai_autogen(llm_config: OpenAIModelConfig, _builder: Builder) -> As
         config_obj["api_key"] = api_key
     if (base_url := llm_config.base_url or os.getenv("OPENAI_BASE_URL")):
         config_obj["base_url"] = base_url
+    if llm_config.request_timeout is not None:
+        config_obj["timeout"] = llm_config.request_timeout
 
     # Define model info for AutoGen 0.7.4 (replaces model_capabilities)
     model_info = ModelInfo(vision=False,
@@ -204,11 +206,14 @@ async def azure_openai_autogen(llm_config: AzureOpenAIModelConfig,
         "api_version":
             llm_config.api_version,
         **llm_config.model_dump(
-            exclude={"type", "azure_deployment", "thinking", "azure_endpoint", "api_version"},
+            exclude={"type", "azure_deployment", "thinking", "azure_endpoint", "api_version", "request_timeout"},
             by_alias=True,
             exclude_none=True,
         ),
     }
+
+    if llm_config.request_timeout is not None:
+        config_obj["timeout"] = llm_config.request_timeout
 
     model_info = ModelInfo(vision=False,
                            function_calling=True,

--- a/packages/nvidia_nat_core/src/nat/llm/azure_openai_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/azure_openai_llm.py
@@ -59,6 +59,7 @@ class AzureOpenAIModelConfig(
                                            le=1.0,
                                            description="Top-p for distribution sampling.",
                                            space=SearchSpace(high=1.0, low=0.5, step=0.1))
+    request_timeout: float | None = Field(default=None, gt=0.0, description="HTTP request timeout in seconds.")
 
     @computed_field
     @property

--- a/packages/nvidia_nat_core/src/nat/llm/openai_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/openai_llm.py
@@ -51,6 +51,7 @@ class OpenAIModelConfig(LLMBaseConfig, RetryMixin, OptimizableMixin, ThinkingMix
                                            le=1.0,
                                            description="Top-p for distribution sampling.",
                                            space=SearchSpace(high=1.0, low=0.5, step=0.1))
+    request_timeout: float | None = Field(default=None, gt=0.0, description="HTTP request timeout in seconds.")
 
 
 @register_llm_provider(config_type=OpenAIModelConfig)

--- a/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
+++ b/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
@@ -96,13 +96,26 @@ async def azure_openai_crewai(llm_config: AzureOpenAIModelConfig, _builder: Buil
     if model is None:
         raise ValueError("Azure model deployment is not set")
 
+    config_dict = llm_config.model_dump(
+        exclude={
+            "type",
+            "api_key",
+            "azure_endpoint",
+            "azure_deployment",
+            "thinking",
+            "api_type",
+            "api_version",
+            "request_timeout"
+        },
+        by_alias=True,
+        exclude_none=True,
+        exclude_unset=True,
+    )
+    if llm_config.request_timeout is not None:
+        config_dict["timeout"] = llm_config.request_timeout
+
     client = LLM(
-        **llm_config.model_dump(
-            exclude={"type", "api_key", "azure_endpoint", "azure_deployment", "thinking", "api_type", "api_version"},
-            by_alias=True,
-            exclude_none=True,
-            exclude_unset=True,
-        ),
+        **config_dict,
         model=model,
         api_version=llm_config.api_version,
     )
@@ -144,7 +157,7 @@ async def openai_crewai(llm_config: OpenAIModelConfig, _builder: Builder):
     validate_no_responses_api(llm_config, LLMFrameworkEnum.CREWAI)
 
     config_dict = llm_config.model_dump(
-        exclude={"type", "thinking", "api_type", "api_key", "base_url"},
+        exclude={"type", "thinking", "api_type", "api_key", "base_url", "request_timeout"},
         by_alias=True,
         exclude_none=True,
         exclude_unset=True,
@@ -154,6 +167,8 @@ async def openai_crewai(llm_config: OpenAIModelConfig, _builder: Builder):
         config_dict["api_key"] = api_key
     if (base_url := llm_config.base_url or os.getenv("OPENAI_BASE_URL")):
         config_dict["base_url"] = base_url
+    if llm_config.request_timeout is not None:
+        config_dict["timeout"] = llm_config.request_timeout
 
     client = LLM(**config_dict)
 

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -153,13 +153,11 @@ async def azure_openai_langchain(llm_config: AzureOpenAIModelConfig, _builder: B
     http_async_client: httpx.AsyncClient = create_metadata_injection_client(**client_kwargs)
 
     config_dict = llm_config.model_dump(
-        exclude={"type", "thinking", "api_type", "api_version", "request_timeout"},
+        exclude={"type", "thinking", "api_type", "api_version"},
         by_alias=True,
         exclude_none=True,
         exclude_unset=True,
     )
-    if llm_config.request_timeout is not None:
-        config_dict["request_timeout"] = llm_config.request_timeout
 
     try:
         client = AzureChatOpenAI(
@@ -207,13 +205,11 @@ async def openai_langchain(llm_config: OpenAIModelConfig, _builder: Builder):
     http_async_client: httpx.AsyncClient = create_metadata_injection_client(**client_kwargs)
 
     config_dict = llm_config.model_dump(
-        exclude={"type", "thinking", "api_type", "api_key", "base_url", "request_timeout"},
+        exclude={"type", "thinking", "api_type", "api_key", "base_url"},
         by_alias=True,
         exclude_none=True,
         exclude_unset=True,
     )
-    if llm_config.request_timeout is not None:
-        config_dict["request_timeout"] = llm_config.request_timeout
     if (api_key := get_secret_value(llm_config.api_key) or os.getenv("OPENAI_API_KEY")):
         config_dict["api_key"] = api_key
     if (base_url := llm_config.base_url or os.getenv("OPENAI_BASE_URL")):

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -152,18 +152,16 @@ async def azure_openai_langchain(llm_config: AzureOpenAIModelConfig, _builder: B
         client_kwargs["timeout"] = llm_config.request_timeout
     http_async_client: httpx.AsyncClient = create_metadata_injection_client(**client_kwargs)
 
-    config_dict = llm_config.model_dump(
-        exclude={"type", "thinking", "api_type", "api_version", "request_timeout"},
-        by_alias=True,
-        exclude_none=True,
-        exclude_unset=True,
-    )
-
     try:
         client = AzureChatOpenAI(
             http_async_client=http_async_client,  # type: ignore[call-arg]
             api_version=llm_config.api_version,  # type: ignore[call-arg]
-            **config_dict,
+            **llm_config.model_dump(
+                exclude={"type", "thinking", "api_type", "api_version"},
+                by_alias=True,
+                exclude_none=True,
+                exclude_unset=True,
+            ),
         )
         if "http_async_client" in client.model_kwargs:
             del client.model_kwargs["http_async_client"]
@@ -205,7 +203,7 @@ async def openai_langchain(llm_config: OpenAIModelConfig, _builder: Builder):
     http_async_client: httpx.AsyncClient = create_metadata_injection_client(**client_kwargs)
 
     config_dict = llm_config.model_dump(
-        exclude={"type", "thinking", "api_type", "api_key", "base_url", "request_timeout"},
+        exclude={"type", "thinking", "api_type", "api_key", "base_url"},
         by_alias=True,
         exclude_none=True,
         exclude_unset=True,

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -153,7 +153,7 @@ async def azure_openai_langchain(llm_config: AzureOpenAIModelConfig, _builder: B
     http_async_client: httpx.AsyncClient = create_metadata_injection_client(**client_kwargs)
 
     config_dict = llm_config.model_dump(
-        exclude={"type", "thinking", "api_type", "api_version"},
+        exclude={"type", "thinking", "api_type", "api_version", "request_timeout"},
         by_alias=True,
         exclude_none=True,
         exclude_unset=True,
@@ -205,7 +205,7 @@ async def openai_langchain(llm_config: OpenAIModelConfig, _builder: Builder):
     http_async_client: httpx.AsyncClient = create_metadata_injection_client(**client_kwargs)
 
     config_dict = llm_config.model_dump(
-        exclude={"type", "thinking", "api_type", "api_key", "base_url"},
+        exclude={"type", "thinking", "api_type", "api_key", "base_url", "request_timeout"},
         by_alias=True,
         exclude_none=True,
         exclude_unset=True,

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -147,16 +147,25 @@ async def azure_openai_langchain(llm_config: AzureOpenAIModelConfig, _builder: B
 
     validate_no_responses_api(llm_config, LLMFrameworkEnum.LANGCHAIN)
 
-    http_async_client: httpx.AsyncClient = create_metadata_injection_client()
+    client_kwargs: dict = {}
+    if llm_config.request_timeout is not None:
+        client_kwargs["timeout"] = llm_config.request_timeout
+    http_async_client: httpx.AsyncClient = create_metadata_injection_client(**client_kwargs)
+
+    config_dict = llm_config.model_dump(
+        exclude={"type", "thinking", "api_type", "api_version", "request_timeout"},
+        by_alias=True,
+        exclude_none=True,
+        exclude_unset=True,
+    )
+    if llm_config.request_timeout is not None:
+        config_dict["request_timeout"] = llm_config.request_timeout
 
     try:
         client = AzureChatOpenAI(
             http_async_client=http_async_client,  # type: ignore[call-arg]
-            **llm_config.model_dump(exclude={"type", "thinking", "api_type", "api_version"},
-                                    by_alias=True,
-                                    exclude_none=True,
-                                    exclude_unset=True),
             api_version=llm_config.api_version,  # type: ignore[call-arg]
+            **config_dict,
         )
         if "http_async_client" in client.model_kwargs:
             del client.model_kwargs["http_async_client"]
@@ -192,14 +201,19 @@ async def openai_langchain(llm_config: OpenAIModelConfig, _builder: Builder):
 
     from langchain_openai import ChatOpenAI
 
-    http_async_client: httpx.AsyncClient = create_metadata_injection_client()
+    client_kwargs: dict = {}
+    if llm_config.request_timeout is not None:
+        client_kwargs["timeout"] = llm_config.request_timeout
+    http_async_client: httpx.AsyncClient = create_metadata_injection_client(**client_kwargs)
 
     config_dict = llm_config.model_dump(
-        exclude={"type", "thinking", "api_type", "api_key", "base_url"},
+        exclude={"type", "thinking", "api_type", "api_key", "base_url", "request_timeout"},
         by_alias=True,
         exclude_none=True,
         exclude_unset=True,
     )
+    if llm_config.request_timeout is not None:
+        config_dict["request_timeout"] = llm_config.request_timeout
     if (api_key := get_secret_value(llm_config.api_key) or os.getenv("OPENAI_API_KEY")):
         config_dict["api_key"] = api_key
     if (base_url := llm_config.base_url or os.getenv("OPENAI_BASE_URL")):

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
@@ -102,11 +102,15 @@ async def azure_openai_llama_index(llm_config: AzureOpenAIModelConfig, _builder:
 
     validate_no_responses_api(llm_config, LLMFrameworkEnum.LLAMA_INDEX)
 
+    config_dict = llm_config.model_dump(exclude={"type", "thinking", "api_type", "api_version", "request_timeout"},
+                                        by_alias=True,
+                                        exclude_none=True,
+                                        exclude_unset=True)
+    if llm_config.request_timeout is not None:
+        config_dict["timeout"] = llm_config.request_timeout
+
     llm = AzureOpenAI(
-        **llm_config.model_dump(exclude={"type", "thinking", "api_type", "api_version"},
-                                by_alias=True,
-                                exclude_none=True,
-                                exclude_unset=True),
+        **config_dict,
         api_version=llm_config.api_version,
     )
 
@@ -133,7 +137,7 @@ async def openai_llama_index(llm_config: OpenAIModelConfig, _builder: Builder):
     from llama_index.llms.openai import OpenAIResponses
 
     config_dict = llm_config.model_dump(
-        exclude={"type", "thinking", "api_type", "api_key", "base_url"},
+        exclude={"type", "thinking", "api_type", "api_key", "base_url", "request_timeout"},
         by_alias=True,
         exclude_none=True,
         exclude_unset=True,
@@ -143,6 +147,8 @@ async def openai_llama_index(llm_config: OpenAIModelConfig, _builder: Builder):
         config_dict["api_key"] = api_key
     if (base_url := llm_config.base_url or os.getenv("OPENAI_BASE_URL")):
         config_dict["base_url"] = base_url
+    if llm_config.request_timeout is not None:
+        config_dict["timeout"] = llm_config.request_timeout
 
     if llm_config.api_type == APITypeEnum.RESPONSES:
         llm = OpenAIResponses(**config_dict)

--- a/packages/nvidia_nat_strands/src/nat/plugins/strands/llm.py
+++ b/packages/nvidia_nat_strands/src/nat/plugins/strands/llm.py
@@ -161,7 +161,7 @@ async def openai_strands(llm_config: OpenAIModelConfig, _builder: Builder) -> As
     from strands.models.openai import OpenAIModel
 
     params = llm_config.model_dump(
-        exclude={"type", "api_type", "api_key", "base_url", "model_name", "max_retries", "thinking"},
+        exclude={"type", "api_type", "api_key", "base_url", "model_name", "max_retries", "thinking", "request_timeout"},
         by_alias=True,
         exclude_none=True,
         exclude_unset=True)
@@ -169,11 +169,15 @@ async def openai_strands(llm_config: OpenAIModelConfig, _builder: Builder) -> As
     api_key = get_secret_value(llm_config.api_key) or os.getenv("OPENAI_API_KEY")
     base_url = llm_config.base_url or os.getenv("OPENAI_BASE_URL")
 
+    client_args: dict[str, Any] = {
+        "api_key": api_key,
+        "base_url": base_url,
+    }
+    if llm_config.request_timeout is not None:
+        client_args["timeout"] = llm_config.request_timeout
+
     client = OpenAIModel(
-        client_args={
-            "api_key": api_key,
-            "base_url": base_url,
-        },
+        client_args=client_args,
         model_id=llm_config.model_name,
         params=params,
     )


### PR DESCRIPTION
## Summary

Fixes #1617

I noticed that the `create_metadata_injection_client()` httpx timeout was getting silently overridden by LangChain/OpenAI SDK behavior. When `ChatOpenAI` passes `timeout=None` (its default for `request_timeout`), the OpenAI SDK treats that as an explicit "no timeout" rather than falling back to the httpx client's timeout. This means LLM requests can hang indefinitely regardless of what timeout is configured on the httpx client.

The Dynamo provider already handles this correctly with its own `request_timeout` field, so I followed the same pattern for OpenAI and Azure OpenAI:

- Added `request_timeout` field to `OpenAIModelConfig` and `AzureOpenAIModelConfig` (defaults to `None` to preserve current behavior)
- When set, the timeout is passed to both `create_metadata_injection_client()` and the `ChatOpenAI`/`AzureChatOpenAI` constructor via LangChain's `request_timeout` parameter
- Updated the LLM docs to document the new field

I validated the fix locally by confirming:
1. Without `request_timeout` set, behavior is unchanged (SDK defaults apply)
2. With `request_timeout` set, the timeout is properly enforced at both the httpx and SDK layers

## Test plan

- [ ] Verify `request_timeout` is properly passed through to the OpenAI SDK for both providers
- [ ] Verify default behavior is preserved when `request_timeout` is not set
- [ ] Existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable request_timeout for OpenAI and Azure OpenAI providers; supported integrations now propagate and honor this HTTP request timeout when set, improving control over LLM call latency and failures.

* **Documentation**
  * Updated provider documentation to describe the new timeout setting and how to configure and use it.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->