### PR TITLE
feat: add embedder inference check and Slack reporting for model health

### DIFF
--- a/ci/scripts/gitlab/common.sh
+++ b/ci/scripts/gitlab/common.sh
@@ -65,5 +65,10 @@ function is_current_commit_release_tagged() {
     echo ${is_tagged}
 }
 
+function install_slack_sdk() {
+    rapids-logger "Installing slack-sdk"
+    uv pip install "slack-sdk~=3.36"
+}
+
 rapids-logger "Environment Variables"
 printenv | sort

--- a/ci/scripts/gitlab/model_health_check.sh
+++ b/ci/scripts/gitlab/model_health_check.sh
@@ -30,17 +30,15 @@ python ${SCRIPT_DIR}/model_health_check.py --output-json "${HEALTH_JSON}"
 HEALTH_RESULT=$?
 set -e
 
-if [ -f "${HEALTH_JSON}" ]; then
-    install_slack_sdk
+set +e
+install_slack_sdk
+rapids-logger "Reporting model health results to Slack"
+${GITLAB_SCRIPT_DIR}/report_test_results.py --model-health-json "${HEALTH_JSON}"
+REPORT_RESULT=$?
+set -e
 
-    rapids-logger "Reporting model health results to Slack"
-    ${GITLAB_SCRIPT_DIR}/report_test_results.py --model-health-json "${HEALTH_JSON}"
-    REPORT_RESULT=$?
-    if [ ${REPORT_RESULT} -ne 0 ]; then
-        rapids-logger "Failed to report model health results to Slack"
-    fi
-else
-    rapids-logger "No JSON results file found, skipping Slack report"
+if [ ${REPORT_RESULT} -ne 0 ]; then
+    rapids-logger "Failed to report model health results to Slack"
 fi
 
 exit ${HEALTH_RESULT}

--- a/ci/scripts/gitlab/model_health_check.sh
+++ b/ci/scripts/gitlab/model_health_check.sh
@@ -23,5 +23,24 @@ source ${GITLAB_SCRIPT_DIR}/common.sh
 create_env
 
 rapids-logger "Running NIM model health check"
-python ${SCRIPT_DIR}/model_health_check.py \
-    --output-json ${CI_PROJECT_DIR:-${PROJECT_ROOT}}/model_health_results.json
+HEALTH_JSON=${CI_PROJECT_DIR:-${PROJECT_ROOT}}/model_health_results.json
+
+set +e
+python ${SCRIPT_DIR}/model_health_check.py --output-json "${HEALTH_JSON}"
+HEALTH_RESULT=$?
+set -e
+
+if [ -f "${HEALTH_JSON}" ]; then
+    install_slack_sdk
+
+    rapids-logger "Reporting model health results to Slack"
+    ${GITLAB_SCRIPT_DIR}/report_test_results.py --model-health-json "${HEALTH_JSON}"
+    REPORT_RESULT=$?
+    if [ ${REPORT_RESULT} -ne 0 ]; then
+        rapids-logger "Failed to report model health results to Slack"
+    fi
+else
+    rapids-logger "No JSON results file found, skipping Slack report"
+fi
+
+exit ${HEALTH_RESULT}

--- a/ci/scripts/gitlab/report_test_results.py
+++ b/ci/scripts/gitlab/report_test_results.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 
 import argparse
+import json
 import logging
 import os
 import sys
@@ -165,10 +166,84 @@ def build_messages(junit_data: dict[str, typing.Any], coverage_data: str) -> Rep
                           failure_blocks=failure_blocks)
 
 
