### PR TITLE
Add TimeoutMiddleware

### DIFF
--- a/docs/source/build-workflows/advanced/middleware.md
+++ b/docs/source/build-workflows/advanced/middleware.md
@@ -372,6 +372,38 @@ async def call_external_api(config: APICallerConfig, builder: Builder):
 - **Streaming**: Always bypasses cache to avoid buffering
 - **Serialization**: Falls back to function call if input can't be serialized
 
+### Timeout Middleware
+
+The timeout middleware enforces configurable time limits on intercepted calls, raising `TimeoutError` when execution exceeds the configured duration.
+
+#### Configuration
+
+```yaml
+middleware:
+  llm_timeout:
+    _type: timeout
+    timeout: 30.0
+    register_llms: true
+
+  tool_timeout:
+    _type: timeout
+    timeout: 10.0
+    timeout_message: "Tool call timed out, try a simpler input."
+```
+
+#### Parameters
+
+- **`timeout`**: Time limit in seconds (must be greater than zero)
+- **`timeout_message`**: Optional additional message appended to the `TimeoutError` raised on expiry
+
+Timeout middleware extends `DynamicFunctionMiddleware`, enabling interception of component methods such as LLMs.
+
+#### Behavior
+
+- **Single invocations**: Enforces the time limit on the intercepted function call
+- **Streaming**: Enforces the time limit across the entire stream duration, not per-chunk
+- **Error handling**: Raises `TimeoutError` with the configured `timeout_message`
+
 ## Advanced Patterns
 
 ### Accessing the Builder
@@ -684,6 +716,7 @@ When chaining multiple middleware:
 3. **Validation**: Validate before expensive operations
 4. **Rate Limiting**: Prevent excessive calls
 5. **Caching**: Final middleware to skip execution
