### PR TITLE
fix: Preserve custom dataset fields in workflow output

### DIFF
--- a/packages/nvidia_nat_eval/src/nat/plugins/eval/dataset_handler/dataset_handler.py
+++ b/packages/nvidia_nat_eval/src/nat/plugins/eval/dataset_handler/dataset_handler.py
@@ -417,8 +417,10 @@ class DatasetHandler:
 
         indent = 2
         if self.is_structured_input():
-            # Extract structured data from EvalInputItems
+            # Extract structured data from EvalInputItems, preserving any additional
+            # fields from the original dataset so they survive --skip_workflow round-trips.
             data = [{
+                **(item.full_dataset_entry if isinstance(item.full_dataset_entry, dict) else {}),
                 self.id_key: item.id,
                 self.question_key: item.input_obj,
                 self.answer_key: item.expected_output_obj,


### PR DESCRIPTION
## Summary

Fixes #1385

When using `--skip_workflow` to re-run evaluators on existing output, custom dataset fields like `difficulty` and `category` were getting dropped from `full_dataset_entry`. This happened because `publish_eval_input()` only wrote the 6 structured keys to `workflow_output.json`, discarding everything else.

The fix merges `full_dataset_entry` as the base dict before overlaying the structured keys, so custom fields are preserved while structured fields still take precedence.

## Validation

Wrote a reproduction script that confirms:
1. **Before fix**: `workflow_output.json` only contains `[id, question, answer, generated_answer, intermediate_steps, expected_intermediate_steps]` -- custom fields like `difficulty`, `category`, `tags` are missing
2. **After fix**: all custom fields are preserved in `workflow_output.json` and survive the `--skip_workflow` reload
3. Structured fields (like `generated_answer`) still override any stale values from `full_dataset_entry`

All existing tests pass (10 dataset handler tests + 23 evaluate tests).

## Test plan

- [x] Reproduce bug: custom fields missing from `full_dataset_entry` when using `--skip_workflow`
- [x] Validate fix: custom fields preserved after round-trip through `publish_eval_input()` 
- [x] Existing test suite passes
- [x] ruff + yapf clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed data preservation in structured input processing to ensure additional dataset fields are now retained during workflow operations and round-trip processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->