+def parse_model_health(json_path: str) -> dict[str, typing.Any]:
+    """Read the structured JSON output from model_health_check.py."""
+    with open(json_path, encoding="utf-8") as f:
+        return json.load(f)
+
+
+def build_model_health_messages(health_data: dict[str, typing.Any]) -> ReportMessages:
+    """Build Slack messages from model health check results."""
+    branch_name = os.environ.get("CI_COMMIT_BRANCH", "unknown")
+
+    removed = health_data.get("removed", [])
+    down = health_data.get("down", [])
+    ok = health_data.get("ok", [])
+    num_failures = len(removed) + len(down)
+
+    plain_text: list[str] = []
+    blocks: list[dict] = []
+
+    summary_line = f"Model Health Check for `{branch_name}` - {date.today()}"
+    plain_text.append(summary_line + "\n")
+
+    if num_failures > 0:
+        formatted_summary_line = f"@nat-core-devs :rotating_light: {summary_line}"
+    else:
+        formatted_summary_line = summary_line
+
+    blocks.append(text_to_block(formatted_summary_line))
+    stats = "\n".join([
+        get_error_string(len(removed), "Removed"),
+        get_error_string(len(down), "Down"),
+        f"OK: {len(ok)}",
+        f"Total models: {len(removed) + len(down) + len(ok)}",
+    ])
+    add_text(stats, blocks, plain_text)
+
+    failure_blocks: list[dict] | None = None
+    failure_text: list[str] | None = None
+
+    if num_failures > 0:
+        failure_blocks = []
+        failure_text = []
+
+        if removed:
+            add_text(f"*Removed from catalog ({len(removed)}):*", failure_blocks, failure_text)
+            for entry in removed:
+                configs = "\n".join(f"  - {c}" for c in entry.get("configs", []))
+                add_text(f"`{entry.get('model', 'unknown')}` ({entry.get('type', 'unknown')})\n{configs}",
+                         failure_blocks,
+                         failure_text)
+            failure_blocks.append({"type": "divider"})
+
+        if down:
+            add_text(f"*Down ({len(down)}):*", failure_blocks, failure_text)
+            for entry in down:
+                status = entry.get("status", "?")
+                detail = entry.get("detail", "")
+                configs = "\n".join(f"  - {c}" for c in entry.get("configs", []))
+                model_name = entry.get('model', 'unknown')
+                model_type = entry.get('type', 'unknown')
+                msg = f"`{model_name}` ({model_type}) HTTP {status}: {detail}\n{configs}"
+                add_text(msg, failure_blocks, failure_text)
+
+        job_url = os.environ.get("CI_JOB_URL")
+        if job_url is not None:
+            failure_blocks.append({"type": "divider"})
+            add_text(f"Full details available at: {job_url}", failure_blocks, failure_text)
+
+    return ReportMessages(plain_text=plain_text,
+                          blocks=blocks,
+                          failure_text=failure_text,
+                          failure_blocks=failure_blocks)
+
+
 def main():
-    parser = argparse.ArgumentParser(description='Report test status to slack channel')
-    parser.add_argument('junit_file', type=str, help='JUnit XML file to parse')
-    parser.add_argument('coverage_file', type=str, help='Coverage report file to parse')
+    parser = argparse.ArgumentParser(description='Report test or model health status to slack channel')
+    parser.add_argument('junit_file', nargs='?', default=None, type=str, help='JUnit XML file to parse')
+    parser.add_argument('coverage_file', nargs='?', default=None, type=str, help='Coverage report file to parse')
+    parser.add_argument('--model-health-json', type=str, default=None, help='Model health check JSON results file')
 
     logging.basicConfig(level=logging.INFO)
 
@@ -181,21 +256,28 @@ def main():
 
     args = parser.parse_args()
 
+    has_test_args = args.junit_file is not None and args.coverage_file is not None
+    has_health_arg = args.model_health_json is not None
+
+    if not has_test_args and not has_health_arg:
+        parser.error("Provide either junit_file + coverage_file, or --model-health-json")
+
     return_code = 0
     try:
