### PR TITLE
improvement: nvext.cache_control warning and HiCache for SgLang images

### DIFF
--- a/external/dynamo/.env.example
+++ b/external/dynamo/.env.example
@@ -89,12 +89,12 @@ export DYNAMO_HTTP_PORT=8000
 # =============================================================================
 
 # Enable hierarchical cache on SGLang workers (required for cache_control pin_prefix)
-export DYNAMO_ENABLE_HIERARCHICAL_CACHE=true
+export DYNAMO_ENABLE_HIERARCHICAL_CACHE=false
 # HiCache configuration (only applies when DYNAMO_ENABLE_HIERARCHICAL_CACHE=true)
 # CPU pool size as a multiple of GPU KV cache pool (default: 1.0 = same size)
-export DYNAMO_HICACHE_RATIO=1.0
+# export DYNAMO_HICACHE_RATIO=1.0
 # Write policy: write_through (copy to CPU on insert) or write_back (copy on evict)
-export DYNAMO_HICACHE_POLICY=write_through
+# export DYNAMO_HICACHE_POLICY=write_through
 
 # =============================================================================
 # OPTIONAL VARIABLES - Disaggregated Mode

--- a/external/dynamo/.env.example
+++ b/external/dynamo/.env.example
@@ -85,6 +85,18 @@ export DYNAMO_HTTP_PORT=8000
 # DYNAMO_SHM_SIZE=16g
 
 # =============================================================================
+# OPTIONAL VARIABLES - HiCache Configuration
+# =============================================================================
+
+# Enable hierarchical cache on SGLang workers (required for cache_control pin_prefix)
+export DYNAMO_ENABLE_HIERARCHICAL_CACHE=true
+# HiCache configuration (only applies when DYNAMO_ENABLE_HIERARCHICAL_CACHE=true)
+# CPU pool size as a multiple of GPU KV cache pool (default: 1.0 = same size)
+export DYNAMO_HICACHE_RATIO=1.0
+# Write policy: write_through (copy to CPU on insert) or write_back (copy on evict)
+export DYNAMO_HICACHE_POLICY=write_through
+
+# =============================================================================
 # OPTIONAL VARIABLES - Disaggregated Mode
 # =============================================================================
 

--- a/external/dynamo/start_dynamo_unified.sh
+++ b/external/dynamo/start_dynamo_unified.sh
@@ -71,6 +71,24 @@ ENABLE_HIERARCHICAL_CACHE="${DYNAMO_ENABLE_HIERARCHICAL_CACHE:-false}"
 HICACHE_RATIO="${DYNAMO_HICACHE_RATIO:-1.0}"
 HICACHE_POLICY="${DYNAMO_HICACHE_POLICY:-write_through}"
 
+# Validate HiCache settings when enabled
+if [ "${ENABLE_HIERARCHICAL_CACHE}" = "true" ]; then
+    if ! printf '%s' "$HICACHE_RATIO" | grep -qE '^[0-9]*\.?[0-9]+$' || \
+       [ "$(echo "$HICACHE_RATIO <= 0" | bc -l 2>/dev/null)" = "1" ]; then
+        echo "ERROR: HICACHE_RATIO must be a positive number (got: '$HICACHE_RATIO')" >&2
+        echo "  Set via DYNAMO_HICACHE_RATIO (e.g., 1.0)" >&2
+        exit 1
+    fi
+    case "$HICACHE_POLICY" in
+        write_through|write_back) ;;
+        *)
+            echo "ERROR: HICACHE_POLICY must be 'write_through' or 'write_back' (got: '$HICACHE_POLICY')" >&2
+            echo "  Set via DYNAMO_HICACHE_POLICY" >&2
+            exit 1
+            ;;
+    esac
+fi
+
 # Compute container-internal GPU indices (GPUs are renumbered 0,1,2,... inside the container)
 NUM_GPUS=$(echo "$WORKER_GPUS" | tr ',' '\n' | wc -l)
 CONTAINER_GPU_INDICES=$(seq -s, 0 $((NUM_GPUS - 1)))

--- a/external/dynamo/start_dynamo_unified.sh
+++ b/external/dynamo/start_dynamo_unified.sh
@@ -65,6 +65,12 @@ MAX_MODEL_LEN="${DYNAMO_MAX_MODEL_LEN:-}"
 # Hard override for the number of GPU KV cache blocks (unset = auto)
 NUM_GPU_BLOCKS_OVERRIDE="${DYNAMO_NUM_GPU_BLOCKS_OVERRIDE:-}"
 
+# HiCache (hierarchical KV cache) configuration
+# Enables CPU-backed overflow cache for the SGLang KV cache.
+ENABLE_HIERARCHICAL_CACHE="${DYNAMO_ENABLE_HIERARCHICAL_CACHE:-false}"
+HICACHE_RATIO="${DYNAMO_HICACHE_RATIO:-1.0}"
+HICACHE_POLICY="${DYNAMO_HICACHE_POLICY:-write_through}"
+
 # Compute container-internal GPU indices (GPUs are renumbered 0,1,2,... inside the container)
 NUM_GPUS=$(echo "$WORKER_GPUS" | tr ',' '\n' | wc -l)
 CONTAINER_GPU_INDICES=$(seq -s, 0 $((NUM_GPUS - 1)))
@@ -159,6 +165,15 @@ if [ "${ENABLE_KV_AWARE_ROUTING}" = "true" ]; then
 else
     echo "  Round-Robin (default)"
     echo "  Set ENABLE_KV_AWARE_ROUTING=true to enable KV cache-aware routing"
