### PR TITLE
Fix Mem0 metadata validation error and improve auto_memory_wrapper example

### DIFF
--- a/docs/source/get-started/tutorials/create-a-new-workflow.md
+++ b/docs/source/get-started/tutorials/create-a-new-workflow.md
@@ -174,7 +174,7 @@ async def text_file_ingest_function(config: TextFileIngestFunctionConfig, builde
 
 ## Creating the Workflow Configuration
 
-Starting from the `custom_config.yml` file you created in the previous section, replace the two `webpage_query` tools with the new `text_file_ingest` tool. For the data source, you can use a collection of text files located in the `examples/documentation_guides/workflows/text_file_ingest/data` directory that describes [DOCA GPUNetIO](https://docs.nvidia.com/doca/sdk/doca+gpunetio/index.html).
+Starting from the `custom_config.yml` file you created in the previous section, replace the two `webpage_query` tools with the new `text_file_ingest` tool. For the data source, you can use a collection of text files located in the `examples/documentation_guides/workflows/text_file_ingest/data` directory that describes [DOCA GPUNetIO](https://docs.nvidia.com/doca/sdk/DOCA-GPUNetIO/index.html).
 
 :::{note}
 <!-- path-check-skip-next-line -->

--- a/examples/agents/auto_memory_wrapper/README.md
+++ b/examples/agents/auto_memory_wrapper/README.md
@@ -73,11 +73,19 @@ export NVIDIA_API_KEY=<YOUR_API_KEY>
 export ZEP_API_KEY=<YOUR_ZEP_API_KEY>
 ```
 
+If you do not have access to a Zep API key, you can use `config_mem0.yml` with a Mem0 API key instead:
+```bash
+export MEM0_API_KEY=<YOUR_MEM0_API_KEY>
+```
+
 ### Running the Example
 
 ```bash
-# Run the agent
+# Run the agent with Zep
 nat run --config examples/agents/auto_memory_wrapper/configs/config_zep.yml
+
+# Or with Mem0
+nat run --config examples/agents/auto_memory_wrapper/configs/config_mem0.yml
 ```
 
 ## Configuration Reference
@@ -208,4 +216,5 @@ workflow:
 ## Examples
 
 See `configs/` directory:
-- `config_zep.yml` - Comprehensive configuration with all parameters documented
+- `config_zep.yml` - Zep Cloud memory backend with all parameters documented
+- `config_mem0.yml` - Mem0 memory backend (alternative if Zep is unavailable)

--- a/examples/agents/auto_memory_wrapper/configs/config_mem0.yml
+++ b/examples/agents/auto_memory_wrapper/configs/config_mem0.yml
@@ -13,9 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Example: ReAct Agent with Automatic Memory (Zep Cloud)
+# Example: ReAct Agent with Automatic Memory (Mem0)
 # This config demonstrates automatic memory capture and retrieval
-# without requiring the LLM to invoke memory tools.
+# using Mem0 as the backend.
 
 general:
   telemetry:
@@ -33,9 +33,9 @@ llms:
 
 # Memory backend configuration
 memory:
-  zep_memory:
-    _type: nat.plugins.zep_cloud/zep_memory
-    # API credentials are loaded from environment variables: ZEP_API_KEY
+  mem0_memory:
+    _type: mem0_memory
+    # API credentials are loaded from environment variables: MEM0_API_KEY
 
 # Tools for the inner agent (no memory tools needed!)
 function_groups:
@@ -55,20 +55,7 @@ functions:
 workflow:
   _type: auto_memory_agent
   inner_agent_name: my_react_agent  # Reference to the agent defined above
-  memory_name: zep_memory           # Reference to the memory backend
+  memory_name: mem0_memory          # Reference to the memory backend
   llm_name: nim_llm                 # Required by AgentBaseConfig
   verbose: true
-  description: "A ReAct agent with automatic Zep memory"
-
-  # Optional feature flags (all default to true)
-  # save_user_messages_to_memory: false      # Set false to skip saving user messages
-  # retrieve_memory_for_every_response: false # Set false to skip memory retrieval
-  # save_ai_messages_to_memory: false        # Set false to skip saving AI responses
-
-  # Optional memory retrieval parameters
-  # search_params:
-  #   mode: "summary"    # Zep: "basic" (fast) or "summary" (comprehensive)
-
-  # Optional memory storage parameters
-  # add_params:
-  #   ignore_roles: ["assistant"]  # Zep: Exclude specific roles from graph memory (e.g., ["assistant"])
+  description: "A ReAct agent with automatic Mem0 memory"

--- a/packages/nvidia_nat_mem0ai/src/nat/plugins/mem0ai/mem0_editor.py
+++ b/packages/nvidia_nat_mem0ai/src/nat/plugins/mem0ai/mem0_editor.py
@@ -91,7 +91,7 @@ class Mem0Editor(MemoryEditor):
         memories = []
 
         for res in search_result["results"]:
-            item_meta = res.pop("metadata", {})
+            item_meta = res.pop("metadata", None) or {}
 
             memories.append(
                 MemoryItem(conversation=res.pop("input", []),


### PR DESCRIPTION
## Description

Fix a `ValidationError` in the Mem0 memory editor when the Mem0 API returns `null` for
the `metadata` field in search results. The `MemoryItem` model expects a `dict`, but
`res.pop("metadata", {})` returns `None` when the key exists with a `null` value, causing
Pydantic validation to fail.

Additionally:
- Remove the Phoenix tracing exporter from `config_zep.yml` to eliminate noisy connection
  errors for users without a local Phoenix server
- Add `config_mem0.yml` as an alternative example config for users who do not have access
  to a Zep API key
- Update the auto_memory_wrapper README to document Mem0 as an alternative memory backend

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Mem0 as an alternative memory backend with example configs and setup guidance.

* **Bug Fixes**
  * Improved robustness of metadata handling in memory operations.

* **Documentation**
  * Updated examples and docs to include Mem0 options and run commands; removed deprecated Phoenix tracing config and fixed a tutorial reference link.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->