### PR TITLE
fix: replace deprecated mistral-nemo-12b and fix reasoning agent tool discovery

### DIFF
--- a/examples/getting_started/simple_calculator/src/nat_simple_calculator/configs/config-reasoning.yml
+++ b/examples/getting_started/simple_calculator/src/nat_simple_calculator/configs/config-reasoning.yml
@@ -34,25 +34,18 @@ functions:
   react_agent:
     _type: tool_calling_agent
     tool_names: [calculator, current_datetime]
-    llm_name: nim_mistral
+    llm_name: nim_llm
     verbose: true
     handle_tool_errors: true
 
 llms:
   nim_llm:
     _type: nim
-    model_name: meta/llama-3.3-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 1024
-  nim_mistral:
-    _type: nim
-    model_name: nv-mistralai/mistral-nemo-12b-instruct
-    temperature: 0.0
-    max_tokens: 2000
-  openai_llm:
-    _type: openai
-    model_name: gpt-3.5-turbo
-    max_tokens: 2000
+    chat_template_kwargs:
+      enable_thinking: false
   nemotron_model:
     _type: nim
     model_name: nvidia/llama-3.3-nemotron-super-49b-v1

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/reasoning_agent/reasoning_agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/reasoning_agent/reasoning_agent.py
@@ -111,16 +111,20 @@ async def build_reasoning_function(config: ReasoningFunctionConfig, builder: Bui
 
     # Get the function dependencies of the augmented function
     function_dependencies = builder.get_function_dependencies(config.augmented_fn)
-    function_used_tools = set()
-    function_used_tools.update(function_dependencies.functions)
-    for function_group in function_dependencies.function_groups:
-        function_used_tools.update(builder.get_function_group_dependencies(function_group).functions)
 
     tool_names_with_desc: list[tuple[str, str]] = []
 
-    for tool in function_used_tools:
-        tool_impl = await builder.get_function(tool)
-        tool_names_with_desc.append((tool, tool_impl.description if hasattr(tool_impl, "description") else ""))
+    for fn_name in function_dependencies.functions:
+        tool_impl = await builder.get_function(fn_name)
+        tool_names_with_desc.append((fn_name, tool_impl.description if hasattr(tool_impl, "description") else ""))
+
+    # Resolve function_group members directly instead of using get_function_group_dependencies,
+    # which only tracks external dependencies and not the functions contained in the group.
+    for fg_name in function_dependencies.function_groups:
+        fg = await builder.get_function_group(fg_name)
+        for fn_name, fn_instance in (await fg.get_accessible_functions()).items():
+            desc = fn_instance.description if hasattr(fn_instance, "description") else ""
+            tool_names_with_desc.append((fn_name, desc))
 
     # Draft the reasoning prompt for the augmented function
     template = PromptTemplate(template=config.reasoning_prompt_template,


### PR DESCRIPTION
Summary
- Replace deprecated \`nv-mistralai/mistral-nemo-12b-instruct\` (HTTP 404) with \`nvidia/nemotron-3-nano-30b-a3b\` in simple_calculator config-reasoning.yml
- Fix bug in reasoning_agent where function_group tools were invisible to the reasoning model's planning prompt
- Remove unused LLM entries and align config with sibling config.yml
## Details
The model health check flagged \`nv-mistralai/mistral-nemo-12b-instruct\` as down (404). While replacing the model, discovered that the reasoning agent's tool discovery was broken for function_groups. \`get_function_group_dependencies()\` returns what a group depends on externally, not what functions it contains. This made the reasoning model blind to calculator tools (add, subtract, multiply, divide). Fixed by using \`FunctionGroup.get_accessible_functions()\` to resolve member functions directly. 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration Updates**
  * Updated AI model selection with revised reasoning parameters.
  * Added thinking configuration controls for reasoning workflows.

* **Improvements**
  * Enhanced tool discovery and description aggregation to include broader function coverage within tool groups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->