### PR TITLE
fix(ci): sanitize sbom license response

### DIFF
--- a/ci/scripts/package_utils.py
+++ b/ci/scripts/package_utils.py
@@ -59,4 +59,10 @@ def pypi_license(name: str, version: str | None = None) -> str:
     if (lic := (info.get("license") or "").strip()):
         candidates.append(lic)
 
-    return typing.cast(str, min(candidates, key=len, default="(License not found)"))
+    text = typing.cast(str, min(candidates, key=len, default="(License not found)"))
+
+    # Escape dangerous characters
+    dangerous_chars = ('=', '+', '-', '@', '\t', '\r')
+    if text.startswith(dangerous_chars):
+        text = f"'{text}"
+    return text


### PR DESCRIPTION
## Description
When we output a TSV/CSV, ensure that any license text is not misinterpreted as a formula in Excel

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved license text handling with enhanced escaping logic to prevent malformed output when license information contains special characters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->