### PR TITLE
Fix incorrect CLI flag in auto_memory_wrapper README

### DIFF
--- a/examples/agents/auto_memory_wrapper/README.md
+++ b/examples/agents/auto_memory_wrapper/README.md
@@ -82,10 +82,10 @@ export MEM0_API_KEY=<YOUR_MEM0_API_KEY>
 
 ```bash
 # Run the agent with Zep
-nat run --config examples/agents/auto_memory_wrapper/configs/config_zep.yml
+nat run --config_file examples/agents/auto_memory_wrapper/configs/config_zep.yml
 
 # Or with Mem0
-nat run --config examples/agents/auto_memory_wrapper/configs/config_mem0.yml
+nat run --config_file examples/agents/auto_memory_wrapper/configs/config_mem0.yml
 ```
 
 ## Configuration Reference
@@ -179,7 +179,7 @@ curl -X POST http://localhost:8000/chat \
 Omit both `user_manager` and `X-User-ID` header to use `"default_user"`:
 
 ```bash
-nat run --config examples/agents/auto_memory_wrapper/configs/config_zep.yml
+nat run --config_file examples/agents/auto_memory_wrapper/configs/config_zep.yml
 ```
 
 ## Advanced Example


### PR DESCRIPTION
## Description

The auto_memory_wrapper README uses `--config` in the `nat run` commands, but the correct
CLI flag is `--config_file`. This was a pre-existing issue from the original contribution.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI parameter examples in documentation to reflect the new parameter naming convention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->