### PR TITLE
Fix ReAct agent parsing failures with reasoning models (`<think>` tags)

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/base.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/base.py
@@ -100,11 +100,19 @@ class BaseAgent(ABC):
         AIMessage
             The LLM response
         """
-        output_message = []
+        content_parts = []
+        reasoning_parts = []
         async for event in runnable.astream(inputs, config=self._runnable_config):
-            output_message.append(event.content)
+            content_parts.append(event.content)
+            reasoning = event.additional_kwargs.get('reasoning_content', '')
+            if reasoning:
+                reasoning_parts.append(reasoning)
 
-        return AIMessage(content="".join(output_message))
+        additional_kwargs: dict[str, Any] = {}
+        if reasoning_parts:
+            additional_kwargs['reasoning_content'] = "".join(reasoning_parts)
+
+        return AIMessage(content="".join(content_parts), additional_kwargs=additional_kwargs)
 
     async def _call_llm(self, llm: Runnable, inputs: dict[str, Any]) -> AIMessage:
         """

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/base.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/base.py
@@ -104,9 +104,11 @@ class BaseAgent(ABC):
         reasoning_parts = []
         async for event in runnable.astream(inputs, config=self._runnable_config):
             content_parts.append(event.content)
-            reasoning = event.additional_kwargs.get('reasoning_content', '')
-            if reasoning:
-                reasoning_parts.append(reasoning)
+            extra = getattr(event, 'additional_kwargs', None)
+            if isinstance(extra, dict):
+                reasoning = extra.get('reasoning_content', '')
+                if reasoning:
+                    reasoning_parts.append(reasoning)
 
         additional_kwargs: dict[str, Any] = {}
         if reasoning_parts:

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
@@ -35,8 +35,6 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel
 from pydantic import Field
 
-from nat.utils.io.model_processing import remove_r1_think_tags
-
 from nat.plugins.langchain.agent.base import AGENT_CALL_LOG_MESSAGE
 from nat.plugins.langchain.agent.base import AGENT_LOG_PREFIX
 from nat.plugins.langchain.agent.base import INPUT_SCHEMA_MESSAGE
@@ -49,6 +47,7 @@ from nat.plugins.langchain.agent.react_agent.output_parser import ReActOutputPar
 from nat.plugins.langchain.agent.react_agent.output_parser import ReActOutputParserException
 from nat.plugins.langchain.agent.react_agent.prompt import SYSTEM_PROMPT
 from nat.plugins.langchain.agent.react_agent.prompt import USER_PROMPT
+from nat.utils.io.model_processing import remove_r1_think_tags
 
 if typing.TYPE_CHECKING:
     from nat.plugins.langchain.agent.react_agent.register import ReActAgentWorkflowConfig
@@ -280,11 +279,12 @@ class ReActAgentGraph(DualNodeAgent):
                     # Reasoning models may answer directly without ReAct format.
                     # Accept as final answer if: missing_action, has content, and no "Thought:" prefix.
                     content_str = str(output_message.content).strip()
-                    if (ex.missing_action
-                            and content_str
+                    if (ex.missing_action and content_str
                             and not re.match(r'\s*thought\s*:', content_str, re.IGNORECASE)):
-                        logger.info("%s Agent produced direct answer without ReAct format, "
-                                    "accepting as final answer", AGENT_LOG_PREFIX)
+                        logger.info(
+                            "%s Agent produced direct answer without ReAct format, "
+                            "accepting as final answer",
+                            AGENT_LOG_PREFIX)
                         state.messages += [AIMessage(content=content_str)]
                         state.final_answer = content_str
                         return state
@@ -319,11 +319,11 @@ class ReActAgentGraph(DualNodeAgent):
                         working_state.append(output_message)
                         working_state.append(HumanMessage(content=str(ex.observation)))
                     else:
-                        working_state.append(HumanMessage(
-                            content=str(ex.observation) +
-                            " If the available tools cannot answer the question, you MUST respond with:\n"
-                            "Thought: <your reasoning>\n"
-                            "Final Answer: <your best answer or explanation>"))
+                        working_state.append(
+                            HumanMessage(content=str(ex.observation) +
+                                         " If the available tools cannot answer the question, you MUST respond with:\n"
+                                         "Thought: <your reasoning>\n"
+                                         "Final Answer: <your best answer or explanation>"))
         except Exception as ex:
             logger.error("%s Failed to call agent_node: %s", AGENT_LOG_PREFIX, ex)
             raise

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
@@ -35,6 +35,8 @@ from langchain_core.tools import BaseTool
 from pydantic import BaseModel
 from pydantic import Field
 
+from nat.utils.io.model_processing import remove_r1_think_tags
+
 from nat.plugins.langchain.agent.base import AGENT_CALL_LOG_MESSAGE
 from nat.plugins.langchain.agent.base import AGENT_LOG_PREFIX
 from nat.plugins.langchain.agent.base import INPUT_SCHEMA_MESSAGE
@@ -178,6 +180,17 @@ class ReActAgentGraph(DualNodeAgent):
                     output_message = await self._stream_llm(self.agent, {
                         "question": question, "chat_history": chat_history
                     })  # type: ignore
+                    if isinstance(output_message.content, str):
+                        raw_content = output_message.content
+                        output_message.content = remove_r1_think_tags(raw_content)
+                        if not output_message.content.strip():
+                            think_match = re.search(r'<think>(.*?)</think>', raw_content, re.DOTALL)
+                            if think_match:
+                                output_message.content = think_match.group(1).strip()
+                        if not output_message.content.strip():
+                            reasoning = output_message.additional_kwargs.get('reasoning_content', '')
+                            if reasoning:
+                                output_message.content = reasoning
 
                     if self.detailed_logs:
                         logger.info(AGENT_CALL_LOG_MESSAGE, question, output_message.content)
@@ -201,6 +214,17 @@ class ReActAgentGraph(DualNodeAgent):
                         self.agent, {
                             "question": question, "agent_scratchpad": agent_scratchpad, "chat_history": chat_history
                         })  # type: ignore
