### PR TITLE
feat(agent): stream tool call chunks

### DIFF
--- a/packages/nvidia_nat_core/src/nat/data_models/api_server.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/api_server.py
@@ -281,10 +281,25 @@ class ChoiceMessage(BaseModel):
     role: UserMessageContentRoleType | None = None
 
 
+class ChoiceDeltaToolCallFunction(BaseModel):
+    """Function details within a streamed tool call delta (OpenAI-compatible)."""
+    name: str | None = None
+    arguments: str | None = None
+
+
+class ChoiceDeltaToolCall(BaseModel):
+    """Tool call delta for streaming responses (OpenAI-compatible)."""
+    index: int
+    id: str | None = None
+    type: str | None = None
+    function: ChoiceDeltaToolCallFunction | None = None
+
+
 class ChoiceDelta(BaseModel):
     """Delta object for streaming responses (OpenAI-compatible)"""
     content: str | None = None
     role: UserMessageContentRoleType | None = None
+    tool_calls: list[ChoiceDeltaToolCall] | None = None
 
 
 class ChoiceBase(BaseModel):

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/agent.py
@@ -18,9 +18,12 @@ import typing
 
 from langchain_core.callbacks.base import AsyncCallbackHandler
 from langchain_core.language_models import BaseChatModel
+from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessageChunk
 from langchain_core.messages import SystemMessage
 from langchain_core.messages import ToolMessage
 from langchain_core.messages.base import BaseMessage
+from langchain_core.messages.utils import convert_to_openai_messages
 from langchain_core.runnables import RunnableLambda
 from langchain_core.tools import BaseTool
 from langgraph.graph import StateGraph
@@ -38,6 +41,29 @@ if typing.TYPE_CHECKING:
     from nat.plugins.langchain.agent.tool_calling_agent.register import ToolCallAgentWorkflowConfig
 
 logger = logging.getLogger(__name__)
+
+
+def _chunk_to_message(chunk: "AIMessageChunk") -> AIMessage:
+    """Convert an accumulated AIMessageChunk into an AIMessage.
+
+    When streaming chunks are accumulated via ``+``, the result has ``tool_calls``
+    but ``additional_kwargs["tool_calls"]`` (the OpenAI wire format) is left empty.
+    LLM providers read the wire format when the message is sent back in conversation
+    history, so we reconstruct it here using ``convert_to_openai_messages``.
+    """
+    additional_kwargs = dict(chunk.additional_kwargs)
+    if chunk.tool_calls and not additional_kwargs.get("tool_calls"):
+        openai_msg = convert_to_openai_messages([chunk])[0]
+        if "tool_calls" in openai_msg:
+            additional_kwargs["tool_calls"] = openai_msg["tool_calls"]
+
+    return AIMessage(
+        content=chunk.content,
+        additional_kwargs=additional_kwargs,
+        response_metadata=chunk.response_metadata,
+        id=chunk.id,
+        usage_metadata=chunk.usage_metadata,
+    )
 
 
 class ToolCallAgentGraphState(BaseModel):
@@ -105,6 +131,10 @@ class ToolCallAgentGraph(DualNodeAgent):
                 response = chunk if response is None else response + chunk
             if response is None:
                 raise RuntimeError('No response received from agent')
+
+            if isinstance(response, AIMessageChunk):
+                response = _chunk_to_message(response)
+
             if self.detailed_logs:
                 agent_input = "\n".join(str(message.content) for message in state.messages)
                 logger.info(AGENT_CALL_LOG_MESSAGE, agent_input, response)

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/register.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/register.py
@@ -13,7 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import json
 import logging
+import uuid
 from collections.abc import AsyncGenerator
 
 from pydantic import Field
@@ -25,6 +28,11 @@ from nat.cli.register_workflow import register_function
 from nat.data_models.agent import AgentBaseConfig
 from nat.data_models.api_server import ChatRequest
 from nat.data_models.api_server import ChatRequestOrMessage
