### PR TITLE
improvement: nvext.agent_hints and nvext.cache_control clean up

### DIFF
--- a/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/configs/config_profile.yml
+++ b/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/configs/config_profile.yml
@@ -70,9 +70,8 @@ llms:
     max_sensitivity: 5
 
     # Dynamo nvext hints configuration
-    enable_nvext_hints: true
+    enable_nvext_hints: false
     nvext_prefix_id_template: "latency-demo-{uuid}"
-
     # Static fallback values (not used because baseline does not use agent hints)
     nvext_prefix_total_requests: 7
     nvext_prefix_osl: MEDIUM

--- a/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/configs/config_profile.yml
+++ b/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/configs/config_profile.yml
@@ -69,13 +69,14 @@ llms:
     max_tokens: 8192
     max_sensitivity: 5
 
-    # Dynamo prefix configuration
-    prefix_template: "latency-demo-{uuid}"
+    # Dynamo nvext hints configuration
+    enable_nvext_hints: true
+    nvext_prefix_id_template: "latency-demo-{uuid}"
 
     # Static fallback values (not used because baseline does not use agent hints)
-    prefix_total_requests: 7
-    prefix_osl: MEDIUM
-    prefix_iat: MEDIUM
+    nvext_prefix_total_requests: 7
+    nvext_prefix_osl: MEDIUM
+    nvext_prefix_iat: MEDIUM
 
 workflow:
   _type: latency_sensitivity_demo

--- a/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/configs/config_with_trie.yml
+++ b/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/configs/config_with_trie.yml
@@ -63,7 +63,7 @@ llms:
     max_sensitivity: 5
 
     # Dynamo nvext hints configuration
-    enable_nvext_hints: true
+    enable_nvext_hints: false
     nvext_prefix_id_template: "latency-demo-{uuid}"
 
     # Static fallback values (used if trie lookup fails)

--- a/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/configs/config_with_trie.yml
+++ b/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/configs/config_with_trie.yml
@@ -62,13 +62,14 @@ llms:
     max_tokens: 8192
     max_sensitivity: 5
 
-    # Dynamo prefix configuration
-    prefix_template: "latency-demo-{uuid}"
+    # Dynamo nvext hints configuration
+    enable_nvext_hints: true
+    nvext_prefix_id_template: "latency-demo-{uuid}"
 
     # Static fallback values (used if trie lookup fails)
-    prefix_total_requests: 7
-    prefix_osl: MEDIUM
-    prefix_iat: MEDIUM
+    nvext_prefix_total_requests: 7
+    nvext_prefix_osl: MEDIUM
+    nvext_prefix_iat: MEDIUM
 
     # UPDATE THIS PATH to your profiled prediction trie
     prediction_trie_path: ./examples/dynamo_integration/latency_sensitivity_demo/outputs/profile/prediction_trie.json

--- a/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/config_dynamo_adk_e2e_test.yml
+++ b/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/config_dynamo_adk_e2e_test.yml
@@ -59,9 +59,7 @@ llms:
     max_tokens: 1024
     
     # ===== DYNAMO NVEXT HINTS CONFIGURATION FOR ADK =====
-    # These headers are passed to LiteLLM via extra_headers
-    # All requests from this LLM instance will share the same prefix ID
-    enable_nvext_hints: true
+    enable_nvext_hints: false
     nvext_prefix_id_template: "adk-dynamo-test-{uuid}"
     nvext_prefix_total_requests: 5  # Expected tool calls per conversation
     nvext_prefix_osl: MEDIUM        # Output Sequence Length hint

--- a/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/config_dynamo_adk_e2e_test.yml
+++ b/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/config_dynamo_adk_e2e_test.yml
@@ -58,14 +58,15 @@ llms:
     temperature: 0.0
     max_tokens: 1024
     
-    # ===== DYNAMO PREFIX CONFIGURATION FOR ADK =====
+    # ===== DYNAMO NVEXT HINTS CONFIGURATION FOR ADK =====
     # These headers are passed to LiteLLM via extra_headers
     # All requests from this LLM instance will share the same prefix ID
-    prefix_template: "adk-dynamo-test-{uuid}"
-    prefix_total_requests: 5  # Expected tool calls per conversation
-    prefix_osl: MEDIUM        # Output Sequence Length hint
-    prefix_iat: MEDIUM        # Inter-Arrival Time hint
-    # ================================================
+    enable_nvext_hints: true
+    nvext_prefix_id_template: "adk-dynamo-test-{uuid}"
+    nvext_prefix_total_requests: 5  # Expected tool calls per conversation
+    nvext_prefix_osl: MEDIUM        # Output Sequence Length hint
+    nvext_prefix_iat: MEDIUM        # Inter-Arrival Time hint
+    # ====================================================
 
 workflow:
   _type: adk

--- a/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/config_dynamo_prefix_e2e_test.yml
+++ b/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/config_dynamo_prefix_e2e_test.yml
@@ -15,19 +15,19 @@
 # <!-- path-check-skip-file -->
 
 # =============================================================================
-# DYNAMO WORKFLOW WITH DYNAMIC PREFIX HEADERS
+# DYNAMO WORKFLOW WITH DYNAMIC NVEXT HINTS
 # =============================================================================
 # Purpose: Demonstrates automatic unique prefix ID generation per request
 # Used by: test_dynamo_integration.sh (test 5)
 #
 # This configuration shows how to use the Predictive KV-Aware Cache router
-# with dynamic prefix headers for optimized request routing.
+# with dynamic nvext hints for optimized request routing.
 #
 # Key Features:
-# - enable_dynamic_prefix: true - Generates unique prefix ID per request
-# - prefix_template: "react-agent-{uuid}" - Template for prefix ID format
-# - prefix_total_requests: Expected requests per conversation
-# - prefix_osl/prefix_iat: Hints for output length and arrival time
+# - enable_nvext_hints: true - Enables nvext agent hints
+# - nvext_prefix_id_template: "react-agent-{uuid}" - Template for prefix ID format
+# - nvext_prefix_total_requests: Expected requests per conversation
+# - nvext_prefix_osl/nvext_prefix_iat: Hints for output length and arrival time
 #
 # Usage:
 #   nat run --config_file configs/config_dynamo_prefix_e2e_test.yml --input "What time is it?"
@@ -50,15 +50,16 @@ llms:
     temperature: 0.0
     max_tokens: 1024
     
-    # ===== DYNAMIC PREFIX CONFIGURATION =====
+    # ===== DYNAMIC NVEXT HINTS CONFIGURATION =====
     # Automatically generates unique prefix ID per request
     # Format: "react-agent-{uuid}" where uuid is 16 hex chars
-    # Note: Setting prefix_template enables dynamic prefix headers
-    prefix_template: "react-agent-{uuid}"
-    prefix_total_requests: 1  # 1 for independent queries, higher for conversations
-    prefix_osl: MEDIUM  # Output Sequence Length: LOW | MEDIUM | HIGH
-    prefix_iat: MEDIUM  # Inter-Arrival Time: LOW | MEDIUM | HIGH
-    # ========================================
+    # Note: Setting enable_nvext_hints enables nvext agent hints
+    enable_nvext_hints: true
+    nvext_prefix_id_template: "react-agent-{uuid}"
+    nvext_prefix_total_requests: 1  # 1 for independent queries, higher for conversations
+    nvext_prefix_osl: MEDIUM  # Output Sequence Length: LOW | MEDIUM | HIGH
+    nvext_prefix_iat: MEDIUM  # Inter-Arrival Time: LOW | MEDIUM | HIGH
+    # =============================================
     
     # Example headers this generates per request:
     #   x-prefix-id: react-agent-a1b2c3d4e5f6g7h8

--- a/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/eval_config_no_rethinking_full_test.yml
+++ b/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/eval_config_no_rethinking_full_test.yml
@@ -81,11 +81,12 @@ llms:
     temperature: 0.0
     max_tokens: 8192
     stop: ["Observation:", "\nThought:"]  # CRITICAL: Prevent LLM from hallucinating observations
-    # Dynamo prefix headers for KV cache optimization (enabled when prefix_template is set)
-    prefix_template: "react-benchmark-{uuid}"  # Template for prefix IDs ({uuid} replaced per request)
-    prefix_total_requests: 10  # 1 for independent questions, higher for conversations
-    prefix_osl: MEDIUM  # Output Sequence Length: LOW | MEDIUM | HIGH
-    prefix_iat: MEDIUM  # Inter-Arrival Time: LOW | MEDIUM | HIGH
+    # Dynamo nvext hints for KV cache optimization (enabled when enable_nvext_hints is set)
+    enable_nvext_hints: true
+    nvext_prefix_id_template: "react-benchmark-{uuid}"  # Template for prefix IDs ({uuid} replaced per request)
+    nvext_prefix_total_requests: 10  # 1 for independent questions, higher for conversations
+    nvext_prefix_osl: MEDIUM  # Output Sequence Length: LOW | MEDIUM | HIGH
+    nvext_prefix_iat: MEDIUM  # Inter-Arrival Time: LOW | MEDIUM | HIGH
     # # Optimizer: Parameters that can be tuned during optimization
     # optimizable_params:
     #   - temperature

--- a/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/eval_config_no_rethinking_minimal_test.yml
+++ b/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/eval_config_no_rethinking_minimal_test.yml
@@ -85,12 +85,13 @@ llms:
     temperature: 0.0
     max_tokens: 2048
     stop: ["Observation:", "\nThought:"]  # CRITICAL: Prevent LLM from hallucinating observations
-    # Dynamic prefix headers - automatically generates unique prefix ID per request
-    # Note: Setting prefix_template enables dynamic prefix headers
-    prefix_template: "react-benchmark-{uuid}"
-    prefix_total_requests: 10  # 1 for independent questions, higher for conversations
-    prefix_osl: MEDIUM  # Output Sequence Length: LOW | MEDIUM | HIGH
-    prefix_iat: MEDIUM  # Inter-Arrival Time: LOW | MEDIUM | HIGH
+    # Nvext agent hints - automatically generates unique prefix ID per request
+    # Note: Setting enable_nvext_hints enables nvext agent hints
+    enable_nvext_hints: true
+    nvext_prefix_id_template: "react-benchmark-{uuid}"
+    nvext_prefix_total_requests: 10  # 1 for independent questions, higher for conversations
+    nvext_prefix_osl: MEDIUM  # Output Sequence Length: LOW | MEDIUM | HIGH
+    nvext_prefix_iat: MEDIUM  # Inter-Arrival Time: LOW | MEDIUM | HIGH
     # NOTE: Optimizer fields temporarily removed due to NAT type resolution bug
     # optimizable_params:
     #   - temperature

--- a/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/eval_config_rethinking_full_test.yml
+++ b/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/eval_config_rethinking_full_test.yml
@@ -133,11 +133,12 @@ llms:
     temperature: 0.0
     max_tokens: 8192
     stop: ["Observation:", "\nThought:"]
-    # Dynamo prefix headers for KV cache optimization (enabled when prefix_template is set)
-    prefix_template: "react-benchmark-{uuid}"
-    prefix_total_requests: 10
-    prefix_osl: MEDIUM
-    prefix_iat: MEDIUM
+    # Dynamo nvext hints for KV cache optimization (enabled when enable_nvext_hints is set)
+    enable_nvext_hints: true
+    nvext_prefix_id_template: "react-benchmark-{uuid}"
+    nvext_prefix_total_requests: 10
+    nvext_prefix_osl: MEDIUM
+    nvext_prefix_iat: MEDIUM
     # # Enable parameter optimization for this LLM
     # optimizable_params: [temperature]
     # search_space:

--- a/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/optimize_rethinking_full_test.yml
+++ b/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/optimize_rethinking_full_test.yml
@@ -15,27 +15,27 @@
 # <!-- path-check-skip-file -->
 
 # =============================================================================
-# PREDICTIVE PREFIX HEADER OPTIMIZATION
+# PREDICTIVE NVEXT HINTS OPTIMIZATION
 # =============================================================================
 # Purpose: Optimize Dynamo Predictive KV-Aware Cache router parameters
 # Run with: nat optimize --config_file configs/optimize_rethinking_full_test.yml
 #
-# This configuration tunes the prefix header parameters that control how the
+# This configuration tunes the nvext agent hints parameters that control how the
 # Thompson Sampling router makes worker assignment decisions:
 #
-# Dynamo Prefix Parameter Reference (from router.py):
+# Dynamo Nvext Parameter Reference (from router.py):
 # ─────────────────────────────────────────────────────────────────────────────
-# prefix_osl (Output Sequence Length):
+# nvext_prefix_osl (Output Sequence Length):
 #   - LOW    → decode_cost = 1.0 (short responses expected)
 #   - MEDIUM → decode_cost = 2.0 (typical responses)
 #   - HIGH   → decode_cost = 3.0 (long responses expected)
 #
-# prefix_iat (Inter-Arrival Time):
+# nvext_prefix_iat (Inter-Arrival Time):
 #   - LOW    → iat_factor = 1.5 (rapid requests, high stickiness)
 #   - MEDIUM → iat_factor = 1.0 (normal pacing)
 #   - HIGH   → iat_factor = 0.6 (slow requests, more exploration)
 #
-# prefix_total_requests:
+# nvext_prefix_total_requests:
 #   - Integer >= 1: How many requests expected for this prefix or conversation
 #   - Higher values increase worker stickiness and KV cache locality
 #   - Lower values allow more worker exploration and load balancing
@@ -43,8 +43,8 @@
 # Router Behavior Summary:
 #   - Higher reuse_budget + LOW iat → strong stickiness to same worker
 #   - Higher reuse_budget → switching penalty increases
