### PR TITLE
fix: preserve nested Pydantic models when unpacking multi-arg functions

### DIFF
--- a/packages/nvidia_nat_core/src/nat/builder/function_info.py
+++ b/packages/nvidia_nat_core/src/nat/builder/function_info.py
@@ -460,8 +460,8 @@ class FunctionInfo:
 
                 async def _convert_input_pydantic(value: input_schema) -> final_single_fn_desc.output_type:
 
-                    # Unpack the pydantic model into the arguments
-                    return await saved_final_single_fn(**value.model_dump())
+                    # Unpack the pydantic model into the arguments, preserving nested model types
+                    return await saved_final_single_fn(**{k: getattr(value, k) for k in type(value).model_fields})
 
                 final_single_fn = _convert_input_pydantic
 
@@ -503,8 +503,8 @@ class FunctionInfo:
                 async def _convert_input_pydantic_stream(
                         value: input_schema) -> AsyncGenerator[final_stream_fn_desc.output_type]:
 
-                    # Unpack the pydantic model into the arguments
-                    async for m in saved_final_stream_fn(**value.model_dump()):
+                    # Unpack the pydantic model into the arguments, preserving nested model types
+                    async for m in saved_final_stream_fn(**{k: getattr(value, k) for k in type(value).model_fields}):
                         yield m
 
                 final_stream_fn = _convert_input_pydantic_stream

--- a/packages/nvidia_nat_core/tests/nat/builder/test_function_info.py
+++ b/packages/nvidia_nat_core/tests/nat/builder/test_function_info.py
@@ -726,56 +726,56 @@ def test_create_and_from_fn(function: Callable,
                                       "data": "test", "data2": 10.0, "data3": 7
                                   }
                               },
-                              "10{'data': 'test', 'data2': 10.0, 'data3': 7}"),
+                              "10" + str(MultipleInputModel(data="test", data2=10.0, data3=7))),
                              (fn_multiple_args_annotated_to_str,
                               False, {
                                   "param1": 10, "param2": {
                                       "data": "test", "data2": 10.0, "data3": 7
                                   }
                               },
-                              "10{'data': 'test', 'data2': 10.0, 'data3': 7}"),
+                              "10" + str(MultipleInputModel(data="test", data2=10.0, data3=7))),
                              (fn_multiple_args_to_str_annotated,
                               False, {
                                   "param1": 10, "param2": {
                                       "data": "test", "data2": 10.0, "data3": 7
                                   }
                               },
-                              "10{'data': 'test', 'data2': 10.0, 'data3': 7}"),
+                              "10" + str(MultipleInputModel(data="test", data2=10.0, data3=7))),
                              (fn_multiple_args_annotated_to_str_annotated,
                               False, {
                                   "param1": 10, "param2": {
                                       "data": "test", "data2": 10.0, "data3": 7
                                   }
                               },
-                              "10{'data': 'test', 'data2': 10.0, 'data3': 7}"),
+                              "10" + str(MultipleInputModel(data="test", data2=10.0, data3=7))),
                              (fn_multiple_args_to_str_stream,
                               True, {
                                   "param1": 10, "param2": {
                                       "data": "test", "data2": 10.0, "data3": 7
                                   }
                               },
-                              "10{'data': 'test', 'data2': 10.0, 'data3': 7}"),
+                              "10" + str(MultipleInputModel(data="test", data2=10.0, data3=7))),
                              (fn_multiple_args_annotated_to_str_stream,
                               True, {
                                   "param1": 10, "param2": {
                                       "data": "test", "data2": 10.0, "data3": 7
                                   }
                               },
-                              "10{'data': 'test', 'data2': 10.0, 'data3': 7}"),
+                              "10" + str(MultipleInputModel(data="test", data2=10.0, data3=7))),
                              (fn_multiple_args_to_str_annotated_stream,
                               True, {
                                   "param1": 10, "param2": {
                                       "data": "test", "data2": 10.0, "data3": 7
                                   }
                               },
-                              "10{'data': 'test', 'data2': 10.0, 'data3': 7}"),
+                              "10" + str(MultipleInputModel(data="test", data2=10.0, data3=7))),
                              (fn_multiple_args_annotated_to_str_annotated_stream,
                               True, {
                                   "param1": 10, "param2": {
                                       "data": "test", "data2": 10.0, "data3": 7
                                   }
                               },
-                              "10{'data': 'test', 'data2': 10.0, 'data3': 7}"),
+                              "10" + str(MultipleInputModel(data="test", data2=10.0, data3=7))),
                              (fn_union_to_str, False, 10, "10"),
                              (fn_int_to_union, False, 10, "10"),
                              (fn_int_to_union, False, 2, 2),


### PR DESCRIPTION
Replace `model_dump()` with `getattr()` in `_convert_input_pydantic` to prevent nested Pydantic models from being flattened to dicts. `model_dump()` recursively serializes all nested models, so parameters like `list[PromptItem]` become `list[dict]`, causing `AttributeError` when functions access model attributes (e.g. p.text).

Using `getattr()` preserves the original types as declared in function signatures. Updated test expectations to match the corrected behavior.


---

This fixes a bug where `_convert_input_pydantic` in `FunctionInfo` uses `model_dump()` to unpack multi-argument function inputs into keyword arguments. The problem is that `model_dump()` recursively serializes everything, including nested Pydantic models, into plain dicts.

For example, say you have a NAT function like this:
```python
class PromptItem(BaseModel):
    text: str
    start: int | None = None
    len: int | None = 300
```

```python
async def render_prompts(author: str, prompts: list[PromptItem], ...):
```

NAT wraps this multi-arg function into a single-arg function with an auto-generated input schema. When it unpacks that schema to call the real function, `model_dump()` converts `list[PromptItem]` into `list[dict]`. Then when the function tries to access p.text, it gets `AttributeError: 'dict' object has no attribute 'text'`.

Any NAT function with multiple arguments that includes nested Pydantic models in its signature would hit this.

The fix swaps `**value.model_dump()` for `**{k: getattr(value, k) for k in type(value).model_fields}`, which unpacks the top-level fields without recursively flattening nested models. Only the top-level unpacking behavior changes. The nested values are passed through as-is, matching what the function signature actually declares.

The test changes are just updating expected values that were inadvertently asserting the broken behavior (they compared against `str(dict)` output instead of `str(PydanticModel)` output, which didn't crash but was technically wrong).

---

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved nested model structures and types when converting composite inputs for both streaming and non-streaming calls, ensuring consistent string representations and preventing unexpected changes in how complex inputs appear during invocation. Public interfaces unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->