### PR TITLE
Refactor defense and red teaming middleware with pre/post invoke hooks

### DIFF
--- a/packages/nvidia_nat_core/src/nat/middleware/common.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/common.py
@@ -1,0 +1,23 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from enum import StrEnum
+
+
+class TargetLocation(StrEnum):
+    """Runtime target for middleware activation: controls whether middleware runs on function input or output."""
+
+    INPUT = "input"
+    OUTPUT = "output"

--- a/packages/nvidia_nat_core/src/nat/middleware/defense/defense_middleware.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/defense/defense_middleware.py
@@ -32,6 +32,7 @@ from pydantic import Field
 
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.data_models.middleware import FunctionMiddlewareBaseConfig
+from nat.middleware.common import TargetLocation
 from nat.middleware.function_middleware import FunctionMiddleware
 
 logger = logging.getLogger(__name__)
@@ -77,11 +78,8 @@ class DefenseMiddlewareConfig(FunctionMiddlewareBaseConfig):
         "If None, defense applies to all functions. "
         "Examples: 'my_calculator', 'my_calculator.divide', 'llm_agent.generate'")
 
-    target_location: Literal["output"] = Field(
-        default="output",
-        description=("Whether to analyze function input or output. "
-                     "Currently only 'output' is supported (analyze after function call). "
-                     "Input analysis is not yet supported."))
+    target_location: TargetLocation = Field(default=TargetLocation.OUTPUT,
+                                            description="Whether to analyze function input or output.")
 
     target_field: str | None = Field(
         default=None,
@@ -103,7 +101,7 @@ class DefenseMiddleware(FunctionMiddleware):
 
     This base class provides:
 
-    * Common configuration fields (action, check_input, check_output, llm_wrapper_type)
+    * Common configuration fields (action, target_location, llm_wrapper_type)
     * Helper methods for LLM loading (for LLM-based defenses)
     * Access to builder for any resources needed
 

--- a/packages/nvidia_nat_core/src/nat/middleware/defense/defense_middleware_content_guard.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/defense/defense_middleware_content_guard.py
@@ -27,13 +27,14 @@ from typing import Any
 
 from pydantic import Field
 
+from nat.middleware.common import TargetLocation
 from nat.middleware.defense.defense_middleware import DefenseMiddleware
 from nat.middleware.defense.defense_middleware import DefenseMiddlewareConfig
 from nat.middleware.defense.defense_middleware_data_models import ContentAnalysisResult
 from nat.middleware.defense.defense_middleware_data_models import GuardResponseResult
-from nat.middleware.function_middleware import CallNext
 from nat.middleware.function_middleware import CallNextStream
 from nat.middleware.middleware import FunctionMiddlewareContext
+from nat.middleware.middleware import InvocationContext
 
 logger = logging.getLogger(__name__)
 
@@ -45,8 +46,6 @@ class ContentSafetyGuardMiddlewareConfig(DefenseMiddlewareConfig, name="content_
 
     Actions: partial_compliance (log warning but allow), refusal (block content),
     or redirection (replace with polite refusal message).
-
-    Note: Only output analysis is currently supported (target_location='output').
     """
 
     llm_name: str = Field(description="Name of the guard model LLM (must be defined in llms section)")
@@ -58,8 +57,6 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
     This middleware analyzes content using guard models (e.g., NVIDIA Nemoguard, Qwen Guard)
     that return "Safe" or "Unsafe" classifications. The middleware extracts safety categories
     when unsafe content is detected.
-
-    Only output analysis is currently supported (``target_location='output'``).
 
     Streaming Behavior:
         For 'refusal' and 'redirection' actions, chunks are buffered and checked
@@ -79,11 +76,6 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
         # Store config with correct type for linter
         self.config: ContentSafetyGuardMiddlewareConfig = config
         self._llm = None  # Lazy loaded LLM
-
-        # Content Safety Guard only supports output analysis
-        if config.target_location == "input":
-            raise ValueError("ContentSafetyGuardMiddleware only supports target_location='output'. "
-                             "Input analysis is not yet supported.")
 
     async def _get_llm(self):
         """Lazy load the guard model LLM when first needed."""
@@ -288,7 +280,7 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
                        ", ".join(categories) if categories else "none")
 
         if action == "refusal":
-            logger.error("Content Safety Guard refusing output of %s", context.name)
+            logger.error("Content Safety Guard refusing function output of %s", context.name)
             raise ValueError("Content blocked by safety policy")
 
         elif action == "redirection":
@@ -301,7 +293,6 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
     async def _process_content_safety_detection(
         self,
         value: Any,
-        location: str,
         context: FunctionMiddlewareContext,
         original_input: Any = None,
     ) -> Any:
@@ -311,8 +302,7 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
         and applying sanitized value back to original structure.
 
         Args:
-            value: The value to analyze (input or output).
-            location: Either input or output (for logging).
+            value: The value to analyze.
             context: Function context metadata.
             original_input: Original function input (for output analysis context).
 
@@ -322,9 +312,8 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
         # Extract field from value if target_field is specified
         content_to_analyze, field_info = self._extract_field_from_value(value)
 
-        logger.info("ContentSafetyGuardMiddleware: Checking %s %s for %s",
-                    f"field '{self.config.target_field}'" if field_info else "entire",
-                    location,
+        logger.info("ContentSafetyGuardMiddleware: Checking %s function output for %s",
+                    f"field '{self.config.target_field}' of" if field_info else "entire",
                     context.name)
         analysis_result = await self._analyze_content(content_to_analyze,
                                                       original_input=original_input,
@@ -332,12 +321,11 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
 
         if not analysis_result.should_refuse:
             # Content is safe, return original value
-            logger.info("ContentSafetyGuardMiddleware: Verified %s of %s as safe", location, context.name)
+            logger.info("ContentSafetyGuardMiddleware: %s function output verified as safe", context.name)
             return value
 
         # Unsafe content detected - handle based on action
-        logger.warning("ContentSafetyGuardMiddleware: Blocking %s for %s (unsafe content detected)",
-                       location,
+        logger.warning("ContentSafetyGuardMiddleware: Blocking %s function output (unsafe content detected)",
                        context.name)
         sanitized_content = await self._handle_threat(content_to_analyze, analysis_result, context)
 
@@ -348,43 +336,33 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
             # No field extraction - return sanitized content directly
             return sanitized_content
 
-    async def function_middleware_invoke(self,
-                                         *args: Any,
-                                         call_next: CallNext,
-                                         context: FunctionMiddlewareContext,
-                                         **kwargs: Any) -> Any:
-        """Apply content safety guard check to function invocation.
-
-        This is the core logic for content safety guard defense - each defense implements
-        its own invoke/stream based on its specific strategy.
+    async def post_invoke(self, context: InvocationContext) -> InvocationContext | None:
+        """Analyze function output for content safety after execution.
 
         Args:
-            args: Positional arguments passed to the function (first arg is typically the input value).
-            call_next: Next middleware/function to call.
-            context: Function metadata (provides context state).
-            kwargs: Keyword arguments passed to the function.
+            context: Invocation context with function metadata and output.
 
         Returns:
-            Function output (potentially blocked or sanitized).
+            Modified context if output was processed, None to pass through.
         """
-        value = args[0] if args else None
+        if self.config.target_location != TargetLocation.OUTPUT:
+            return None
 
         # Check if defense should apply to this function
-        if not self._should_apply_defense(context.name):
-            logger.debug("ContentSafetyGuardMiddleware: Skipping %s (not targeted)", context.name)
-            return await call_next(value, *args[1:], **kwargs)
+        func_ctx: FunctionMiddlewareContext = context.function_context
+        if not self._should_apply_defense(func_ctx.name):
+            logger.debug("ContentSafetyGuardMiddleware: Skipping %s (not targeted)", func_ctx.name)
+            return None
 
         try:
-            # Call the function
-            output = await call_next(value, *args[1:], **kwargs)
-
-            # Handle output analysis (only output is supported)
-            output = await self._process_content_safety_detection(output, "output", context, original_input=value)
-
-            return output
-
+            # Handle function output analysis
+            original_input = context.original_args[0] if context.original_args else None
+            context.output = await self._process_content_safety_detection(context.output,
+                                                                          func_ctx,
+                                                                          original_input=original_input)
+            return context
         except Exception as e:
-            logger.error("Failed to apply content safety guard to function %s: %s", context.name, e, exc_info=True)
+            logger.error("Failed to apply content safety guard to function %s: %s", func_ctx.name, e, exc_info=True)
             raise
 
     async def function_middleware_stream(self,
@@ -430,10 +408,7 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
             # Join chunks efficiently (only convert to string if needed)
             full_output = "".join(chunk if isinstance(chunk, str) else str(chunk) for chunk in accumulated_chunks)
 
-            processed_output = await self._process_content_safety_detection(full_output,
-                                                                            "output",
-                                                                            context,
-                                                                            original_input=value)
+            processed_output = await self._process_content_safety_detection(full_output, context, original_input=value)
 
             processed_str = str(processed_output)
             if self.config.action == "redirection" and processed_str != full_output:

--- a/packages/nvidia_nat_core/src/nat/middleware/defense/defense_middleware_data_models.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/defense/defense_middleware_data_models.py
@@ -77,7 +77,7 @@ class OutputVerificationResult(BaseModel):
         confidence: Confidence score (0.0-1.0) in the threat detection.
         reason: Explanation for the detection result.
         correct_answer: The correct output value if threat detected, otherwise None.
-        content_type: Type of content analyzed ('input' or 'output').
+        content_type: TargetLocation indicating what was analyzed (input or output).
         should_refuse: Whether the content should be refused based on threshold.
         error: Whether an error occurred during verification.
     """

--- a/packages/nvidia_nat_core/src/nat/middleware/defense/defense_middleware_output_verifier.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/defense/defense_middleware_output_verifier.py
@@ -27,12 +27,13 @@ from typing import Any
 
 from pydantic import Field
 
+from nat.middleware.common import TargetLocation
 from nat.middleware.defense.defense_middleware import DefenseMiddleware
 from nat.middleware.defense.defense_middleware import DefenseMiddlewareConfig
 from nat.middleware.defense.defense_middleware_data_models import OutputVerificationResult
-from nat.middleware.function_middleware import CallNext
 from nat.middleware.function_middleware import CallNextStream
 from nat.middleware.middleware import FunctionMiddlewareContext
+from nat.middleware.middleware import InvocationContext
 
 logger = logging.getLogger(__name__)
 
@@ -45,10 +46,8 @@ class OutputVerifierMiddlewareConfig(DefenseMiddlewareConfig, name="output_verif
 
     Actions:
     - 'partial_compliance': Detect and log threats, but allow content to pass through
-    - 'refusal': Block output if threat detected (hard stop)
-    - 'redirection': Replace incorrect output with correct answer from LLM
-
-    Note: Only output analysis is currently supported (target_location='output').
+    - 'refusal': Block function output if threat detected (hard stop)
+    - 'redirection': Replace incorrect function output with correct answer from LLM
     """
 
     llm_name: str = Field(description="Name of the LLM to use for verification (must be defined in llms section)")
@@ -68,8 +67,6 @@ class OutputVerifierMiddleware(DefenseMiddleware):
     * Security validation (detecting malicious content and manipulated values)
     * Providing automatic corrections when errors are detected
 
-    Only output analysis is currently supported (``target_location='output'``).
-
     Streaming Behavior:
         For 'refusal' and 'redirection' actions, chunks are buffered and checked
         before yielding to prevent incorrect content from being streamed to clients.
@@ -87,12 +84,6 @@ class OutputVerifierMiddleware(DefenseMiddleware):
         super().__init__(config, builder)
         # Store config with correct type for linter
         self.config: OutputVerifierMiddlewareConfig = config
-
-        # Output Verifier only supports output analysis
-        if config.target_location == "input":
-            raise ValueError("OutputVerifierMiddleware only supports target_location='output'. "
-                             "Input analysis is not yet supported.")
-
         self._llm = None  # Lazy loaded LLM
 
     async def _get_llm(self):
@@ -125,14 +116,14 @@ class OutputVerifierMiddleware(DefenseMiddleware):
 
     async def _analyze_content(self,
                                content: Any,
-                               content_type: str,
+                               content_type: TargetLocation,
                                inputs: Any = None,
                                function_name: str | None = None) -> OutputVerificationResult:
         """Check content for threats using the configured LLM.
 
         Args:
             content: The content to analyze
-            content_type: Either 'input' or 'output' (for logging only)
+            content_type: TargetLocation used in the LLM prompt and result model.
             inputs: Optional function inputs for context (helps LLM calculate correct answers)
             function_name: Name of the function being verified (for context)
 
@@ -238,7 +229,7 @@ Respond ONLY with valid JSON in this exact format:
         action = self.config.action
 
         if action == "refusal":
-            logger.error("Output Verifier refusing output of %s: %s", context.name, analysis_result.reason)
+            logger.error("Output Verifier refusing function output of %s: %s", context.name, analysis_result.reason)
             raise ValueError(f"Content blocked by security policy: {analysis_result.reason}")
 
         elif action == "redirection":
@@ -281,7 +272,6 @@ Respond ONLY with valid JSON in this exact format:
     async def _process_output_verification(
         self,
         value: Any,
-        location: str,
         context: FunctionMiddlewareContext,
         inputs: Any = None,
     ) -> Any:
@@ -294,10 +284,9 @@ Respond ONLY with valid JSON in this exact format:
         - Applying corrected value back to original structure
 
         Args:
-            value: The value to analyze (input or output)
-            location: Either "input" or "output" (for logging)
-            context: Function context metadata
-            inputs: Original function inputs (for analysis context)
+            value: The value to analyze.
+            context: Function context metadata.
+            inputs: Original function inputs (for analysis context).
 
         Returns:
             The value after output verification handling (may be unchanged, corrected, or raise exception)
@@ -305,20 +294,17 @@ Respond ONLY with valid JSON in this exact format:
         # Extract field from value if target_field is specified
         content_to_analyze, field_info = self._extract_field_from_value(value)
 
-        # Check the output (either extracted field or entire value)
-        logger.info("OutputVerifierMiddleware: Checking %s %s for %s",
-                    f"field '{self.config.target_field}'" if field_info else "entire",
-                    location,
+        logger.info("OutputVerifierMiddleware: Checking %s function output for %s",
+                    f"field '{self.config.target_field}' of" if field_info else "entire",
                     context.name)
         output_result = await self._analyze_content(content_to_analyze,
-                                                    location,
+                                                    TargetLocation.OUTPUT,
                                                     inputs=inputs,
                                                     function_name=context.name)
 
         if not output_result.should_refuse:
             # Content verified as correct, return original value
-            logger.info("OutputVerifierMiddleware: Verified %s of %s as correct (confidence=%s)",
-                        location,
+            logger.info("OutputVerifierMiddleware: %s function output verified as correct (confidence=%s)",
                         context.name,
                         output_result.confidence)
             return value
@@ -333,44 +319,33 @@ Respond ONLY with valid JSON in this exact format:
             # No field extraction - return sanitized content directly
             return sanitized_content
 
-    async def function_middleware_invoke(self,
-                                         *args: Any,
-                                         call_next: CallNext,
-                                         context: FunctionMiddlewareContext,
-                                         **kwargs: Any) -> Any:
-        """Apply output verifier to function invocation.
-
-        Analyzes function outputs for correctness and security, with auto-correction.
+    async def post_invoke(self, context: InvocationContext) -> InvocationContext | None:
+        """Analyze function output for correctness and security after execution.
 
         Args:
-            args: Positional arguments passed to the function (first arg is typically the input value).
-            call_next: Next middleware/function to call.
-            context: Function metadata.
-            kwargs: Keyword arguments passed to the function.
+            context: Invocation context with function metadata and output.
 
         Returns:
-            Function output (potentially corrected, blocked, or sanitized).
+            Modified context if output was processed, None to pass through.
         """
-        value = args[0] if args else None
+        if self.config.target_location != TargetLocation.OUTPUT:
+            return None
 
         # Check if defense should apply to this function
-        if not self._should_apply_defense(context.name):
-            logger.debug("OutputVerifierMiddleware: Skipping %s (not targeted)", context.name)
-            return await call_next(value, *args[1:], **kwargs)
+        func_ctx: FunctionMiddlewareContext = context.function_context
+        if not self._should_apply_defense(func_ctx.name):
+            logger.debug("OutputVerifierMiddleware: Skipping %s (not targeted)", func_ctx.name)
+            return None
 
         try:
-            # Call the function
-            output = await call_next(value, *args[1:], **kwargs)
-
             # Process output verification (handles field extraction, analysis, and application)
-            output = await self._process_output_verification(output, "output", context, inputs=value)
-
-            return output
-
+            original_input = context.original_args[0] if context.original_args else None
+            context.output = await self._process_output_verification(context.output, func_ctx, inputs=original_input)
+            return context
         except Exception:
             logger.error(
                 "Failed to apply output verification to function %s",
-                context.name,
+                func_ctx.name,
                 exc_info=True,
             )
             raise
@@ -418,7 +393,7 @@ Respond ONLY with valid JSON in this exact format:
             full_output_str = "".join(chunk if isinstance(chunk, str) else str(chunk) for chunk in accumulated_chunks)
 
             # Process output verification (handles field extraction, analysis, and application)
-            processed_output = await self._process_output_verification(full_output_str, "output", context, inputs=value)
+            processed_output = await self._process_output_verification(full_output_str, context, inputs=value)
 
             processed_str = str(processed_output)
             if self.config.action == "redirection" and processed_str != full_output_str:

--- a/packages/nvidia_nat_core/src/nat/middleware/defense/defense_middleware_pii.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/defense/defense_middleware_pii.py
@@ -25,12 +25,13 @@ from typing import Any
 
 from pydantic import Field
 
+from nat.middleware.common import TargetLocation
 from nat.middleware.defense.defense_middleware import DefenseMiddleware
 from nat.middleware.defense.defense_middleware import DefenseMiddlewareConfig
 from nat.middleware.defense.defense_middleware_data_models import PIIAnalysisResult
-from nat.middleware.function_middleware import CallNext
 from nat.middleware.function_middleware import CallNextStream
 from nat.middleware.middleware import FunctionMiddlewareContext
+from nat.middleware.middleware import InvocationContext
 
 logger = logging.getLogger(__name__)
 
@@ -46,8 +47,6 @@ class PIIDefenseMiddlewareConfig(DefenseMiddlewareConfig, name="pii_defense"):
     - 'partial_compliance': Detect and log PII, but allow content to pass through
     - 'refusal': Block content if PII detected (hard stop)
     - 'redirection': Replace PII with anonymized placeholders (e.g., <EMAIL_ADDRESS>)
-
-    Note: Only output analysis is currently supported (target_location='output').
     """
 
     llm_name: str | None = Field(default=None, description="Not used for PII defense (Presidio is rule-based)")
@@ -67,7 +66,6 @@ class PIIDefenseMiddleware(DefenseMiddleware):
     """PII Defense Middleware using Microsoft Presidio.
 
     Detects PII in function outputs using Presidio's rule-based entity recognition.
-    Only output analysis is currently supported (``target_location='output'``).
 
     See https://github.com/microsoft/presidio for more information about Presidio.
 
@@ -83,11 +81,6 @@ class PIIDefenseMiddleware(DefenseMiddleware):
         self.config: PIIDefenseMiddlewareConfig = config
         self._analyzer = None
         self._anonymizer = None
-
-        # PII Defense only supports output analysis
-        if config.target_location == "input":
-            raise ValueError("PIIDefenseMiddleware only supports target_location='output'. "
-                             "Input analysis is not yet supported.")
 
         logger.info(f"PIIDefenseMiddleware initialized: "
                     f"action={config.action}, entities={config.entities}, "
@@ -154,7 +147,6 @@ class PIIDefenseMiddleware(DefenseMiddleware):
     def _process_pii_detection(
         self,
         value: Any,
-        location: str,
         context: FunctionMiddlewareContext,
     ) -> Any:
         """Process PII detection and sanitization for a given value.
@@ -166,9 +158,8 @@ class PIIDefenseMiddleware(DefenseMiddleware):
         - Applying sanitized value back to original structure
 
         Args:
-            value: The value to analyze (input or output)
-            location: Either "input" or "output" (for logging)
-            context: Function context metadata
+            value: The value to analyze.
+            context: Function context metadata.
 
         Returns:
             The value after PII handling (may be unchanged, sanitized, or raise exception)
@@ -176,23 +167,22 @@ class PIIDefenseMiddleware(DefenseMiddleware):
         # Extract field from value if target_field is specified
         content_to_analyze, field_info = self._extract_field_from_value(value)
 
-        logger.info("PIIDefenseMiddleware: Checking %s %s for %s",
-                    f"field '{self.config.target_field}'" if field_info else "entire",
-                    location,
+        logger.info("PIIDefenseMiddleware: Checking %s function output for %s",
+                    f"field '{self.config.target_field}' of" if field_info else "entire",
                     context.name)
         # Analyze for PII (convert to string for Presidio)
         content_text = str(content_to_analyze)
         analysis_result = self._analyze_content(content_text)
 
         if not analysis_result.pii_detected:
-            logger.info("PIIDefenseMiddleware: Verified %s of %s: No PII detected", location, context.name)
+            logger.info("PIIDefenseMiddleware: %s function output verified: No PII detected", context.name)
             return value
 
         # PII detected - handle based on action
         entities = analysis_result.entities
         # Build entities string efficiently without intermediate list
         entities_str = ", ".join(f"{k}({len(v)})" for k, v in entities.items())
-        sanitized_content = self._handle_threat(content_to_analyze, analysis_result, context, location, entities_str)
+        sanitized_content = self._handle_threat(content_to_analyze, analysis_result, context, entities_str)
 
         # If field was extracted, apply sanitized value back to original structure
         if field_info is not None:
@@ -206,7 +196,6 @@ class PIIDefenseMiddleware(DefenseMiddleware):
         content: Any,
         analysis_result: PIIAnalysisResult,
         context: FunctionMiddlewareContext,
-        location: str,
         entities_str: str,
     ) -> Any:
         """Handle detected PII threat based on configured action.
@@ -215,20 +204,18 @@ class PIIDefenseMiddleware(DefenseMiddleware):
             content: The content with PII
             analysis_result: Detection result from Presidio
             context: Function context
-            location: Either "input" or "output" (for logging)
             entities_str: String representation of detected entities
 
         Returns:
             Handled content (anonymized, original, or raises exception for refusal)
         """
         if self.config.action == "refusal":
-            logger.error("PII Defense refusing %s of %s: %s", location, context.name, entities_str)
-            raise ValueError(f"PII detected in {location}: {entities_str}. Output refused.")
+            logger.error("PII Defense refusing function output of %s: %s", context.name, entities_str)
+            raise ValueError(f"PII detected in function output: {entities_str}. Function output refused.")
 
         elif self.config.action == "redirection":
-            logger.warning("PII Defense detected PII in %s of %s: %s", location, context.name, entities_str)
-            logger.info("PII Defense anonymizing %s for %s", location, context.name)
-            str(content)
+            logger.warning("PII Defense detected PII in function output of %s: %s", context.name, entities_str)
+            logger.info("PII Defense anonymizing function output of %s", context.name)
             anonymized_content = analysis_result.anonymized_text
 
             # Convert anonymized_text back to original type if needed
@@ -245,47 +232,35 @@ class PIIDefenseMiddleware(DefenseMiddleware):
             return redirected_value
 
         else:  # action == "partial_compliance"
-            logger.warning("PII Defense detected PII in %s of %s: %s", location, context.name, entities_str)
+            logger.warning("PII Defense detected PII in %s function result: %s", context.name, entities_str)
             return content  # No modification, just log
 
-    async def function_middleware_invoke(
-        self,
-        *args: Any,
-        call_next: CallNext,
-        context: FunctionMiddlewareContext,
-        **kwargs: Any,
-    ) -> Any:
-        """Intercept function calls to detect and anonymize PII in inputs or outputs.
+    async def post_invoke(self, context: InvocationContext) -> InvocationContext | None:
+        """Detect and anonymize PII in function output after execution.
 
         Args:
-            args: Positional arguments passed to the function (first arg is typically the input value).
-            call_next: Function to call the next middleware or the actual function.
-            context: Context containing function metadata.
-            kwargs: Keyword arguments passed to the function.
+            context: Invocation context with function metadata and output.
 
         Returns:
-            The function result, with PII anonymized if action='redirection'.
+            Modified context if output was processed, None to pass through.
         """
-        value = args[0] if args else None
+        if self.config.target_location != TargetLocation.OUTPUT:
+            return None
 
         # Check if this defense should apply to this function
-        if not self._should_apply_defense(context.name):
-            logger.debug("PIIDefenseMiddleware: Skipping %s (not targeted)", context.name)
-            return await call_next(value, *args[1:], **kwargs)
+        func_ctx: FunctionMiddlewareContext = context.function_context
+        if not self._should_apply_defense(func_ctx.name):
+            logger.debug("PIIDefenseMiddleware: Skipping %s (not targeted)", func_ctx.name)
+            return None
 
         try:
-            # Call the actual function
-            result = await call_next(value, *args[1:], **kwargs)
-
-            # Handle output analysis (only output is supported)
-            result = self._process_pii_detection(result, "output", context)
-
-            return result
-
+            # Handle function output analysis
+            context.output = self._process_pii_detection(context.output, func_ctx)
+            return context
         except Exception:
             logger.error(
                 "Failed to apply PII defense to function %s",
-                context.name,
+                func_ctx.name,
                 exc_info=True,
             )
             raise
@@ -332,9 +307,9 @@ class PIIDefenseMiddleware(DefenseMiddleware):
                     yield chunk
                     accumulated_chunks.append(chunk)
 
-            # Analyze the full output for PII
+            # Analyze the full function output for PII
             full_output = "".join(chunk if isinstance(chunk, str) else str(chunk) for chunk in accumulated_chunks)
-            processed_output = self._process_pii_detection(full_output, "output", context)
+            processed_output = self._process_pii_detection(full_output, context)
 
             processed_str = str(processed_output)
             if self.config.action == "redirection" and processed_str != full_output:

--- a/packages/nvidia_nat_core/src/nat/middleware/red_teaming/red_teaming_middleware.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/red_teaming/red_teaming_middleware.py
@@ -37,9 +37,10 @@ from typing import cast
 from jsonpath_ng import parse
 from pydantic import BaseModel
 
-from nat.middleware.function_middleware import CallNext
+from nat.middleware.common import TargetLocation
 from nat.middleware.function_middleware import FunctionMiddleware
-from nat.middleware.function_middleware import FunctionMiddlewareContext
+from nat.middleware.middleware import FunctionMiddlewareContext
+from nat.middleware.middleware import InvocationContext
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,7 @@ class RedTeamingMiddleware(FunctionMiddleware):
         attack_payload: str,
         target_function_or_group: str | None = None,
         payload_placement: Literal["replace", "append_start", "append_middle", "append_end"] = "append_end",
-        target_location: Literal["input", "output"] = "input",
+        target_location: TargetLocation | str,
         target_field: str | None = None,
         target_field_resolution_strategy: Literal["random", "first", "last", "all", "error"] = "error",
         call_limit: int | None = None,
@@ -105,7 +106,7 @@ class RedTeamingMiddleware(FunctionMiddleware):
         self._attack_payload = attack_payload
         self._target_function_or_group = target_function_or_group
         self._payload_placement = payload_placement
-        self._target_location = target_location
+        self._target_location: TargetLocation = TargetLocation(target_location)
         self._target_field = target_field
         self._target_field_resolution_strategy = target_field_resolution_strategy
         self._call_count: int = 0  # Count the number of times the middleware has applied a payload
@@ -304,43 +305,51 @@ class RedTeamingMiddleware(FunctionMiddleware):
             logger.error("Failed to apply red team attack to function %s: %s", context.name, e, exc_info=True)
             raise
 
-    async def function_middleware_invoke(self,
-                                         *args: Any,
-                                         call_next: CallNext,
-                                         context: FunctionMiddlewareContext,
-                                         **kwargs: Any) -> Any:
-        """Invoke middleware for single-output functions.
+    async def pre_invoke(self, context: InvocationContext) -> InvocationContext | None:
+        """Inject attack payload into function input before execution.
 
         Args:
-            args: Positional arguments passed to the function (first arg is typically the input value).
-            call_next: Callable to invoke next middleware/function.
-            context: Metadata about the function being wrapped.
-            kwargs: Keyword arguments passed to the function.
+            context: Invocation context with function metadata and args.
 
         Returns:
-            The output value (potentially modified if attacking output).
+            Modified context if input was attacked, None to pass through.
         """
-        value = args[0] if args else None
+        if self._target_location != TargetLocation.INPUT:
+            return None
 
         # Check if we should attack this function
-        if not self._should_apply_payload(context.name):
-            logger.debug("Skipping function %s (not targeted)", context.name)
-            return await call_next(value, *args[1:], **kwargs)
+        func_ctx: FunctionMiddlewareContext = context.function_context
+        if not self._should_apply_payload(func_ctx.name):
+            logger.debug("Skipping function %s (not targeted)", func_ctx.name)
+            return None
 
-        if self._target_location == "input":
-            # Attack the input before calling the function
-            modified_input = self._apply_payload_to_function_value_with_exception(value, context)
-            # Call next with modified input
-            return await call_next(modified_input, *args[1:], **kwargs)
+        # Attack the input before calling the function
+        value = context.modified_args[0] if context.modified_args else None
+        modified_input = self._apply_payload_to_function_value_with_exception(value, func_ctx)
+        context.modified_args = (modified_input, ) + context.modified_args[1:]
+        return context
 
-        elif self._target_location == "output":  # target_location == "output"
-            # Call function first, then attack the output
-            output = await call_next(value, *args[1:], **kwargs)
-            modified_output = self._apply_payload_to_function_value_with_exception(output, context)
-            return modified_output
-        else:
-            raise ValueError(f"Unknown target_location: {self._target_location}. "
-                             "Attack payloads can only be applied to function input or output.")
+    async def post_invoke(self, context: InvocationContext) -> InvocationContext | None:
+        """Inject attack payload into function output after execution.
+
+        Args:
+            context: Invocation context with function metadata and output.
+
+        Returns:
+            Modified context if output was attacked, None to pass through.
+        """
+        if self._target_location != TargetLocation.OUTPUT:
+            return None
+
+        # Check if we should attack this function
+        func_ctx: FunctionMiddlewareContext = context.function_context
+        if not self._should_apply_payload(func_ctx.name):
+            logger.debug("Skipping function %s (not targeted)", func_ctx.name)
+            return None
+
+        # Attack the output after function execution
+        context.output = self._apply_payload_to_function_value_with_exception(context.output, func_ctx)
+        return context
 
 
 __all__ = ["RedTeamingMiddleware"]

--- a/packages/nvidia_nat_core/src/nat/middleware/red_teaming/red_teaming_middleware_config.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/red_teaming/red_teaming_middleware_config.py
@@ -21,6 +21,7 @@ from typing import Literal
 from pydantic import Field
 
 from nat.data_models.middleware import FunctionMiddlewareBaseConfig
+from nat.middleware.common import TargetLocation
 
 
 class RedTeamingMiddlewareConfig(FunctionMiddlewareBaseConfig, name="red_teaming"):
@@ -79,8 +80,8 @@ class RedTeamingMiddlewareConfig(FunctionMiddlewareBaseConfig, name="red_teaming
                      "'append_middle' (insert at middle sentence)"),
     )
 
-    target_location: Literal["input", "output"] = Field(
-        default="input",
+    target_location: TargetLocation = Field(
+        default=TargetLocation.INPUT,
         description="Whether to attack the function's input or output",
     )
 

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_defense_middleware.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_defense_middleware.py
@@ -24,10 +24,12 @@ from jsonpath_ng import parse
 from pydantic import BaseModel
 
 from nat.builder.function import FunctionGroup
+from nat.middleware.common import TargetLocation
 from nat.middleware.defense.defense_middleware import DefenseMiddleware
 from nat.middleware.defense.defense_middleware import DefenseMiddlewareConfig
 from nat.middleware.defense.defense_middleware import MultipleTargetFieldMatchesError
 from nat.middleware.middleware import FunctionMiddlewareContext
+from nat.middleware.middleware import InvocationContext
 
 
 class _TestOutputModel(BaseModel):
@@ -40,35 +42,24 @@ class _TestOutputModel(BaseModel):
 class _TestDefenseMiddleware(DefenseMiddleware):
     """Concrete implementation for testing base class methods."""
 
-    async def function_middleware_invoke(self, value, call_next, context):
-        """Test implementation that extracts fields from output and stores them for verification."""
-        # Check if defense should apply
-        if not self._should_apply_defense(context.name):
-            return await call_next(value)
-
-        # Call next to get output
-        output = await call_next(value)
-
-        # Extract field from output if target_field is specified
-        content, field_info = self._extract_field_from_value(output)
-
-        # Store extracted content for test verification
-        self._last_extracted_content = content
-        self._last_field_info = field_info
-
-        # Return output
-        return output
-
-    async def function_middleware_stream(self, value, call_next, _context):
-        """Dummy implementation."""
-        async for item in call_next(value):
-            yield item
-
     def __init__(self, config: DefenseMiddlewareConfig, builder):
-        """Initialize test middleware."""
         super().__init__(config, builder)
         self._last_extracted_content = None
         self._last_field_info = None
+
+    async def post_invoke(self, context: InvocationContext) -> InvocationContext | None:
+        """Test implementation that extracts fields from output and stores them for verification."""
+        if self.config.target_location != TargetLocation.OUTPUT:
+            return None
+
+        func_ctx: FunctionMiddlewareContext = context.function_context
+        if not self._should_apply_defense(func_ctx.name):
+            return None
+
+        content, field_info = self._extract_field_from_value(context.output)
+        self._last_extracted_content = content
+        self._last_field_info = field_info
+        return context
 
 
 @pytest.fixture(name="mock_builder")
@@ -449,7 +440,7 @@ class TestDefenseMiddlewareEndToEnd:
                                             single_output_schema=_TestOutputModel,
                                             stream_output_schema=type(None))
 
-        await middleware.function_middleware_invoke(10.0, mock_call_next, context)
+        await middleware.function_middleware_invoke(10.0, call_next=mock_call_next, context=context)
 
         # Verify field was extracted
         assert middleware._last_extracted_content == 42.0
@@ -477,7 +468,7 @@ class TestDefenseMiddlewareEndToEnd:
                                             single_output_schema=NestedOutput,
                                             stream_output_schema=type(None))
 
-        await middleware.function_middleware_invoke({}, mock_call_next, context)
+        await middleware.function_middleware_invoke({}, call_next=mock_call_next, context=context)
 
         # Verify deeply nested field was extracted
         assert middleware._last_extracted_content == "Hello world"
@@ -498,7 +489,7 @@ class TestDefenseMiddlewareEndToEnd:
                                             single_output_schema=_TestOutputModel,
                                             stream_output_schema=type(None))
 
-        await middleware.function_middleware_invoke(10.0, mock_call_next, context)
+        await middleware.function_middleware_invoke(10.0, call_next=mock_call_next, context=context)
 
         # Defense should not apply, so no field extraction should occur
         assert middleware._last_extracted_content is None
@@ -526,7 +517,7 @@ class TestDefenseMiddlewareEndToEnd:
                                             single_output_schema=MultiFieldOutput,
                                             stream_output_schema=type(None))
 
-        await middleware.function_middleware_invoke({}, mock_call_next, context)
+        await middleware.function_middleware_invoke({}, call_next=mock_call_next, context=context)
 
         # Verify all fields were extracted as a list
         assert middleware._last_extracted_content == [10.0, 20.0, 30.0]
@@ -555,7 +546,7 @@ class TestDefenseMiddlewareEndToEnd:
                                             single_output_schema=MultiFieldOutput,
                                             stream_output_schema=type(None))
 
-        await middleware.function_middleware_invoke({}, mock_call_next, context)
+        await middleware.function_middleware_invoke({}, call_next=mock_call_next, context=context)
 
         # Verify only first field was extracted
         assert middleware._last_extracted_content == 10.0
@@ -586,7 +577,7 @@ class TestDefenseMiddlewareEndToEnd:
 
         # Defense middleware catches ValueError and analyzes entire value instead
         # (unlike red teaming which raises the error)
-        await middleware.function_middleware_invoke({}, mock_call_next, context)
+        await middleware.function_middleware_invoke({}, call_next=mock_call_next, context=context)
 
         # Should fall back to analyzing entire value when error strategy encounters multiple matches
         assert middleware._last_extracted_content == output_value
@@ -607,7 +598,7 @@ class TestDefenseMiddlewareEndToEnd:
                                             single_output_schema=str,
                                             stream_output_schema=type(None))
 
-        await middleware.function_middleware_invoke({}, mock_call_next, context)
+        await middleware.function_middleware_invoke({}, call_next=mock_call_next, context=context)
 
         # Should extract entire value when no target_field
         assert middleware._last_extracted_content == "simple string output"

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_defense_middleware_content_guard.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_defense_middleware_content_guard.py
@@ -24,6 +24,7 @@ import pytest
 from pydantic import BaseModel
 
 from nat.builder.function import FunctionGroup
+from nat.middleware.common import TargetLocation
 from nat.middleware.defense.defense_middleware_content_guard import ContentSafetyGuardMiddleware
 from nat.middleware.defense.defense_middleware_content_guard import ContentSafetyGuardMiddlewareConfig
 from nat.middleware.middleware import FunctionMiddlewareContext
@@ -431,36 +432,25 @@ class TestContentSafetyGuardInvoke:
         assert not mock_llm.ainvoke.called  # Defense should not run
         assert result == "content"
 
-    async def test_target_location_validation(self, mock_builder, middleware_context):
-        """Test target_location validation and default behavior."""
-        # Test that target_location='input' raises ValidationError
-        from pydantic import ValidationError
-        with pytest.raises(ValidationError, match="Input should be 'output'"):
-            ContentSafetyGuardMiddlewareConfig(
-                llm_name="test_llm",
-                target_location="input",  # type: ignore[arg-type]
-                action="partial_compliance")
-
-        # Test default is 'output'
+    async def test_target_location_defaults_to_output(self):
+        """Test that target_location defaults to OUTPUT."""
         config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="partial_compliance")
-        assert config.target_location == "output"
+        assert config.target_location == TargetLocation.OUTPUT
 
-        # Test explicit 'output' works
+    async def test_target_location_input_skips_output_analysis(self, mock_builder, middleware_context):
+        """Test that setting target_location=INPUT skips output analysis entirely."""
         config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm",
-                                                    target_location="output",
+                                                    target_location=TargetLocation.INPUT,
                                                     action="partial_compliance")
         middleware = ContentSafetyGuardMiddleware(config, mock_builder)
         mock_llm = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.content = "Safe"
-        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
         middleware._llm = mock_llm
 
         async def mock_next(_value):
             return "content"
 
         result = await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
-        assert mock_llm.ainvoke.called
+        assert not mock_llm.ainvoke.called
         assert result == "content"
 
     async def test_non_string_output_converts_to_string(self, mock_builder, middleware_context):

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_defense_middleware_output_verifier.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_defense_middleware_output_verifier.py
@@ -24,6 +24,7 @@ import pytest
 from pydantic import BaseModel
 
 from nat.builder.function import FunctionGroup
+from nat.middleware.common import TargetLocation
 from nat.middleware.defense.defense_middleware_output_verifier import OutputVerifierMiddleware
 from nat.middleware.defense.defense_middleware_output_verifier import OutputVerifierMiddlewareConfig
 from nat.middleware.middleware import FunctionMiddlewareContext
@@ -370,36 +371,25 @@ class TestOutputVerifierInvoke:
         assert not mock_llm.ainvoke.called  # Defense should not run
         assert result == 42.0
 
-    async def test_target_location_validation(self, mock_builder, middleware_context):
-        """Test target_location validation and default behavior."""
-        # Test that target_location='input' raises ValidationError
-        from pydantic import ValidationError
-        with pytest.raises(ValidationError, match="Input should be 'output'"):
-            OutputVerifierMiddlewareConfig(
-                llm_name="test_llm",
-                target_location="input",  # type: ignore[arg-type]
-                action="partial_compliance")
-
-        # Test default is 'output'
+    async def test_target_location_defaults_to_output(self):
+        """Test that target_location defaults to OUTPUT."""
         config = OutputVerifierMiddlewareConfig(llm_name="test_llm", action="partial_compliance")
-        assert config.target_location == "output"
+        assert config.target_location == TargetLocation.OUTPUT
 
-        # Test explicit 'output' works
+    async def test_target_location_input_skips_output_analysis(self, mock_builder, middleware_context):
+        """Test that setting target_location=INPUT skips output analysis entirely."""
         config = OutputVerifierMiddlewareConfig(llm_name="test_llm",
-                                                target_location="output",
+                                                target_location=TargetLocation.INPUT,
                                                 action="partial_compliance")
         middleware = OutputVerifierMiddleware(config, mock_builder)
         mock_llm = AsyncMock()
-        mock_response = MagicMock()
-        mock_response.content = '{"threat_detected": false, "confidence": 0.9}'
-        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
         middleware._llm = mock_llm
 
         async def mock_next(_value):
             return 42.0
 
         result = await middleware.function_middleware_invoke(10.0, call_next=mock_next, context=middleware_context)
-        assert mock_llm.ainvoke.called
+        assert not mock_llm.ainvoke.called
         assert result == 42.0
 
     async def test_non_string_output_converts_to_string(self, mock_builder, middleware_context):

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_defense_middleware_pii.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_defense_middleware_pii.py
@@ -23,6 +23,7 @@ import pytest
 from pydantic import BaseModel
 
 from nat.builder.function import FunctionGroup
+from nat.middleware.common import TargetLocation
 from nat.middleware.defense.defense_middleware_pii import PIIDefenseMiddleware
 from nat.middleware.defense.defense_middleware_pii import PIIDefenseMiddlewareConfig
 from nat.middleware.middleware import FunctionMiddlewareContext
@@ -400,24 +401,16 @@ class TestPIIDefenseInvoke:
         assert not mock_analyzer.analyze.called  # Defense should not run
         assert result == "content"
 
-    async def test_target_location_validation(self, mock_builder, middleware_context):
-        """Test target_location validation and default behavior."""
-        # Test that target_location='input' raises ValidationError
-        from pydantic import ValidationError
-        with pytest.raises(ValidationError, match="Input should be 'output'"):
-            PIIDefenseMiddlewareConfig(
-                target_location="input",  # type: ignore[arg-type]
-                action="partial_compliance")
-
-        # Test default is 'output'
+    async def test_target_location_defaults_to_output(self):
+        """Test that target_location defaults to OUTPUT."""
         config = PIIDefenseMiddlewareConfig(action="partial_compliance")
-        assert config.target_location == "output"
+        assert config.target_location == TargetLocation.OUTPUT
 
-        # Test explicit 'output' works
-        config = PIIDefenseMiddlewareConfig(target_location="output", action="partial_compliance")
+    async def test_target_location_input_skips_output_analysis(self, mock_builder, middleware_context):
+        """Test that setting target_location=INPUT skips output analysis entirely."""
+        config = PIIDefenseMiddlewareConfig(target_location=TargetLocation.INPUT, action="partial_compliance")
         middleware = PIIDefenseMiddleware(config, mock_builder)
         mock_analyzer = MagicMock()
-        mock_analyzer.analyze.return_value = []
         middleware._analyzer = mock_analyzer
         middleware._anonymizer = MagicMock()
 
@@ -425,7 +418,7 @@ class TestPIIDefenseInvoke:
             return "content"
 
         result = await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
-        assert mock_analyzer.analyze.called
+        assert not mock_analyzer.analyze.called
         assert result == "content"
 
     async def test_non_string_output_converts_to_string(self, mock_builder, middleware_context):
@@ -516,7 +509,7 @@ class TestPIIDefenseStreaming:
             yield "Contact "
             yield "john.doe@example.com"
 
-        with pytest.raises(ValueError, match="PII detected in output"):
+        with pytest.raises(ValueError, match="PII detected in function output"):
             async for _ in middleware.function_middleware_stream({}, call_next=mock_stream, context=middleware_context):
                 pass
 

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_red_teaming_middleware.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_red_teaming_middleware.py
@@ -423,6 +423,6 @@ async def test_multiple_field_matches_with_error_strategy():
 )
 def test_string_placement_modes(placement, original, expected):
     """Test all payload placement modes for string values."""
-    middleware = RedTeamingMiddleware(attack_payload="PAYLOAD", payload_placement=placement)
+    middleware = RedTeamingMiddleware(attack_payload="PAYLOAD", payload_placement=placement, target_location="input")
     result = middleware._apply_payload_to_function_value(original)
     assert result == expected


### PR DESCRIPTION
## Description

Simplifies defense and red teaming middleware by using `pre_invoke`/`post_invoke` hooks directly, since these middlewares only need to act on function inputs or outputs — not control the full invocation lifecycle. This makes each middleware's execution phase explicit from its method signature alone, improving readability and reducing boilerplate. It also removes the control flow logic that was previously needed inside `function_middleware_invoke` to determine whether to run before or after function execution, that routing is now handled naturally by which hook the middleware implements.

### Changes

- **Use pre/post hooks directly**: Defense middlewares (PII, content safety guard, output verifier) now implement `post_invoke` instead of overriding `function_middleware_invoke`. Red teaming middleware implements both `pre_invoke` and `post_invoke`, with each hook handling its respective `TargetLocation`.
- **Introduce `TargetLocation` enum**: Extracted a shared `TargetLocation` enum (`input`/`output`) into `nat.middleware.common` as a runtime config for controlling which hook phase a middleware activates in. This replaces scattered `Literal["input", "output"]` annotations and hard-coded string comparisons.
- **Remove input-unsupported guards**: Defense middlewares previously raised `ValueError` when `target_location="input"` was set. Now they simply return `None` from `post_invoke` (no-op), allowing future input analysis support without breaking changes.
- **Clean up redundant docstrings**: Removed class-level docstring lines that restated which hook the middleware uses, since the method signatures (`post_invoke`, `pre_invoke`) already convey that.

### Files changed (core middleware only)

- `middleware/common.py` — new shared module with `TargetLocation` enum
- `middleware/defense/defense_middleware.py` — config field type updated to `TargetLocation`
- `middleware/defense/defense_middleware_content_guard.py` — migrated to `post_invoke`
- `middleware/defense/defense_middleware_output_verifier.py` — migrated to `post_invoke`
- `middleware/defense/defense_middleware_pii.py` — migrated to `post_invoke`
- `middleware/red_teaming/red_teaming_middleware.py` — split into `pre_invoke` + `post_invoke`
- `middleware/red_teaming/red_teaming_middleware_config.py` — updated to use `TargetLocation`
- Tests updated across all middleware test files (113 tests passing)

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a TargetLocation enum to let middleware explicitly target function input or function output.
  * Introduced pre_invoke/post_invoke hooks so middleware can run before input or after output execution.

* **Refactor**
  * Strengthened middleware configuration typing to use TargetLocation and updated defenses, PII, output verification, and red‑teaming flows to operate based on this enum.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->