-#   - prefix_total_requests affects reuse_budget calculation:
-#     reuse_budget = prefix_total_requests - requests_processed_so_far
+#   - nvext_prefix_total_requests affects reuse_budget calculation:
+#     reuse_budget = nvext_prefix_total_requests - requests_processed_so_far
 # =============================================================================
 
 functions:
@@ -139,34 +139,35 @@ llms:
     max_tokens: 8192
     stop: ["Observation:", "\nThought:"]
     
-    # Dynamo prefix configuration
-    # Note: Setting prefix_template enables dynamic prefix headers
-    prefix_template: "react-benchmark-{uuid}"
+    # Dynamo nvext hints configuration
+    # Note: Setting enable_nvext_hints enables nvext agent hints
+    enable_nvext_hints: true
+    nvext_prefix_id_template: "react-benchmark-{uuid}"
     # OPTIMIZABLE: Total expected requests per conversation or prefix
     # Default search space: low=1, high=20, step=5
-    prefix_total_requests: 10
+    nvext_prefix_total_requests: 10
     # OPTIMIZABLE: Output Sequence Length hint (LOW | MEDIUM | HIGH)
-    prefix_osl: MEDIUM
+    nvext_prefix_osl: MEDIUM
     # OPTIMIZABLE: Inter-Arrival Time hint (LOW | MEDIUM | HIGH)
-    prefix_iat: MEDIUM
+    nvext_prefix_iat: MEDIUM
     
     # =========================================================================
     # OPTIMIZER: Which parameters to optimize and their search spaces
     # =========================================================================
     optimizable_params:
-      - prefix_total_requests
-      - prefix_osl
-      - prefix_iat
+      - nvext_prefix_total_requests
+      - nvext_prefix_osl
+      - nvext_prefix_iat
     
     # Override default search spaces if needed
     search_space:
-      prefix_total_requests:
+      nvext_prefix_total_requests:
         low: 1
         high: 20
         step: 5
-      prefix_osl:
+      nvext_prefix_osl:
         values: ["LOW", "MEDIUM", "HIGH"]
-      prefix_iat:
+      nvext_prefix_iat:
         values: ["LOW", "MEDIUM", "HIGH"]
 
   # Secondary LLM for self-evaluation (not optimized)

--- a/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/profile_rethinking_full_test.yml
+++ b/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/profile_rethinking_full_test.yml
@@ -151,11 +151,12 @@ llms:
     # Including </think> as a stop token disables extended thinking (shorter, faster calls).
     # Removing it enables full thinking (longer calls, higher GPU utilization).
     stop: ["Observation:", "\nObservation"]
-    # Note: Setting prefix_template enables dynamic prefix headers
-    prefix_template: "react-benchmark-{uuid}"
-    prefix_total_requests: 10 # 6
-    prefix_osl: MEDIUM # HIGH
-    prefix_iat: MEDIUM # LOW
+    # Note: Setting enable_nvext_hints enables nvext agent hints
+    enable_nvext_hints: true
+    nvext_prefix_id_template: "react-benchmark-{uuid}"
+    nvext_prefix_total_requests: 10 # 6
+    nvext_prefix_osl: MEDIUM # HIGH
+    nvext_prefix_iat: MEDIUM # LOW
     # Enable parameter optimization for this LLM
     # optimizable_params: [temperature]
     # search_space:

--- a/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/run_with_prediction_trie.yml
+++ b/examples/dynamo_integration/react_benchmark_agent/src/react_benchmark_agent/configs/run_with_prediction_trie.yml
@@ -147,13 +147,14 @@ llms:
     max_tokens: 16384
     stop: ["Observation:", "\nThought:"]
 
-    # Dynamo prefix configuration (required for prefix routing)
-    prefix_template: "react-benchmark-{uuid}"
+    # Dynamo nvext hints configuration (required for prefix routing)
+    enable_nvext_hints: true
+    nvext_prefix_id_template: "react-benchmark-{uuid}"
 
     # Static fallback values (used if trie lookup fails)
-    prefix_total_requests: 10
-    prefix_osl: MEDIUM
-    prefix_iat: MEDIUM
+    nvext_prefix_total_requests: 10
+    nvext_prefix_osl: MEDIUM
+    nvext_prefix_iat: MEDIUM
 
     # =========================================================================
     # PREDICTION TRIE - Dynamic per-call header injection

--- a/external/dynamo/components/processor.py
+++ b/external/dynamo/components/processor.py
@@ -427,9 +427,7 @@ class ProcessorRequestHandler:
             value < thresholds[1]  → MEDIUM
             value >= thresholds[1] → HIGH
 
-        This makes the processor agnostic to whether the client sends raw
-        integers (``prefix_use_raw_values: true``) or categorical strings
-        (``prefix_use_raw_values: false``).
+        Values are always raw integers.
         """
         if not value:
             return default

--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/llm.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/llm.py
@@ -144,34 +144,22 @@ async def openai_adk(config: OpenAIModelConfig, _builder: Builder):
 
 @register_llm_client(config_type=DynamoModelConfig, wrapper_type=LLMFrameworkEnum.ADK)
 async def dynamo_adk(config: DynamoModelConfig, _builder: Builder):
-    """Create and yield a Google ADK LiteLlm client for Dynamo with prefix header support.
+    """Create and yield a Google ADK LiteLlm client for Dynamo with nvext.agent_hints support.
 
-    This client configures Dynamo routing hints via LiteLLM's extra_headers parameter.
-    Unlike the LangChain implementation which injects headers per-request via httpx hooks,
-    LiteLLM sets headers at initialization time.
-
-    For dynamic prefix IDs (e.g., per-evaluation-question), use the DynamoPrefixContext class::
-
-        from nat.llm.dynamo_llm import DynamoPrefixContext
-
-        DynamoPrefixContext.set("my-prefix-id")
-        # ... run LLM calls ...
-        DynamoPrefixContext.clear()
-
-        # Or use the context manager:
-        with DynamoPrefixContext.scope("my-prefix-id"):
-            # ... run LLM calls ...
-
-    Note: The context variable approach requires custom integration as LiteLLM's headers
-    are static. For full dynamic prefix ID support, consider using the LangChain client.
+    When ``enable_nvext_hints`` is True, this client injects Dynamo routing hints via
+    nvext.agent_hints in the request body using a custom httpx transport wrapped in an
+    AsyncOpenAI client. This gives the same per-request hint injection as the LangChain
+    implementation, including dynamic prefix IDs via DynamoPrefixContext.
 
     Args:
         config (DynamoModelConfig): The configuration for the Dynamo model.
         _builder (Builder): The NAT builder instance.
     """
-    import uuid
+    import os
 
     from google.adk.models.lite_llm import LiteLlm
+
+    from nat.llm.dynamo_llm import create_httpx_client_with_dynamo_hooks
 
     validate_no_responses_api(config, LLMFrameworkEnum.ADK)
 
@@ -194,27 +182,53 @@ async def dynamo_adk(config: DynamoModelConfig, _builder: Builder):
     if config.base_url:
         config_dict["api_base"] = config.base_url
 
-    # Build Dynamo prefix headers if prefix_template is configured and headers are enabled
-    if config.prefix_template is not None and not config.disable_headers:
-        # Generate a static prefix ID for this LLM instance
-        # For dynamic prefix IDs, users should use the LangChain client or manage sessions manually
-        unique_id = uuid.uuid4().hex[:16]
-        prefix_id = config.prefix_template.format(uuid=unique_id)
+    if config.enable_nvext_hints:
+        from pathlib import Path
 
-        extra_headers = {
-            "x-prefix-id": prefix_id,
-            "x-prefix-total-requests": str(config.prefix_total_requests),
-            "x-prefix-osl": str(config.prefix_osl),
-            "x-prefix-iat": str(config.prefix_iat),
-        }
-        config_dict["extra_headers"] = extra_headers
+        from openai import AsyncOpenAI
+
+        from nat.profiler.prediction_trie import load_prediction_trie
+        from nat.profiler.prediction_trie.trie_lookup import PredictionTrieLookup
+
+        prediction_lookup: PredictionTrieLookup | None = None
+        if config.nvext_prediction_trie_path:
+            try:
+                trie_path = Path(config.nvext_prediction_trie_path)
+                trie = load_prediction_trie(trie_path)
+                prediction_lookup = PredictionTrieLookup(trie)
+                logger.info("Loaded prediction trie from %s", config.nvext_prediction_trie_path)
+            except FileNotFoundError:
+                logger.warning("Prediction trie file not found: %s", config.nvext_prediction_trie_path)
+            except Exception as e:
+                logger.warning("Failed to load prediction trie: %s", e)
+
+        http_client = create_httpx_client_with_dynamo_hooks(
+            total_requests=config.nvext_prefix_total_requests,
+            osl=config.nvext_prefix_osl,
+            iat=config.nvext_prefix_iat,
+            timeout=config.request_timeout,
+            prediction_lookup=prediction_lookup,
+            cache_pin_type=config.nvext_cache_pin_type,
+            cache_control_mode=config.nvext_cache_control_mode,
+            max_sensitivity=config.nvext_max_sensitivity,
+        )
+
+        api_key = (config.api_key.get_secret_value() if config.api_key else os.getenv("OPENAI_API_KEY", "unused"))
+        base_url = config.base_url or os.getenv("OPENAI_BASE_URL", "http://localhost:8000/v1")
+
+        openai_client = AsyncOpenAI(
+            api_key=api_key,
+            base_url=base_url,
+            http_client=http_client,
+        )
+        config_dict["client"] = openai_client
 
         logger.info(
-            "Dynamo prefix headers configured for ADK: prefix_id=%s, total_requests=%d, osl=%s, iat=%s",
-            prefix_id,
-            config.prefix_total_requests,
-            config.prefix_osl,
-            config.prefix_iat,
+            "Dynamo agent hints enabled for ADK: total_requests=%d, osl=%s, iat=%s, prediction_trie=%s",
+            config.nvext_prefix_total_requests,
+            config.nvext_prefix_osl,
+            config.nvext_prefix_iat,
+            "loaded" if prediction_lookup else "disabled",
         )
 
     yield LiteLlm(config.model_name, **config_dict)

--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/llm.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/llm.py
@@ -200,7 +200,7 @@ async def dynamo_adk(config: DynamoModelConfig, _builder: Builder):
             except FileNotFoundError:
                 logger.warning("Prediction trie file not found: %s", config.nvext_prediction_trie_path)
             except Exception as e:
