### PR TITLE
Ensure that we allways spell vLLM with the same casing that the proje…

### DIFF
--- a/ci/vale/styles/config/vocabularies/nat/accept.txt
+++ b/ci/vale/styles/config/vocabularies/nat/accept.txt
@@ -201,8 +201,7 @@ URIs
 uv
 Vanna
 VectorDB
-[Vv]llm
-[Vv]LLM
+vLLM
 [Ww]alkthrough
 [Ww]eb[Ss]ocket
 XGBoost


### PR DESCRIPTION
## Description
* Remove alternate casing for vLLM, ensuring that we always spell the name the same way the project does https://docs.vllm.ai/en/latest/


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated spell-check vocabulary configuration to enforce standardized terminology capitalization, restricting accepted spellings to the canonical form only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->