### PR TITLE
CI fix: exclude CHANGELOG.md from pre-commit checks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -73,7 +73,7 @@ repos:
     hooks:
       - id: markdown-link-check
         args: ["-q", "--config", "ci/markdown-link-check-config.json"]
-        exclude: "^src/nat/meta/pypi\\.md$"
+        exclude: "^(src/nat/meta/pypi\\.md|CHANGELOG\\.md)$"
 
 default_language_version:
   python: python3


### PR DESCRIPTION
## Description
False positives from the markdown link checker in CI on the CHANGELOG.md file has been annoying and unhelpful. Adding CHANGELOG.md to the markdown link checker pre-commit will save us some failed CIs.


Here's an example:

```
(node:10223) [DEP0184] DeprecationWarning: Instantiating Gunzip without the 'new' keyword has been deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)

  ERROR: 3 dead links found in CHANGELOG.md !
  [✖] https://github.com/NVIDIA/NeMo-Agent-Toolkit/pull/1024 → Status: 502
  [✖] https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/release/1.2/docs/source/extend/object-store.md → Status: 502
  [✖] https://github.com/NVIDIA/NeMo-Agent-Toolkit/pull/110 → Status: 502
(node:10225) [DEP0184] DeprecationWarning: Instantiating Gunzip without the 'new' keyword has been deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:10224) [DEP0184] DeprecationWarning: Instantiating Gunzip without the 'new' keyword has been deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
(node:10226) [DEP0184] DeprecationWarning: Instantiating Gunzip without the 'new' keyword has been deprecated.
(Use `node --trace-deprecation ...` to show where the warning was created)
```

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the markdown link-check pre-commit hook configuration to exclude the changelog file from link validation. This addition complements existing exclusions for package metadata documentation, improving the efficiency of continuous integration validation processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->