-        junit_data = parse_junit(args.junit_file)
-        coverage_data = parse_coverage(args.coverage_file)
-
-        report_messages = build_messages(junit_data, coverage_data)
+        if has_health_arg:
+            health_data = parse_model_health(args.model_health_json)
+            report_messages = build_model_health_messages(health_data)
+        else:
+            junit_data = parse_junit(args.junit_file)
+            coverage_data = parse_coverage(args.coverage_file)
+            report_messages = build_messages(junit_data, coverage_data)
     except Exception as e:
-        # Intentionally not using logger.exception to limit what we log in CI.
-        msg = f"Error: Failed to parse test results or coverage data: {e}"
+        msg = f"Error: Failed to parse report data: {e}"
         logger.error(msg)
         plain_text = []
         blocks = []
         add_text(msg, blocks, plain_text)
 
-        # Not using the failure fields here since this is not a test failure but a script failure.
         report_messages = ReportMessages(plain_text=plain_text, blocks=blocks, failure_text=None, failure_blocks=None)
         return_code = 1
 

--- a/ci/scripts/gitlab/tests.sh
+++ b/ci/scripts/gitlab/tests.sh
@@ -47,9 +47,7 @@ python ${GITLAB_SCRIPT_DIR}/../run_tests.py ${PYTEST_ARGS} --junit_xml=${REPORT_
 PYTEST_RESULTS=$?
 
 if [ "${CI_CRON_NIGHTLY}" == "1" ]; then
-       # Since this dependency is specific to only this script, we will just install it here
-       rapids-logger "Installing slack-sdk"
-       uv pip install "slack-sdk~=3.36"
+       install_slack_sdk
 
        rapids-logger "Reporting test results"
        ${GITLAB_SCRIPT_DIR}/report_test_results.py ${REPORT_NAME} ${COV_REPORT_NAME}

--- a/ci/scripts/model_health_check.py
+++ b/ci/scripts/model_health_check.py
@@ -21,9 +21,9 @@ and checks each model in two passes:
 
   1. Catalog check  -- models missing from /v1/models have been removed.
      Applies to both LLMs and embedders.
-  2. Inference check -- LLMs present in the catalog but returning non-200
-     on a minimal /v1/chat/completions call are temporarily down.
-     Embedders in the catalog are marked OK without an inference call.
+  2. Inference check -- models present in the catalog but returning non-200
+     on a minimal API call are temporarily down.  LLMs are tested via
+     /v1/chat/completions, embedders via /v1/embeddings.
 
 Reports removed and down models separately so the team can tell whether a
 config needs a model swap (removed) or just needs to wait (down).
@@ -141,31 +141,17 @@ def get_catalog_models(api_key: str) -> set[str]:
         return set()
 
 
-def check_model(model: str, api_key: str) -> tuple[int, str]:
-    """Make a minimal inference call and return (status_code, detail).
-
-    Returns (200, "") on success, (status_code, error_detail) on API error,
-    or (0, error_message) on connection/timeout failure.
-    """
-    payload = json.dumps({
-        "model": model,
-        "messages": [{
-            "role": "user", "content": "hi"
-        }],
-        "max_tokens": 1,
-    }).encode()
-
+def _nim_post(endpoint: str, payload: bytes, api_key: str) -> tuple[int, str]:
+    """POST *payload* to NIM_API_BASE/*endpoint* and return (status, detail)."""
     req = urllib.request.Request(
-        f"{NIM_API_BASE}/chat/completions",
+        f"{NIM_API_BASE}/{endpoint}",
         data=payload,
         headers={
             "Authorization": f"Bearer {api_key}",
             "Content-Type": "application/json",
         },
     )
-
     ctx = ssl.create_default_context()
-
     try:
         with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=ctx) as resp:
             return resp.status, ""
@@ -179,6 +165,28 @@ def check_model(model: str, api_key: str) -> tuple[int, str]:
         return e.code, detail
     except (urllib.error.URLError, TimeoutError, OSError) as e:
         return 0, f"Connection error: {e}"