+from nat.data_models.api_server import ChatResponseChunk
+from nat.data_models.api_server import ChatResponseChunkChoice
+from nat.data_models.api_server import ChoiceDelta
+from nat.data_models.api_server import ChoiceDeltaToolCall
+from nat.data_models.api_server import ChoiceDeltaToolCallFunction
 from nat.data_models.component_ref import FunctionGroupRef
 from nat.data_models.component_ref import FunctionRef
 from nat.utils.type_converter import GlobalTypeConverter
@@ -53,6 +61,7 @@ class ToolCallAgentWorkflowConfig(AgentBaseConfig, name="tool_calling_agent"):
 
 @register_function(config_type=ToolCallAgentWorkflowConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, builder: Builder):
+    from langchain_core.messages import AIMessage
     from langchain_core.messages import AIMessageChunk
     from langchain_core.messages import trim_messages
     from langchain_core.messages.base import BaseMessage
@@ -132,19 +141,21 @@ async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, build
             logger.error("%s Tool Calling Agent failed with exception: %s", AGENT_LOG_PREFIX, ex)
             raise
 
-    async def _stream_fn(chat_request_or_message: ChatRequestOrMessage) -> AsyncGenerator[str]:
+    async def _stream_fn(chat_request_or_message: ChatRequestOrMessage) -> AsyncGenerator[ChatResponseChunk]:
         """
         Streaming workflow entry function for the Tool Calling Agent.
 
-        Uses graph.astream with stream_mode="messages" to yield token-level content chunks from the LLM,
+        Uses graph.astream with stream_mode="messages" to yield token-level chunks from the LLM,
         enabling real-time SSE streaming over the OpenAI-compatible /v1/chat/completions endpoint.
+        Yields both content tokens and tool call chunks as ChatResponseChunk objects.
 
         Args:
             chat_request_or_message (ChatRequestOrMessage): The input message to process
 
         Yields:
-            str: Individual content chunks from the agent's response
+            ChatResponseChunk: Streaming chunks containing content deltas or tool call deltas
         """
+        chunk_id = str(uuid.uuid4())
         try:
             message = GlobalTypeConverter.get().convert(chat_request_or_message, to_type=ChatRequest)
 
@@ -156,25 +167,58 @@ async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, build
                                                         include_system=True)
             state = ToolCallAgentGraphState(messages=messages)
 
-            # stream the Tool Calling Agent Graph token-by-token using LangGraph message streaming
             async for msg, metadata in graph.astream(
                     state,
                     config={'recursion_limit': (config.max_iterations + 1) * 2},
                     stream_mode="messages"):
-                if not isinstance(msg, AIMessageChunk):
+                if not isinstance(msg, (AIMessage, AIMessageChunk)):
                     continue
-                # only yield content tokens from the agent node, skip tool call metadata
-                if metadata.get("langgraph_node") == "agent":
-                    if msg.content and not msg.tool_call_chunks:
-                        yield msg.content
+                if metadata.get("langgraph_node") != "agent":
+                    continue
+
+                if isinstance(msg.content, str) and msg.content:
+                    yield ChatResponseChunk.create_streaming_chunk(msg.content, id_=chunk_id)
+
+                tool_calls = getattr(msg, "tool_call_chunks", None) or getattr(msg, "tool_calls", None)
+                if tool_calls:
+                    delta_tool_calls = []
+                    for i, tc in enumerate(tool_calls):
+                        idx = tc.get("index") if isinstance(tc.get("index"), int) else i
+                        args = tc.get("args", "")
+                        if isinstance(args, dict):
+                            args = json.dumps(args)
+                        delta_tool_calls.append(
+                            ChoiceDeltaToolCall(index=idx,
+                                                id=tc.get("id"),
+                                                type="function" if tc.get("id") else None,
+                                                function=ChoiceDeltaToolCallFunction(
+                                                    name=tc.get("name"),
+                                                    arguments=args,
+                                                )))
+                    yield ChatResponseChunk(
+                        id=chunk_id,
+                        choices=[
+                            ChatResponseChunkChoice(
+                                index=0,
+                                delta=ChoiceDelta(tool_calls=delta_tool_calls),
+                                finish_reason=None,
+                            )
+                        ],
+                        created=datetime.datetime.now(datetime.UTC),
+                        model="unknown-model",
+                        object="chat.completion.chunk",
+                    )
         except GraphRecursionError:
             logger.warning(
                 "%s Tool Calling Agent reached its maximum iteration limit (%d) without producing a final answer. "
                 "This typically means the LLM kept calling tools instead of returning a response.",
                 AGENT_LOG_PREFIX,
                 config.max_iterations)
