### PR TITLE
Fix Milvus connection failures in RAG integration tests

### DIFF
--- a/packages/nvidia_nat_rag/tests/test_rag_function.py
+++ b/packages/nvidia_nat_rag/tests/test_rag_function.py
@@ -149,7 +149,7 @@ class TestNvidiaRAGIntegration:
     """Integration tests for NvidiaRAG with live services."""
 
     @pytest.fixture(name="create_collection")
-    def fixture_create_collection(self):
+    def fixture_create_collection(self, milvus_uri: str):
         """Factory to create Milvus collections with specific embedding models."""
         from langchain_core.documents import Document
         from langchain_milvus import Milvus
@@ -164,7 +164,7 @@ class TestNvidiaRAGIntegration:
             model_name = EMBEDDER_CONFIGS[embedder_ref].model_name
             sanitized = re.sub(r"[^a-zA-Z0-9_]", "_", model_name)
             collection_name = f"test_{sanitized}"
-            client = MilvusClient(uri="http://localhost:19530")
+            client = MilvusClient(uri=milvus_uri)
             if client.has_collection(collection_name):
                 client.drop_collection(collection_name)
 
@@ -173,14 +173,14 @@ class TestNvidiaRAGIntegration:
                 documents=[Document(page_content="Test document", metadata={"source": "test"})],
                 embedding=embeddings,
                 collection_name=collection_name,
-                connection_args={"uri": "http://localhost:19530"},
+                connection_args={"uri": milvus_uri},
             )
             created.append(collection_name)
             return collection_name
 
         yield _create
 
-        client = MilvusClient(uri="http://localhost:19530")
+        client = MilvusClient(uri=milvus_uri)
         for name in created:
             if client.has_collection(name):
                 client.drop_collection(name)
@@ -199,6 +199,7 @@ class TestNvidiaRAGIntegration:
         self,
         mock_builder: MagicMock,
         create_collection,
+        milvus_uri: str,
         llm_ref: str,
         embedder_ref: str,
         retriever_ref: str,
@@ -217,7 +218,7 @@ class TestNvidiaRAGIntegration:
         rag_config.llm.server_url = llm_config.base_url
         rag_config.embeddings.model_name = embedder_config.model_name
         rag_config.embeddings.server_url = embedder_config.base_url
-        rag_config.vector_store.url = "http://localhost:19530"
+        rag_config.vector_store.url = milvus_uri
         rag_config.vector_store.default_collection_name = collection_name
 
         rag = NvidiaRAG(config=rag_config)
@@ -238,6 +239,7 @@ class TestNvidiaRAGIntegration:
     async def test_generate(
         self,
         mock_builder: MagicMock,
+        milvus_uri: str,
         llm_ref: str,
         embedder_ref: str,
         retriever_ref: str,
@@ -254,7 +256,7 @@ class TestNvidiaRAGIntegration:
         rag_config.llm.server_url = llm_config.base_url
         rag_config.embeddings.model_name = embedder_config.model_name
         rag_config.embeddings.server_url = embedder_config.base_url
-        rag_config.vector_store.url = "http://localhost:19530"
+        rag_config.vector_store.url = milvus_uri
 
         rag = NvidiaRAG(config=rag_config)
         messages = [{"role": "user", "content": "What is RAG?"}]
@@ -275,6 +277,7 @@ class TestNvidiaRAGIntegration:
     async def test_health(
         self,
         mock_builder: MagicMock,
+        milvus_uri: str,
         llm_ref: str,
         embedder_ref: str,
         retriever_ref: str,
@@ -291,7 +294,7 @@ class TestNvidiaRAGIntegration:
         rag_config.llm.server_url = llm_config.base_url
         rag_config.embeddings.model_name = embedder_config.model_name
         rag_config.embeddings.server_url = embedder_config.base_url
-        rag_config.vector_store.url = "http://localhost:19530"
+        rag_config.vector_store.url = milvus_uri
 
         rag = NvidiaRAG(config=rag_config)
         result = await rag.health()


### PR DESCRIPTION
## Description

RAG integration tests in `test_rag_function.py` hardcoded `http://localhost:19530` for Milvus connections across 7 locations. This fails in CI where Milvus runs as a service container with hostname `milvus`, not `localhost`.

Replaced all hardcoded Milvus URIs with the existing `milvus_uri` fixture from `nvidia_nat_test`, which:
- Reads `NAT_CI_MILVUS_HOST` / `NAT_CI_MILVUS_PORT` env vars (defaults to `localhost:19530` for local dev)
- Skips tests gracefully when Milvus is unavailable instead of crashing with `MilvusException`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored test suite to use parameterized Milvus connection configuration, replacing hardcoded endpoint values with configurable URIs.
  * Updated test fixtures and methods throughout the integration test suite for improved environment flexibility and deployment portability.
  * Enhanced test maintainability by supporting dynamic endpoint configuration across test initialization, execution, and teardown phases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->