-                logger.warning("Failed to load prediction trie: %s", e)
+                logger.exception("Failed to load prediction trie: %s", e)
 
         http_client = create_httpx_client_with_dynamo_hooks(
             total_requests=config.nvext_prefix_total_requests,

--- a/packages/nvidia_nat_adk/tests/test_adk_llm.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_llm.py
@@ -166,30 +166,30 @@ class TestDynamoAdk:
 
     @pytest.fixture
     def dynamo_cfg_no_prefix(self):
-        """Dynamo config without prefix template (no header injection)."""
+        """Dynamo config without nvext hints (no custom client injection)."""
         return DynamoModelConfig(
             model_name="test-model",
             base_url="http://localhost:8000/v1",
-            prefix_template=None,
+            nvext_prefix_id_template=None,
         )
 
     @pytest.fixture
     def dynamo_cfg_with_prefix(self):
-        """Dynamo config with prefix template (enables header injection)."""
+        """Dynamo config with nvext hints enabled (injects custom client)."""
         return DynamoModelConfig(
             model_name="test-model",
             base_url="http://localhost:8000/v1",
-            prefix_template="session-{uuid}",
-            prefix_total_requests=15,
-            prefix_osl=2048,
-            prefix_iat=50,
-            disable_headers=False,
+            nvext_prefix_id_template="session-{uuid}",
+            nvext_prefix_total_requests=15,
+            nvext_prefix_osl=2048,
+            nvext_prefix_iat=50,
+            enable_nvext_hints=True,
         )
 
     @patch('google.adk.models.lite_llm.LiteLlm')
     @pytest.mark.asyncio
     async def test_basic_creation_without_prefix(self, mock_litellm_class, dynamo_cfg_no_prefix, mock_builder):
-        """Wrapper should create LiteLlm without extra_headers when no prefix template."""
+        """Wrapper should create LiteLlm without client kwarg when nvext hints are disabled."""
         mock_llm_instance = MagicMock()
         mock_litellm_class.return_value = mock_llm_instance
 
@@ -199,14 +199,13 @@ class TestDynamoAdk:
 
             assert mock_litellm_class.call_args.args[0] == "test-model"
             assert kwargs["api_base"] == "http://localhost:8000/v1"
-            # Should NOT have extra_headers
-            assert "extra_headers" not in kwargs
+            assert "client" not in kwargs
             assert client is mock_llm_instance
 
     @patch('google.adk.models.lite_llm.LiteLlm')
     @pytest.mark.asyncio
-    async def test_creation_with_prefix_template(self, mock_litellm_class, dynamo_cfg_with_prefix, mock_builder):
-        """Wrapper should create LiteLlm with extra_headers when prefix template is set."""
+    async def test_creation_with_nvext_hints_enabled(self, mock_litellm_class, dynamo_cfg_with_prefix, mock_builder):
+        """Wrapper should create LiteLlm with a custom AsyncOpenAI client when nvext hints are enabled."""
         mock_llm_instance = MagicMock()
         mock_litellm_class.return_value = mock_llm_instance
 
@@ -214,16 +213,7 @@ class TestDynamoAdk:
             mock_litellm_class.assert_called_once()
             kwargs = mock_litellm_class.call_args.kwargs
 
-            # Should have extra_headers with Dynamo headers
-            assert "extra_headers" in kwargs
-            headers = kwargs["extra_headers"]
-
-            assert "x-prefix-id" in headers
-            assert headers["x-prefix-id"].startswith("session-")
-            assert headers["x-prefix-total-requests"] == "15"
-            assert headers["x-prefix-osl"] == "2048"
-            assert headers["x-prefix-iat"] == "50"
-
+            assert "client" in kwargs
             assert client is mock_llm_instance
 
     @patch('google.adk.models.lite_llm.LiteLlm')
@@ -231,10 +221,11 @@ class TestDynamoAdk:
     async def test_excludes_dynamo_specific_fields(self, mock_litellm_class, dynamo_cfg_with_prefix, mock_builder):
         """Dynamo-specific fields should be excluded from LiteLlm kwargs.
 
-        DynamoModelConfig has fields (prefix_template, prefix_total_requests, prefix_osl,
-        prefix_iat, request_timeout) that are only used internally by NAT to configure
-        the Dynamo headers. These fields must NOT be passed directly to LiteLlm because
-        LiteLlm doesn't understand them - they're NAT-specific configuration.
+        DynamoModelConfig has fields (nvext_prefix_id_template, nvext_prefix_total_requests,
+        nvext_prefix_osl, nvext_prefix_iat, enable_nvext_hints, request_timeout, etc.) that
+        are only used internally by NAT to configure the Dynamo client hooks. These fields
+        must NOT be passed directly to LiteLlm because LiteLlm doesn't understand them -
+        they're NAT-specific configuration.
 
         This test ensures the `exclude` set in model_dump() properly filters these fields.
         """
@@ -246,40 +237,30 @@ class TestDynamoAdk:
 
         kwargs = mock_litellm_class.call_args.kwargs
 
-        # These Dynamo-specific fields should NOT be passed to LiteLlm
-        assert "prefix_template" not in kwargs
-        assert "prefix_total_requests" not in kwargs
-        assert "prefix_osl" not in kwargs
-        assert "prefix_iat" not in kwargs
-        assert "prefix_use_raw_values" not in kwargs
-        assert "disable_headers" not in kwargs
+        assert "nvext_prefix_id_template" not in kwargs
+        assert "nvext_prefix_total_requests" not in kwargs
+        assert "nvext_prefix_osl" not in kwargs
+        assert "nvext_prefix_iat" not in kwargs
+        assert "enable_nvext_hints" not in kwargs
         assert "request_timeout" not in kwargs
 
     @patch('google.adk.models.lite_llm.LiteLlm')
     @pytest.mark.asyncio
-    async def test_prefix_id_is_unique_per_instance(self, mock_litellm_class, mock_builder):
-        """Each LiteLlm instance should get a unique prefix ID."""
+    async def test_client_passed_per_instance(self, mock_litellm_class, mock_builder):
+        """Each LiteLlm instance should receive a client kwarg when nvext hints are enabled."""
         mock_llm_instance = MagicMock()
         mock_litellm_class.return_value = mock_llm_instance
 
         config = DynamoModelConfig(
             model_name="test-model",
-            prefix_template="session-{uuid}",
-            disable_headers=False,
+            nvext_prefix_id_template="session-{uuid}",
+            enable_nvext_hints=True,
         )
 
-        prefix_ids = set()
-
-        # Create multiple instances
         for _ in range(5):
             async with dynamo_adk(config, mock_builder):
                 pass
-            headers = mock_litellm_class.call_args.kwargs.get("extra_headers", {})
-            if "x-prefix-id" in headers:
-                prefix_ids.add(headers["x-prefix-id"])
-
-        # All IDs should be unique
-        assert len(prefix_ids) == 5
+            assert "client" in mock_litellm_class.call_args.kwargs
 
     @pytest.mark.asyncio
     async def test_dynamo_adk_decorator_registration(self):

--- a/packages/nvidia_nat_core/src/nat/data_models/profiler.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/profiler.py
@@ -64,7 +64,7 @@ class DynamoMetricsConfig(BaseModel):
        Token-agnostic measure of computational work saved via KV cache.
        Formula: ``KVE = cached_tokens / prompt_tokens``
        A KVE of 0.8 means 80% of prompt tokens were served from cache.
-       Affected by prefix routing hints (prefix_id, prefix_osl, prefix_iat).
+       Affected by prefix routing hints (prefix_id, nvext_prefix_osl, nvext_prefix_iat).
 
     2. **Time to First Token - TTFT** (``collect_ttft``):
        Latency from request to first token. Lower = faster initial response.

--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Dynamo LLM provider with automatic nvext.agent_hints injection for KV cache optimization.
+Dynamo LLM provider with automatic nvext.agent_hints and nvnext.cache_control injection for KV cache optimization.
 
 This module provides a specialized OpenAI-compatible LLM that sends Dynamo routing
 hints for optimal KV cache management and request routing. The hint parameters are
 optimizable via the NAT optimizer.
 
 The implementation uses a custom httpx transport to inject hints at the HTTP level,
-making it framework-agnostic (works with LangChain, LlamaIndex, ADK, etc.).
+making it framework-agnostic (works with LangChain, LlamaIndex, ADK).
 
 Transport Mechanism
 -------------------
@@ -279,7 +279,7 @@ class DynamoPrefixContext(metaclass=Singleton):
 
 class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
     """
-    A Dynamo LLM provider with automatic nvext.agent_hints injection for KV cache optimization.
+    A Dynamo LLM provider with automatic nvext.agent_hints and nvext.cache_control injection for KV cache optimization.
 
     This is a specialized OpenAI-compatible LLM that sends Dynamo routing hints
     for optimal KV cache management and request routing. Hints are injected when
@@ -505,11 +505,13 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         osl_raw = self._osl
         iat_raw = self._iat
 
-        # Increment per-prefix call counter. Used for prediction trie lookups
-        # and for cache_control_mode="first_only" gating.
+        # Read the tentative per-prefix call index for prediction trie lookups.
+        # The counter is committed to _call_counts only after the request is
+        # confirmed eligible for injection (see below), so non-injectable requests
+        # (non-POST, empty body, invalid JSON, non-dict body) do not consume the
+        # FIRST_ONLY slot.
         with self._call_counts_lock:
             call_index = self._call_counts.get(prefix_id, 0) + 1
-            self._call_counts[prefix_id] = call_index
 
         # Check for prediction override
         if self._prediction_lookup is not None:
@@ -622,6 +624,11 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
                     if not isinstance(existing, dict):
                         existing = {}
                     body["nvext"]["agent_hints"] = {**existing, **agent_hints}
+
+                    # Commit the per-prefix counter now that the request is
+                    # confirmed eligible for injection.
+                    with self._call_counts_lock:
+                        self._call_counts[prefix_id] = call_index
 
                     # Inject cache_control for KV cache lifetime management.
                     # TTL = total_requests * iat_raw (ms): estimated total conversation

--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -13,14 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """
-Dynamo LLM provider with automatic prefix hint injection for KV cache optimization.
+Dynamo LLM provider with automatic nvext.agent_hints injection for KV cache optimization.
 
-This module provides a specialized OpenAI-compatible LLM that sends Dynamo prefix hints
-for optimal KV cache management and request routing. The prefix parameters are optimizable
-via the NAT optimizer.
+This module provides a specialized OpenAI-compatible LLM that sends Dynamo routing
+hints for optimal KV cache management and request routing. The hint parameters are
+optimizable via the NAT optimizer.
 
 The implementation uses a custom httpx transport to inject hints at the HTTP level,
-making it framework-agnostic (works with LangChain, LlamaIndex, etc.).
+making it framework-agnostic (works with LangChain, LlamaIndex, ADK, etc.).
 
 Transport Mechanism
 -------------------
@@ -33,34 +33,22 @@ Standard Dynamo fields (``latency_sensitivity``, ``osl``, ``priority``) are cons
 by Dynamo's built-in router and engine scheduler. Custom fields (``prefix_id``,
 ``total_requests``, ``iat``) are consumed by our custom ``processor.py``.
 
-Dynamo Prefix Parameters
--------------------------
+nvext Hint Parameters
+---------------------
 
-prefix_osl (Output Sequence Length)
-    Expected output tokens for response length hinting. By default, the raw
-    integer value is sent. When ``prefix_use_raw_values`` is False, values are
-    converted to categories:
+nvext_prefix_osl (Output Sequence Length)
+    Expected output tokens for response length hinting. Raw integer value is always
+    sent in ``nvext.agent_hints``. Accepts categorical strings (LOW/MEDIUM/HIGH) for
+    backward compatibility, which are converted to representative token counts
+    (128/512/2048).
 
-    - < 256 tokens: LOW (decode_cost=1.0, short responses)
-    - < 1024 tokens: MEDIUM (decode_cost=2.0, typical responses)
-    - >= 1024 tokens: HIGH (decode_cost=3.0, long responses)
+nvext_prefix_iat (Inter-Arrival Time)
+    Expected inter-arrival time in milliseconds. Raw integer value is always sent in
+    ``nvext.agent_hints``. Accepts categorical strings (LOW/MEDIUM/HIGH) for backward
+    compatibility, which are converted to representative millisecond values
+    (50/250/750).
 
-    Accepts categorical strings (LOW/MEDIUM/HIGH) for backward compatibility,
-    which are converted to representative token counts (128/512/2048).
-
-prefix_iat (Inter-Arrival Time)
-    Expected inter-arrival time in milliseconds. By default, the raw integer
-    value is sent. When ``prefix_use_raw_values`` is False, values are converted
-    to categories:
-
-    - < 100ms: LOW (iat_factor=1.5, rapid bursts, high worker stickiness)
-    - < 500ms: MEDIUM (iat_factor=1.0, normal pacing)
-    - >= 500ms: HIGH (iat_factor=0.6, slow requests, more exploration)
-
-    Accepts categorical strings (LOW/MEDIUM/HIGH) for backward compatibility,
-    which are converted to representative millisecond values (50/250/750).
-
-prefix_total_requests
+nvext_prefix_total_requests
     Expected requests per conversation:
 
     - Higher values increase KV cache affinity and worker stickiness
@@ -76,7 +64,6 @@ from contextlib import contextmanager
 from contextvars import ContextVar
 from enum import StrEnum
 from typing import TYPE_CHECKING
-from typing import Literal
 
 import httpx
 
@@ -96,9 +83,6 @@ from nat.data_models.optimizable import SearchSpace
 from nat.llm.openai_llm import OpenAIModelConfig
 
 logger = logging.getLogger(__name__)
-
-# Define valid prefix hint values
-PrefixLevel = Literal["LOW", "MEDIUM", "HIGH"]
 
 # Representative token counts for categorical levels (midpoint of ranges):
 # LOW: 128 tokens (midpoint of 0-256 range)
@@ -130,41 +114,18 @@ class CachePinType(StrEnum):
     EPHEMERAL = "ephemeral"
 
 
-# =============================================================================
-# CATEGORY CONVERSION HELPERS
-# =============================================================================
+class CacheControlMode(StrEnum):
+    """Controls when ``nvext.cache_control`` is injected into requests.
 
-
-def _output_tokens_to_osl(output_tokens: float) -> PrefixLevel:
+    - ALWAYS: Inject on every request (refreshes TTL each turn).
+    - FIRST_ONLY: Inject only on the first request per prefix_id, pinning
+      the system prompt when it is first established in the KV cache.
+      Subsequent requests benefit from prefix matching without re-pinning
+      the growing conversation context.
     """
-    Convert predicted output tokens to OSL category.
 
-    Thresholds:
-        - < 256 tokens: LOW (short responses)
-        - < 1024 tokens: MEDIUM (typical responses)
-        - >= 1024 tokens: HIGH (long responses)
-    """
-    if output_tokens < 256:
-        return "LOW"
-    if output_tokens < 1024:
-        return "MEDIUM"
-    return "HIGH"
-
-
-def _interarrival_ms_to_iat(interarrival_ms: float) -> PrefixLevel:
-    """
-    Convert predicted interarrival time to IAT category.
-
-    Thresholds:
-        - < 100ms: LOW (rapid bursts, high worker stickiness)
-        - < 500ms: MEDIUM (normal pacing)
-        - >= 500ms: HIGH (slow requests, more exploration)
-    """
-    if interarrival_ms < 100:
-        return "LOW"
-    if interarrival_ms < 500:
-        return "MEDIUM"
-    return "HIGH"
+    ALWAYS = "always"
+    FIRST_ONLY = "first_only"
 
 
 # =============================================================================
@@ -318,33 +279,40 @@ class DynamoPrefixContext(metaclass=Singleton):
 
 class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
     """
-    A Dynamo LLM provider with automatic prefix hint injection for KV cache optimization.
+    A Dynamo LLM provider with automatic nvext.agent_hints injection for KV cache optimization.
 
-    This is a specialized OpenAI-compatible LLM that sends Dynamo prefix hints
-    for optimal KV cache management and request routing. Prefix hints are enabled
-    by default using the template "nat-dynamo-{uuid}". The prefix routing parameters
-    (prefix_total_requests, prefix_osl, prefix_iat) are optimizable via the NAT optimizer.
+    This is a specialized OpenAI-compatible LLM that sends Dynamo routing hints
+    for optimal KV cache management and request routing. Hints are injected when
+    ``enable_nvext_hints`` is True. The hint parameters (nvext_prefix_total_requests,
+    nvext_prefix_osl, nvext_prefix_iat) are optimizable via the NAT optimizer.
 
     All hints are sent via ``nvext.agent_hints`` in the request body. Standard Dynamo
     fields (``latency_sensitivity``, ``osl``, ``priority``) are consumed by Dynamo's
     built-in router and engine scheduler. Custom fields (``prefix_id``,
     ``total_requests``, ``iat``) are consumed by the custom ``processor.py``.
 
