### PR TITLE
Fix mixture of agent example from reaching `GRAPH_RECURSION_LIMIT`

### DIFF
--- a/examples/agents/mixture_of_agents/configs/config.yml
+++ b/examples/agents/mixture_of_agents/configs/config.yml
@@ -28,8 +28,6 @@ llms:
     model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 250
-    chat_template_kwargs:
-      enable_thinking: false
 
 function_groups:
   calculator:


### PR DESCRIPTION
## Description
* Enable thinking for the agent executor LLM.
* This is a partial revert of change introduced in PR #1659 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Configuration Updates**
  * Removed explicit thinking disable in agent executor configuration, allowing the thinking capability to use default behavior instead of being forcibly disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->