### PR TITLE
Cleanup vale vocabulary

### DIFF
--- a/ci/vale/styles/config/vocabularies/nat/accept.txt
+++ b/ci/vale/styles/config/vocabularies/nat/accept.txt
@@ -110,7 +110,8 @@ Loghub
 Mem0
 [Mm]iddleware
 Milvus
-MiniMax
+# Minimax the algorithm, not the MiniMax model
+Minimax
 [Mm]itigation(s?)
 [Mm]ixin(s?)
 MLflow

--- a/ci/vale/styles/config/vocabularies/nat/accept.txt
+++ b/ci/vale/styles/config/vocabularies/nat/accept.txt
@@ -4,6 +4,8 @@
 
 [Aa]gentic
 [Aa]gno
+# Allow AIQ for AIQ Blueprint
+AIQ
 [Aa]llowlist
 [Aa]nonymize(d?)
 API(s?)

--- a/ci/vale/styles/config/vocabularies/nat/accept.txt
+++ b/ci/vale/styles/config/vocabularies/nat/accept.txt
@@ -4,7 +4,6 @@
 
 [Aa]gentic
 [Aa]gno
-AIQ
 [Aa]llowlist
 [Aa]nonymize(d?)
 API(s?)
@@ -12,7 +11,7 @@ Arize
 ART
 arXiv
 [Aa]sync
-[Aa]nthropic('s)?
+Anthropic
 Authlib
 [Aa]utoencoder
 [Bb]ackdoor(s?)
@@ -20,7 +19,7 @@ Authlib
 [Bb]ackpressure
 [Bb]atcher
 [Bb]oolean
-[Bb]rev
+Brev
 [Cc]allable(s?)
 # Documentation for ccache only capitalizes the name at the start of a sentence https://ccache.dev/
 [Cc]cache
@@ -69,7 +68,7 @@ etcd
 Faiss
 [Ff]inetunable
 [Ff]inetune(d?)
-[Ff]inetune(r|rs|ing)
+[Ff]inetune(r|rs)
 [Ff]inetuning
 Gantt
 [Gg]eneratable
@@ -93,7 +92,6 @@ Jira
 jsonlines
 [Kk]aggle
 [Kk]eycloak
-kv
 KV
 LangChain
 Langfuse
@@ -112,7 +110,7 @@ Loghub
 Mem0
 [Mm]iddleware
 Milvus
-Minimax
+MiniMax
 [Mm]itigation(s?)
 [Mm]ixin(s?)
 MLflow
@@ -208,4 +206,4 @@ vLLM
 [Ww]eb[Ss]ocket
 XGBoost
 Zep
-zsh
+Zsh

--- a/ci/vale/styles/config/vocabularies/nat/reject.txt
+++ b/ci/vale/styles/config/vocabularies/nat/reject.txt
@@ -2,7 +2,6 @@
 # Regular expressions are parsed according to the Go syntax: https://golang.org/pkg/regexp/syntax/
 (?i)Agent-IQ
 (?i)AgentIQ
-(?i)AIQ
 (?i)A-IQ
 (?i)AI-Q
 (?i)[Bb]lacklist

--- a/ci/vale/styles/config/vocabularies/nat/reject.txt
+++ b/ci/vale/styles/config/vocabularies/nat/reject.txt
@@ -2,6 +2,7 @@
 # Regular expressions are parsed according to the Go syntax: https://golang.org/pkg/regexp/syntax/
 (?i)Agent-IQ
 (?i)AgentIQ
+(?i)AIQ
 (?i)A-IQ
 (?i)AI-Q
 (?i)[Bb]lacklist


### PR DESCRIPTION
## Description
* Anthropic and Brev should only ever be capitalized
* Disallow 'kv' abbreviations should always be capitalized
* Zsh should be cased the way the project cases the name.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated style vocabulary: standardized names/capitalization (Anthropic, Brev, Zsh, Minimax).
  * Removed obsolete token ("kv") and tightened finetune variation handling.
  * Added explicit allowance for "AIQ" in one list and added an additional case-insensitive "AIQ" matching rule in the counterpart list to refine validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->