+6. **Timeout**: Timing starts from where it is positioned and runs until the remaining chain completes
 
 ```yaml
 middleware:

--- a/packages/nvidia_nat_core/src/nat/middleware/timeout/__init__.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/timeout/__init__.py
@@ -12,12 +12,3 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-# flake8: noqa
-
-from nat.middleware.cache import register as register_cache
-from nat.middleware.defense import register as register_defense
-from nat.middleware.dynamic import register as register_dynamic
-from nat.middleware.logging import register as register_logging
-from nat.middleware.red_teaming import register as register_red_teaming
-from nat.middleware.timeout import register as register_timeout

--- a/packages/nvidia_nat_core/src/nat/middleware/timeout/register.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/timeout/register.py
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Registration for timeout middleware."""
+
+from collections.abc import AsyncGenerator
+
+from nat.builder.builder import Builder
+from nat.cli.register_workflow import register_middleware
+from nat.middleware.timeout.timeout_middleware import TimeoutMiddleware
+from nat.middleware.timeout.timeout_middleware_config import TimeoutMiddlewareConfig
+
+
+@register_middleware(config_type=TimeoutMiddlewareConfig)
+async def timeout_middleware(
+    config: TimeoutMiddlewareConfig,
+    builder: Builder,
+) -> AsyncGenerator[TimeoutMiddleware, None]:
+    """Build a timeout middleware from configuration.
+
+    Args:
+        config: The timeout middleware configuration
+        builder: The workflow builder
+
+    Yields:
+        A configured timeout middleware instance
+    """
+    yield TimeoutMiddleware(config=config, builder=builder)

--- a/packages/nvidia_nat_core/src/nat/middleware/timeout/timeout_middleware.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/timeout/timeout_middleware.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Timeout middleware that enforces time limits on intercepted function calls."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from nat.builder.builder import Builder
+from nat.middleware.dynamic.dynamic_function_middleware import DynamicFunctionMiddleware
+from nat.middleware.middleware import CallNext
+from nat.middleware.middleware import CallNextStream
+from nat.middleware.middleware import FunctionMiddlewareContext
+from nat.middleware.timeout.timeout_middleware_config import TimeoutMiddlewareConfig
+
+logger = logging.getLogger(__name__)
+
+
+class TimeoutMiddleware(DynamicFunctionMiddleware):
+    """Middleware that enforces configurable time limits on intercepted calls.
+
+    Raises ``TimeoutError`` when execution exceeds the configured duration.
+    When used in a middleware chain, the timeout covers everything downstream
+    from its position — place it last to time only the target function.
+    """
+
+    def __init__(self, config: TimeoutMiddlewareConfig, builder: Builder) -> None:
+        super().__init__(config=config, builder=builder)
+        self._timeout_config: TimeoutMiddlewareConfig = config
+
+    async def function_middleware_invoke(
+        self,
+        *args: Any,
+        call_next: CallNext,
+        context: FunctionMiddlewareContext,
+        **kwargs: Any,
+    ) -> Any:
+        """Wrap the downstream call with an asyncio timeout.
+
+        Args:
+            args: Positional arguments for the function.
+            call_next: Callable to invoke next middleware or target function.
+            context: Static function metadata.
+            kwargs: Keyword arguments for the function.
+
+        Returns:
+            The function output if it completes within the timeout.
+
+        Raises:
+            TimeoutError: If the downstream call exceeds the configured timeout.
+        """
+        timeout: float = self._timeout_config.timeout
+        try:
+            return await asyncio.wait_for(
+                super().function_middleware_invoke(*args, call_next=call_next, context=context, **kwargs),
+                timeout=timeout,
+            )
+        except TimeoutError:
+            logger.error("Function '%s' exceeded timeout of %ss", context.name, timeout)
+            msg: str = f"Execution exceeded the configured timeout of {timeout}s."
+            if self._timeout_config.timeout_message:
+                msg = f"{msg} {self._timeout_config.timeout_message}"
+            raise TimeoutError(msg) from None
+
+    async def function_middleware_stream(
+        self,
+        *args: Any,
+        call_next: CallNextStream,
+        context: FunctionMiddlewareContext,
+        **kwargs: Any,
+    ) -> AsyncIterator[Any]:
+        """Wrap the downstream stream with an asyncio timeout.
+
+        The timeout covers the total stream duration (time from the first
+        chunk request to the final chunk), not individual inter-chunk gaps.
+
+        Args:
+            args: Positional arguments for the function.
+            call_next: Callable to invoke next middleware or target stream.
+            context: Static function metadata.
+            kwargs: Keyword arguments for the function.
+
+        Yields:
+            Stream chunks from the downstream call.
+
+        Raises:
+            TimeoutError: If the full stream exceeds the configured timeout.
+        """
+        timeout: float = self._timeout_config.timeout
+        try:
+            async with asyncio.timeout(timeout):
+                async for chunk in super().function_middleware_stream(*args,
+                                                                      call_next=call_next,
+                                                                      context=context,
+                                                                      **kwargs):
+                    yield chunk
+        except TimeoutError:
+            logger.error("Streaming function '%s' exceeded timeout of %ss", context.name, timeout)
+            msg: str = f"Execution exceeded the configured timeout of {timeout}s."
+            if self._timeout_config.timeout_message:
+                msg = f"{msg} {self._timeout_config.timeout_message}"
+            raise TimeoutError(msg) from None
+
+
+__all__ = ["TimeoutMiddleware"]

--- a/packages/nvidia_nat_core/src/nat/middleware/timeout/timeout_middleware_config.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/timeout/timeout_middleware_config.py
@@ -12,12 +12,25 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Configuration for timeout middleware."""
 
-# flake8: noqa
+from __future__ import annotations
 
-from nat.middleware.cache import register as register_cache
-from nat.middleware.defense import register as register_defense
-from nat.middleware.dynamic import register as register_dynamic
-from nat.middleware.logging import register as register_logging
-from nat.middleware.red_teaming import register as register_red_teaming
-from nat.middleware.timeout import register as register_timeout
+from pydantic import Field
+
+from nat.middleware.dynamic.dynamic_middleware_config import DynamicMiddlewareConfig
+
+
+class TimeoutMiddlewareConfig(DynamicMiddlewareConfig, name="timeout"):
+    """Configuration for timeout middleware.
+    """
+
+    timeout: float = Field(
+        description="Timeout in seconds for all calls intercepted by this middleware instance.",
+        gt=0,
+    )
+
+    timeout_message: str | None = Field(
+        default=None,
+        description="Additional message appended to the TimeoutError raised on expiry.",
+    )

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_timeout_middleware.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_timeout_middleware.py
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for TimeoutMiddleware."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+
+import pytest
+
+from nat.middleware.middleware import FunctionMiddlewareContext
+from nat.middleware.timeout.timeout_middleware import TimeoutMiddleware
+from nat.middleware.timeout.timeout_middleware_config import TimeoutMiddlewareConfig
+
+# ==================== Fixtures ====================
+
+
+@pytest.fixture(name="mock_builder")
+def fixture_mock_builder():
+    """Create a mock builder with all required methods."""
+    builder: Mock = Mock()
+    builder._functions = {}
+    builder.get_llm = AsyncMock()
+    builder.get_embedder = AsyncMock()
+    builder.get_retriever = AsyncMock()
+    builder.get_memory_client = AsyncMock()
+    builder.get_object_store_client = AsyncMock()
+    builder.get_auth_provider = AsyncMock()
+    builder.get_function = AsyncMock()
+    builder.get_function_config = Mock()
+    return builder
+
+
+@pytest.fixture(name="function_context")
+def fixture_function_context():
+    """Create a test FunctionMiddlewareContext."""
+    return FunctionMiddlewareContext(
+        name="test_function",
+        config=Mock(),
+        description="A test function",
+        input_schema=None,
+        single_output_schema=type(None),
+        stream_output_schema=type(None),
+    )
+
+
+def _make_middleware(
+    mock_builder: Mock,
+    *,
+    timeout: float,
+    timeout_message: str | None = None,
+) -> TimeoutMiddleware:
+    """Create a TimeoutMiddleware with the given timeout."""
+    kwargs: dict[str, Any] = {"timeout": timeout}
+    if timeout_message is not None:
+        kwargs["timeout_message"] = timeout_message
+    config: TimeoutMiddlewareConfig = TimeoutMiddlewareConfig(**kwargs)
+    return TimeoutMiddleware(config=config, builder=mock_builder)
+
+
+# ==================== Single Invocation Tests ====================
+
+
+class TestTimeoutMiddlewareInvoke:
+    """Tests for function_middleware_invoke timeout enforcement."""
+
+    async def test_completes_within_timeout(self, mock_builder, function_context):
+        """Function that completes within the timeout returns normally."""
+        middleware: TimeoutMiddleware = _make_middleware(mock_builder, timeout=5.0)
+
+        async def fast_function(*args, **kwargs):
+            return "result"
+
+        call_next: AsyncMock = AsyncMock(side_effect=fast_function)
+
+        result = await middleware.function_middleware_invoke(
+            "input",
+            call_next=call_next,
+            context=function_context,
+        )
+
+        assert result == "result"
+        call_next.assert_called_once()
+
+    async def test_exceeds_timeout_raises(self, mock_builder, function_context):
+        """Function that exceeds the timeout raises TimeoutError with the configured message."""
+        middleware: TimeoutMiddleware = _make_middleware(mock_builder, timeout=0.05)
+
+        async def slow_function(*args, **kwargs):
+            await asyncio.sleep(10)
+            return "never"
+
+        call_next: AsyncMock = AsyncMock(side_effect=slow_function)
+
+        with pytest.raises(TimeoutError, match=r"Execution exceeded the configured timeout of 0\.05s"):
+            await middleware.function_middleware_invoke(
+                "input",
+                call_next=call_next,
+                context=function_context,
+            )
+
+    async def test_propagates_function_exception(self, mock_builder, function_context):
+        """Non-timeout exceptions from the function propagate unchanged."""
+        middleware: TimeoutMiddleware = _make_middleware(mock_builder, timeout=5.0)
+
+        call_next: AsyncMock = AsyncMock(side_effect=ValueError("bad input"))
+
+        with pytest.raises(ValueError, match="bad input"):
+            await middleware.function_middleware_invoke(
+                "input",
+                call_next=call_next,
+                context=function_context,
+            )
+
+    async def test_custom_timeout_message(self, mock_builder, function_context):
+        """Custom timeout_message is used in the TimeoutError."""
+        middleware: TimeoutMiddleware = _make_middleware(
+            mock_builder,
+            timeout=0.01,
+            timeout_message="LLM call timed out, try a smaller prompt",
+        )
+
+        async def slow_function(*args, **kwargs):
+            await asyncio.sleep(10)
+
+        call_next: AsyncMock = AsyncMock(side_effect=slow_function)
+
+        with pytest.raises(TimeoutError, match="LLM call timed out, try a smaller prompt"):
+            await middleware.function_middleware_invoke(
+                "input",
+                call_next=call_next,
+                context=function_context,
+            )
+
+
+# ==================== Streaming Tests ====================
+
+
+class TestTimeoutMiddlewareStream:
+    """Tests for function_middleware_stream timeout enforcement."""
+
+    async def test_stream_completes_within_timeout(self, mock_builder, function_context):
+        """Stream that completes within the timeout yields all chunks."""
+        middleware: TimeoutMiddleware = _make_middleware(mock_builder, timeout=5.0)
+
+        async def fast_stream(*args, **kwargs):
+            for i in range(3):
+                yield f"chunk_{i}"
+
+        collected: list[str] = []
+        async for chunk in middleware.function_middleware_stream(
+                "input",
+                call_next=fast_stream,
+                context=function_context,
+        ):
+            collected.append(chunk)
+
+        assert collected == ["chunk_0", "chunk_1", "chunk_2"]
+
+    async def test_stream_exceeds_timeout_raises(self, mock_builder, function_context):
+        """Stream that exceeds the timeout raises TimeoutError with the configured message."""
+        middleware: TimeoutMiddleware = _make_middleware(mock_builder, timeout=0.05)
+
+        async def slow_stream(*args, **kwargs):
+            yield "chunk_0"
+            await asyncio.sleep(10)
+            yield "chunk_1"
+
+        with pytest.raises(TimeoutError, match=r"Execution exceeded the configured timeout of 0\.05s"):
+            async for _ in middleware.function_middleware_stream(
+                    "input",
+                    call_next=slow_stream,
+                    context=function_context,
+            ):
+                pass
+
+    async def test_stream_propagates_function_exception(self, mock_builder, function_context):
+        """Non-timeout exceptions from the stream propagate unchanged."""
+        middleware: TimeoutMiddleware = _make_middleware(mock_builder, timeout=5.0)
+
+        async def error_stream(*args, **kwargs):
+            yield "chunk_0"
+            raise RuntimeError("stream failed")
+
+        with pytest.raises(RuntimeError, match="stream failed"):
+            async for _ in middleware.function_middleware_stream(
+                    "input",
+                    call_next=error_stream,
+                    context=function_context,
+            ):
+                pass
+
+    async def test_stream_custom_timeout_message(self, mock_builder, function_context):
+        """Custom timeout_message is used in the streaming TimeoutError."""
+        middleware: TimeoutMiddleware = _make_middleware(
+            mock_builder,
+            timeout=0.01,
+            timeout_message="Stream took too long",
+        )
+
+        async def slow_stream(*args, **kwargs):
+            await asyncio.sleep(10)
+            yield "never"
+
+        with pytest.raises(TimeoutError, match="Stream took too long"):
+            async for _ in middleware.function_middleware_stream(
+                    "input",
+                    call_next=slow_stream,
+                    context=function_context,
+            ):
+                pass


### PR DESCRIPTION
## Description

Adds `TimeoutMiddleware` — a new built-in middleware that enforces configurable time limits on intercepted calls. Extends `DynamicFunctionMiddleware` to support both direct function application and dynamic component interception (e.g., LLMs, embedders).

### TimeoutMiddleware
- Configurable `timeout` (seconds) and optional `timeout_message`
- Supports single invocations (`asyncio.wait_for`) and streaming (`asyncio.timeout`)
- Raises `TimeoutError` with a clear message including the configured duration
- Chain-position-aware: timing covers all downstream middleware and the target call

### Documentation
- Added Timeout Middleware section to `middleware.md` with configuration, parameters, and behavior
- Added timeout to the recommended middleware chain order

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Timeout Middleware to enforce configurable timeouts on LLM and tool operations with custom error messages.
  * Supports both single invocations and streaming operations.

* **Documentation**
  * Updated middleware documentation with Timeout Middleware configuration details and recommended execution ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->