-    To disable prefix hints, set prefix_template to null/None in your config.
+    To disable hints, set ``enable_nvext_hints: false`` in your config (the default).
     """
 
     # =========================================================================
-    # DYNAMO PREFIX PARAMETERS
+    # NVEXT HINT PARAMETERS
     # =========================================================================
 
-    prefix_template: str | None = Field(
-        default="nat-dynamo-{uuid}",
-        description="Template for prefix ID. The {uuid} placeholder will be replaced with a unique ID. "
-        "Prefix headers are sent by default for KV cache optimization. "
-        "Set to null/None to disable prefix header injection.",
+    enable_nvext_hints: bool = Field(
+        default=False,
+        description="When True, inject nvext.agent_hints and nvext.cache_control "
+        "into requests via a custom httpx transport. "
+        "When False (default), no routing hints are injected.",
     )
 
-    prefix_total_requests: int = OptimizableField(
+    nvext_prefix_id_template: str | None = Field(
+        default="nat-dynamo-{uuid}",
+        description="Template for prefix ID. The {uuid} placeholder will be replaced with a unique ID. "
+        "Currently unused by the transport (prefix IDs come from DynamoPrefixContext), "
+        "but retained for configuration reference.",
+    )
+
+    nvext_prefix_total_requests: int = OptimizableField(
         default=10,
         ge=1,
         le=50,
@@ -353,20 +321,20 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
                      "Lower values allow more load balancing across workers."),
         space=SearchSpace(low=1, high=20, step=5))
 
-    prefix_osl: int = OptimizableField(
+    nvext_prefix_osl: int = OptimizableField(
         default=512,
         ge=1,
         description="Expected output tokens for response length hinting (Output Sequence Length). "
-        "Raw integer value is sent by default. Accepts categorical strings "
+        "Raw integer value is sent in nvext.agent_hints. Accepts categorical strings "
         "(LOW/MEDIUM/HIGH) for backward compatibility (mapped to 128/512/2048).",
         space=SearchSpace(low=64, high=4096, step=64),
     )
 
-    prefix_iat: int = OptimizableField(
+    nvext_prefix_iat: int = OptimizableField(
         default=250,
         ge=1,
         description="Expected inter-arrival time in milliseconds for request pacing. "
-        "Raw integer value is sent by default. Accepts categorical strings "
+        "Raw integer value is sent in nvext.agent_hints. Accepts categorical strings "
         "(LOW/MEDIUM/HIGH) for backward compatibility (mapped to 50/250/750).",
         space=SearchSpace(low=10, high=1000, step=50),
     )
@@ -377,19 +345,13 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
         description="HTTP request timeout in seconds for LLM requests.",
     )
 
-    prefix_use_raw_values: bool = Field(
-        default=True,
-        description="When True, send raw integer values for OSL (output tokens) and IAT (interarrival ms) "
-        "in nvext.agent_hints. When False, convert to categorical LOW/MEDIUM/HIGH.",
-    )
-
-    prediction_trie_path: str | None = Field(
+    nvext_prediction_trie_path: str | None = Field(
         default=None,
         description="Path to prediction_trie.json file. When set, predictions are "
         "looked up and used to override nvext.agent_hints for each LLM call.",
     )
 
-    cache_pin_type: CachePinType | None = Field(
+    nvext_cache_pin_type: CachePinType | None = Field(
         default=CachePinType.EPHEMERAL,
         description="Cache pinning strategy for KV cache entries. "
         "When set, injects nvext.cache_control with the pin type and a TTL "
@@ -397,14 +359,15 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
         "Set to null/None to disable cache control hints.",
     )
 
-    disable_headers: bool = Field(
-        default=False,
-        description="When True, disable injection of Dynamo prefix headers (x-prefix-id, "
-        "x-prefix-total-requests, x-prefix-osl, x-prefix-iat) even when prefix_template is set. "
-        "Useful for A/B testing or debugging without prefix routing.",
+    nvext_cache_control_mode: CacheControlMode = Field(
+        default=CacheControlMode.ALWAYS,
+        description="Controls when nvext.cache_control is injected. "
+        "'always' injects on every request (refreshes TTL each turn). "
+        "'first_only' injects only on the first request per prefix_id, "
+        "pinning the system prompt when it is first established in the KV cache.",
     )
 
-    max_sensitivity: int = Field(
+    nvext_max_sensitivity: int = Field(
         default=1000,
         ge=1,
         description="Maximum latency sensitivity value used to compute request priority. "
@@ -416,9 +379,10 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
     # VALIDATORS (backward compatibility: categorical strings -> integers)
     # =========================================================================
 
-    @field_validator("prefix_osl", mode="before")
+    @field_validator("nvext_prefix_osl", mode="before")
     @classmethod
-    def _coerce_prefix_osl(cls, v: object) -> int:
+    def _coerce_nvext_prefix_osl(cls, v: object) -> int:
+        """Convert categorical OSL strings (LOW/MEDIUM/HIGH) to representative token counts."""
         if isinstance(v, int):
             return v
         if isinstance(v, str):
@@ -427,11 +391,11 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
                 return _OSL_CATEGORY_TO_INT[upper]
             raise ValueError(f"Invalid OSL value '{v}'. Must be an integer >= 1 "
                              f"or one of: {', '.join(_OSL_CATEGORY_TO_INT.keys())}")
-        raise TypeError(f"prefix_osl must be int or str, got {type(v)}")
+        raise TypeError(f"nvext_prefix_osl must be int or str, got {type(v)}")
 
-    @field_validator("prefix_iat", mode="before")
+    @field_validator("nvext_prefix_iat", mode="before")
     @classmethod
-    def _coerce_prefix_iat(cls, v: object) -> int:
+    def _coerce_nvext_prefix_iat(cls, v: object) -> int:
         """Convert categorical IAT strings (LOW/MEDIUM/HIGH) to representative millisecond values."""
         if isinstance(v, int):
             return v
@@ -441,7 +405,7 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
                 return _IAT_CATEGORY_TO_INT[upper]
             raise ValueError(f"Invalid IAT value '{v}'. Must be an integer >= 1 "
                              f"or one of: {', '.join(_IAT_CATEGORY_TO_INT.keys())}")
-        raise TypeError(f"prefix_iat must be int or str, got {type(v)}")
+        raise TypeError(f"nvext_prefix_iat must be int or str, got {type(v)}")
 
     # =========================================================================
     # UTILITY METHODS
@@ -466,16 +430,16 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
             )
         """
         return frozenset({
-            "prefix_template",
-            "prefix_total_requests",
-            "prefix_osl",
-            "prefix_iat",
-            "prefix_use_raw_values",
-            "disable_headers",
+            "enable_nvext_hints",
+            "nvext_prefix_id_template",
+            "nvext_prefix_total_requests",
+            "nvext_prefix_osl",
+            "nvext_prefix_iat",
             "request_timeout",
-            "prediction_trie_path",
-            "cache_pin_type",
-            "max_sensitivity",
+            "nvext_prediction_trie_path",
+            "nvext_cache_pin_type",
+            "nvext_cache_control_mode",
+            "nvext_max_sensitivity",
         })
 
 
@@ -506,8 +470,8 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         osl: int,
         iat: int,
         prediction_lookup: "PredictionTrieLookup | None" = None,
-        use_raw_values: bool = True,
         cache_pin_type: CachePinType | None = CachePinType.EPHEMERAL,
+        cache_control_mode: CacheControlMode = CacheControlMode.ALWAYS,
         max_sensitivity: int = 1000,
     ):
         self._transport = transport
@@ -515,8 +479,8 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         self._osl = osl
         self._iat = iat
         self._prediction_lookup = prediction_lookup
-        self._use_raw_values = use_raw_values
         self._cache_pin_type = cache_pin_type
+        self._cache_control_mode = cache_control_mode
         self._max_sensitivity = max_sensitivity
         # Per-prefix call counter so call_index advances across requests
         # for the same prefix_id (keyed by prefix_id string).
@@ -541,17 +505,17 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         osl_raw = self._osl
         iat_raw = self._iat
 
+        # Increment per-prefix call counter. Used for prediction trie lookups
+        # and for cache_control_mode="first_only" gating.
+        with self._call_counts_lock:
+            call_index = self._call_counts.get(prefix_id, 0) + 1
+            self._call_counts[prefix_id] = call_index
+
         # Check for prediction override
         if self._prediction_lookup is not None:
             try:
                 ctx = Context.get()
                 path = ctx.function_path
-
-                # Increment per-prefix call counter to advance through trie predictions.
-                # This is self-contained — no dependency on intermediate_step_manager.
-                with self._call_counts_lock:
-                    call_index = self._call_counts.get(prefix_id, 0) + 1
-                    self._call_counts[prefix_id] = call_index
 
                 # Look up prediction
                 prediction = self._prediction_lookup.find(path, call_index)
@@ -592,14 +556,6 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
             except Exception:
                 logger.exception("Failed to lookup prediction")
 
-        # Compute final osl/iat values — raw integers or categorical strings
-        if self._use_raw_values:
-            osl_value: int | str = osl_raw
-            iat_value: int | str = iat_raw
-        else:
-            osl_value = _output_tokens_to_osl(osl_raw)
-            iat_value = _interarrival_ms_to_iat(iat_raw)
-
         headers = dict(request.headers)
 
         # Modify body to inject nvext.agent_hints (if JSON POST request).
@@ -612,7 +568,7 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         #   Custom processor.py fields:
         #     prefix_id            — KV cache prefix identity for worker stickiness
         #     total_requests       — expected session length for reuse_budget computation
-        #     iat                  — inter-arrival time hint for stickiness/opportunity weighting
+        #     iat                  — inter-arrival time in ms (always raw integer)
         content = request.content
         if request.method == "POST" and content:
             try:
@@ -654,18 +610,13 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
                     if not isinstance(body["nvext"], dict):
                         body["nvext"] = {}
 
-                    # osl must be an integer for Dynamo's AgentHints (u32).
-                    # When use_raw_values=False, osl_value is a category string —
-                    # map it back to its representative integer for agent_hints.
-                    osl_int = osl_value if isinstance(osl_value, int) else _OSL_CATEGORY_TO_INT[osl_value]
-
                     agent_hints = {
                         "latency_sensitivity": float(latency_sensitivity),
-                        "osl": osl_int,
+                        "osl": osl_raw,
                         "priority": priority,
                         "prefix_id": prefix_id,
                         "total_requests": total_requests,
-                        "iat": iat_value,
+                        "iat": iat_raw,
                     }
                     existing = body["nvext"].get("agent_hints", {})
                     if not isinstance(existing, dict):
@@ -676,7 +627,14 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
                     # TTL = total_requests * iat_raw (ms): estimated total conversation
                     # duration before the cache entry should auto-expire.
                     # Formatted as "<N>m" (whole minutes) or "<N>s", rounded up.
