### PR TITLE
fix: toplevel `pyproject.toml` should specify `tool.uv.managed=true`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -213,6 +213,7 @@ conflicts = [
     [{ extra = "rag" }, { extra = "autogen" }],
     [{ extra = "rag" }, { extra = "most" }],
 ]
+managed = true
 
 [tool.uv.sources]
 # Packages


### PR DESCRIPTION
## Description
Our internal scanning system seems to need this explicitly specified in order for scans to come back without error. During the package restructuring, the top-level added `pyproject.toml` omitted this stanza.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration for virtual environment management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->