### PR TITLE
fix: replace llama-3.1-405b model in email phishing analyzer

### DIFF
--- a/examples/evaluation_and_profiling/email_phishing_analyzer/README.md
+++ b/examples/evaluation_and_profiling/email_phishing_analyzer/README.md
@@ -166,7 +166,7 @@ functions:
 llms:
   phishing_llm:
     _type: nim
-    model_name: meta/llama-3.1-405b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 1024
     optimizable_params:
@@ -177,7 +177,7 @@ llms:
     search_space:
       model_name:
         values:
-          - meta/llama-3.1-405b-instruct
+          - nvidia/nemotron-3-nano-30b-a3b
           - meta/llama-3.1-70b-instruct
     
 eval:

--- a/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/configs/config-langsmith-eval.yml
+++ b/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/configs/config-langsmith-eval.yml
@@ -57,7 +57,7 @@ functions:
 llms:
   nim_llm:
     _type: nim
-    model_name: meta/llama-3.1-405b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 512
   nim_rag_eval_llm:

--- a/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/configs/config-langsmith-optimize.yml
+++ b/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/configs/config-langsmith-optimize.yml
@@ -57,7 +57,7 @@ functions:
 llms:
   phishing_llm:
     _type: nim
-    model_name: meta/llama-3.1-405b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 1024
     optimizable_params:
@@ -68,7 +68,7 @@ llms:
     search_space:
       model_name:
         values:
-          - meta/llama-3.1-405b-instruct
+          - nvidia/nemotron-3-nano-30b-a3b
           - meta/llama-3.1-70b-instruct
 
   prompt_optimizer:

--- a/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/configs/config.yml
+++ b/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/configs/config.yml
@@ -44,7 +44,7 @@ functions:
 llms:
   nim_llm:
     _type: nim
-    model_name: meta/llama-3.1-405b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 512
   nim_rag_eval_llm:

--- a/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/configs/config_optimizer.yml
+++ b/examples/evaluation_and_profiling/email_phishing_analyzer/src/nat_email_phishing_analyzer/configs/config_optimizer.yml
@@ -42,7 +42,7 @@ functions:
 llms:
   phishing_llm:
     _type: nim
-    model_name: meta/llama-3.1-405b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 1024
     optimizable_params:
@@ -53,7 +53,7 @@ llms:
     search_space:
       model_name:
         values:
-          - meta/llama-3.1-405b-instruct
+          - nvidia/nemotron-3-nano-30b-a3b
           - meta/llama-3.1-70b-instruct
 
   prompt_optimizer:


### PR DESCRIPTION
The meta/llama-3.1-405b-instruct model endpoint returns HTTP 404 from the NVIDIA NIM API (NVCF function decommissioned). This breaks both the e2e test and running the example as documented.

Replace with nvidia/nemotron-3-nano-30b-a3b across the default config, LangSmith configs, optimizer configs, and README.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated AI model selections in email phishing analyzer example configurations to use an optimized alternative model, with changes reflected across multiple evaluation, optimization, and base configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->