-            yield (f"The tool calling agent could not produce a final answer within {config.max_iterations} "
-                   "iterations. The agent repeatedly called tools without converging on a response.")
+            yield ChatResponseChunk.create_streaming_chunk(
+                f"The tool calling agent could not produce a final answer within {config.max_iterations} "
+                "iterations. The agent repeatedly called tools without converging on a response.",
+                id_=chunk_id,
+            )
         except Exception as ex:
             logger.error("%s Tool Calling Agent streaming failed with exception: %s", AGENT_LOG_PREFIX, ex)
             raise

--- a/packages/nvidia_nat_langchain/tests/agent/test_tool_calling.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_tool_calling.py
@@ -13,16 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import datetime
+import json
+
 import pytest
 from langchain_core.messages import AIMessage
+from langchain_core.messages import AIMessageChunk
 from langchain_core.messages import HumanMessage
 from langchain_core.messages import ToolMessage
 from langgraph.graph.state import CompiledStateGraph
 from langgraph.prebuilt import ToolNode
 
+from nat.data_models.api_server import ChatResponseChunk
+from nat.data_models.api_server import ChatResponseChunkChoice
+from nat.data_models.api_server import ChoiceDelta
+from nat.data_models.api_server import ChoiceDeltaToolCall
+from nat.data_models.api_server import ChoiceDeltaToolCallFunction
 from nat.plugins.langchain.agent.base import AgentDecision
 from nat.plugins.langchain.agent.tool_calling_agent.agent import ToolCallAgentGraph
 from nat.plugins.langchain.agent.tool_calling_agent.agent import ToolCallAgentGraphState
+from nat.plugins.langchain.agent.tool_calling_agent.agent import _chunk_to_message
 from nat.plugins.langchain.agent.tool_calling_agent.agent import create_tool_calling_agent_prompt
 from nat.plugins.langchain.agent.tool_calling_agent.register import ToolCallAgentWorkflowConfig
 
@@ -326,3 +336,110 @@ async def test_graph_astream_yields_message_chunks(mock_tool_graph):
     assert len(agent_messages) > 0, "Expected at least one message from the agent node via stream_mode='messages'"
     combined_content = "".join(m.content for m in agent_messages if m.content)
     assert len(combined_content) > 0, "Expected non-empty content from streamed agent messages"