+
+
+def check_model(model: str, api_key: str) -> tuple[int, str]:
+    """Make a minimal chat/completions call and return (status_code, detail)."""
+    payload = json.dumps({
+        "model": model,
+        "messages": [{
+            "role": "user", "content": "hi"
+        }],
+        "max_tokens": 1,
+    }).encode()
+    return _nim_post("chat/completions", payload, api_key)
+
+
+def check_embedder(model: str, api_key: str) -> tuple[int, str]:
+    """Make a minimal embeddings call and return (status_code, detail)."""
+    payload = json.dumps({
+        "model": model,
+        "input": ["hi"],
+        "input_type": "query",
+    }).encode()
+    return _nim_post("embeddings", payload, api_key)
 
 
 def main() -> int:
@@ -264,26 +272,21 @@ def main() -> int:
         removed = []
         catalog_ok = all_model_names
 
-    # Embedders can only be considered OK when catalog data is available
-    embedder_ok: list[str] = []
-    if catalog:
-        embedder_ok = sorted(set(embedder_models.keys()) & catalog_ok)
-        for model in embedder_ok:
-            print(f"  OK      {model}  (embedder)")
-    elif embedder_models:
-        print("  WARNING: embedder status unknown (catalog check failed)")
-
     print()
 
-    # -- Pass 2: inference check on LLMs still in catalog --------------------
+    # -- Pass 2: inference check on models still in catalog ------------------
     llm_to_test = sorted(set(llm_models.keys()) & catalog_ok)
-    if llm_to_test:
-        print("Pass 2: inference check on catalog-listed LLMs...")
-    down: list[tuple[str, int, str]] = []
+    embedder_to_test = sorted(set(embedder_models.keys()) & catalog_ok)
 
-    for i, model in enumerate(llm_to_test):
-        if i > 0:
+    if llm_to_test or embedder_to_test:
+        print("Pass 2: inference check on catalog-listed models...")
+    down: list[tuple[str, int, str]] = []
+    call_count = 0
+
+    for model in llm_to_test:
+        if call_count > 0:
             time.sleep(INTER_REQUEST_DELAY)
+        call_count += 1
 
         status, detail = check_model(model, api_key)
         if status in (401, 403):
@@ -294,6 +297,22 @@ def main() -> int:
         else:
             label = f"HTTP {status}" if status > 0 else "ERROR"
             print(f"  DOWN    {model} -> {label}: {detail}")
+            down.append((model, status, detail))
+
+    for model in embedder_to_test:
+        if call_count > 0:
+            time.sleep(INTER_REQUEST_DELAY)
+        call_count += 1
+
+        status, detail = check_embedder(model, api_key)
+        if status in (401, 403):
+            print(f"\n  ERROR: API key is invalid or expired (HTTP {status}): {detail}", file=sys.stderr)
+            return 1
+        if status == 200:
+            print(f"  OK      {model}  (embedder)")
+        else:
+            label = f"HTTP {status}" if status > 0 else "ERROR"
+            print(f"  DOWN    {model} -> {label} (embedder): {detail}")
             down.append((model, status, detail))
 
     print()
@@ -331,7 +350,7 @@ def main() -> int:
             } for m in removed],
             "down": [{
                 "model": m,
-                "type": "llm",
+                "type": "embedder" if m in embedder_models else "llm",
                 "status": s,
                 "detail": d,
                 "configs": sorted(set(all_configs[m])),


### PR DESCRIPTION
Add inference checks for embedder models via /v1/embeddings (previously only LLMs were tested). Wire model health results into the existing Slack reporting pipeline via report_test_results.py so failures are visible to the team. Extract install_slack_sdk helper into common.sh.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Model health checks now include embedder checks alongside language-model checks.
  * CI posts model-health results to Slack automatically.

* **Improvements**
  * Unified and clearer model-health report format with richer per-model detail.
  * More robust network/error handling and controlled pacing between requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->