-                    if self._cache_pin_type is not None:
+                    #
+                    # When cache_control_mode is FIRST_ONLY, only inject on the
+                    # first request per prefix_id — pinning the system prompt when
+                    # it is first established in the KV cache.
+                    should_pin = (self._cache_pin_type is not None
+                                  and (self._cache_control_mode == CacheControlMode.ALWAYS or
+                                       (self._cache_control_mode == CacheControlMode.FIRST_ONLY and call_index == 1)))
+                    if should_pin:
                         ttl_ms = total_requests * iat_raw
                         ttl_seconds = max(1, -(-ttl_ms // 1000))  # ceil division
                         if ttl_seconds >= 60 and ttl_seconds % 60 == 0:
@@ -708,8 +666,8 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         logger.debug("Injected Dynamo hints: prefix_id=%s, total_requests=%d, osl=%s, iat=%s, latency_sensitivity=%s",
                      prefix_id,
                      total_requests,
-                     osl_value,
-                     iat_value,
+                     osl_raw,
+                     iat_raw,
                      latency_sensitivity)
 
         return await self._transport.handle_async_request(new_request)
@@ -725,42 +683,36 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
 
 
 def create_httpx_client_with_dynamo_hooks(
-    prefix_template: str | None,
     total_requests: int,
     osl: int,
     iat: int,
     timeout: float = 600.0,
     prediction_lookup: "PredictionTrieLookup | None" = None,
-    use_raw_values: bool = True,
     cache_pin_type: CachePinType | None = CachePinType.EPHEMERAL,
+    cache_control_mode: CacheControlMode = CacheControlMode.ALWAYS,
     max_sensitivity: int = 1000,
 ) -> "httpx.AsyncClient":
     """
     Create an httpx.AsyncClient with Dynamo hint injection via custom transport.
 
-    This client can be passed to the OpenAI SDK to inject hints at the HTTP level,
-    making it framework-agnostic. All hints are injected into ``nvext.agent_hints``
+    This client can be passed to the OpenAI SDK or wrapped in an AsyncOpenAI client
+    for use with LiteLLM/ADK. All hints are injected into ``nvext.agent_hints``
     in the request body.
 
     Args:
-        prefix_template: Template string with {uuid} placeholder (unused, kept for API compat)
         total_requests: Expected number of requests for this prefix
-        osl: Expected output tokens (raw integer value)
-        iat: Expected inter-arrival time in milliseconds (raw integer value)
+        osl: Expected output tokens (raw integer, always sent as int in agent_hints)
+        iat: Expected inter-arrival time in ms (raw integer, always sent as int)
         timeout: HTTP request timeout in seconds
         prediction_lookup: Optional PredictionTrieLookup for dynamic hint injection
-        use_raw_values: When True send raw integers; when False convert to LOW/MEDIUM/HIGH
         cache_pin_type: Cache pinning strategy. When set, injects nvext.cache_control with TTL. Set to None to disable.
+        cache_control_mode: When to inject cache_control: 'always' or 'first_only' per prefix.
         max_sensitivity: Maximum latency sensitivity for computing priority
 
     Returns:
         An httpx.AsyncClient configured with Dynamo hint injection.
     """
     import httpx
-
-    # Note: prefix_template is kept for API compatibility but no longer used.
-    # Prefix IDs are now managed by DynamoPrefixContext with depth-awareness.
-    _ = prefix_template
 
     # Create base transport and wrap with custom transport
     base_transport = httpx.AsyncHTTPTransport()
@@ -770,8 +722,8 @@ def create_httpx_client_with_dynamo_hooks(
         osl=osl,
         iat=iat,
         prediction_lookup=prediction_lookup,
-        use_raw_values=use_raw_values,
         cache_pin_type=cache_pin_type,
+        cache_control_mode=cache_control_mode,
         max_sensitivity=max_sensitivity,
     )
 

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamic_prediction_hook.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamic_prediction_hook.py
@@ -108,47 +108,6 @@ class TestDynamicPredictionTransport:
 
         DynamoPrefixContext.clear()
 
-    async def test_transport_injects_prediction_agent_hints_categorical(self, sample_trie_lookup):
-        """Test that transport converts predictions to categories when use_raw_values=False."""
-        mock_response = httpx.Response(200, json={"result": "ok"})
-        mock_transport = MagicMock()
-        mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
-
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=10,
-            osl=512,
-            iat=250,
-            prediction_lookup=sample_trie_lookup,
-            use_raw_values=False,
-        )
-
-        ctx = Context.get()
-        state = ctx._context_state
-        state._function_path_stack.set(None)
-
-        DynamoPrefixContext.set("test-prediction-cat")
-
-        with ctx.push_active_function("my_workflow", input_data=None):
-            with ctx.push_active_function("react_agent", input_data=None):
-                tracker = get_call_tracker()
-                tracker.increment(ctx.active_function.function_id)
-
-                request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
-                await transport.handle_async_request(request)
-
-                modified_request = mock_transport.handle_async_request.call_args[0][0]
-                body = json.loads(modified_request.content.decode("utf-8"))
-                agent_hints = body["nvext"]["agent_hints"]
-
-                # Categorical conversion:
-                # - output_tokens.p90=200.0 -> LOW (< 256) -> mapped back to int 128 for osl
-                # - interarrival_ms.mean=500.0 -> HIGH (>= 500) -> kept as "HIGH" string for iat
-                assert agent_hints["osl"] == 128  # LOW -> _OSL_CATEGORY_TO_INT["LOW"]
-                assert agent_hints["iat"] == "HIGH"
-
-        DynamoPrefixContext.clear()
-
     async def test_transport_uses_root_fallback(self, sample_trie_lookup):
         """Test that transport falls back to root prediction for unknown paths."""
         mock_response = httpx.Response(200, json={"result": "ok"})

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
@@ -19,6 +19,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from nat.llm.dynamo_llm import CacheControlMode
 from nat.llm.dynamo_llm import CachePinType
 from nat.llm.dynamo_llm import DynamoModelConfig
 from nat.llm.dynamo_llm import DynamoPrefixContext
@@ -37,97 +38,106 @@ class TestDynamoModelConfig:
         config = DynamoModelConfig(model_name="test-model")
 
         assert config.model_name == "test-model"
-        assert config.prefix_template == "nat-dynamo-{uuid}"  # Enabled by default
-        assert config.prefix_total_requests == 10
-        assert config.prefix_osl == 512
-        assert config.prefix_iat == 250
-        assert config.prefix_use_raw_values is True
+        assert config.nvext_prefix_id_template == "nat-dynamo-{uuid}"  # Enabled by default
+        assert config.nvext_prefix_total_requests == 10
+        assert config.nvext_prefix_osl == 512
+        assert config.nvext_prefix_iat == 250
         assert config.request_timeout == 600.0
-        assert config.cache_pin_type == CachePinType.EPHEMERAL
-        assert config.max_sensitivity == 1000
+        assert config.nvext_cache_pin_type == CachePinType.EPHEMERAL
+        assert config.nvext_cache_control_mode == CacheControlMode.ALWAYS
+        assert config.enable_nvext_hints is False
+        assert config.nvext_max_sensitivity == 1000
+
+    def test_enable_nvext_hints_toggle(self):
+        """Test that enable_nvext_hints can be set to True."""
+        config = DynamoModelConfig(model_name="test-model", enable_nvext_hints=True)
+        assert config.enable_nvext_hints is True
+
+        config = DynamoModelConfig(model_name="test-model", enable_nvext_hints=False)
+        assert config.enable_nvext_hints is False
 
     def test_custom_prefix_values(self):
         """Test custom prefix parameter values."""
         config = DynamoModelConfig(
             model_name="test-model",
-            prefix_template="session-{uuid}",
-            prefix_total_requests=20,
-            prefix_osl=2048,
-            prefix_iat=50,
+            nvext_prefix_id_template="session-{uuid}",
+            nvext_prefix_total_requests=20,
+            nvext_prefix_osl=2048,
+            nvext_prefix_iat=50,
             request_timeout=300.0,
         )
 
-        assert config.prefix_template == "session-{uuid}"
-        assert config.prefix_total_requests == 20
-        assert config.prefix_osl == 2048
-        assert config.prefix_iat == 50
+        assert config.nvext_prefix_id_template == "session-{uuid}"
+        assert config.nvext_prefix_total_requests == 20
+        assert config.nvext_prefix_osl == 2048
+        assert config.nvext_prefix_iat == 50
         assert config.request_timeout == 300.0
 
     def test_disable_prefix_headers(self):
-        """Test that prefix headers can be disabled by setting prefix_template to None."""
+        """Test that agent hints can be disabled by setting prefix_template to None."""
         config = DynamoModelConfig(
             model_name="test-model",
-            prefix_template=None,  # Explicitly disable prefix headers
+            nvext_prefix_id_template=None,  # Explicitly disable agent hints
         )
 
-        assert config.prefix_template is None
+        assert config.nvext_prefix_id_template is None
 
     def test_prefix_total_requests_validation(self):
         """Test that prefix_total_requests validates bounds."""
         # Valid range
-        config = DynamoModelConfig(model_name="test-model", prefix_total_requests=1)
-        assert config.prefix_total_requests == 1
+        config = DynamoModelConfig(model_name="test-model", nvext_prefix_total_requests=1)
+        assert config.nvext_prefix_total_requests == 1
 
-        config = DynamoModelConfig(model_name="test-model", prefix_total_requests=50)
-        assert config.prefix_total_requests == 50
+        config = DynamoModelConfig(model_name="test-model", nvext_prefix_total_requests=50)
+        assert config.nvext_prefix_total_requests == 50
 
         # Invalid: below minimum
         with pytest.raises(ValueError):
-            DynamoModelConfig(model_name="test-model", prefix_total_requests=0)
+            DynamoModelConfig(model_name="test-model", nvext_prefix_total_requests=0)
 
         # Invalid: above maximum
         with pytest.raises(ValueError):
-            DynamoModelConfig(model_name="test-model", prefix_total_requests=51)
+            DynamoModelConfig(model_name="test-model", nvext_prefix_total_requests=51)
 
     def test_prefix_osl_iat_accept_integers(self):
         """Test that prefix_osl and prefix_iat accept integer values."""
-        config = DynamoModelConfig(model_name="test-model", prefix_osl=1024, prefix_iat=100)
-        assert config.prefix_osl == 1024
-        assert config.prefix_iat == 100
+        config = DynamoModelConfig(model_name="test-model", nvext_prefix_osl=1024, nvext_prefix_iat=100)
+        assert config.nvext_prefix_osl == 1024
+        assert config.nvext_prefix_iat == 100
 
     def test_prefix_osl_iat_reject_invalid(self):
         """Test that prefix_osl and prefix_iat reject invalid values."""
         with pytest.raises(ValueError):
-            DynamoModelConfig(model_name="test-model", prefix_osl=0)
+            DynamoModelConfig(model_name="test-model", nvext_prefix_osl=0)
 
         with pytest.raises(ValueError):
-            DynamoModelConfig(model_name="test-model", prefix_iat=0)
+            DynamoModelConfig(model_name="test-model", nvext_prefix_iat=0)
 
         with pytest.raises(ValueError):
-            DynamoModelConfig(model_name="test-model", prefix_osl="INVALID")
+            DynamoModelConfig(model_name="test-model", nvext_prefix_osl="INVALID")
 
         with pytest.raises(ValueError):
-            DynamoModelConfig(model_name="test-model", prefix_iat="INVALID")
+            DynamoModelConfig(model_name="test-model", nvext_prefix_iat="INVALID")
 
     def test_backward_compat_categorical_strings(self):
         """Test that categorical string values (LOW/MEDIUM/HIGH) are coerced to integers."""
-        config = DynamoModelConfig(model_name="test-model", prefix_osl="LOW", prefix_iat="LOW")
-        assert config.prefix_osl == 128
-        assert config.prefix_iat == 50
+        config = DynamoModelConfig(model_name="test-model", nvext_prefix_osl="LOW", nvext_prefix_iat="LOW")
+        assert config.nvext_prefix_osl == 128
+        assert config.nvext_prefix_iat == 50
 
-        config = DynamoModelConfig(model_name="test-model", prefix_osl="MEDIUM", prefix_iat="MEDIUM")
-        assert config.prefix_osl == 512
-        assert config.prefix_iat == 250
+        config = DynamoModelConfig(model_name="test-model", nvext_prefix_osl="MEDIUM", nvext_prefix_iat="MEDIUM")
+        assert config.nvext_prefix_osl == 512
+        assert config.nvext_prefix_iat == 250
 
-        config = DynamoModelConfig(model_name="test-model", prefix_osl="HIGH", prefix_iat="HIGH")
-        assert config.prefix_osl == 2048
-        assert config.prefix_iat == 750
+        config = DynamoModelConfig(model_name="test-model", nvext_prefix_osl="HIGH", nvext_prefix_iat="HIGH")
+        assert config.nvext_prefix_osl == 2048
+        assert config.nvext_prefix_iat == 750
 
     def test_backward_compat_case_insensitive(self):
         """Test that categorical coercion is case-insensitive."""
-        config = DynamoModelConfig(model_name="test-model", prefix_osl="low", prefix_iat="high")
-        assert config.prefix_osl == 128
-        assert config.prefix_iat == 750
+        config = DynamoModelConfig(model_name="test-model", nvext_prefix_osl="low", nvext_prefix_iat="high")
+        assert config.nvext_prefix_osl == 128
+        assert config.nvext_prefix_iat == 750
 
     def test_request_timeout_validation(self):
         """Test that request_timeout validates positive values."""
@@ -155,34 +165,73 @@ class TestDynamoModelConfig:
 
     def test_cache_pin_type_none_disables(self):
         """Test that cache_pin_type can be set to None to disable cache control."""
-        config = DynamoModelConfig(model_name="test-model", cache_pin_type=None)
-        assert config.cache_pin_type is None
+        config = DynamoModelConfig(model_name="test-model", nvext_cache_pin_type=None)
+        assert config.nvext_cache_pin_type is None
 
     def test_cache_pin_type_accepts_enum(self):
         """Test that cache_pin_type accepts CachePinType enum values."""
-        config = DynamoModelConfig(model_name="test-model", cache_pin_type=CachePinType.EPHEMERAL)
-        assert config.cache_pin_type == CachePinType.EPHEMERAL
+        config = DynamoModelConfig(model_name="test-model", nvext_cache_pin_type=CachePinType.EPHEMERAL)
+        assert config.nvext_cache_pin_type == CachePinType.EPHEMERAL
 
     def test_cache_pin_type_accepts_string(self):
         """Test that cache_pin_type accepts string values matching enum."""
-        config = DynamoModelConfig(model_name="test-model", cache_pin_type="ephemeral")
-        assert config.cache_pin_type == CachePinType.EPHEMERAL
+        config = DynamoModelConfig(model_name="test-model", nvext_cache_pin_type="ephemeral")
+        assert config.nvext_cache_pin_type == CachePinType.EPHEMERAL
+
+    def test_cache_pin_type_rejects_invalid_string(self):
+        """Test that cache_pin_type rejects invalid string values."""
+        with pytest.raises(ValueError):
+            DynamoModelConfig(model_name="test-model", nvext_cache_pin_type="invalid")
+
+    def test_cache_control_mode_default(self):
+        """Test that cache_control_mode defaults to ALWAYS."""
+        config = DynamoModelConfig(model_name="test-model")
+        assert config.nvext_cache_control_mode == CacheControlMode.ALWAYS
+
+    def test_cache_control_mode_accepts_enum(self):
+        """Test that cache_control_mode accepts CacheControlMode enum values."""
+        config = DynamoModelConfig(model_name="test-model", nvext_cache_control_mode=CacheControlMode.FIRST_ONLY)
+        assert config.nvext_cache_control_mode == CacheControlMode.FIRST_ONLY
+
+    def test_cache_control_mode_accepts_string(self):
+        """Test that cache_control_mode accepts string values matching enum."""
+        config = DynamoModelConfig(model_name="test-model", nvext_cache_control_mode="first_only")
+        assert config.nvext_cache_control_mode == CacheControlMode.FIRST_ONLY
+
+    def test_cache_control_mode_rejects_invalid_string(self):
+        """Test that cache_control_mode rejects invalid string values."""
+        with pytest.raises(ValueError):
+            DynamoModelConfig(model_name="test-model", nvext_cache_control_mode="invalid")
+
+    def test_max_sensitivity_validation(self):
+        """Test that nvext_max_sensitivity validates bounds."""
+        config = DynamoModelConfig(model_name="test-model", nvext_max_sensitivity=1)
+        assert config.nvext_max_sensitivity == 1
+
+        config = DynamoModelConfig(model_name="test-model", nvext_max_sensitivity=10000)
+        assert config.nvext_max_sensitivity == 10000
+
+        with pytest.raises(ValueError):
+            DynamoModelConfig(model_name="test-model", nvext_max_sensitivity=0)
+
+        with pytest.raises(ValueError):
+            DynamoModelConfig(model_name="test-model", nvext_max_sensitivity=-1)
 
     def test_get_dynamo_field_names(self):
         """Test that get_dynamo_field_names returns the correct field set."""
         field_names = DynamoModelConfig.get_dynamo_field_names()
 
         expected = frozenset({
-            "prefix_template",
-            "prefix_total_requests",
-            "prefix_osl",
-            "prefix_iat",
-            "prefix_use_raw_values",
-            "disable_headers",
+            "enable_nvext_hints",
+            "nvext_prefix_id_template",
+            "nvext_prefix_total_requests",
+            "nvext_prefix_osl",
+            "nvext_prefix_iat",
             "request_timeout",
-            "prediction_trie_path",
-            "cache_pin_type",
-            "max_sensitivity",
+            "nvext_prediction_trie_path",
+            "nvext_cache_pin_type",
+            "nvext_cache_control_mode",
+            "nvext_max_sensitivity",
         })
 
         assert field_names == expected
@@ -288,6 +337,67 @@ class TestDynamoPrefixContext:
         DynamoPrefixContext.clear()
         assert DynamoPrefixContext.is_set() is True
 
+    def test_prefix_id_stable_across_multiple_calls(self):
+        """Test that the same prefix ID is returned for multiple calls within the same context."""
+        DynamoPrefixContext.clear()
+
+        first = DynamoPrefixContext.get()
+        second = DynamoPrefixContext.get()
+        third = DynamoPrefixContext.get()
+
+        assert first == second == third
+        assert "-d0" in first
+
+    def test_override_prefix_id_stable_across_multiple_calls(self):
+        """Test that an override prefix ID is stable across multiple get() calls."""
+        DynamoPrefixContext.clear()
+        DynamoPrefixContext.set("workflow-abc-123")
+
+        assert DynamoPrefixContext.get() == "workflow-abc-123"
+        assert DynamoPrefixContext.get() == "workflow-abc-123"
+        assert DynamoPrefixContext.get() == "workflow-abc-123"
+
+        DynamoPrefixContext.clear()
+
+    async def test_prefix_id_consistent_across_transport_requests(self):
+        """Test that the same prefix_id appears in agent_hints across multiple LLM requests.
+
+        This verifies the critical property that all requests within the same
+        workflow/conversation share the same prefix_id for KV cache affinity.
+        """
+        import json
+
+        import httpx
+
+        from nat.llm.dynamo_llm import _DynamoTransport
+
+        mock_response = httpx.Response(200, json={"result": "ok"})
+        mock_transport = MagicMock()
+        mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
+
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+        )
+
+        DynamoPrefixContext.set("stable-prefix-test")
+
+        prefix_ids = []
+        for _ in range(5):
+            request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
+            await transport.handle_async_request(request)
+
+            body = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
+            prefix_ids.append(body["nvext"]["agent_hints"]["prefix_id"])
+
+        assert all(pid == "stable-prefix-test" for pid in prefix_ids)
+        assert len(prefix_ids) == 5
+
+        DynamoPrefixContext.clear()
+
 
 # ---------------------------------------------------------------------------
 # HTTPX Client Creation Tests
