### PR TITLE
Add validation alias for nvext_max_sensitivity in DynamoLLM

### DIFF
--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -70,6 +70,7 @@ import httpx
 if TYPE_CHECKING:
     from nat.profiler.prediction_trie.trie_lookup import PredictionTrieLookup
 
+from pydantic import AliasChoices
 from pydantic import Field
 from pydantic import field_validator
 
@@ -370,6 +371,7 @@ class DynamoModelConfig(OpenAIModelConfig, name="dynamo"):
     nvext_max_sensitivity: int = Field(
         default=1000,
         ge=1,
+        validation_alias=AliasChoices("nvext_max_sensitivity", "max_sensitivity"),
         description="Maximum latency sensitivity value used to compute request priority. "
         "Priority is the integer complement: priority = max_sensitivity - latency_sensitivity. "
         "Lower priority values indicate higher priority requests.",


### PR DESCRIPTION
## Description
Introduced the `validation_alias` using `AliasChoices` to support alternative field names for `nvext_max_sensitivity`. This enhances flexibility in handling input data, allowing the use of both "nvext_max_sensitivity" and "max_sensitivity" as valid keys.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Added backward-compatibility support for configuration field aliasing, allowing users to use alternative field names when setting model parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->