### PR TITLE
fix: Skip output directory cleanup when --skip_workflow is set

### DIFF
--- a/packages/nvidia_nat_eval/src/nat/plugins/eval/runtime/evaluate.py
+++ b/packages/nvidia_nat_eval/src/nat/plugins/eval/runtime/evaluate.py
@@ -585,9 +585,11 @@ class EvaluationRun:
         workflow_alias = self._get_workflow_alias(config.workflow.type)
         logger.debug("Loaded %s evaluation configuration: %s", workflow_alias, self.eval_config)
 
-        # Cleanup the output directory
-        if self.eval_config.general.output:
+        # Cleanup the output directory (skip when reusing existing workflow output)
+        if self.eval_config.general.output and not self.config.skip_workflow:
             self.cleanup_output_directory()
+        elif self.config.skip_workflow:
+            logger.info("Skipping output directory cleanup because --skip_workflow is set")
 
         # Generate a job_id if append_job_id_to_output_dir is enabled and no job_id provided
         if (self.eval_config.general.output

--- a/packages/nvidia_nat_eval/src/nat/plugins/eval/runtime/evaluate.py
+++ b/packages/nvidia_nat_eval/src/nat/plugins/eval/runtime/evaluate.py
@@ -586,10 +586,11 @@ class EvaluationRun:
         logger.debug("Loaded %s evaluation configuration: %s", workflow_alias, self.eval_config)
 
         # Cleanup the output directory (skip when reusing existing workflow output)
-        if self.eval_config.general.output and not self.config.skip_workflow:
-            self.cleanup_output_directory()
-        elif self.config.skip_workflow:
-            logger.info("Skipping output directory cleanup because --skip_workflow is set")
+        if self.eval_config.general.output:
+            if self.config.skip_workflow:
+                logger.info("Skipping output directory cleanup because --skip_workflow is set")
+            else:
+                self.cleanup_output_directory()
 
         # Generate a job_id if append_job_id_to_output_dir is enabled and no job_id provided
         if (self.eval_config.general.output


### PR DESCRIPTION
## Summary

Fixes #1587

I ran into this while testing eval workflows: running `nat eval --skip_workflow` without `--dataset` was silently deleting the `workflow_output.json` from a previous run. The cleanup step in `run_and_evaluate()` runs before the dataset is loaded, so by the time the code tries to load the previous output, it's already been wiped by `shutil.rmtree()`.

Since `--skip_workflow` exists specifically to reuse existing workflow output, it doesn't make sense to clean up the output directory when that flag is set. This change skips cleanup when `--skip_workflow` is active and logs an info message explaining why.

Normal eval behavior (without `--skip_workflow`) is unchanged.

## Test plan

- [ ] Run `nat eval` normally, confirm output directory cleanup still works
- [ ] Run `nat eval --skip_workflow` after a previous run, confirm `workflow_output.json` is preserved
- [ ] Existing eval tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected output directory cleanup so it is skipped when the workflow is intentionally bypassed, preserving generated files.
  * Added user-facing logs that indicate when cleanup operations are being skipped to improve transparency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->