### PR TITLE
Document the need to set the `NVIDIA_API_KEY` in the Redis example

### DIFF
--- a/examples/memory/redis/README.md
+++ b/examples/memory/redis/README.md
@@ -79,6 +79,13 @@ This example shows how to have a simple chat that uses a Redis memory backend fo
 
 An embeddings model is used to create embeddings for queries and for stored memories. Uses HNSW and L2 distance metric.
 
+### Set Up API Keys
+If you have not already done so, follow the [Obtaining API Keys](../../../docs/source/get-started/quick-start.md#obtaining-api-keys) instructions to obtain an NVIDIA API key. You need to set your NVIDIA API key as an environment variable to access NVIDIA AI services:
+
+```bash
+export NVIDIA_API_KEY=<YOUR_API_KEY>
+```
+
 ### Create Memory
 
 Here we will add a memory for the workflow to use in following invocations. The memory tool will automatically determine the intent as to whether or not an input should be stored as a "fact" or if the input should be used to query the memory.


### PR DESCRIPTION
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added API key setup instructions to the Redis memory example documentation, including environment variable configuration steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->