@@ -300,7 +410,6 @@ class TestCreateHttpxClient:
     def test_uses_custom_timeout(self):
         """Test that the function uses the provided timeout."""
         client = create_httpx_client_with_dynamo_hooks(
-            prefix_template=None,
             total_requests=10,
             osl=512,
             iat=250,
@@ -314,7 +423,6 @@ class TestCreateHttpxClient:
     def test_uses_default_timeout(self):
         """Test that the function uses default timeout when not specified."""
         client = create_httpx_client_with_dynamo_hooks(
-            prefix_template=None,
             total_requests=10,
             osl=512,
             iat=250,
@@ -327,7 +435,6 @@ class TestCreateHttpxClient:
         from nat.llm.dynamo_llm import _DynamoTransport
 
         client = create_httpx_client_with_dynamo_hooks(
-            prefix_template="test-{uuid}",
             total_requests=7,
             osl=2048,
             iat=50,
@@ -342,7 +449,6 @@ class TestCreateHttpxClient:
         assert client._transport._total_requests == 7
         assert client._transport._osl == 2048
         assert client._transport._iat == 50
-        assert client._transport._use_raw_values is True
         assert client._transport._cache_pin_type == CachePinType.EPHEMERAL
 
         # Verify timeout
@@ -353,7 +459,6 @@ class TestCreateHttpxClient:
         from nat.llm.dynamo_llm import _DynamoTransport
 
         client = create_httpx_client_with_dynamo_hooks(
-            prefix_template="test-{uuid}",
             total_requests=10,
             osl=512,
             iat=250,
@@ -362,6 +467,20 @@ class TestCreateHttpxClient:
 
         assert isinstance(client._transport, _DynamoTransport)
         assert client._transport._cache_pin_type is None
+
+    def test_creates_client_with_cache_control_mode_first_only(self):
+        """Test that create_httpx_client_with_dynamo_hooks passes cache_control_mode through."""
+        from nat.llm.dynamo_llm import _DynamoTransport
+
+        client = create_httpx_client_with_dynamo_hooks(
+            total_requests=10,
+            osl=512,
+            iat=250,
+            cache_control_mode=CacheControlMode.FIRST_ONLY,
+        )
+
+        assert isinstance(client._transport, _DynamoTransport)
+        assert client._transport._cache_control_mode == CacheControlMode.FIRST_ONLY
 
 
 # ---------------------------------------------------------------------------
@@ -405,44 +524,6 @@ class TestDynamoTransport:
         assert agent_hints["total_requests"] == 15
         assert agent_hints["osl"] == 2048
         assert agent_hints["iat"] == 50
-
-        DynamoPrefixContext.clear()
-
-    async def test_transport_injects_categorical_agent_hints_when_raw_disabled(self):
-        """Test that _DynamoTransport maps categorical values correctly when use_raw_values=False."""
-        import json
-
-        import httpx
-
-        from nat.llm.dynamo_llm import _DynamoTransport
-
-        mock_response = httpx.Response(200, json={"result": "ok"})
-        mock_transport = MagicMock()
-        mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
-
-        # osl=2048 -> HIGH (mapped to int 2048), iat=50 -> LOW (mapped to int 50)
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=15,
-            osl=2048,
-            iat=50,
-            prediction_lookup=None,
-            use_raw_values=False,
-        )
-
-        DynamoPrefixContext.set("test-categorical")
-
-        request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
-        await transport.handle_async_request(request)
-
-        modified_request = mock_transport.handle_async_request.call_args[0][0]
-        body = json.loads(modified_request.content.decode("utf-8"))
-        agent_hints = body["nvext"]["agent_hints"]
-
-        # osl: "HIGH" maps back to integer 2048 for agent_hints.osl (Dynamo u32)
-        assert agent_hints["osl"] == 2048
-        # iat: "LOW" string is kept as-is in agent_hints for processor.py
-        assert agent_hints["iat"] == "LOW"
 
         DynamoPrefixContext.clear()
 
@@ -645,53 +726,6 @@ class TestDynamoTransport:
 
         # Verify lookup was called
         assert mock_lookup.find.called
-
-        DynamoPrefixContext.clear()
-
-    async def test_transport_uses_prediction_override_categorical(self):
-        """Test that prediction lookup converts to categories when use_raw_values=False."""
-        import httpx
-
-        from nat.llm.dynamo_llm import _DynamoTransport
-        from nat.profiler.prediction_trie.data_models import LLMCallPrediction
-        from nat.profiler.prediction_trie.data_models import PredictionMetrics
-
-        mock_prediction = LLMCallPrediction(
-            remaining_calls=PredictionMetrics(mean=25.0, p50=25.0, p90=30.0),
-            output_tokens=PredictionMetrics(mean=2000.0, p50=2000.0, p90=2500.0),  # >= 1024 -> HIGH
-            interarrival_ms=PredictionMetrics(mean=50.0, p50=50.0, p90=70.0),  # < 100 -> LOW
-        )
-
-        mock_lookup = MagicMock()
-        mock_lookup.find = MagicMock(return_value=mock_prediction)
-
-        mock_response = httpx.Response(200, json={"result": "ok"})
-        mock_transport = MagicMock()
-        mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
-
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=10,
-            osl=512,
-            iat=250,
-            prediction_lookup=mock_lookup,
-            use_raw_values=False,
-        )
-
-        DynamoPrefixContext.set("prediction-categorical")
-
-        request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
-        await transport.handle_async_request(request)
-
-        modified_request = mock_transport.handle_async_request.call_args[0][0]
-
-        import json
-        body = json.loads(modified_request.content.decode("utf-8"))
-        agent_hints = body["nvext"]["agent_hints"]
-        # osl: "HIGH" maps back to integer 2048 for agent_hints.osl (Dynamo u32)
-        assert agent_hints["osl"] == 2048
-        # iat: "LOW" string kept for processor.py
-        assert agent_hints["iat"] == "LOW"
 
         DynamoPrefixContext.clear()
 
@@ -1290,6 +1324,169 @@ class TestDynamoTransport:
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
         with pytest.raises(ValueError, match="iat must be >= 1"):
             await transport.handle_async_request(request)
+
+        DynamoPrefixContext.clear()
+
+    async def test_transport_first_only_injects_cache_control_on_first_request(self):
+        """Test that FIRST_ONLY mode injects cache_control on the first request for a prefix."""
+        import json
+
+        import httpx
+
+        from nat.llm.dynamo_llm import _DynamoTransport
+
+        mock_response = httpx.Response(200, json={"result": "ok"})
+        mock_transport = MagicMock()
+        mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
+
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+            cache_control_mode=CacheControlMode.FIRST_ONLY,
+        )
+
+        DynamoPrefixContext.set("first-only-test")
+
+        # First request: cache_control should be injected
+        request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test", "messages": []})
+        await transport.handle_async_request(request)
+
+        modified_request = mock_transport.handle_async_request.call_args[0][0]
+        body = json.loads(modified_request.content.decode("utf-8"))
+
+        assert "cache_control" in body["nvext"]
+        assert body["nvext"]["cache_control"]["type"] == "ephemeral"
+        assert body["nvext"]["cache_control"]["ttl"] == "3s"  # 10 * 250 = 2500ms -> ceil = 3s
+
+        DynamoPrefixContext.clear()
+
+    async def test_transport_first_only_skips_cache_control_on_subsequent_requests(self):
+        """Test that FIRST_ONLY mode does NOT inject cache_control on the second+ request."""
+        import json
+
+        import httpx
+
+        from nat.llm.dynamo_llm import _DynamoTransport
+
+        mock_response = httpx.Response(200, json={"result": "ok"})
+        mock_transport = MagicMock()
+        mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
+
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+            cache_control_mode=CacheControlMode.FIRST_ONLY,
+        )
+
+        DynamoPrefixContext.set("first-only-skip-test")
+
+        # First request (call_index=1): should have cache_control
+        request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
+        await transport.handle_async_request(request)
+
+        first_body = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
+        assert "cache_control" in first_body["nvext"]
+
+        # Second request (call_index=2): should NOT have cache_control
+        request2 = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
+        await transport.handle_async_request(request2)
+
+        second_body = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
+        assert "cache_control" not in second_body["nvext"]
+
+        # Third request (call_index=3): should still NOT have cache_control
+        request3 = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
+        await transport.handle_async_request(request3)
+
+        third_body = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
+        assert "cache_control" not in third_body["nvext"]
+
+        # agent_hints should still be present on all requests
+        assert "agent_hints" in third_body["nvext"]
+
+        DynamoPrefixContext.clear()
+
+    async def test_transport_first_only_tracks_prefixes_independently(self):
+        """Test that FIRST_ONLY mode tracks each prefix_id independently."""
+        import json
+
+        import httpx
+
+        from nat.llm.dynamo_llm import _DynamoTransport
+
+        mock_response = httpx.Response(200, json={"result": "ok"})
+        mock_transport = MagicMock()
+        mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
+
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+            cache_control_mode=CacheControlMode.FIRST_ONLY,
+        )
+
+        # First prefix, first request: should have cache_control
+        DynamoPrefixContext.set("prefix-a")
+        request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
+        await transport.handle_async_request(request)
+
+        body_a1 = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
+        assert "cache_control" in body_a1["nvext"]
+
+        # First prefix, second request: should NOT have cache_control
+        request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
+        await transport.handle_async_request(request)
+
+        body_a2 = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
+        assert "cache_control" not in body_a2["nvext"]
+
+        # Second prefix, first request: SHOULD have cache_control (new prefix)
+        DynamoPrefixContext.set("prefix-b")
+        request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
+        await transport.handle_async_request(request)
+
+        body_b1 = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
+        assert "cache_control" in body_b1["nvext"]
+
+        DynamoPrefixContext.clear()
+
+    async def test_transport_always_mode_injects_cache_control_every_request(self):
+        """Test that ALWAYS mode (default) injects cache_control on every request."""
+        import json
+
+        import httpx
+
+        from nat.llm.dynamo_llm import _DynamoTransport
+
+        mock_response = httpx.Response(200, json={"result": "ok"})
+        mock_transport = MagicMock()
+        mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
+
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+            cache_control_mode=CacheControlMode.ALWAYS,
+        )
+
+        DynamoPrefixContext.set("always-mode-test")
+
+        for i in range(3):
+            request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
+            await transport.handle_async_request(request)
+
+            body = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
+            assert "cache_control" in body["nvext"], f"cache_control missing on request {i + 1}"
 
         DynamoPrefixContext.clear()
 

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
@@ -73,11 +73,15 @@ class TestDynamoModelConfig:
         assert config.nvext_prefix_iat == 50
         assert config.request_timeout == 300.0
 
