### PR TITLE
Fix DynamicFunctionMiddleware builder patching regression

### DIFF
--- a/packages/nvidia_nat_core/src/nat/builder/workflow_builder.py
+++ b/packages/nvidia_nat_core/src/nat/builder/workflow_builder.py
@@ -1338,9 +1338,8 @@ class WorkflowBuilder(Builder, AbstractAsyncContextManager):
         try:
             middleware_info = self._registry.get_middleware(type(config))
 
-            with ChildBuilder.use(config, self) as inner_builder:
-                middleware_instance = await self._get_exit_stack().enter_async_context(
-                    middleware_info.build_fn(config, inner_builder))
+            middleware_instance = await self._get_exit_stack().enter_async_context(
+                middleware_info.build_fn(config, self))
 
             self._middleware[name] = ConfiguredMiddleware(config=config, instance=middleware_instance)
 

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_dynamic_middleware.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_dynamic_middleware.py
@@ -500,3 +500,28 @@ def test_unregister_component_method_raises_error_if_not_registered():
 
     with pytest.raises(ValueError, match=r"'fake__method' is not registered"):
         middleware.unregister(fake_registered)
+
+
+# ==================== WorkflowBuilder Integration Tests ====================
+
+
+async def test_dynamic_middleware_patches_workflow_builder():
+    """DynamicFunctionMiddleware patches persist on the builder used by the workflow."""
+    from nat.builder.builder import Builder
+    from nat.builder.workflow_builder import WorkflowBuilder
+    from nat.cli.register_workflow import register_middleware
+
+    class _PatchTestConfig(DynamicMiddlewareConfig, name="_patch_regression_test"):
+        pass
+
+    @register_middleware(config_type=_PatchTestConfig)
+    async def _patch_test_middleware(config: _PatchTestConfig, builder: Builder):
+        yield DynamicFunctionMiddleware(config=config, builder=builder)
+
+    config = _PatchTestConfig(register_llms=True)
+
+    async with WorkflowBuilder() as builder:
+        middleware = await builder.add_middleware("patch_test", config)
+
+        assert isinstance(middleware, DynamicFunctionMiddleware)
+        assert builder.get_llm == middleware._discover_and_register_llm


### PR DESCRIPTION
## Description

A refactor in #1322 (Jan 2, 2026) changed `WorkflowBuilder.add_middleware()` to pass a temporary `ChildBuilder` instead of the `WorkflowBuilder` itself. This caused `DynamicFunctionMiddleware` to patch the disposable `ChildBuilder`, making `register_llms: true` and other auto-discovery flags silently ineffective.

Reverted middleware building to pass the `WorkflowBuilder` directly — `ChildBuilder` dependency tracking was never consumed for middleware. Added a regression test.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.