### PR TITLE
Remove unneeded warning filter

### DIFF
--- a/.pytest.ini
+++ b/.pytest.ini
@@ -13,9 +13,6 @@ markers =
     integration: Integration tests which do not use mocks and may require external services
     requires_cache: Tests that require a reverse-proxy cache to be running
     slow: Slow tests
-filterwarnings =
-    # Work-around for a warning emitted by strands https://github.com/strands-agents/sdk-python/issues/1236
-    ignore:^These events have been moved to production.*strands:DeprecationWarning
 asyncio_mode = auto
 asyncio_default_fixture_loop_scope = session
 

--- a/ci/scripts/copyright.py
+++ b/ci/scripts/copyright.py
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 
 FilesToCheck = [
     # Get all of these extensions and templates (*.in)
-    re.compile(r"[.](cmake|cpp|cc|css|cu|cuh|h|hpp|md|rst|sh|pxd|py|pyx|yml|yaml)(\.in)?$"),
+    re.compile(r"[.](cmake|cpp|cc|css|cu|cuh|h|hpp|md|rst|sh|pxd|py|pyx|toml|yml|yaml)(\.in)?$"),
     # And files with a particular file/extension combo
     re.compile(r"CMakeLists[.]txt$"),
     re.compile(r"setup[.]cfg$"),
@@ -48,6 +48,7 @@ ExemptFiles: list[re.Pattern] = [
     re.compile(r"[^ \/\n]*conda/environments/.*\.yaml$"),  # Ignore generated environment files
     re.compile(r"LICENSE\.md$"),  # Ignore the license file itself
     re.compile(r"^examples/.*/data/.*.md$"),  # Ignore data files in examples
+    re.compile(r"^.nspect-allowlist.toml$"),  # Ignore the nspect allowlist file
 ]
 
 # this will break starting at year 10000, which is probably OK :)
@@ -457,6 +458,7 @@ EXT_LIC_MAPPING = {
     'pyx': A2_LIC_HASH,
     'rst': A2_LIC_RST,
     'sh': A2_LIC_HASH,
+    'toml': A2_LIC_HASH,
     'txt': A2_LIC_HASH,
     'yaml': A2_LIC_HASH,
     'yml': A2_LIC_HASH,

--- a/ci/scripts/copyright.py
+++ b/ci/scripts/copyright.py
@@ -48,7 +48,7 @@ ExemptFiles: list[re.Pattern] = [
     re.compile(r"[^ \/\n]*conda/environments/.*\.yaml$"),  # Ignore generated environment files
     re.compile(r"LICENSE\.md$"),  # Ignore the license file itself
     re.compile(r"^examples/.*/data/.*.md$"),  # Ignore data files in examples
-    re.compile(r"^.nspect-allowlist.toml$"),  # Ignore the nspect allowlist file
+    re.compile(r"^\.nspect-allowlist\.toml$"),  # Ignore the nspect allowlist file
 ]
 
 # this will break starting at year 10000, which is probably OK :)

--- a/examples/frameworks/strands_demo/uv.lock
+++ b/examples/frameworks/strands_demo/uv.lock
@@ -2462,7 +2462,7 @@ dependencies = [
 requires-dist = [
     { name = "nvidia-nat-core", editable = "../../../packages/nvidia_nat_core" },
     { name = "nvidia-nat-test", marker = "extra == 'test'", editable = "../../../packages/nvidia_nat_test" },
-    { name = "strands-agents", extras = ["openai"], specifier = "~=1.17" },
+    { name = "strands-agents", extras = ["openai"], specifier = "~=1.21" },
     { name = "strands-agents-tools", specifier = "~=0.2" },
 ]
 provides-extras = ["test"]

--- a/packages/nvidia_nat_adk/pyproject.toml
+++ b/packages/nvidia_nat_adk/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/nvidia_nat_agno/pyproject.toml
+++ b/packages/nvidia_nat_agno/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/packages/nvidia_nat_strands/pyproject.toml
+++ b/packages/nvidia_nat_strands/pyproject.toml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2025, NVIDIA CORPORATION & AFFILIATES.
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES.
 # All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #

--- a/packages/nvidia_nat_strands/pyproject.toml
+++ b/packages/nvidia_nat_strands/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   # version when adding a new package. If unsure, default to using `~=` instead of `==`. Does not apply to nvidia-nat packages.
   # Keep sorted!!!
   "nvidia-nat-core == {version}",
-  "strands-agents[openai]~=1.17",
+  "strands-agents[openai]~=1.21",
   "strands-agents-tools~=0.2",
 ]
 

--- a/packages/nvidia_nat_strands/uv.lock
+++ b/packages/nvidia_nat_strands/uv.lock
@@ -1634,7 +1634,7 @@ test = [
 requires-dist = [
     { name = "nvidia-nat-core", editable = "../nvidia_nat_core" },
     { name = "nvidia-nat-test", marker = "extra == 'test'", editable = "../nvidia_nat_test" },
-    { name = "strands-agents", extras = ["openai"], specifier = "~=1.17" },
+    { name = "strands-agents", extras = ["openai"], specifier = "~=1.21" },
     { name = "strands-agents-tools", specifier = "~=0.2" },
 ]
 provides-extras = ["test"]

--- a/uv.lock
+++ b/uv.lock
@@ -7366,7 +7366,7 @@ dependencies = [
 requires-dist = [
     { name = "nvidia-nat-core", editable = "packages/nvidia_nat_core" },
     { name = "nvidia-nat-test", marker = "extra == 'test'", editable = "packages/nvidia_nat_test" },
-    { name = "strands-agents", extras = ["openai"], specifier = "~=1.17" },
+    { name = "strands-agents", extras = ["openai"], specifier = "~=1.21" },
     { name = "strands-agents-tools", specifier = "~=0.2" },
 ]
 provides-extras = ["test"]


### PR DESCRIPTION
## Description
* This filter warning was originally added to work-around strands-agents/sdk-python#1236 which was fixed in Strands v1.21
* `uv` has been installing v1.27, change the version req to pull in a minimum version of 1.21.
* Update the copyright.py script to scan toml files.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated dependency compatibility to a newer patchline (strands-agents[openai] ~= 1.21).
  * Updated project metadata year ranges to 2025–2026.
  * Extended license/header checks to include TOML files and added an exemption for the allowlist.

* **Tests**
  * Made a previously-suppressed deprecation warning visible in test configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->