### PR TITLE
Treat explicit null defaults as nullable in MCP schema translation

### DIFF
--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/utils.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/utils.py
@@ -219,6 +219,7 @@ def model_from_mcp_schema(name: str, mcp_input_schema: dict) -> type[BaseModel]:
 
         # Determine the default value based on whether the field is required
         default_value = field_properties.get("default")
+        has_explicit_null_default = "default" in field_properties and default_value is None
 
         if field_name in required_fields:
             # Field is required - use explicit default if provided, otherwise use ... to enforce presence
@@ -232,6 +233,10 @@ def model_from_mcp_schema(name: str, mcp_input_schema: dict) -> type[BaseModel]:
             # Field is optional - use explicit default if provided, otherwise None
             if default_value is None:
                 default_value = None
+            # MCP schemas sometimes set default to null without declaring null in the type.
+            # Treat explicit null defaults as nullable for validation compatibility.
+            if has_explicit_null_default and not has_null:
+                field_type = field_type | None
             # Make the type optional if no default was provided and not already nullable
             if "default" not in field_properties and not has_null:
                 field_type = field_type | None

--- a/packages/nvidia_nat_mcp/tests/client/test_mcp_schema.py
+++ b/packages/nvidia_nat_mcp/tests/client/test_mcp_schema.py
@@ -858,3 +858,33 @@ def test_type_list_with_object_properties():
     # Test with null value
     m2 = _model.model_validate({"config_or_null": None})
     assert m2.config_or_null is None
+
+
+def test_optional_field_with_explicit_null_default_becomes_nullable():
+    """Test explicit default null with non-null type is treated as nullable."""
+    schema = {
+        'type': 'object',
+        'properties': {
+            'cursor': {
+                'description': 'Pagination cursor',
+                'type': 'string',
+                'default': None
+            }
+        },
+        'required': []
+    }
+
+    _model = model_from_mcp_schema("test_explicit_null_default", schema)
+
+    # Verify field type includes str and None
+    field_type = _model.model_fields["cursor"].annotation
+    args = get_args(field_type)
+    assert str in args and type(None) in args, f"Expected str | None, got {field_type}"
+
+    # Test explicit null value validates
+    m1 = _model.model_validate({"cursor": None})
+    assert m1.cursor is None
+
+    # Test string value validates
+    m2 = _model.model_validate({"cursor": "abc123"})
+    assert m2.cursor == "abc123"

--- a/packages/nvidia_nat_mcp/tests/client/test_mcp_schema.py
+++ b/packages/nvidia_nat_mcp/tests/client/test_mcp_schema.py
@@ -866,9 +866,7 @@ def test_optional_field_with_explicit_null_default_becomes_nullable():
         'type': 'object',
         'properties': {
             'cursor': {
-                'description': 'Pagination cursor',
-                'type': 'string',
-                'default': None
+                'description': 'Pagination cursor', 'type': 'string', 'default': None
             }
         },
         'required': []


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Adds a temporary MCP schema-translation workaround so fields with an explicit default: null are treated as nullable, even when the schema type does not explicitly include null.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Schema processing now treats optional fields that explicitly default to null as nullable, so validators accept both the original type and null as valid values.

* **Tests**
  * New tests confirm optional fields with explicit null defaults validate correctly for null and for values of the declared type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->