+                    if isinstance(output_message.content, str):
+                        raw_content = output_message.content
+                        output_message.content = remove_r1_think_tags(raw_content)
+                        if not output_message.content.strip():
+                            think_match = re.search(r'<think>(.*?)</think>', raw_content, re.DOTALL)
+                            if think_match:
+                                output_message.content = think_match.group(1).strip()
+                        if not output_message.content.strip():
+                            reasoning = output_message.additional_kwargs.get('reasoning_content', '')
+                            if reasoning:
+                                output_message.content = reasoning
 
                     if self.detailed_logs:
                         logger.info(AGENT_CALL_LOG_MESSAGE, question, output_message.content)
@@ -252,6 +276,19 @@ class ReActAgentGraph(DualNodeAgent):
                     # the agent mentioned a tool, but already has the final answer, this can happen with Llama models
                     #   - the ReAct Agent already has the answer, and is reflecting on how it obtained the answer
                     # the agent might have also missed Action or Action Input in its output
+
+                    # Reasoning models may answer directly without ReAct format.
+                    # Accept as final answer if: missing_action, has content, and no "Thought:" prefix.
+                    content_str = str(output_message.content).strip()
+                    if (ex.missing_action
+                            and content_str
+                            and not re.match(r'\s*thought\s*:', content_str, re.IGNORECASE)):
+                        logger.info("%s Agent produced direct answer without ReAct format, "
+                                    "accepting as final answer", AGENT_LOG_PREFIX)
+                        state.messages += [AIMessage(content=content_str)]
+                        state.final_answer = content_str
+                        return state
+
                     logger.debug("%s Error parsing agent output\nObservation:%s\nAgent Output:\n%s",
                                  AGENT_LOG_PREFIX,
                                  ex.observation,
@@ -280,7 +317,13 @@ class ReActAgentGraph(DualNodeAgent):
                     # when empty content is forwarded via agent_scratchpad (#1611)
                     if output_message.content and str(output_message.content).strip():
                         working_state.append(output_message)
-                    working_state.append(HumanMessage(content=str(ex.observation)))
+                        working_state.append(HumanMessage(content=str(ex.observation)))
+                    else:
+                        working_state.append(HumanMessage(
+                            content=str(ex.observation) +
+                            " If the available tools cannot answer the question, you MUST respond with:\n"
+                            "Thought: <your reasoning>\n"
+                            "Final Answer: <your best answer or explanation>"))
         except Exception as ex:
             logger.error("%s Failed to call agent_node: %s", AGENT_LOG_PREFIX, ex)
             raise

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
@@ -277,10 +277,11 @@ class ReActAgentGraph(DualNodeAgent):
                     # the agent might have also missed Action or Action Input in its output
 
                     # Reasoning models may answer directly without ReAct format.
-                    # Accept as final answer if: missing_action, has content, and no "Thought:" prefix.
+                    # Accept as final answer if: missing_action, has content, and doesn't look like
+                    # a ReAct prompt echo (Thought:/Question:/Previous conversation history:).
                     content_str = str(output_message.content).strip()
-                    if (ex.missing_action and content_str
-                            and not re.match(r'\s*thought\s*:', content_str, re.IGNORECASE)):
+                    if (ex.missing_action and content_str and not re.match(
+                            r'\s*(thought\s*:|question\s*:|previous\s+conversation)', content_str, re.IGNORECASE)):
                         logger.info(
                             "%s Agent produced direct answer without ReAct format, "
                             "accepting as final answer",


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

- Reasoning models (e.g., nemotron-3-nano-30b-a3b) wrap their chain-of-thought in <think>...</think> tags, which breaks the ReAct output parser. This PR adds multi-layered handling to recover usable content from reasoning model outputs.
- Preserve reasoning_content from streamed LLM chunks in _stream_llm, which previously discarded additional_kwargs when constructing the final AIMessage
- Strip <think> tags from LLM output before parsing, with fallbacks: extract content from inside tags, then fall back to reasoning_content from additional_kwargs
- Accept direct (non-ReAct-formatted) answers from reasoning models instead of failing with ReActAgentParsingFailedError
- Improve retry hints when content is empty, guiding the model toward producing a Final Answer:

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Streaming responses from reasoning models now capture and combine main content and separate reasoning streams reliably.
  * Agents more reliably recognize direct final answers even when not in strict ReAct format, reducing missed responses.
  * Improved fallback behavior that adds clear guidance prompts when parsing fails.

* **Improvements**
  * More consistent normalization of agent outputs across initial and subsequent interaction flows for steadier results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->