### PR TITLE
examples(mcp): make example more robust to LLM hallucination

### DIFF
--- a/examples/MCP/simple_calculator_mcp/README.md
+++ b/examples/MCP/simple_calculator_mcp/README.md
@@ -70,6 +70,11 @@ function_groups:
       transport: stdio
       command: "python"
       args: ["-m", "mcp_server_time", "--local-timezone=America/Los_Angeles"]
+    tool_overrides:
+      # Optionally override the tool name and description from the MCP server
+      get_current_time:
+        alias: get_current_time_mcp_tool
+        description: "Returns the current date and time. Always pass in the timezone as America/Los_Angeles"
   mcp_math:
     _type: mcp_client
     server:
@@ -84,7 +89,7 @@ workflow:
 ```
 
 This configuration creates two function groups:
-- `mcp_time`: Connects to a local MCP server using stdio transport to get current date and time
+- `mcp_time`: Connects to a local MCP server using stdio transport to get current date and time. The timezone is always assumed to be America/Los_Angeles
 - `mcp_math`: Connects to a remote MCP server using streamable-http transport to access calculator tools
 
 To run this example:

--- a/examples/MCP/simple_calculator_mcp/configs/config-mcp-client.yml
+++ b/examples/MCP/simple_calculator_mcp/configs/config-mcp-client.yml
@@ -37,7 +37,7 @@ function_groups:
       # Optionally override the tool name and description from the MCP server
       get_current_time:
         alias: get_current_time_mcp_tool
-        description: "Returns the current date and time"
+        description: "Returns the current date and time. Always pass in the timezone as America/Los_Angeles"
 
   mcp_math:
     _type: mcp_client

--- a/examples/MCP/simple_calculator_mcp/configs/config-per-user-mcp-client.yml
+++ b/examples/MCP/simple_calculator_mcp/configs/config-per-user-mcp-client.yml
@@ -37,7 +37,7 @@ function_groups:
       # Optionally override the tool name and description from the MCP server
       get_current_time:
         alias: get_current_time_mcp_tool
-        description: "Returns the current date and time"
+        description: "Returns the current date and time. Always pass in the timezone as America/Los_Angeles"
 
   mcp_math:
     _type: per_user_mcp_client


### PR DESCRIPTION
## Description
- Explicitly specify timezone in MCP tool description.
- Add note in example README.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified timezone handling guidance for the MCP time tool to explicitly indicate America/Los_Angeles timezone usage across related configuration materials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->