### PR TITLE
Fix `_running_workflow_task` always being `None` due to method chaining

### DIFF
--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
@@ -250,13 +250,16 @@ class WebSocketMessageHandler:
                     if self._conversation_id:
                         self._worker.remove_conversation_handler(self._conversation_id)
 
+                if self._workflow_schema_type is None:
+                    raise ValueError("Workflow schema type is not initialized")
                 self._running_workflow_task = asyncio.create_task(
                     self._run_workflow(payload=message_content,
                                        user_message_id=self._message_parent_id,
                                        conversation_id=self._conversation_id,
                                        result_type=self._schema_output_mapping[self._workflow_schema_type],
                                        output_type=self._schema_output_mapping[
-                                           self._workflow_schema_type])).add_done_callback(_done_callback)
+                                           self._workflow_schema_type]))
+                self._running_workflow_task.add_done_callback(_done_callback)
 
         except ValueError as e:
             logger.exception("User message content not found: %s", str(e))

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
@@ -257,8 +257,7 @@ class WebSocketMessageHandler:
                                        user_message_id=self._message_parent_id,
                                        conversation_id=self._conversation_id,
                                        result_type=self._schema_output_mapping[self._workflow_schema_type],
-                                       output_type=self._schema_output_mapping[
-                                           self._workflow_schema_type]))
+                                       output_type=self._schema_output_mapping[self._workflow_schema_type]))
                 self._running_workflow_task.add_done_callback(_done_callback)
 
         except ValueError as e:

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
@@ -251,7 +251,7 @@ class WebSocketMessageHandler:
                         self._worker.remove_conversation_handler(self._conversation_id)
 
                 if self._workflow_schema_type is None:
-                    raise ValueError("Workflow schema type is not initialized")
+                    raise RuntimeError("Workflow schema type is not initialized")
                 self._running_workflow_task = asyncio.create_task(
                     self._run_workflow(payload=message_content,
                                        user_message_id=self._message_parent_id,
@@ -264,6 +264,14 @@ class WebSocketMessageHandler:
             logger.exception("User message content not found: %s", str(e))
             await self.create_websocket_message(data_model=Error(code=ErrorTypes.INVALID_USER_MESSAGE_CONTENT,
                                                                  message="User message content could not be found",
+                                                                 details=str(e)),
+                                                message_type=WebSocketMessageType.ERROR_MESSAGE,
+                                                status=WebSocketMessageStatus.IN_PROGRESS)
+
+        except RuntimeError as e:
+            logger.exception("Internal workflow initialization error: %s", str(e))
+            await self.create_websocket_message(data_model=Error(code=ErrorTypes.WORKFLOW_ERROR,
+                                                                 message=type(e).__name__,
                                                                  details=str(e)),
                                                 message_type=WebSocketMessageType.ERROR_MESSAGE,
                                                 status=WebSocketMessageStatus.IN_PROGRESS)


### PR DESCRIPTION
### Two bugs existed in process_workflow_request:

- `asyncio.create_task(...).add_done_callback(...)` was chained in a single expression. Since `add_done_callback` returns `None`, `self._running_workflow_task` was always assigned `None` instead of the actual `Task` object. This caused the running task to never be tracked, preventing cancellation and allowing duplicate workflow executions.
- `self._workflow_schema_type` is typed as `str | None` but was used directly as a dict key in `self._schema_output_mapping[self._workflow_schema_type]` without a null check, producing a type error.

### Fix

- Split the chained method call so `self._running_workflow_task` is assigned the `Task` object, then `add_done_callback` is called on it separately.
- Added an explicit `None` guard before accessing `self._schema_output_mapping`, raising a `ValueError` if `_workflow_schema_type` is uninitialized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adds runtime validation to prevent scheduling when a workflow schema is missing, surfacing a clear error instead of proceeding.
  * Ensures workflow tasks are created before attaching callbacks so callbacks are reliably invoked.
  * Enhances error handling: processing errors are logged and sent to clients as workflow errors.
  * Sends explicit invalid-content errors to clients when user message content is missing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->