### PR TITLE
Add monkey patching for ADK's litellm import

### DIFF
--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/callback_handler.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/callback_handler.py
@@ -59,6 +59,7 @@ class ADKProfilerHandler(BaseProfilerCallback):
         # Original references to Google ADK Tool and LLM methods (for uninstrumenting if needed)
         self._original_tool_call = None
         self._original_llm_call = None
+        self._original_adk_llm_call = None
         self._instrumented = False
 
     def instrument(self) -> None:
@@ -77,6 +78,7 @@ class ADKProfilerHandler(BaseProfilerCallback):
             logger.exception("litellm import failed; skipping instrumentation")
             return
         try:
+            import google.adk.models.lite_llm as adk_lite_llm
             from google.adk.tools.function_tool import FunctionTool
         except Exception as _e:
             logger.exception("ADK import failed; skipping instrumentation")
@@ -85,9 +87,12 @@ class ADKProfilerHandler(BaseProfilerCallback):
         # Save the originals
         self._original_tool_call = FunctionTool.run_async
         self._original_llm_call = litellm.acompletion
+        self._original_adk_llm_call = adk_lite_llm.acompletion
 
+        wrapped_llm = self._llm_call_monkey_patch()
         FunctionTool.run_async = self._tool_use_monkey_patch()
-        litellm.acompletion = self._llm_call_monkey_patch()
+        litellm.acompletion = wrapped_llm
+        adk_lite_llm.acompletion = wrapped_llm
 
         logger.debug("ADKProfilerHandler instrumentation applied successfully.")
         self._instrumented = True
@@ -97,6 +102,7 @@ class ADKProfilerHandler(BaseProfilerCallback):
         Add an explicit unpatch to avoid side-effects across tests/process lifetime.
         """
         try:
+            import google.adk.models.lite_llm as adk_lite_llm
             import litellm
             from google.adk.tools.function_tool import FunctionTool
             if self._original_tool_call is not None:
@@ -106,6 +112,10 @@ class ADKProfilerHandler(BaseProfilerCallback):
             if self._original_llm_call is not None:
                 litellm.acompletion = self._original_llm_call
                 self._original_llm_call = None
+
+            if self._original_adk_llm_call is not None:
+                adk_lite_llm.acompletion = self._original_adk_llm_call
+                self._original_adk_llm_call = None
 
             self._instrumented = False
             self.last_call_ts = 0.0


### PR DESCRIPTION
## Description

The `ADKProfilerHandler` monkey patch for `litellm.acompletion` works usually intercepts LLM calls made through `litellm`. But depending on how NAT and ADK are initiated, this would at times fail.

Root Cause
Google ADK's `lite_llm.py` uses a direct import of `acompletion`

This creates a local reference in the ADK module's namespace. When the profiler patched `litellm.acompletion`, it only modified the reference in the `litellm` module, not the local copy that ADK already had.

Since `LiteLLMClient.acompletion()` calls the local `acompletion`, it bypassed the monkey patch entirely.

This fix adds monkey-patching for `google.adk.models.lite_llm.acompletion` alongside the existing `litellm.acompletion` to ensure that the calls are always intercepted.
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