-    def test_disable_prefix_headers(self):
-        """Test that agent hints can be disabled by setting prefix_template to None."""
+    def test_prefix_template_none_does_not_toggle_hints(self):
+        """Test that setting nvext_prefix_id_template to None only clears the template value.
+
+        Hint injection is controlled by enable_nvext_hints, not by this field,
+        so this assignment does not affect whether hints are enabled or disabled.
+        """
         config = DynamoModelConfig(
             model_name="test-model",
-            nvext_prefix_id_template=None,  # Explicitly disable agent hints
+            nvext_prefix_id_template=None,
         )
 
         assert config.nvext_prefix_id_template is None

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_prediction_trie.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_prediction_trie.py
@@ -49,41 +49,41 @@ def fixture_trie_file() -> Path:
 
 
 def test_dynamo_config_with_trie_path(trie_file):
-    """Test that DynamoModelConfig accepts prediction_trie_path."""
+    """Test that DynamoModelConfig accepts nvext_prediction_trie_path."""
     config = DynamoModelConfig(
         base_url="http://localhost:8000",
         model_name="test-model",
         api_key="test-key",
-        prediction_trie_path=str(trie_file),
+        nvext_prediction_trie_path=str(trie_file),
     )
 
-    assert config.prediction_trie_path == str(trie_file)
-    assert "prediction_trie_path" in DynamoModelConfig.get_dynamo_field_names()
+    assert config.nvext_prediction_trie_path == str(trie_file)
+    assert "nvext_prediction_trie_path" in DynamoModelConfig.get_dynamo_field_names()
 
 
 def test_dynamo_config_without_trie_path():
-    """Test that DynamoModelConfig works without prediction_trie_path."""
+    """Test that DynamoModelConfig works without nvext_prediction_trie_path."""
     config = DynamoModelConfig(
         base_url="http://localhost:8000",
         model_name="test-model",
         api_key="test-key",
     )
 
-    assert config.prediction_trie_path is None
+    assert config.nvext_prediction_trie_path is None
 
 
 def test_dynamo_field_names_excludes_trie_path():
-    """Test that prediction_trie_path is excluded from OpenAI client kwargs."""
+    """Test that nvext_prediction_trie_path is excluded from OpenAI client kwargs."""
     config = DynamoModelConfig(
         base_url="http://localhost:8000",
         model_name="test-model",
         api_key="test-key",
-        prediction_trie_path="/path/to/trie.json",
+        nvext_prediction_trie_path="/path/to/trie.json",
     )
 
     # Simulate what would be passed to an OpenAI client
     exclude_fields = {"type", "thinking", *DynamoModelConfig.get_dynamo_field_names()}
     config_dict = config.model_dump(exclude=exclude_fields, exclude_none=True)
 
-    # prediction_trie_path should not be in the config dict
-    assert "prediction_trie_path" not in config_dict
+    # nvext_prediction_trie_path should not be in the config dict
+    assert "nvext_prediction_trie_path" not in config_dict

--- a/packages/nvidia_nat_core/tests/nat/llm/test_runtime_prediction_e2e.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_runtime_prediction_e2e.py
@@ -110,7 +110,7 @@ async def test_e2e_prediction_headers_injected_correctly():
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        # Create transport with prediction lookup (default use_raw_values=True)
+        # Create transport with prediction lookup
         transport = _DynamoTransport(
             transport=mock_transport,
             total_requests=10,

--- a/packages/nvidia_nat_eval/src/nat/plugins/eval/profiler/inference_optimization/dynamo_metrics.py
+++ b/packages/nvidia_nat_eval/src/nat/plugins/eval/profiler/inference_optimization/dynamo_metrics.py
@@ -252,7 +252,8 @@ class DynamoCoreMetrics(BaseModel):
         description="KV Efficiency (0-1): fraction of prompt tokens served from cache. "
         "Computed as cached_tokens / prompt_tokens from Thompson Sampling processor. "
         "Higher values indicate more computational work saved via KV cache reuse. "
-        "This is the PRIMARY metric affected by prefix routing hints (prefix_id, nvext_prefix_osl, nvext_prefix_iat).",
+        "This is the PRIMARY metric affected by prefix routing hints "
+        "(nvext_prefix_id, nvext_prefix_osl, nvext_prefix_iat).",
     )
     kv_efficiency_fallback: float | None = Field(
         default=None,

--- a/packages/nvidia_nat_eval/src/nat/plugins/eval/profiler/inference_optimization/dynamo_metrics.py
+++ b/packages/nvidia_nat_eval/src/nat/plugins/eval/profiler/inference_optimization/dynamo_metrics.py
@@ -252,7 +252,7 @@ class DynamoCoreMetrics(BaseModel):
         description="KV Efficiency (0-1): fraction of prompt tokens served from cache. "
         "Computed as cached_tokens / prompt_tokens from Thompson Sampling processor. "
         "Higher values indicate more computational work saved via KV cache reuse. "
-        "This is the PRIMARY metric affected by prefix routing hints (prefix_id, prefix_osl, prefix_iat).",
+        "This is the PRIMARY metric affected by prefix routing hints (prefix_id, nvext_prefix_osl, nvext_prefix_iat).",
     )
     kv_efficiency_fallback: float | None = Field(
         default=None,

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -239,9 +239,9 @@ async def openai_langchain(llm_config: OpenAIModelConfig, _builder: Builder):
 @register_llm_client(config_type=DynamoModelConfig, wrapper_type=LLMFrameworkEnum.LANGCHAIN)
 async def dynamo_langchain(llm_config: DynamoModelConfig, _builder: Builder):
     """
-    Create a LangChain ChatOpenAI client for Dynamo with automatic prefix header injection.
+    Create a LangChain ChatOpenAI client for Dynamo with automatic agent hint injection.
 
-    This client injects Dynamo prefix headers at the HTTP transport level using httpx event hooks,
+    This client injects Dynamo routing hints via nvext.agent_hints at the HTTP transport level,
     enabling KV cache optimization and request routing.
     """
     from langchain_openai import ChatOpenAI
@@ -262,38 +262,35 @@ async def dynamo_langchain(llm_config: DynamoModelConfig, _builder: Builder):
 
     # Load prediction trie if configured
     prediction_lookup: PredictionTrieLookup | None = None
-    if llm_config.prediction_trie_path:
+    if llm_config.nvext_prediction_trie_path:
         try:
-            trie_path = Path(llm_config.prediction_trie_path)
+            trie_path = Path(llm_config.nvext_prediction_trie_path)
             trie = load_prediction_trie(trie_path)
             prediction_lookup = PredictionTrieLookup(trie)
-            logger.info("Loaded prediction trie from %s", llm_config.prediction_trie_path)
+            logger.info("Loaded prediction trie from %s", llm_config.nvext_prediction_trie_path)
         except FileNotFoundError:
-            logger.warning("Prediction trie file not found: %s", llm_config.prediction_trie_path)
+            logger.warning("Prediction trie file not found: %s", llm_config.nvext_prediction_trie_path)
         except Exception as e:
             logger.warning("Failed to load prediction trie: %s", e)
 
     try:
-        # If prefix_template is set, create a custom httpx client with Dynamo hooks
-        if llm_config.prefix_template is not None:
+        if llm_config.enable_nvext_hints:
             http_async_client = create_httpx_client_with_dynamo_hooks(
-                prefix_template=llm_config.prefix_template,
-                total_requests=llm_config.prefix_total_requests,
-                osl=llm_config.prefix_osl,
-                iat=llm_config.prefix_iat,
+                total_requests=llm_config.nvext_prefix_total_requests,
+                osl=llm_config.nvext_prefix_osl,
+                iat=llm_config.nvext_prefix_iat,
                 timeout=llm_config.request_timeout,
                 prediction_lookup=prediction_lookup,
-                use_raw_values=llm_config.prefix_use_raw_values,
-                cache_pin_type=llm_config.cache_pin_type,
-                max_sensitivity=llm_config.max_sensitivity,
+                cache_pin_type=llm_config.nvext_cache_pin_type,
+                cache_control_mode=llm_config.nvext_cache_control_mode,
+                max_sensitivity=llm_config.nvext_max_sensitivity,
             )
             config_dict["http_async_client"] = http_async_client
             logger.info(
-                "Dynamo prefix headers enabled: template=%s, total_requests=%d, osl=%s, iat=%s, prediction_trie=%s",
-                llm_config.prefix_template,
-                llm_config.prefix_total_requests,
-                llm_config.prefix_osl,
-                llm_config.prefix_iat,
+                "Dynamo agent hints enabled: total_requests=%d, osl=%s, iat=%s, prediction_trie=%s",
+                llm_config.nvext_prefix_total_requests,
+                llm_config.nvext_prefix_osl,
+                llm_config.nvext_prefix_iat,
                 "loaded" if prediction_lookup else "disabled",
             )
 

--- a/packages/nvidia_nat_langchain/tests/test_dynamo_trie_loading.py
+++ b/packages/nvidia_nat_langchain/tests/test_dynamo_trie_loading.py
@@ -64,10 +64,10 @@ def test_dynamo_config_with_valid_trie_path(trie_file):
         base_url="http://localhost:8000/v1",
         model_name="test-model",
         api_key="test-key",
-        prediction_trie_path=trie_file,
+        nvext_prediction_trie_path=trie_file,
     )
 
-    assert config.prediction_trie_path == trie_file
+    assert config.nvext_prediction_trie_path == trie_file
 
 
 def test_dynamo_config_with_nonexistent_trie_path():
@@ -76,11 +76,11 @@ def test_dynamo_config_with_nonexistent_trie_path():
         base_url="http://localhost:8000/v1",
         model_name="test-model",
         api_key="test-key",
-        prediction_trie_path="/nonexistent/path/trie.json",
+        nvext_prediction_trie_path="/nonexistent/path/trie.json",
     )
 
     # Config creation should succeed; error happens at runtime
-    assert config.prediction_trie_path == "/nonexistent/path/trie.json"
+    assert config.nvext_prediction_trie_path == "/nonexistent/path/trie.json"
 
 
 @patch("nat.plugins.langchain.llm.create_httpx_client_with_dynamo_hooks")
@@ -95,8 +95,9 @@ async def test_dynamo_langchain_loads_trie_and_passes_to_client(mock_chat, mock_
         base_url="http://localhost:8000/v1",
         model_name="test-model",
         api_key="test-key",
-        prefix_template="test-{uuid}",
-        prediction_trie_path=trie_file,
+        enable_nvext_hints=True,
+        nvext_prefix_id_template="test-{uuid}",
+        nvext_prediction_trie_path=trie_file,
     )
 
     async with dynamo_langchain(config, mock_builder):
@@ -121,8 +122,9 @@ async def test_dynamo_langchain_handles_nonexistent_trie_gracefully(mock_chat, m
         base_url="http://localhost:8000/v1",
         model_name="test-model",
         api_key="test-key",
-        prefix_template="test-{uuid}",
-        prediction_trie_path="/nonexistent/path/trie.json",
+        enable_nvext_hints=True,
+        nvext_prefix_id_template="test-{uuid}",
+        nvext_prediction_trie_path="/nonexistent/path/trie.json",
     )
 
     # Should not raise an exception
@@ -147,7 +149,8 @@ async def test_dynamo_langchain_no_trie_path_means_no_lookup(mock_chat, mock_cre
         base_url="http://localhost:8000/v1",
         model_name="test-model",
         api_key="test-key",
-        prefix_template="test-{uuid}",  # prediction_trie_path is None by default
+        enable_nvext_hints=True,
+        nvext_prefix_id_template="test-{uuid}",  # nvext_prediction_trie_path is None by default
     )
 
     async with dynamo_langchain(config, mock_builder):
@@ -175,8 +178,9 @@ async def test_dynamo_langchain_handles_invalid_trie_file_gracefully(mock_chat, 
             base_url="http://localhost:8000/v1",
             model_name="test-model",
             api_key="test-key",
-            prefix_template="test-{uuid}",
-            prediction_trie_path=invalid_trie_path,
+            enable_nvext_hints=True,
+            nvext_prefix_id_template="test-{uuid}",
+            nvext_prediction_trie_path=invalid_trie_path,
         )
 
         # Should not raise an exception