+
+
+def test_tool_call_chunk_serialization():
+    """Test that ChatResponseChunk with tool_calls in ChoiceDelta serializes to OpenAI-compatible SSE format."""
+    chunk = ChatResponseChunk(
+        id="test-chunk-id",
+        choices=[
+            ChatResponseChunkChoice(
+                index=0,
+                delta=ChoiceDelta(tool_calls=[
+                    ChoiceDeltaToolCall(index=0,
+                                        id="call_abc123",
+                                        type="function",
+                                        function=ChoiceDeltaToolCallFunction(
+                                            name="test_tool",
+                                            arguments="",
+                                        ))
+                ]),
+                finish_reason=None,
+            )
+        ],
+        created=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+    )
+
+    sse_data = chunk.get_stream_data()
+    assert sse_data.startswith("data: ")
+    assert sse_data.endswith("\n\n")
+
+    payload = json.loads(sse_data[len("data: "):])
+    assert payload["id"] == "test-chunk-id"
+    assert len(payload["choices"]) == 1
+
+    delta = payload["choices"][0]["delta"]
+    assert "tool_calls" in delta
+    assert len(delta["tool_calls"]) == 1
+
+    tc = delta["tool_calls"][0]
+    assert tc["index"] == 0
+    assert tc["id"] == "call_abc123"
+    assert tc["type"] == "function"
+    assert tc["function"]["name"] == "test_tool"
+    assert tc["function"]["arguments"] == ""
+
+
+def test_tool_call_chunk_arguments_streaming():
+    """Test that incremental tool call argument chunks serialize correctly (no id/type on follow-up chunks)."""
+    chunk = ChatResponseChunk(
+        id="test-chunk-id",
+        choices=[
+            ChatResponseChunkChoice(
+                index=0,
+                delta=ChoiceDelta(tool_calls=[
+                    ChoiceDeltaToolCall(index=0,
+                                        id=None,
+                                        type=None,
+                                        function=ChoiceDeltaToolCallFunction(
+                                            name=None,
+                                            arguments='{"author":',
+                                        ))
+                ]),
+                finish_reason=None,
+            )
+        ],
+        created=datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC),
+    )
+
+    payload = json.loads(chunk.model_dump_json())
+    tc = payload["choices"][0]["delta"]["tool_calls"][0]
+    assert tc["index"] == 0
+    assert tc["id"] is None
+    assert tc["type"] is None
+    assert tc["function"]["arguments"] == '{"author":'
+
+
+def test_content_chunk_has_no_tool_calls():
+    """Test that a content-only ChatResponseChunk does not include tool_calls in the delta."""
+    chunk = ChatResponseChunk.create_streaming_chunk("Hello world", id_="test-id")
+    payload = json.loads(chunk.model_dump_json())
+    delta = payload["choices"][0]["delta"]
+    assert delta["content"] == "Hello world"
+    assert delta.get("tool_calls") is None
+
+
+def test_chunk_to_message_rehydrates_empty_tool_calls():
+    """Test that _chunk_to_message rehydrates when additional_kwargs["tool_calls"] is an empty list."""
+    chunk = AIMessageChunk(
+        content="",
+        tool_call_chunks=[{
+            "name": "test_tool",
+            "args": '{"query": "hello"}',
+            "id": "call_abc123",
+            "index": 0,
+            "type": "tool_call_chunk",
+        }],
+        additional_kwargs={"tool_calls": []},
+    )
+
+    assert chunk.tool_calls, "Chunk should have parsed tool_calls"
+    assert not chunk.additional_kwargs.get("tool_calls"), "Wire format tool_calls should be empty"
+
+    msg = _chunk_to_message(chunk)
+
+    assert isinstance(msg, AIMessage)
+    assert len(msg.additional_kwargs["tool_calls"]) == 1
+    tc = msg.additional_kwargs["tool_calls"][0]
+    assert tc["function"]["name"] == "test_tool"
+    assert json.loads(tc["function"]["arguments"]) == {"query": "hello"}


### PR DESCRIPTION
Stream tool call chunks to frontend:
- Add ChoiceDeltaToolCall and ChoiceDeltaToolCallFunction models to
  ChoiceDelta in api_server.py for OpenAI-compatible tool call deltas
- Change _stream_fn return type from AsyncGenerator[str] to
  AsyncGenerator[ChatResponseChunk] and yield structured chunks for
  both content tokens and tool call deltas
- Add unit tests for tool call chunk serialization

Fix agent_node streaming accumulation bug:
- When agent_node accumulates AIMessageChunk objects via astream, the
  resulting chunk has tool_call_chunks but additional_kwargs["tool_calls"]
  (the wire format) is left empty, causing the second LLM call to fail
  with "messages with role 'tool' must be a response to a preceeding
  message with 'tool_calls'"
- Add _chunk_to_message helper that converts accumulated AIMessageChunk
  to AIMessage, using LangChain's convert_to_openai_messages to
  reconstruct the wire format rather than hardcoding it

Streaming handler hardening:
- Guard msg.content with isinstance(str) check for non-string content
- Fall back to msg.tool_calls when tool_call_chunks is missing (AIMessage)
- Normalize tool call index via enumerate to handle None values
- Serialize dict args to JSON string for AIMessage tool_calls
- Yield ChatResponseChunk instead of plain string in GraphRecursionError handler


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming now emits unified, structured chunks that include tool-call deltas alongside content, with per-chunk IDs, timestamps, and consistent formatting.
  * Final streamed chunks are converted into full message objects that preserve tool-call details and arguments.

* **Tests**
  * Added tests verifying tool-call chunk serialization, delta formatting, content-only behavior, argument preservation, and rehydration of tool-call data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->