+fi
+echo ""
+echo "HiCache:"
+if [ "${ENABLE_HIERARCHICAL_CACHE}" = "true" ]; then
+    echo "  Enabled (DYNAMO_ENABLE_HIERARCHICAL_CACHE=true)"
+    echo "  Ratio: $HICACHE_RATIO, Policy: $HICACHE_POLICY"
+else
+    echo "  Disabled (default)"
+    echo "  Set DYNAMO_ENABLE_HIERARCHICAL_CACHE=true to enable"
 fi
 echo ""
 echo "========================================================="
@@ -356,6 +371,9 @@ docker run -d \
   -e KV_BLOCK_SIZE=$KV_BLOCK_SIZE \
   -e MAX_MODEL_LEN=$MAX_MODEL_LEN \
   -e NUM_GPU_BLOCKS_OVERRIDE=$NUM_GPU_BLOCKS_OVERRIDE \
+  -e ENABLE_HIERARCHICAL_CACHE=$ENABLE_HIERARCHICAL_CACHE \
+  -e HICACHE_RATIO=$HICACHE_RATIO \
+  -e HICACHE_POLICY=$HICACHE_POLICY \
   $IMAGE \
   bash -c "
     set -e  # Exit on any error
@@ -465,6 +483,11 @@ docker run -d \
         fi
         if [ -n \"\$NUM_GPU_BLOCKS_OVERRIDE\" ]; then
             EXTRA_WORKER_FLAGS=\"\$EXTRA_WORKER_FLAGS --num-gpu-blocks-override \$NUM_GPU_BLOCKS_OVERRIDE\"
+        fi
+        if [ \"\$ENABLE_HIERARCHICAL_CACHE\" = \"true\" ]; then
+            EXTRA_WORKER_FLAGS=\"\$EXTRA_WORKER_FLAGS --enable-hierarchical-cache\"
+            EXTRA_WORKER_FLAGS=\"\$EXTRA_WORKER_FLAGS --hicache-ratio \$HICACHE_RATIO\"
+            EXTRA_WORKER_FLAGS=\"\$EXTRA_WORKER_FLAGS --hicache-write-policy \$HICACHE_POLICY\"
         fi
         # DYN_SYSTEM_PORT: unique Prometheus metrics port per worker (required by --enable-metrics;
         # workers share the host network so each needs a distinct port).

--- a/external/dynamo/start_dynamo_unified.sh
+++ b/external/dynamo/start_dynamo_unified.sh
@@ -74,7 +74,7 @@ HICACHE_POLICY="${DYNAMO_HICACHE_POLICY:-write_through}"
 # Validate HiCache settings when enabled
 if [ "${ENABLE_HIERARCHICAL_CACHE}" = "true" ]; then
     if ! printf '%s' "$HICACHE_RATIO" | grep -qE '^[0-9]*\.?[0-9]+$' || \
-       [ "$(echo "$HICACHE_RATIO <= 0" | bc -l 2>/dev/null)" = "1" ]; then
+       [ "$(awk -v v="$HICACHE_RATIO" 'BEGIN{print (v+0)<=0 ? 1 : 0}')" = "1" ]; then
         echo "ERROR: HICACHE_RATIO must be a positive number (got: '$HICACHE_RATIO')" >&2
         echo "  Set via DYNAMO_HICACHE_RATIO (e.g., 1.0)" >&2
         exit 1

--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -490,10 +490,11 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
 
         if cache_pin_type is not None:
             warnings.warn(
-                "nvext.cache_control.type and nvext.cache_control.ttl are configured but "
-                "not supported until sglang >v0.5.9. Dynamo 1.0.0 uses sglang ==0.5.9. "
-                "These parameters will not be sent. "
-                "See https://github.com/sgl-project/sglang/pull/18941",
+                "nvext.cache_control is configured (type=%s). cache_control requires "
+                "sglang >v0.5.9 with hierarchical cache enabled. Parameters will be "
+                "sent but may be silently ignored by the backend. "
+                "See https://github.com/sgl-project/sglang/pull/18941"
+                % cache_pin_type.value,
                 stacklevel=2,
             )
 
@@ -640,9 +641,6 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
                     with self._call_counts_lock:
                         self._call_counts[prefix_id] = call_index
 
-                    # TODO: Uncomment when sglang >v0.5.9 lands in Dynamo and
-                    # https://github.com/sgl-project/sglang/pull/18941 is merged.
-                    #
                     # Inject cache_control for KV cache lifetime management.
                     # TTL = total_requests * iat_raw (ms): estimated total conversation
                     # duration before the cache entry should auto-expire.
@@ -651,21 +649,20 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
                     # When cache_control_mode is FIRST_ONLY, only inject on the
                     # first request per prefix_id — pinning the system prompt when
                     # it is first established in the KV cache.
-                    #
-                    # should_pin = (self._cache_pin_type is not None
-                    #               and (self._cache_control_mode == CacheControlMode.ALWAYS or
-                    #                    (self._cache_control_mode == CacheControlMode.FIRST_ONLY and call_index == 1)))
-                    # if should_pin:
-                    #     ttl_ms = total_requests * iat_raw
-                    #     ttl_seconds = max(1, -(-ttl_ms // 1000))  # ceil division
-                    #     if ttl_seconds >= 60 and ttl_seconds % 60 == 0:
-                    #         ttl_str = f"{ttl_seconds // 60}m"
-                    #     else:
-                    #         ttl_str = f"{ttl_seconds}s"
-                    #     body["nvext"]["cache_control"] = {
-                    #         "type": self._cache_pin_type.value,
-                    #         "ttl": ttl_str,
-                    #     }
+                    should_pin = (self._cache_pin_type is not None
+                                  and (self._cache_control_mode == CacheControlMode.ALWAYS or
+                                       (self._cache_control_mode == CacheControlMode.FIRST_ONLY and call_index == 1)))
+                    if should_pin:
+                        ttl_ms = total_requests * iat_raw
+                        ttl_seconds = max(1, -(-ttl_ms // 1000))  # ceil division
+                        if ttl_seconds >= 60 and ttl_seconds % 60 == 0:
+                            ttl_str = f"{ttl_seconds // 60}m"
+                        else:
+                            ttl_str = f"{ttl_seconds}s"
+                        body["nvext"]["cache_control"] = {
+                            "type": self._cache_pin_type.value,
+                            "ttl": ttl_str,
+                        }
 
                     content = json.dumps(body).encode("utf-8")
                     headers["content-length"] = str(len(content))

--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -490,11 +490,10 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
 
         if cache_pin_type is not None:
             warnings.warn(
-                "nvext.cache_control is configured (type=%s). cache_control requires "
+                f"nvext.cache_control is configured (type={cache_pin_type.value}). cache_control requires "
                 "sglang >v0.5.9 with hierarchical cache enabled. Parameters will be "
                 "sent but may be silently ignored by the backend. "
-                "See https://github.com/sgl-project/sglang/pull/18941"
-                % cache_pin_type.value,
+                "See https://github.com/sgl-project/sglang/pull/18941",
                 stacklevel=2,
             )
 

--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -59,6 +59,7 @@ import json
 import logging
 import threading
 import uuid
+import warnings
 from collections.abc import Iterator
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -487,6 +488,15 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
         self._call_counts: dict[str, int] = {}
         self._call_counts_lock = threading.Lock()
 
+        if cache_pin_type is not None:
+            warnings.warn(
+                "nvext.cache_control.type and nvext.cache_control.ttl are configured but "
+                "not supported until sglang >v0.5.9. Dynamo 1.0.0 uses sglang ==0.5.9. "
+                "These parameters will not be sent. "
+                "See https://github.com/sgl-project/sglang/pull/18941",
+                stacklevel=2,
+            )
+
     async def handle_async_request(self, request: "httpx.Request") -> "httpx.Response":
         # Get prefix ID from context (supports depth-awareness and overrides)
         prefix_id = DynamoPrefixContext.get()
@@ -630,6 +640,9 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
                     with self._call_counts_lock:
                         self._call_counts[prefix_id] = call_index
 
+                    # TODO: Uncomment when sglang >v0.5.9 lands in Dynamo and
+                    # https://github.com/sgl-project/sglang/pull/18941 is merged.
+                    #
                     # Inject cache_control for KV cache lifetime management.
                     # TTL = total_requests * iat_raw (ms): estimated total conversation
                     # duration before the cache entry should auto-expire.
@@ -638,20 +651,21 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
                     # When cache_control_mode is FIRST_ONLY, only inject on the
                     # first request per prefix_id — pinning the system prompt when
                     # it is first established in the KV cache.
-                    should_pin = (self._cache_pin_type is not None
-                                  and (self._cache_control_mode == CacheControlMode.ALWAYS or
-                                       (self._cache_control_mode == CacheControlMode.FIRST_ONLY and call_index == 1)))
-                    if should_pin:
-                        ttl_ms = total_requests * iat_raw
-                        ttl_seconds = max(1, -(-ttl_ms // 1000))  # ceil division
-                        if ttl_seconds >= 60 and ttl_seconds % 60 == 0:
-                            ttl_str = f"{ttl_seconds // 60}m"
-                        else:
-                            ttl_str = f"{ttl_seconds}s"
-                        body["nvext"]["cache_control"] = {
-                            "type": self._cache_pin_type.value,
-                            "ttl": ttl_str,
-                        }
+                    #
+                    # should_pin = (self._cache_pin_type is not None
+                    #               and (self._cache_control_mode == CacheControlMode.ALWAYS or
+                    #                    (self._cache_control_mode == CacheControlMode.FIRST_ONLY and call_index == 1)))
+                    # if should_pin:
+                    #     ttl_ms = total_requests * iat_raw
+                    #     ttl_seconds = max(1, -(-ttl_ms // 1000))  # ceil division
+                    #     if ttl_seconds >= 60 and ttl_seconds % 60 == 0:
+                    #         ttl_str = f"{ttl_seconds // 60}m"
+                    #     else:
+                    #         ttl_str = f"{ttl_seconds}s"
+                    #     body["nvext"]["cache_control"] = {
+                    #         "type": self._cache_pin_type.value,
+                    #         "ttl": ttl_str,
+                    #     }
 
                     content = json.dumps(body).encode("utf-8")
                     headers["content-length"] = str(len(content))

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
@@ -812,8 +812,14 @@ class TestDynamoTransport:
         DynamoPrefixContext.clear()
 
     async def test_transport_injects_cache_control_by_default(self):
-        """Test that _DynamoTransport injects nvext.cache_control with ephemeral type and computed TTL."""
+        """Test that cache_control is NOT injected (disabled until sglang >v0.5.9).
+
+        TODO: Revert to assert cache_control IS injected when
+        https://github.com/sgl-project/sglang/pull/18941 is merged and
+        Dynamo uses that version of sglang.
+        """
         import json
+        import warnings
 
         import httpx
 
@@ -824,13 +830,15 @@ class TestDynamoTransport:
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
         # total_requests=10, iat=250 -> TTL = 10 * 250 = 2500ms
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=10,
-            osl=512,
-            iat=250,
-            prediction_lookup=None,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            transport = _DynamoTransport(
+                transport=mock_transport,
+                total_requests=10,
+                osl=512,
+                iat=250,
+                prediction_lookup=None,
+            )
 
         DynamoPrefixContext.set("cache-control-test")
 
@@ -841,16 +849,19 @@ class TestDynamoTransport:
         body = json.loads(modified_request.content.decode("utf-8"))
 
         assert "nvext" in body
-        assert "cache_control" in body["nvext"]
-        cache_control = body["nvext"]["cache_control"]
-        assert cache_control["type"] == "ephemeral"
-        assert cache_control["ttl"] == "3s"  # 10 * 250 = 2500ms -> ceil = 3s
+        assert "cache_control" not in body["nvext"]
 
         DynamoPrefixContext.clear()
 
     async def test_transport_cache_control_ttl_formatted_as_minutes(self):
-        """Test that TTL is formatted as '<N>m' when evenly divisible by 60 seconds."""
+        """Test that cache_control is NOT injected (disabled until sglang >v0.5.9).
+
+        TODO: Revert to assert TTL is formatted as '<N>m' when
+        https://github.com/sgl-project/sglang/pull/18941 is merged and
+        Dynamo uses that version of sglang.
+        """
         import json
+        import warnings
 
         import httpx
 
@@ -861,13 +872,15 @@ class TestDynamoTransport:
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
         # total_requests=20, iat=3000 -> TTL = 60000ms = 60s = 1m
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=20,
-            osl=512,
-            iat=3000,
-            prediction_lookup=None,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            transport = _DynamoTransport(
+                transport=mock_transport,
+                total_requests=20,
+                osl=512,
+                iat=3000,
+                prediction_lookup=None,
+            )
 
         DynamoPrefixContext.set("ttl-minutes-test")
 
@@ -877,13 +890,19 @@ class TestDynamoTransport:
         modified_request = mock_transport.handle_async_request.call_args[0][0]
         body = json.loads(modified_request.content.decode("utf-8"))
 
-        assert body["nvext"]["cache_control"]["ttl"] == "1m"  # 20 * 3000 = 60000ms = 1m
+        assert "cache_control" not in body["nvext"]
 
         DynamoPrefixContext.clear()
 
     async def test_transport_cache_control_ttl_formatted_as_seconds(self):
-        """Test that TTL is formatted as '<N>s' when not evenly divisible by 60."""
+        """Test that cache_control is NOT injected (disabled until sglang >v0.5.9).
+
+        TODO: Revert to assert TTL is formatted as '<N>s' when
+        https://github.com/sgl-project/sglang/pull/18941 is merged and
+        Dynamo uses that version of sglang.
+        """
         import json
+        import warnings
 
         import httpx
 
@@ -894,13 +913,15 @@ class TestDynamoTransport:
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
         # total_requests=20, iat=500 -> TTL = 10000ms = 10s
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=20,
-            osl=512,
-            iat=500,
-            prediction_lookup=None,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            transport = _DynamoTransport(
+                transport=mock_transport,
+                total_requests=20,
+                osl=512,
+                iat=500,
+                prediction_lookup=None,
+            )
 
         DynamoPrefixContext.set("ttl-seconds-test")
 
@@ -910,7 +931,7 @@ class TestDynamoTransport:
         modified_request = mock_transport.handle_async_request.call_args[0][0]
         body = json.loads(modified_request.content.decode("utf-8"))
 
-        assert body["nvext"]["cache_control"]["ttl"] == "10s"  # 20 * 500 = 10000ms = 10s
+        assert "cache_control" not in body["nvext"]
 
         DynamoPrefixContext.clear()
 
@@ -951,8 +972,14 @@ class TestDynamoTransport:
         DynamoPrefixContext.clear()
 
     async def test_transport_cache_control_uses_prediction_override(self):
-        """Test that cache_control TTL uses prediction-overridden total_requests and iat."""
+        """Test that cache_control is NOT injected (disabled until sglang >v0.5.9).
+
+        TODO: Revert to assert cache_control TTL uses prediction-overridden
+        values when https://github.com/sgl-project/sglang/pull/18941 is
+        merged and Dynamo uses that version of sglang.
+        """
         import json
+        import warnings
 
         import httpx
 
@@ -975,13 +1002,15 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=10,
-            osl=512,
-            iat=250,
-            prediction_lookup=mock_lookup,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            transport = _DynamoTransport(
+                transport=mock_transport,
+                total_requests=10,
+                osl=512,
+                iat=250,
+                prediction_lookup=mock_lookup,
+            )
 
         DynamoPrefixContext.set("prediction-cache-test")
 
@@ -991,9 +1020,7 @@ class TestDynamoTransport:
         modified_request = mock_transport.handle_async_request.call_args[0][0]
         body = json.loads(modified_request.content.decode("utf-8"))
 
-        cache_control = body["nvext"]["cache_control"]
-        assert cache_control["type"] == "ephemeral"
-        assert cache_control["ttl"] == "2s"  # 25 * 50 = 1250ms -> ceil = 2s
+        assert "cache_control" not in body["nvext"]
 
         DynamoPrefixContext.clear()
 
@@ -1332,8 +1359,15 @@ class TestDynamoTransport:
         DynamoPrefixContext.clear()
 
     async def test_transport_first_only_injects_cache_control_on_first_request(self):
-        """Test that FIRST_ONLY mode injects cache_control on the first request for a prefix."""
+        """Test that cache_control is NOT injected even on first request (disabled until sglang >v0.5.9).
+
+        TODO: Revert to assert FIRST_ONLY mode injects cache_control on
+        the first request when
+        https://github.com/sgl-project/sglang/pull/18941 is merged and
+        Dynamo uses that version of sglang.
+        """
         import json
+        import warnings
 
         import httpx
 
@@ -1343,33 +1377,39 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=10,
-            osl=512,
-            iat=250,
-            prediction_lookup=None,
-            cache_control_mode=CacheControlMode.FIRST_ONLY,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            transport = _DynamoTransport(
+                transport=mock_transport,
+                total_requests=10,
+                osl=512,
+                iat=250,
+                prediction_lookup=None,
+                cache_control_mode=CacheControlMode.FIRST_ONLY,
+            )
 
         DynamoPrefixContext.set("first-only-test")
 
-        # First request: cache_control should be injected
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test", "messages": []})
         await transport.handle_async_request(request)
 
         modified_request = mock_transport.handle_async_request.call_args[0][0]
         body = json.loads(modified_request.content.decode("utf-8"))
 
-        assert "cache_control" in body["nvext"]
-        assert body["nvext"]["cache_control"]["type"] == "ephemeral"
-        assert body["nvext"]["cache_control"]["ttl"] == "3s"  # 10 * 250 = 2500ms -> ceil = 3s
+        assert "cache_control" not in body["nvext"]
 
         DynamoPrefixContext.clear()
 
     async def test_transport_first_only_skips_cache_control_on_subsequent_requests(self):
-        """Test that FIRST_ONLY mode does NOT inject cache_control on the second+ request."""
+        """Test that cache_control is NOT injected on any request (disabled until sglang >v0.5.9).
+
+        TODO: Revert to assert FIRST_ONLY mode injects on first request
+        but not subsequent ones when
+        https://github.com/sgl-project/sglang/pull/18941 is merged and
+        Dynamo uses that version of sglang.
+        """
         import json
+        import warnings
 
         import httpx
 
@@ -1379,23 +1419,25 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=10,
-            osl=512,
-            iat=250,
-            prediction_lookup=None,
-            cache_control_mode=CacheControlMode.FIRST_ONLY,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            transport = _DynamoTransport(
+                transport=mock_transport,
+                total_requests=10,
+                osl=512,
+                iat=250,
+                prediction_lookup=None,
+                cache_control_mode=CacheControlMode.FIRST_ONLY,
+            )
 
         DynamoPrefixContext.set("first-only-skip-test")
 
-        # First request (call_index=1): should have cache_control
+        # First request (call_index=1): cache_control NOT injected (disabled)
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
         await transport.handle_async_request(request)
 
         first_body = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
-        assert "cache_control" in first_body["nvext"]
+        assert "cache_control" not in first_body["nvext"]
 
         # Second request (call_index=2): should NOT have cache_control
         request2 = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
@@ -1417,8 +1459,15 @@ class TestDynamoTransport:
         DynamoPrefixContext.clear()
 
     async def test_transport_first_only_tracks_prefixes_independently(self):
-        """Test that FIRST_ONLY mode tracks each prefix_id independently."""
+        """Test that cache_control is NOT injected for any prefix (disabled until sglang >v0.5.9).
+
+        TODO: Revert to assert FIRST_ONLY mode tracks each prefix_id
+        independently when
+        https://github.com/sgl-project/sglang/pull/18941 is merged and
+        Dynamo uses that version of sglang.
+        """
         import json
+        import warnings
 
         import httpx
 
@@ -1428,22 +1477,24 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=10,
-            osl=512,
-            iat=250,
-            prediction_lookup=None,
-            cache_control_mode=CacheControlMode.FIRST_ONLY,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            transport = _DynamoTransport(
+                transport=mock_transport,
+                total_requests=10,
+                osl=512,
+                iat=250,
+                prediction_lookup=None,
+                cache_control_mode=CacheControlMode.FIRST_ONLY,
+            )
 
-        # First prefix, first request: should have cache_control
+        # First prefix, first request: cache_control NOT injected (disabled)
         DynamoPrefixContext.set("prefix-a")
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
         await transport.handle_async_request(request)
 
         body_a1 = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
-        assert "cache_control" in body_a1["nvext"]
+        assert "cache_control" not in body_a1["nvext"]
 
         # First prefix, second request: should NOT have cache_control
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
@@ -1452,19 +1503,73 @@ class TestDynamoTransport:
         body_a2 = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
         assert "cache_control" not in body_a2["nvext"]
 
-        # Second prefix, first request: SHOULD have cache_control (new prefix)
+        # Second prefix, first request: cache_control NOT injected (disabled)
         DynamoPrefixContext.set("prefix-b")
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
         await transport.handle_async_request(request)
 
         body_b1 = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
-        assert "cache_control" in body_b1["nvext"]
+        assert "cache_control" not in body_b1["nvext"]
 
         DynamoPrefixContext.clear()
 
+    def test_transport_warns_when_cache_pin_type_is_set(self):
+        """Test that _DynamoTransport emits a warning when cache_pin_type is not None.
+
+        TODO: Remove this test when
+        https://github.com/sgl-project/sglang/pull/18941 is merged and
+        Dynamo uses that version of sglang.
+        """
+        import warnings
+
+        from nat.llm.dynamo_llm import _DynamoTransport
+
+        mock_transport = MagicMock()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _DynamoTransport(
+                transport=mock_transport,
+                total_requests=10,
+                osl=512,
+                iat=250,
+                prediction_lookup=None,
+            )
+
+        assert len(w) == 1
+        assert "not supported until sglang >v0.5.9" in str(w[0].message)
+        assert "sgl-project/sglang/pull/18941" in str(w[0].message)
+
+    def test_transport_no_warning_when_cache_pin_type_is_none(self):
+        """Test that _DynamoTransport does NOT emit a warning when cache_pin_type is None."""
+        import warnings
+
+        from nat.llm.dynamo_llm import _DynamoTransport
+
+        mock_transport = MagicMock()
+
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            _DynamoTransport(
+                transport=mock_transport,
+                total_requests=10,
+                osl=512,
+                iat=250,
+                prediction_lookup=None,
+                cache_pin_type=None,
+            )
+
+        assert len(w) == 0
+
     async def test_transport_always_mode_injects_cache_control_every_request(self):
-        """Test that ALWAYS mode (default) injects cache_control on every request."""
+        """Test that cache_control is NOT injected on any request (disabled until sglang >v0.5.9).
+
+        TODO: Revert to assert ALWAYS mode injects cache_control on every
+        request when https://github.com/sgl-project/sglang/pull/18941 is
+        merged and Dynamo uses that version of sglang.
+        """
         import json
+        import warnings
 
         import httpx
 
@@ -1474,14 +1579,16 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        transport = _DynamoTransport(
-            transport=mock_transport,
-            total_requests=10,
-            osl=512,
-            iat=250,
-            prediction_lookup=None,
-            cache_control_mode=CacheControlMode.ALWAYS,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            transport = _DynamoTransport(
+                transport=mock_transport,
+                total_requests=10,
+                osl=512,
+                iat=250,
+                prediction_lookup=None,
+                cache_control_mode=CacheControlMode.ALWAYS,
+            )
 
         DynamoPrefixContext.set("always-mode-test")
 
@@ -1490,7 +1597,7 @@ class TestDynamoTransport:
             await transport.handle_async_request(request)
 
             body = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
-            assert "cache_control" in body["nvext"], f"cache_control missing on request {i + 1}"
+            assert "cache_control" not in body["nvext"], f"cache_control should not be injected on request {i + 1}"
 
         DynamoPrefixContext.clear()
 

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
@@ -812,14 +812,8 @@ class TestDynamoTransport:
         DynamoPrefixContext.clear()
 
     async def test_transport_injects_cache_control_by_default(self):
-        """Test that cache_control is NOT injected (disabled until sglang >v0.5.9).
-
-        TODO: Revert to assert cache_control IS injected when
-        https://github.com/sgl-project/sglang/pull/18941 is merged and
-        Dynamo uses that version of sglang.
-        """
+        """Test that _DynamoTransport injects nvext.cache_control with ephemeral type and computed TTL."""
         import json
-        import warnings
 
         import httpx
 
@@ -830,15 +824,13 @@ class TestDynamoTransport:
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
         # total_requests=10, iat=250 -> TTL = 10 * 250 = 2500ms
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            transport = _DynamoTransport(
-                transport=mock_transport,
-                total_requests=10,
-                osl=512,
-                iat=250,
-                prediction_lookup=None,
-            )
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+        )
 
         DynamoPrefixContext.set("cache-control-test")
 
@@ -849,19 +841,16 @@ class TestDynamoTransport:
         body = json.loads(modified_request.content.decode("utf-8"))
 
         assert "nvext" in body
-        assert "cache_control" not in body["nvext"]
+        assert "cache_control" in body["nvext"]
+        cache_control = body["nvext"]["cache_control"]
+        assert cache_control["type"] == "ephemeral"
+        assert cache_control["ttl"] == "3s"  # 10 * 250 = 2500ms -> ceil = 3s
 
         DynamoPrefixContext.clear()
 
     async def test_transport_cache_control_ttl_formatted_as_minutes(self):
-        """Test that cache_control is NOT injected (disabled until sglang >v0.5.9).
-
-        TODO: Revert to assert TTL is formatted as '<N>m' when
-        https://github.com/sgl-project/sglang/pull/18941 is merged and
-        Dynamo uses that version of sglang.
-        """
+        """Test that TTL is formatted as '<N>m' when evenly divisible by 60 seconds."""
         import json
-        import warnings
 
         import httpx
 
@@ -872,15 +861,13 @@ class TestDynamoTransport:
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
         # total_requests=20, iat=3000 -> TTL = 60000ms = 60s = 1m
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            transport = _DynamoTransport(
-                transport=mock_transport,
-                total_requests=20,
-                osl=512,
-                iat=3000,
-                prediction_lookup=None,
-            )
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=20,
+            osl=512,
+            iat=3000,
+            prediction_lookup=None,
+        )
 
         DynamoPrefixContext.set("ttl-minutes-test")
 
@@ -890,19 +877,13 @@ class TestDynamoTransport:
         modified_request = mock_transport.handle_async_request.call_args[0][0]
         body = json.loads(modified_request.content.decode("utf-8"))
 
-        assert "cache_control" not in body["nvext"]
+        assert body["nvext"]["cache_control"]["ttl"] == "1m"  # 20 * 3000 = 60000ms = 1m
 
         DynamoPrefixContext.clear()
 
     async def test_transport_cache_control_ttl_formatted_as_seconds(self):
-        """Test that cache_control is NOT injected (disabled until sglang >v0.5.9).
-
-        TODO: Revert to assert TTL is formatted as '<N>s' when
-        https://github.com/sgl-project/sglang/pull/18941 is merged and
-        Dynamo uses that version of sglang.
-        """
+        """Test that TTL is formatted as '<N>s' when not evenly divisible by 60."""
         import json
-        import warnings
 
         import httpx
 
@@ -913,15 +894,13 @@ class TestDynamoTransport:
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
         # total_requests=20, iat=500 -> TTL = 10000ms = 10s
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            transport = _DynamoTransport(
-                transport=mock_transport,
-                total_requests=20,
-                osl=512,
-                iat=500,
-                prediction_lookup=None,
-            )
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=20,
+            osl=512,
+            iat=500,
+            prediction_lookup=None,
+        )
 
         DynamoPrefixContext.set("ttl-seconds-test")
 
@@ -931,7 +910,7 @@ class TestDynamoTransport:
         modified_request = mock_transport.handle_async_request.call_args[0][0]
         body = json.loads(modified_request.content.decode("utf-8"))
 
-        assert "cache_control" not in body["nvext"]
+        assert body["nvext"]["cache_control"]["ttl"] == "10s"  # 20 * 500 = 10000ms = 10s
 
         DynamoPrefixContext.clear()
 
@@ -972,14 +951,8 @@ class TestDynamoTransport:
         DynamoPrefixContext.clear()
 
     async def test_transport_cache_control_uses_prediction_override(self):
-        """Test that cache_control is NOT injected (disabled until sglang >v0.5.9).
-
-        TODO: Revert to assert cache_control TTL uses prediction-overridden
-        values when https://github.com/sgl-project/sglang/pull/18941 is
-        merged and Dynamo uses that version of sglang.
-        """
+        """Test that cache_control TTL uses prediction-overridden total_requests and iat."""
         import json
-        import warnings
 
         import httpx
 
@@ -1002,15 +975,13 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            transport = _DynamoTransport(
-                transport=mock_transport,
-                total_requests=10,
-                osl=512,
-                iat=250,
-                prediction_lookup=mock_lookup,
-            )
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=mock_lookup,
+        )
 
         DynamoPrefixContext.set("prediction-cache-test")
 
@@ -1020,7 +991,9 @@ class TestDynamoTransport:
         modified_request = mock_transport.handle_async_request.call_args[0][0]
         body = json.loads(modified_request.content.decode("utf-8"))
 
-        assert "cache_control" not in body["nvext"]
+        cache_control = body["nvext"]["cache_control"]
+        assert cache_control["type"] == "ephemeral"
+        assert cache_control["ttl"] == "2s"  # 25 * 50 = 1250ms -> ceil = 2s
 
         DynamoPrefixContext.clear()
 
@@ -1359,15 +1332,8 @@ class TestDynamoTransport:
         DynamoPrefixContext.clear()
 
     async def test_transport_first_only_injects_cache_control_on_first_request(self):
-        """Test that cache_control is NOT injected even on first request (disabled until sglang >v0.5.9).
-
-        TODO: Revert to assert FIRST_ONLY mode injects cache_control on
-        the first request when
-        https://github.com/sgl-project/sglang/pull/18941 is merged and
-        Dynamo uses that version of sglang.
-        """
+        """Test that FIRST_ONLY mode injects cache_control on the first request for a prefix."""
         import json
-        import warnings
 
         import httpx
 
@@ -1377,39 +1343,33 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            transport = _DynamoTransport(
-                transport=mock_transport,
-                total_requests=10,
-                osl=512,
-                iat=250,
-                prediction_lookup=None,
-                cache_control_mode=CacheControlMode.FIRST_ONLY,
-            )
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+            cache_control_mode=CacheControlMode.FIRST_ONLY,
+        )
 
         DynamoPrefixContext.set("first-only-test")
 
+        # First request: cache_control should be injected
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test", "messages": []})
         await transport.handle_async_request(request)
 
         modified_request = mock_transport.handle_async_request.call_args[0][0]
         body = json.loads(modified_request.content.decode("utf-8"))
 
-        assert "cache_control" not in body["nvext"]
+        assert "cache_control" in body["nvext"]
+        assert body["nvext"]["cache_control"]["type"] == "ephemeral"
+        assert body["nvext"]["cache_control"]["ttl"] == "3s"  # 10 * 250 = 2500ms -> ceil = 3s
 
         DynamoPrefixContext.clear()
 
     async def test_transport_first_only_skips_cache_control_on_subsequent_requests(self):
-        """Test that cache_control is NOT injected on any request (disabled until sglang >v0.5.9).
-
-        TODO: Revert to assert FIRST_ONLY mode injects on first request
-        but not subsequent ones when
-        https://github.com/sgl-project/sglang/pull/18941 is merged and
-        Dynamo uses that version of sglang.
-        """
+        """Test that FIRST_ONLY mode does NOT inject cache_control on the second+ request."""
         import json
-        import warnings
 
         import httpx
 
@@ -1419,25 +1379,23 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            transport = _DynamoTransport(
-                transport=mock_transport,
-                total_requests=10,
-                osl=512,
-                iat=250,
-                prediction_lookup=None,
-                cache_control_mode=CacheControlMode.FIRST_ONLY,
-            )
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+            cache_control_mode=CacheControlMode.FIRST_ONLY,
+        )
 
         DynamoPrefixContext.set("first-only-skip-test")
 
-        # First request (call_index=1): cache_control NOT injected (disabled)
+        # First request (call_index=1): should have cache_control
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
         await transport.handle_async_request(request)
 
         first_body = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
-        assert "cache_control" not in first_body["nvext"]
+        assert "cache_control" in first_body["nvext"]
 
         # Second request (call_index=2): should NOT have cache_control
         request2 = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
@@ -1459,15 +1417,8 @@ class TestDynamoTransport:
         DynamoPrefixContext.clear()
 
     async def test_transport_first_only_tracks_prefixes_independently(self):
-        """Test that cache_control is NOT injected for any prefix (disabled until sglang >v0.5.9).
-
-        TODO: Revert to assert FIRST_ONLY mode tracks each prefix_id
-        independently when
-        https://github.com/sgl-project/sglang/pull/18941 is merged and
-        Dynamo uses that version of sglang.
-        """
+        """Test that FIRST_ONLY mode tracks each prefix_id independently."""
         import json
-        import warnings
 
         import httpx
 
@@ -1477,24 +1428,22 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            transport = _DynamoTransport(
-                transport=mock_transport,
-                total_requests=10,
-                osl=512,
-                iat=250,
-                prediction_lookup=None,
-                cache_control_mode=CacheControlMode.FIRST_ONLY,
-            )
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+            cache_control_mode=CacheControlMode.FIRST_ONLY,
+        )
 
