### PR TITLE
Fix Unicode escape sequences showing in console workflow output

### DIFF
--- a/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
@@ -15,6 +15,7 @@
 
 import asyncio
 import logging
+import re
 import select
 import sys
 import unicodedata
@@ -33,23 +34,21 @@ from nat.runtime.session import SessionManager
 
 logger = logging.getLogger(__name__)
 
-_UNICODE_REPLACEMENTS = {
-    '\u202f': ' ',  # narrow no-break space
-    '\u00a0': ' ',  # no-break space
-    '\u2011': '-',  # non-breaking hyphen
-    '\u2013': '-',  # en dash
-    '\u2014': '--',  # em dash
-    '\u2018': "'",  # left single quotation mark
-    '\u2019': "'",  # right single quotation mark
-    '\u201c': '"',  # left double quotation mark
-    '\u201d': '"',  # right double quotation mark
-}
+_RE_UNICODE_WHITESPACE = re.compile(r'[\u00a0\u2000-\u200a\u202f\u205f\u3000]')
+_RE_ZERO_WIDTH = re.compile(r'[\u200b-\u200d\u2060\ufeff]')
+_RE_UNICODE_DASHES = re.compile(r'[\u2010-\u2015\ufe58\ufe63\uff0d]')
+_RE_SINGLE_QUOTES = re.compile(r'[\u2018\u2019\u201a\u201b]')
+_RE_DOUBLE_QUOTES = re.compile(r'[\u201c\u201d\u201e\u201f]')
 
 
 def _normalize_unicode(text: str) -> str:
     """Replace common Unicode whitespace and punctuation with ASCII equivalents for clean console display."""
-    for orig, repl in _UNICODE_REPLACEMENTS.items():
-        text = text.replace(orig, repl)
+    text = _RE_UNICODE_WHITESPACE.sub(' ', text)
+    text = _RE_ZERO_WIDTH.sub('', text)
+    text = _RE_UNICODE_DASHES.sub('-', text)
+    text = _RE_SINGLE_QUOTES.sub("'", text)
+    text = _RE_DOUBLE_QUOTES.sub('"', text)
+    text = text.replace('\u2026', '...')
     return unicodedata.normalize('NFKC', text)
 
 

--- a/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 import select
 import sys
+import unicodedata
 
 import click
 from colorama import Fore
@@ -31,6 +32,32 @@ from nat.front_ends.simple_base.simple_front_end_plugin_base import SimpleFrontE
 from nat.runtime.session import SessionManager
 
 logger = logging.getLogger(__name__)
+
+_UNICODE_REPLACEMENTS = {
+    '\u202f': ' ',  # narrow no-break space
+    '\u00a0': ' ',  # no-break space
+    '\u2011': '-',  # non-breaking hyphen
+    '\u2013': '-',  # en dash
+    '\u2014': '--',  # em dash
+    '\u2018': "'",  # left single quotation mark
+    '\u2019': "'",  # right single quotation mark
+    '\u201c': '"',  # left double quotation mark
+    '\u201d': '"',  # right double quotation mark
+}
+
+
+def _normalize_unicode(text: str) -> str:
+    """Replace common Unicode whitespace and punctuation with ASCII equivalents for clean console display."""
+    for orig, repl in _UNICODE_REPLACEMENTS.items():
+        text = text.replace(orig, repl)
+    return unicodedata.normalize('NFKC', text)
+
+
+def _format_output(runner_outputs) -> str:
+    """Format workflow outputs as human-readable text with normalized Unicode."""
+    if isinstance(runner_outputs, list):
+        return "\n".join(_normalize_unicode(str(item)) for item in runner_outputs)
+    return _normalize_unicode(str(runner_outputs))
 
 
 async def prompt_for_input_cli(question: InteractionPrompt) -> HumanResponse:
@@ -125,10 +152,12 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         prefix = f"{line}\n{Fore.GREEN}Workflow Result:\n"
         suffix = f"{Fore.RESET}\n{line}"
 
-        logger.info(f"{prefix}%s{suffix}", runner_outputs)
+        display_output = _format_output(runner_outputs)
+
+        logger.info(f"{prefix}%s{suffix}", display_output)
 
         # (handler is a stream handler) => (level > INFO)
         effective_level_too_high = all(
             type(h) is not logging.StreamHandler or h.level > logging.INFO for h in logging.getLogger().handlers)
         if effective_level_too_high:
-            print(f"{prefix}{runner_outputs}{suffix}")
+            print(f"{prefix}{display_output}{suffix}")


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

- Fix console front end displaying raw Unicode escape sequences (e.g. \u202f) in workflow results by formatting list output as plain text instead of Python repr()
- Normalize common non-ASCII characters from LLM responses (narrow no-break spaces, non-breaking hyphens, smart quotes) to ASCII equivalents for clean terminal display

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved console output display with enhanced Unicode character normalization. The console now properly handles and formats special characters, whitespace variations, dashes, and quotation marks to ensure consistent rendering and improved readability across all console outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->