--- a/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
+++ b/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
@@ -25,6 +25,7 @@ from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.data_models.llm import APITypeEnum
 from nat.llm.aws_bedrock_llm import AWSBedrockModelConfig
+from nat.llm.dynamo_llm import CacheControlMode
 from nat.llm.dynamo_llm import CachePinType
 from nat.llm.dynamo_llm import DynamoModelConfig
 from nat.llm.nim_llm import NIMModelConfig
@@ -178,23 +179,23 @@ class TestDynamoLangChain:
 
     @pytest.fixture
     def dynamo_cfg_no_prefix(self):
-        """Dynamo config without prefix template (no header injection)."""
+        """Dynamo config with nvext hints disabled (no header injection)."""
         return DynamoModelConfig(
             model_name="test-model",
             base_url="http://localhost:8000/v1",
-            prefix_template=None,
         )
 
     @pytest.fixture
     def dynamo_cfg_with_prefix(self):
-        """Dynamo config with prefix template (enables header injection)."""
+        """Dynamo config with nvext hints enabled (enables header injection)."""
         return DynamoModelConfig(
             model_name="test-model",
             base_url="http://localhost:8000/v1",
-            prefix_template="session-{uuid}",
-            prefix_total_requests=15,
-            prefix_osl=2048,
-            prefix_iat=50,
+            enable_nvext_hints=True,
+            nvext_prefix_id_template="session-{uuid}",
+            nvext_prefix_total_requests=15,
+            nvext_prefix_osl=2048,
+            nvext_prefix_iat=50,
             request_timeout=300.0,
         )
 
@@ -205,12 +206,13 @@ class TestDynamoLangChain:
             model_name="test-model",
             base_url="http://localhost:8000/v1",
             api_type=APITypeEnum.RESPONSES,
-            prefix_template="session-{uuid}",
+            enable_nvext_hints=True,
+            nvext_prefix_id_template="session-{uuid}",
         )
 
     @patch("langchain_openai.ChatOpenAI")
     async def test_basic_creation_without_prefix(self, mock_chat, dynamo_cfg_no_prefix, mock_builder):
-        """Wrapper should create ChatOpenAI without custom httpx client when no prefix template."""
+        """Wrapper should create ChatOpenAI without custom httpx client when nvext hints disabled."""
         async with dynamo_langchain(dynamo_cfg_no_prefix, mock_builder) as client:
             mock_chat.assert_called_once()
             kwargs = mock_chat.call_args.kwargs
@@ -229,7 +231,7 @@ class TestDynamoLangChain:
                                                  mock_create_client,
                                                  dynamo_cfg_with_prefix,
                                                  mock_builder):
-        """Wrapper should create ChatOpenAI with custom httpx client when prefix template is set."""
+        """Wrapper should create ChatOpenAI with custom httpx client when nvext hints enabled."""
         mock_httpx_client = MagicMock()
         mock_httpx_client.aclose = AsyncMock()  # Make aclose awaitable
         mock_create_client.return_value = mock_httpx_client
@@ -237,14 +239,13 @@ class TestDynamoLangChain:
         async with dynamo_langchain(dynamo_cfg_with_prefix, mock_builder) as client:
             # Verify httpx client was created with correct parameters
             mock_create_client.assert_called_once_with(
-                prefix_template="session-{uuid}",
                 total_requests=15,
                 osl=2048,
                 iat=50,
                 timeout=300.0,
                 prediction_lookup=None,
-                use_raw_values=True,
                 cache_pin_type=CachePinType.EPHEMERAL,
+                cache_control_mode=CacheControlMode.ALWAYS,
                 max_sensitivity=1000,
             )
 
@@ -287,10 +288,10 @@ class TestDynamoLangChain:
                                                    mock_builder):
         """Dynamo-specific fields should be excluded from ChatOpenAI kwargs.
 
-        DynamoModelConfig has fields (prefix_template, prefix_total_requests, prefix_osl,
-        prefix_iat, request_timeout) that are only used internally by NAT to configure
-        the custom httpx client for Dynamo header injection. These fields must NOT be
-        passed to ChatOpenAI because:
+        DynamoModelConfig has fields (enable_nvext_hints, nvext_prefix_id_template,
+        nvext_prefix_total_requests, nvext_prefix_osl, nvext_prefix_iat, request_timeout)
+        that are only used internally by NAT to configure the custom httpx client for
+        Dynamo header injection. These fields must NOT be passed to ChatOpenAI because:
 
         1. ChatOpenAI doesn't understand them and would error or ignore them
         2. They configure NAT's header injection behavior, not the LLM client itself
@@ -308,12 +309,11 @@ class TestDynamoLangChain:
         kwargs = mock_chat.call_args.kwargs
 
         # These Dynamo-specific fields should NOT be passed to ChatOpenAI
-        assert "prefix_template" not in kwargs
-        assert "prefix_total_requests" not in kwargs
-        assert "prefix_osl" not in kwargs
-        assert "prefix_iat" not in kwargs
-        assert "prefix_use_raw_values" not in kwargs
-        assert "disable_headers" not in kwargs
+        assert "nvext_prefix_id_template" not in kwargs
+        assert "nvext_prefix_total_requests" not in kwargs
+        assert "nvext_prefix_osl" not in kwargs
+        assert "nvext_prefix_iat" not in kwargs
+        assert "enable_nvext_hints" not in kwargs
         assert "request_timeout" not in kwargs
 
         # Verify the httpx client was properly closed

--- a/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
+++ b/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
@@ -179,7 +179,7 @@ class TestDynamoLangChain:
 
     @pytest.fixture
     def dynamo_cfg_no_prefix(self):
-        """Dynamo config with nvext hints disabled (no header injection)."""
+        """Dynamo config with nvext hints disabled (no nvext request-body injection)."""
         return DynamoModelConfig(
             model_name="test-model",
             base_url="http://localhost:8000/v1",
@@ -187,7 +187,7 @@ class TestDynamoLangChain:
 
     @pytest.fixture
     def dynamo_cfg_with_prefix(self):
-        """Dynamo config with nvext hints enabled (enables header injection)."""
+        """Dynamo config with nvext hints enabled (injects nvext fields into the JSON request body)."""
         return DynamoModelConfig(
             model_name="test-model",
             base_url="http://localhost:8000/v1",
@@ -291,10 +291,11 @@ class TestDynamoLangChain:
         DynamoModelConfig has fields (enable_nvext_hints, nvext_prefix_id_template,
         nvext_prefix_total_requests, nvext_prefix_osl, nvext_prefix_iat, request_timeout)
         that are only used internally by NAT to configure the custom httpx client for
-        Dynamo header injection. These fields must NOT be passed to ChatOpenAI because:
+        Dynamo nvext request-body injection (injects nvext.agent_hints / nvext.cache_control
+        into the JSON body). These fields must NOT be passed to ChatOpenAI because:
 
         1. ChatOpenAI doesn't understand them and would error or ignore them
-        2. They configure NAT's header injection behavior, not the LLM client itself
+        2. They configure NAT's nvext request-body injection behavior, not the LLM client itself
 
         This test ensures the `exclude` set in model_dump() properly filters these fields.
         If someone accidentally removes a field from the exclude set, this test will fail.


### PR DESCRIPTION
## Description
This PR cleans the logic around nvext optional parameters for the NAT-dynamo integration and updates corresponding examples and unit tests. This is aligned with the scope of current examples and the expected status of dynamo 1.0.0.

Here is a table summarizing the parameters:

# nvext Field Reference

Fields injected into the OpenAI-compatible request body by NAT's `_DynamoTransport`.
All fields live under the top-level `nvext` key in the JSON request body.

---

## `nvext.agent_hints`

Routing hints consumed by Dynamo's built-in router/scheduler and the custom `processor.py`.

| Field | Description | Used in NAT Source/Components | Used in Dynamo Source/Components |
|---|---|---|---|
| `prefix_id` | Unique string identifying the KV cache prefix for a conversation. | Yes — `DynamoPrefixContext` generates it; `processor.py` routes on it. | No |
| `total_requests` | Expected number of LLM calls in this conversation. | Yes — `processor.py` computes `reuse_budget` from it. | No |
| `osl` | Expected output tokens (always raw integer in `agent_hints`). Config accepts `LOW`/`MEDIUM`/`HIGH` strings for backward compat (mapped to 128/512/2048). | Yes — `processor.py` uses it for router decode cost weighting. Validated for pass-through to Dynamo. | Yes — native `AgentHints.osl` read by Dynamo's built-in frontend. |
| `iat` | Expected inter-arrival time in milliseconds (always raw integer). Config accepts `LOW`/`MEDIUM`/`HIGH` strings for backward compat (mapped to 50/250/750). | Yes — `processor.py` uses it for router stickiness weighting. Also used client-side to compute `cache_control.ttl`. | No |
| `latency_sensitivity` | How latency-sensitive this request is (from `@latency_sensitive` decorator or prediction trie). Increase to prioritize a request. | Validated, passed through to Dynamo. Sets a context variable via `Context.push_latency_sensitivity()`. | Yes — native `AgentHints.latency_sensitivity` → Dynamo queue ordering. |
| `priority` | Engine scheduling priority (`nvext_max_sensitivity - latency_sensitivity`). Lower values = higher priority for vLLM; SGLang is configurable. | Validated, passed through to Dynamo. | Yes — native `AgentHints.priority` → engine queue, eviction, preemption. |

---

## `nvext.cache_control`

KV cache lifetime management. Injected as a sibling of `agent_hints` under `nvext`.
Only injected when `nvext_cache_pin_type` is set (not `None`).

| Field | Description | Used in NAT Source/Components | Used in Dynamo Source/Components |
|---|---|---|---|
| `type` | Cache pinning strategy. Only valid value is `"ephemeral"`. Required in JSON (no serde default on deserialization). | `dynamo_llm.py`: Injected client-side via `CachePinType.EPHEMERAL` (default). Configurable via `nvext_cache_pin_type` param; set to `null` to disable `cache_control` entirely. | `nvext.rs`: Deserialized into `CacheControlType` enum (single variant: `Ephemeral`). Presence of `cache_control` triggers `pin_prefix` after generation in the KV push router. Requires `--enable-cache-control` on the frontend. |
| `ttl` | Duration string for how long to pin the prefix in the KV cache. Optional; defaults to `"5m"` (300s) when omitted. | `dynamo_llm.py`: Computed client-side as `total_requests * iat` (ms), converted to seconds, formatted as `"<N>m"` (whole minutes) or `"<N>s"`. The `iat` field is not consumed by Dynamo — it is only used here for this TTL computation and by the custom Thompson Sampling `processor.py`. | `nvext.rs` `CacheControl::ttl_seconds()`: Only parses `"5m"` (300s) and `"1h"` (3600s). Any other value logs a warning and falls back to 300s. The parsed TTL is forwarded as `ttl_seconds` to `pin_prefix` on the worker via the `cache_control` service mesh endpoint (`cache_control.rs` / `handler_base.py`). |

### `nvext_cache_control_mode` (NAT config field)

Controls **when** `nvext.cache_control` is injected (not a wire-format field — only affects client-side behavior):

| Mode | Behavior |
|---|---|
| `always` (default) | Inject `cache_control` on every request. Refreshes TTL each turn. |
| `first_only` | Inject only on the first request per `prefix_id`. Pins the system prompt when first established in the KV cache; subsequent requests benefit from prefix matching without re-pinning the growing conversation context. |

This field is only relevant when `nvext_cache_pin_type` is set (i.e., `"ephemeral"`). When `nvext_cache_pin_type` is `null`, no `cache_control` is injected regardless of this mode.

---

## NAT Config → Wire Format Mapping

| NAT Config Field | Wire Format Location | Notes |
|---|---|---|
| `enable_nvext_hints` | *(gating only)* | When `false` (default), no `nvext` injection occurs. |
| `nvext_prefix_id_template` | *(unused by transport)* | Prefix IDs come from `DynamoPrefixContext` at request time. |
| `nvext_prefix_total_requests` | `nvext.agent_hints.total_requests` | |
| `nvext_prefix_osl` | `nvext.agent_hints.osl` | Always sent as raw integer. |
| `nvext_prefix_iat` | `nvext.agent_hints.iat` | Always sent as raw integer. Also used to compute `cache_control.ttl`. |
| `nvext_max_sensitivity` | `nvext.agent_hints.priority` | `priority = nvext_max_sensitivity - latency_sensitivity` |
| *(from Context)* | `nvext.agent_hints.latency_sensitivity` | Set by `@latency_sensitive` decorator or prediction trie. |
| *(from DynamoPrefixContext)* | `nvext.agent_hints.prefix_id` | Auto-generated per workflow run + call depth. |
| `nvext_cache_pin_type` | `nvext.cache_control.type` | `null` disables `cache_control` entirely. |
| `nvext_cache_control_mode` | *(gating only)* | Controls whether `cache_control` is injected on every request or just the first. |
| `nvext_prediction_trie_path` | *(overrides agent_hints values)* | When set, per-call predictions override `total_requests`, `osl`, `iat`, and optionally `latency_sensitivity`. |

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * NVEXT-based agent hints for Dynamo LLMs.
  * Configurable cache control modes (ALWAYS, FIRST_ONLY) and optional prediction-trie support.

* **Changes**
  * Renamed public config fields from prefix_* → nvext_prefix_*.
  * Added enable_nvext_hints toggle to enable NVEXT flow.
  * Switched from static prefix headers to dynamic per-request agent hints injection.

* **Documentation**
  * Updated docs and log messages to reference NVEXT terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->