### PR TITLE
fix: Filter empty LLM responses from ReAct retry scratchpad

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
@@ -276,7 +276,10 @@ class ReActAgentGraph(DualNodeAgent):
                         return state
                     # retry parsing errors, if configured
                     logger.info("%s Retrying ReAct Agent, including output parsing Observation", AGENT_LOG_PREFIX)
-                    working_state.append(output_message)
+                    # Only append non-empty messages to prevent LLM 400 errors
+                    # when empty content is forwarded via agent_scratchpad (#1611)
+                    if output_message.content and str(output_message.content).strip():
+                        working_state.append(output_message)
                     working_state.append(HumanMessage(content=str(ex.observation)))
         except Exception as ex:
             logger.error("%s Failed to call agent_node: %s", AGENT_LOG_PREFIX, ex)


### PR DESCRIPTION
## Summary
- Fixes #1611 where asking the ReAct agent 3+ questions could trigger a 400 error from OpenAI/LiteLLM ("message content cannot be empty")
- When the LLM returns empty content during a ReAct cycle and parsing fails, the empty `AIMessage` was being appended to `working_state` and forwarded to the LLM on the next retry via `agent_scratchpad`
- Now we validate that `output_message.content` is non-empty before adding it to `working_state`. The error observation `HumanMessage` is still always appended so the retry mechanism works as before

## Test plan
- [x] Reproduced the bug: without the fix, empty `AIMessage` objects end up in `agent_scratchpad` (confirmed via test that checks scratchpad contents)
- [x] Validated the fix: empty messages are now filtered, while non-empty messages are still preserved for retry context
- [x] All 95 existing ReAct agent tests pass (`packages/nvidia_nat_langchain/tests/agent/test_react.py`)
- [x] ruff and yapf pass clean

Signed-off-by: Blake Ledden <bledden@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved system stability by fixing an issue in error recovery that could cause failures. Enhanced content validation during error handling reduces potential errors and improves overall reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->