### PR TITLE
fix: handle GraphRecursionError gracefully in tool_calling_agent

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/register.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/register.py
@@ -56,6 +56,7 @@ async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, build
     from langchain_core.messages import AIMessageChunk
     from langchain_core.messages import trim_messages
     from langchain_core.messages.base import BaseMessage
+    from langgraph.errors import GraphRecursionError
     from langgraph.graph.state import CompiledStateGraph
 
     from nat.plugins.langchain.agent.base import AGENT_LOG_PREFIX
@@ -119,6 +120,14 @@ async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, build
             state = ToolCallAgentGraphState(**state)
             output_message = state.messages[-1]
             return str(output_message.content)
+        except GraphRecursionError:
+            logger.warning(
+                "%s Tool Calling Agent reached its maximum iteration limit (%d) without producing a final answer. "
+                "This typically means the LLM kept calling tools instead of returning a response.",
+                AGENT_LOG_PREFIX,
+                config.max_iterations)
+            return (f"The tool calling agent could not produce a final answer within {config.max_iterations} "
+                    "iterations. The agent repeatedly called tools without converging on a response.")
         except Exception as ex:
             logger.error("%s Tool Calling Agent failed with exception: %s", AGENT_LOG_PREFIX, ex)
             raise
@@ -158,6 +167,14 @@ async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, build
                 if metadata.get("langgraph_node") == "agent":
                     if msg.content and not msg.tool_call_chunks:
                         yield msg.content
+        except GraphRecursionError:
+            logger.warning(
+                "%s Tool Calling Agent reached its maximum iteration limit (%d) without producing a final answer. "
+                "This typically means the LLM kept calling tools instead of returning a response.",
+                AGENT_LOG_PREFIX,
+                config.max_iterations)
+            yield (f"The tool calling agent could not produce a final answer within {config.max_iterations} "
+                   "iterations. The agent repeatedly called tools without converging on a response.")
         except Exception as ex:
             logger.error("%s Tool Calling Agent streaming failed with exception: %s", AGENT_LOG_PREFIX, ex)
             raise


### PR DESCRIPTION
## Summary 

When a tool_calling_agent hits its recursion limit (e.g. the LLM keeps calling tools instead of returning a final answer), catch GraphRecursionError and return a clean error string instead of re-raising. This prevents a cascade of 3 ERROR log entries and a full stack trace through register.py, function.py, and base.py when the agent is used as a nested tool (e.g. mixture_of_agents example).

The outer agent now receives a clear message it can reason about, and the logs show a single WARNING instead of noisy ERROR tracebacks.

## Description

When a `tool_calling_agent` hits its `max_iterations` recursion limit (e.g. the LLM keeps calling tools instead of producing a final answer), the `GraphRecursionError` was re-raised and cascaded through three layers (`register.py` → `function.py` → `base.py`), each logging at ERROR level with a full stack trace.

This caused the QA-reported issue where the mixture_of_agents example would either loop indefinitely or produce a correct answer but with alarming error logs.

### Changes

Catch `GraphRecursionError` specifically in the tool_calling_agent's `_response_fn` and `_stream_fn` before the generic `except Exception` handler. Instead of re-raising:
- Log a single WARNING (not ERROR)
- Return a clean error string describing the failure

The outer agent (e.g. ReAct orchestrator) receives a clear message it can reason about, and the logs are clean.

### Related

- Complements PR #1697 (config fix for mixture_of_agents example)
- Addresses the QA issue: "Mixture of agent kept on answering and did not end / errors seen in logs"

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error messaging when the tool-calling agent reaches its iteration limit. Users now see a clear message instead of an unhandled error when the agent cannot produce a final answer within maximum iterations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->