### PR TITLE
fix(notebooks): add missing nat workflow reinstall before nat run

### DIFF
--- a/examples/notebooks/multi_agent_orchestration.ipynb
+++ b/examples/notebooks/multi_agent_orchestration.ipynb
@@ -1267,6 +1267,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!nat workflow reinstall retail_sales_agent_nb5"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "!nat run --config_file retail_sales_agent_nb5/configs/config_multi_agent.yml \\\n",
     "  --input \"What is the Ark S12 Ultra tablet and what are its specifications?\" \\\n",
     "  --input \"How do laptop sales compare to phone sales?\" \\\n",
@@ -1862,6 +1871,15 @@
    "metadata": {},
    "source": [
     "The HITL tool will prompt the user for input when it is called. This works when running in an interactive terminal, but in a notebook environment like this one, the prompt may not function as expected, so we will simulate user input by echoing \"yes\" into the command. This can be replaced with \"no\" to simulate a negative response, or run directly in a terminal for interactive input."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!nat workflow reinstall retail_sales_agent_nb5"
    ]
   },
   {

--- a/examples/notebooks/observability_evaluation_and_profiling.ipynb
+++ b/examples/notebooks/observability_evaluation_and_profiling.ipynb
@@ -1237,6 +1237,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "!nat workflow reinstall retail_sales_agent_nb6"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "!nat run --config_file retail_sales_agent_nb6/configs/config.yml \\\n",
     "  --input \"What is the Ark S12 Ultra tablet and what are its specifications?\" \\\n",
     "  --input \"How do laptop sales compare to phone sales?\" \\\n",


### PR DESCRIPTION
## Description

multi_agent_orchestration.ipynb and observability_evaluation_and_profiling.ipynb add new Python tool files after nat workflow create but never call nat workflow reinstall to refresh the editable install. This causes graph_summarizer and data_visualization_agent function types to not be recognized by NAT's schema validator on some environments.

Adds reinstall cells before each nat run call, matching the pattern in adding_tools_to_agents.ipynb

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated multi-agent orchestration example notebook with workflow reinstallation instructions added after the "Running the Workflow" and HITL description sections.
  * Updated observability evaluation and profiling example notebook with workflow reinstallation instructions.
  * These additions provide practical guidance for reinitializing workflows in example scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->