### PR TITLE
Fix alert_triage_agent empty reports in offline mode (#1699)

### DIFF
--- a/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/configs/config_offline_mode.yml
+++ b/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/configs/config_offline_mode.yml
@@ -72,38 +72,38 @@ workflow:
 llms:
   ata_agent_llm:
     _type: nim
-    model_name: nvidia/nemotron-3-nano-30b-a3b
+    model_name: nvidia/llama-3.3-nemotron-super-49b-v1.5
     temperature: 0.2
     max_tokens: 2048
 
   tool_reasoning_llm:
     _type: nim
-    model_name: nvidia/nemotron-3-nano-30b-a3b
+    model_name: nvidia/llama-3.3-nemotron-super-49b-v1.5
     temperature: 0.2
     top_p: 0.7
     max_tokens: 2048
 
   telemetry_metrics_analysis_agent_llm:
     _type: nim
-    model_name: nvidia/nemotron-3-nano-30b-a3b
+    model_name: nvidia/llama-3.3-nemotron-super-49b-v1.5
     temperature: 0
     max_tokens: 2048
 
   maintenance_check_llm:
     _type: nim
-    model_name: nvidia/nemotron-3-nano-30b-a3b
+    model_name: nvidia/llama-3.3-nemotron-super-49b-v1.5
     temperature: 0
     max_tokens: 2048
 
   categorizer_llm:
     _type: nim
-    model_name: nvidia/nemotron-3-nano-30b-a3b
+    model_name: nvidia/llama-3.3-nemotron-super-49b-v1.5
     temperature: 0
     max_tokens: 2048
 
   nim_rag_eval_llm:
     _type: nim
-    model_name: nvidia/nemotron-3-nano-30b-a3b
+    model_name: nvidia/llama-3.3-nemotron-super-49b-v1.5
     max_tokens: 8
 
 eval:

--- a/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/register.py
+++ b/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/register.py
@@ -138,6 +138,12 @@ async def alert_triage_agent_workflow(config: AlertTriageAgentWorkflowConfig, bu
         output = await agent_executor.ainvoke({"messages": [HumanMessage(content=input_message)]})
         result = output["messages"][-1].content
 
+        if not result or not result.strip():
+            utils.logger.warning("Agent returned empty triage report for input: %s", input_message[:200])
+            result = ("The agent was unable to generate a triage report for this alert. "
+                      "This may indicate the LLM model is insufficient for the task complexity. "
+                      "Consider using a larger model (e.g. meta/llama-3.3-70b-instruct).\n\n")
+
         # Determine and append root cause category
         root_cause = await categorizer_tool.arun(result)
         return result + root_cause

--- a/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/register.py
+++ b/examples/advanced_agents/alert_triage_agent/src/nat_alert_triage_agent/register.py
@@ -136,10 +136,14 @@ async def alert_triage_agent_workflow(config: AlertTriageAgentWorkflowConfig, bu
 
         # Process alert through agent since no maintenance is occurring
         output = await agent_executor.ainvoke({"messages": [HumanMessage(content=input_message)]})
-        result = output["messages"][-1].content
+        raw_result = output["messages"][-1].content
+        if isinstance(raw_result, str):
+            result = raw_result.strip()
+        else:
+            result = ""
 
-        if not result or not result.strip():
-            utils.logger.warning("Agent returned empty triage report for input: %s", input_message[:200])
+        if not result:
+            utils.logger.warning("Agent returned empty triage report (input_length=%d)", len(input_message))
             result = ("The agent was unable to generate a triage report for this alert. "
                       "This may indicate the LLM model is insufficient for the task complexity. "
                       "Consider using a larger model (e.g. meta/llama-3.3-70b-instruct).\n\n")

--- a/examples/advanced_agents/alert_triage_agent/tests/test_alert_triage_agent_workflow.py
+++ b/examples/advanced_agents/alert_triage_agent/tests/test_alert_triage_agent_workflow.py
@@ -48,5 +48,18 @@ async def test_full_workflow(root_repo_dir: Path):
                                 question=input_data["question"],
                                 expected_answer=input_data["label"])
 
-    # Check that rows with hosts not under maintenance contain root cause categorization
+    # Check that the result contains a root cause categorization
     assert "root cause category" in result.lower()
+
+    # Check that the expected label appears in the result
+    assert input_data["label"] in result.lower(), (
+        f"Expected label '{input_data['label']}' not found in result. "
+        f"Got: {result[:500]}"
+    )
+
+    # Check that the agent produced a triage report, not just a bare categorizer output.
+    # A bare categorizer output is ~100 chars; a real report is much longer.
+    assert len(result) > 200, (
+        f"Result too short ({len(result)} chars), agent likely returned an empty report. "
+        f"Got: {result[:500]}"
+    )

--- a/examples/advanced_agents/alert_triage_agent/tests/test_alert_triage_agent_workflow.py
+++ b/examples/advanced_agents/alert_triage_agent/tests/test_alert_triage_agent_workflow.py
@@ -52,14 +52,11 @@ async def test_full_workflow(root_repo_dir: Path):
     assert "root cause category" in result.lower()
 
     # Check that the expected label appears in the result
-    assert input_data["label"] in result.lower(), (
-        f"Expected label '{input_data['label']}' not found in result. "
-        f"Got: {result[:500]}"
-    )
+    expected_label = input_data["label"].lower()
+    assert expected_label in result.lower(), (f"Expected label '{input_data['label']}' not found in result. "
+                                              f"Got: {result[:500]}")
 
     # Check that the agent produced a triage report, not just a bare categorizer output.
     # A bare categorizer output is ~100 chars; a real report is much longer.
-    assert len(result) > 200, (
-        f"Result too short ({len(result)} chars), agent likely returned an empty report. "
-        f"Got: {result[:500]}"
-    )
+    assert len(result) > 200, (f"Result too short ({len(result)} chars), agent likely returned an empty report. "
+                               f"Got: {result[:500]}")


### PR DESCRIPTION
## Summary
- Replace undersized `nvidia/nemotron-3-nano-30b-a3b` with `nvidia/llama-3.3-nemotron-super-49b-v1.5` in `config_offline_mode.yml`. The nano model produces empty triage reports for several alerts (particularly alert_id=2), causing the categorizer to default to `need_investigation`.
- Add defensive validation in `register.py` for empty agent output, with a warning log and a clear fallback message.
- Strengthen the integration test to assert the expected label is present and the report has substantive content (>200 chars).

Ran `alert_id=2` locally with updated config; full report produced, categorized as "software"

Fixes #1699

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added fallback response when AI output is empty, logging a warning and suggesting use of a larger model.

* **Chores**
  * Updated default language model selection across alert triage components to enhance inference capability.

* **Tests**
  * Expanded integration tests to assert presence of a root-cause category, expected label, and a minimum detailed report length (>200 chars) to ensure comprehensive triage outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->