-        # First prefix, first request: cache_control NOT injected (disabled)
+        # First prefix, first request: should have cache_control
         DynamoPrefixContext.set("prefix-a")
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
         await transport.handle_async_request(request)
 
         body_a1 = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
-        assert "cache_control" not in body_a1["nvext"]
+        assert "cache_control" in body_a1["nvext"]
 
         # First prefix, second request: should NOT have cache_control
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
@@ -1503,73 +1452,19 @@ class TestDynamoTransport:
         body_a2 = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
         assert "cache_control" not in body_a2["nvext"]
 
-        # Second prefix, first request: cache_control NOT injected (disabled)
+        # Second prefix, first request: SHOULD have cache_control (new prefix)
         DynamoPrefixContext.set("prefix-b")
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
         await transport.handle_async_request(request)
 
         body_b1 = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
-        assert "cache_control" not in body_b1["nvext"]
+        assert "cache_control" in body_b1["nvext"]
 
         DynamoPrefixContext.clear()
 
-    def test_transport_warns_when_cache_pin_type_is_set(self):
-        """Test that _DynamoTransport emits a warning when cache_pin_type is not None.
-
-        TODO: Remove this test when
-        https://github.com/sgl-project/sglang/pull/18941 is merged and
-        Dynamo uses that version of sglang.
-        """
-        import warnings
-
-        from nat.llm.dynamo_llm import _DynamoTransport
-
-        mock_transport = MagicMock()
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            _DynamoTransport(
-                transport=mock_transport,
-                total_requests=10,
-                osl=512,
-                iat=250,
-                prediction_lookup=None,
-            )
-
-        assert len(w) == 1
-        assert "not supported until sglang >v0.5.9" in str(w[0].message)
-        assert "sgl-project/sglang/pull/18941" in str(w[0].message)
-
-    def test_transport_no_warning_when_cache_pin_type_is_none(self):
-        """Test that _DynamoTransport does NOT emit a warning when cache_pin_type is None."""
-        import warnings
-
-        from nat.llm.dynamo_llm import _DynamoTransport
-
-        mock_transport = MagicMock()
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-            _DynamoTransport(
-                transport=mock_transport,
-                total_requests=10,
-                osl=512,
-                iat=250,
-                prediction_lookup=None,
-                cache_pin_type=None,
-            )
-
-        assert len(w) == 0
-
     async def test_transport_always_mode_injects_cache_control_every_request(self):
