### PR TITLE
Fix `thought` matching issue in ReAct agent with the `Llama-3.1-Nemotron-Nano-4B-v1.1` model

### DIFF
--- a/docs/source/build-workflows/llms/using-local-llms.md
+++ b/docs/source/build-workflows/llms/using-local-llms.md
@@ -161,7 +161,9 @@ uv pip install -e examples/getting_started/simple_web_query
 Similar to the NIM approach we will be running the LLM on the default port of 8000 and the embedding model on port 8001.
 
 :::{note}
-The `CUDA_VISIBLE_DEVICES` environment variable is used to specify the GPUs to use for the LLM and embedding model. Each user's setup may vary, so adjust the commands to suit the system.
+For this example we are using vLLM v0.16.0, the command line flags and configuration may differ for other versions, refer to the vLLM documentation for the version you are using.
+
+The `CUDA_VISIBLE_DEVICES` environment variable is used to specify the GPUs to use for the LLM and embedding model. The following commands assume a system with at least two GPUs. Each user's setup may vary, so adjust the commands to suit the system.
 :::
 
 In a terminal from within the vLLM environment, run the following command to serve the LLM:
@@ -171,7 +173,7 @@ CUDA_VISIBLE_DEVICES=0 vllm serve nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1
 
 In a second terminal also from within the vLLM environment, run the following command to serve the embedding model:
 ```bash
-CUDA_VISIBLE_DEVICES=1 vllm serve --task embed --override-pooler-config '{"pooling_type": "MEAN"}' --port 8001 ssmits/Qwen2-7B-Instruct-embed-base
+CUDA_VISIBLE_DEVICES=1 vllm serve --port 8001 --runner pooling --convert embed --pooler-config '{"pooling_type": "MEAN"}' ssmits/Qwen2-7B-Instruct-embed-base
 ```
 
 :::{note}

--- a/docs/source/build-workflows/llms/using-local-llms.md
+++ b/docs/source/build-workflows/llms/using-local-llms.md
@@ -62,7 +62,7 @@ docker pull nvcr.io/nim/nvidia/nv-embedqa-e5-v5:latest
 ### Running the NIM Containers
 
 :::{note}
-The `--gpus` flag is used to specify the GPUs to use for the LLM and embedding model. Each user's setup may vary, so adjust the commands to suit the system.
+The `--gpus` flag is used to specify the GPUs to use for the LLM and embedding model. The following commands assume the system is equipped with at least two GPUs, one for each model. Each user's setup may vary, so adjust the commands to suit the system.
 :::
 
 Run the LLM container listening on port 8000:
@@ -71,6 +71,7 @@ export NGC_API_KEY=<PASTE_API_KEY_HERE>
 export LOCAL_NIM_CACHE=~/.cache/nim
 mkdir -p "$LOCAL_NIM_CACHE"
 docker run -it --rm \
+    --runtime=nvidia \
     --gpus '"device=0"' \
     --shm-size=16GB \
     -e NGC_API_KEY \
@@ -85,6 +86,7 @@ Open a new terminal and run the embedding model container, listening on port 800
 export NGC_API_KEY=<PASTE_API_KEY_HERE>
 export LOCAL_NIM_CACHE=~/.cache/nim
 docker run -it --rm \
+    --runtime=nvidia \
     --gpus '"device=1"' \
     --shm-size=16GB \
     -e NGC_API_KEY \

--- a/docs/source/build-workflows/llms/using-local-llms.md
+++ b/docs/source/build-workflows/llms/using-local-llms.md
@@ -177,7 +177,7 @@ CUDA_VISIBLE_DEVICES=1 vllm serve --port 8001 --runner pooling --convert embed -
 ```
 
 :::{note}
-The `--override-pooler-config` flag is taken from the [vLLM Supported Models](https://docs.vllm.ai/en/latest/models/supported_models.html#embedding) documentation.
+The `--pooler-config` flag is taken from the [vLLM Supported Models](https://docs.vllm.ai/en/v0.16.0/models/supported_models.html#embedding) documentation.
 :::
 
 

--- a/examples/documentation_guides/locally_hosted_llms/nim_config.yml
+++ b/examples/documentation_guides/locally_hosted_llms/nim_config.yml
@@ -27,7 +27,7 @@ llms:
   nim_llm:
     _type: nim
     base_url: "http://localhost:8000/v1"
-    model_name: nvidia/llama3.1-nemotron-nano-4b-v1.1
+    model_name: nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1
 
 embedders:
   nv-embedqa-e5-v5:

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
@@ -322,7 +322,7 @@ class ReActAgentGraph(DualNodeAgent):
                     # a ReAct prompt echo (Thought:/Question:/Previous conversation history:).
                     content_str = str(output_message.content).strip()
                     if (ex.missing_action and content_str and not re.match(
-                            r'\s*(thought\s*:|question\s*:|previous\s+conversation)', content_str, re.IGNORECASE)):
+                            r'\s*(thought\s*:?|question\s*:|previous\s+conversation)', content_str, re.IGNORECASE)):
                         logger.info(
                             "%s Agent produced direct answer without ReAct format, "
                             "accepting as final answer",


### PR DESCRIPTION
## Description
* The model's first response to the prompt from the `docs/source/build-workflows/llms/using-local-llms.md` example is (I have no idea why the `<think>` tags aren't balanced):
```
<think>
Okay, the user is asking about LangSmith now. Let me check the conversation history. In the previous question, they asked, "What is LangSmith?" and I need to continue answering based on that context.

Since the user hasn't provided any new information that requires a tool, I should try to answer based on existing knowledge. However, LangSmith might be a specific tool or project that isn't widely known, so maybe I should look it up. But the only tool available is webpage_query. I need to structure the query correctly.

The user might be referring to a software tool, a language processing system, or something else. To use the webpage_query tool, I need to frame a proper question. If LangSmith is a project, maybe the query should be about its documentation, features, or purpose. Let me try a general query first.

So, the query would be to search for LangSmith on the web. The proper JSON format for the query would be {'query': 'What is LangSmith?'}. That should get relevant results. Since there's no specific information given to use the current datetime, I don't need that tool here.

Wait, maybe the user is referring to the new AI assistant LangSmith. If that's the case, the main response should explain that LangSmith is a hypothetical or upcoming tool. But since I might not have up-to-date info, using the webpage_query is safer. Let me proceed with that.
</think>

Thought
</think>

Thought
```

The agent is looking for `Thought:` to indicate that the LLM isn't done yet, however this LLM responds without the `:`. 

This PR relaxes that a little bit.

Also FWIW this same model hosted on build.nvidia.com doesn't exhibit this behavior, my only guess is that this is the result of running locally on a GPU with constrained resources.

* Fix model spelling error
* Misc drive-by documentation improvement.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified local LLM guide to assume two GPUs, added GPU-enabled container runtime guidance, expanded vLLM version-specific notes, and updated embedding-serving instructions and multi-GPU setup explanation.

* **Bug Fixes**
  * Improved agent final-answer detection to better handle varied output formats.

* **Configuration**
  * Updated the referenced model identifier for local deployment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->