### PR TITLE
Add a server-side override for the A2A Agent Card URL

### DIFF
--- a/docs/source/run-workflows/a2a-server.md
+++ b/docs/source/run-workflows/a2a-server.md
@@ -114,10 +114,10 @@ general:
     _type: a2a
     host: 0.0.0.0
     port: 10000
-    public_base_url: ${PUBLIC_BASE_URL}
+    public_base_url: ${NAT_PUBLIC_BASE_URL}
 ```
 
-Use your deployment tooling (for example Helm values or environment injection) to provide `PUBLIC_BASE_URL` at runtime.
+Use your deployment tooling (for example Helm values or environment injection) to provide `NAT_PUBLIC_BASE_URL` at runtime.
 
 ## How Workflows Map to A2A Agents
 

--- a/docs/source/run-workflows/a2a-server.md
+++ b/docs/source/run-workflows/a2a-server.md
@@ -73,6 +73,7 @@ general:
     description: "A calculator agent for mathematical operations"
     host: localhost
     port: 10000
+    public_base_url: "https://agents.example.com/calculator"  # Optional public URL for Agent Card
     version: "1.0.0"
 ```
 
@@ -102,6 +103,21 @@ You can get the complete list of configuration options and their schemas by runn
 ```bash
 nat info components -t front_end -q a2a
 ```
+
+### Kubernetes and Ingress Deployments
+
+In Kubernetes deployments, the server bind address (`host` and `port`) is often not the public address that clients use. Set `public_base_url` so the generated Agent Card advertises the external URL:
+
+```yaml
+general:
+  front_end:
+    _type: a2a
+    host: 0.0.0.0
+    port: 10000
+    public_base_url: ${PUBLIC_BASE_URL}
+```
+
+Use your deployment tooling (for example Helm values or environment injection) to provide `PUBLIC_BASE_URL` at runtime.
 
 ## How Workflows Map to A2A Agents
 

--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/server/front_end_config.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/server/front_end_config.py
@@ -17,6 +17,7 @@ import logging
 
 from pydantic import BaseModel
 from pydantic import Field
+from pydantic import HttpUrl
 from pydantic import model_validator
 
 from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
@@ -54,6 +55,12 @@ class A2AFrontEndConfig(FrontEndBaseConfig, name="a2a"):
         description="Port to bind the server to (default: 10000)",
         ge=0,
         le=65535,
+    )
+    public_base_url: HttpUrl | None = Field(
+        default=None,
+        description="Public base URL advertised in the Agent Card for external discovery. "
+        "Use this for deployments behind ingress, gateways, or proxies. "
+        "If not set, defaults to http://{host}:{port}/.",
     )
     version: str = Field(
         default="1.0.0",

--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/server/front_end_plugin_worker.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/server/front_end_plugin_worker.py
@@ -202,7 +202,7 @@ class A2AFrontEndPluginWorker:
             )
 
         # Build agent card
-        agent_url = f"http://{config.host}:{config.port}/"
+        agent_url = self._resolve_agent_url()
         agent_card = AgentCard(
             name=config.name,
             description=config.description,
@@ -223,6 +223,13 @@ class A2AFrontEndPluginWorker:
             logger.info("Security: OAuth2 authentication required")
 
         return agent_card
+
+    def _resolve_agent_url(self) -> str:
+        """Resolve public URL to advertise in the Agent Card."""
+        config = self.front_end_config
+        if config.public_base_url:
+            return f"{str(config.public_base_url).rstrip('/')}/"
+        return f"http://{config.host}:{config.port}/"
 
     def create_agent_executor(self, workflow: Workflow, builder: WorkflowBuilder) -> NATWorkflowAgentExecutor:
         """Create agent executor adapter for the workflow.

--- a/packages/nvidia_nat_a2a/tests/server/test_agent_card_generation.py
+++ b/packages/nvidia_nat_a2a/tests/server/test_agent_card_generation.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 from nat.builder.function import FunctionGroup
+from nat.data_models.config import Config
+from nat.data_models.config import GeneralConfig
+from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
 from nat.plugins.a2a.server.front_end_plugin_worker import A2AFrontEndPluginWorker
 
 
@@ -104,6 +107,22 @@ class TestAgentCardGeneration:
 
         # URL should be formatted as http://host:port/
         assert agent_card.url == "http://localhost:10000/"
+
+    async def test_agent_card_url_uses_public_base_url_when_configured(self, mock_workflow_with_functions):
+        """Test agent card URL uses public base URL override when configured."""
+        config = Config(general=GeneralConfig(front_end=A2AFrontEndConfig(
+            name="Test Agent",
+            description="Test agent for unit tests",
+            host="0.0.0.0",
+            port=10000,
+            public_base_url="https://agents.example.com/calculator",
+            version="1.0.0",
+        )))
+        worker = A2AFrontEndPluginWorker(config)
+        agent_card = await worker.create_agent_card(mock_workflow_with_functions)
+
+        # URL should be normalized with trailing slash
+        assert agent_card.url == "https://agents.example.com/calculator/"
 
     async def test_agent_card_capabilities_from_config(self, mock_workflow_with_functions, a2a_server_config):
         """Test agent card capabilities from configuration.


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes #1501

This PR adds a server-side override for the A2A Agent Card URL so deployments behind Kubernetes ingress/proxies can publish the correct external endpoint.

Sample Usage:
```
 nat a2a serve --config_file examples/getting_start
ed/simple_calculator/configs/config.yml --port 10000 --public_base_url "http://nat.isamazing.com"
```
<img width="674" height="208" alt="image" src="https://github.com/user-attachments/assets/c9feb92f-68c5-4e31-86ff-cc52a8ee194e" />

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional public_base_url setting to let deployments advertise a custom external URL for the Agent Card.

* **Tests**
  * Added test coverage ensuring public_base_url is respected and normalized (trailing slash behavior).

* **Documentation**
  * New Kubernetes & Ingress deployment guide showing how to provide a public URL (including runtime/env-var injection examples) for proper Agent Card advertisement.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->