-        """Test that cache_control is NOT injected on any request (disabled until sglang >v0.5.9).
-
-        TODO: Revert to assert ALWAYS mode injects cache_control on every
-        request when https://github.com/sgl-project/sglang/pull/18941 is
-        merged and Dynamo uses that version of sglang.
-        """
+        """Test that ALWAYS mode (default) injects cache_control on every request."""
         import json
-        import warnings
 
         import httpx
 
@@ -1579,16 +1474,14 @@ class TestDynamoTransport:
         mock_transport = MagicMock()
         mock_transport.handle_async_request = AsyncMock(return_value=mock_response)
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            transport = _DynamoTransport(
-                transport=mock_transport,
-                total_requests=10,
-                osl=512,
-                iat=250,
-                prediction_lookup=None,
-                cache_control_mode=CacheControlMode.ALWAYS,
-            )
+        transport = _DynamoTransport(
+            transport=mock_transport,
+            total_requests=10,
+            osl=512,
+            iat=250,
+            prediction_lookup=None,
+            cache_control_mode=CacheControlMode.ALWAYS,
+        )
 
         DynamoPrefixContext.set("always-mode-test")
 
@@ -1597,7 +1490,7 @@ class TestDynamoTransport:
             await transport.handle_async_request(request)
 
             body = json.loads(mock_transport.handle_async_request.call_args[0][0].content.decode("utf-8"))
-            assert "cache_control" not in body["nvext"], f"cache_control should not be injected on request {i + 1}"
+            assert "cache_control" in body["nvext"], f"cache_control missing on request {i + 1}"
 
         DynamoPrefixContext.clear()
 


### PR DESCRIPTION
## Description
`nvext.cache_control.type` and `nvext.cache_control.ttl` won't make it into dynamo 1.0.0 as these features were dependent on: 
| Repo | PR | Branch |
|------|----|--------|
| **SGLang** | [#18941](https://github.com/sgl-project/sglang/pull/18941) | `idhanani/dyn-1986-poc-pin-v2` |
| **Dynamo** | [#6213](https://github.com/ai-dynamo/dynamo/pull/6213) | `idhanani/dyn-1986-pin-on-router-queue` |

Therefore, we are going to add a warning to these parameters in `dynamo_llm.py` so that users are made aware of the support issue until the next dynamo release. Users can still build from source and use these features using the dev branches above, or their targets once the MR is complete.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional hierarchical cache (HiCache) support with configurable ratio and write policy, startup validation, and status reporting.

* **Documentation**
  * Added HiCache options to example environment settings, including an enable/disable toggle (default: disabled).

* **Improvements**
  * HiCache settings are propagated to runtime/startup and produce runtime warnings when provided parameters may be ignored by the backend.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->