### PR TITLE
fix(release/1.4): specify explicit sub-package versions

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -184,6 +184,8 @@ numpydoc_class_members_toctree = False
 # mysql.com  reports a 403 when requested by linkcheck
 # api.service.com is a placeholder for a service example
 # Ignore example.com/mcp as it is inaccessible when building the docs
+# The way Github handles anchors into markdown files is not compatible with the way linkcheck handles them.
+# This allows us to continue to verify that the links are valid, but ignore the anchors.
 linkcheck_ignore = [
     r'http://localhost:\d+',
     r'https://localhost:\d+',
@@ -196,7 +198,8 @@ linkcheck_ignore = [
     r'https?://example\.com/mcp/?',
     r'http://custom-server',
     r'^\?provider=',
-    r'https://agent\.example\.com'
+    r'https://agent\.example\.com',
+    r"^https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/.*#.+$",
 ]
 
 templates_path = ['_templates']

--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -22,7 +22,7 @@ limitations under the License.
 > ⚠️ **EXPERIMENTAL**: This integration between NeMo Agent toolkit and Dynamo is experimental and under active development. APIs, configurations, and features may change without notice.
 
 > [!WARNING]
-> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/archive/0.7.0/reference/support-matrix.html) for full details.
+> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/v-0-7-0/getting-started/support-matrix.html) for full details.
 >
 > **Supported Platforms:**
 > - Ubuntu 22.04 / 24.04 (x86_64)

--- a/examples/dynamo_integration/README.md
+++ b/examples/dynamo_integration/README.md
@@ -22,7 +22,7 @@ limitations under the License.
 > ⚠️ **EXPERIMENTAL**: This integration between NeMo Agent toolkit and Dynamo is experimental and under active development. APIs, configurations, and features may change without notice.
 
 > [!WARNING]
-> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/v-0-7-0/getting-started/support-matrix.html) for full details.
+> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/v-0-7-0/getting-started/support-matrix) for full details.
 >
 > **Supported Platforms:**
 > - Ubuntu 22.04 / 24.04 (x86_64)

--- a/examples/dynamo_integration/react_benchmark_agent/README.md
+++ b/examples/dynamo_integration/react_benchmark_agent/README.md
@@ -49,7 +49,7 @@ Currently this agent supports evaluation exclusively for the [Galileo Agent Lead
 ### Software Requirements
 
 > [!WARNING]
-> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/v-0-7-0/getting-started/support-matrix.html) for full details.
+> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/v-0-7-0/getting-started/support-matrix) for full details.
 >
 > **Supported Platforms:**
 > - Ubuntu 22.04 / 24.04 (x86_64)

--- a/examples/dynamo_integration/react_benchmark_agent/README.md
+++ b/examples/dynamo_integration/react_benchmark_agent/README.md
@@ -49,7 +49,7 @@ Currently this agent supports evaluation exclusively for the [Galileo Agent Lead
 ### Software Requirements
 
 > [!WARNING]
-> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/archive/0.7.0/reference/support-matrix.html) for full details.
+> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/v-0-7-0/getting-started/support-matrix.html) for full details.
 >
 > **Supported Platforms:**
 > - Ubuntu 22.04 / 24.04 (x86_64)

--- a/external/dynamo/README.md
+++ b/external/dynamo/README.md
@@ -181,7 +181,7 @@ Dynamo is NVIDIA's high-performance LLM serving platform with KV cache optimizat
 ### Platform Requirements
 
 > [!WARNING]
-> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/archive/0.7.0/reference/support-matrix.html) for full details.
+> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/v-0-7-0/getting-started/support-matrix.html) for full details.
 >
 > **Supported Platforms:**
 > - Ubuntu 22.04 / 24.04 (x86_64)

--- a/external/dynamo/README.md
+++ b/external/dynamo/README.md
@@ -181,7 +181,7 @@ Dynamo is NVIDIA's high-performance LLM serving platform with KV cache optimizat
 ### Platform Requirements
 
 > [!WARNING]
-> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/v-0-7-0/getting-started/support-matrix.html) for full details.
+> **This example requires a Linux system with an NVIDIA GPU.** See the [Dynamo Support Matrix](https://docs.nvidia.com/dynamo/v-0-7-0/getting-started/support-matrix) for full details.
 >
 > **Supported Platforms:**
 > - Ubuntu 22.04 / 24.04 (x86_64)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,41 +91,41 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 [project.optional-dependencies]
 # Optional dependencies are things that users would want to install with NAT. i.e. `uv pip install "nvidia-nat[langchain]"`
 # Keep sorted!!!
-all = ["nvidia-nat-all == {version}"] # meta-package
-a2a = ["nvidia-nat-a2a == {version}"]
-adk = ["nvidia-nat-adk == {version}"]
-agno = ["nvidia-nat-agno == {version}"]
-autogen = ["nvidia-nat-autogen == {version}"]
-crewai = ["nvidia-nat-crewai == {version}"]
-data-flywheel = ["nvidia-nat-data-flywheel == {version}"]
-ingestion = ["nvidia-nat-ingestion == {version}"] # meta-package
-langchain = ["nvidia-nat-langchain == {version}"]
-llama-index = ["nvidia-nat-llama-index == {version}"]
-mcp = ["nvidia-nat-mcp == {version}"]
-mem0ai = ["nvidia-nat-mem0ai == {version}"]
-opentelemetry = ["nvidia-nat-opentelemetry == {version}"]
-phoenix = ["nvidia-nat-phoenix == {version}"]
-pii-defense = ["presidio-analyzer == {version}", "presidio-anonymizer == {version}"]
-profiling = ["nvidia-nat-profiling == {version}"] # meta-package
-ragaai = ["nvidia-nat-ragaai == {version}"]
-mysql = ["nvidia-nat-mysql == {version}"]
-redis = ["nvidia-nat-redis == {version}"]
-s3 = ["nvidia-nat-s3 == {version}"]
-semantic-kernel = ["nvidia-nat-semantic-kernel == {version}"]
-strands = ["nvidia-nat-strands == {version}"]
+all = ["nvidia-nat-all ~= 1.4.0"] # meta-package
+a2a = ["nvidia-nat-a2a ~= 1.4.0"]
+adk = ["nvidia-nat-adk ~= 1.4.0"]
+agno = ["nvidia-nat-agno ~= 1.4.0"]
+autogen = ["nvidia-nat-autogen ~= 1.4.0"]
+crewai = ["nvidia-nat-crewai ~= 1.4.0"]
+data-flywheel = ["nvidia-nat-data-flywheel ~= 1.4.0"]
+ingestion = ["nvidia-nat-ingestion ~= 1.4.0"] # meta-package
+langchain = ["nvidia-nat-langchain ~= 1.4.0"]
+llama-index = ["nvidia-nat-llama-index ~= 1.4.0"]
+mcp = ["nvidia-nat-mcp ~= 1.4.0"]
+mem0ai = ["nvidia-nat-mem0ai ~= 1.4.0"]
+opentelemetry = ["nvidia-nat-opentelemetry ~= 1.4.0"]
+phoenix = ["nvidia-nat-phoenix ~= 1.4.0"]
+pii-defense = ["presidio-analyzer", "presidio-anonymizer"]
+profiling = ["nvidia-nat-profiling ~= 1.4.0"] # meta-package
+ragaai = ["nvidia-nat-ragaai ~= 1.4.0"]
+mysql = ["nvidia-nat-mysql ~= 1.4.0"]
+redis = ["nvidia-nat-redis ~= 1.4.0"]
+s3 = ["nvidia-nat-s3 ~= 1.4.0"]
+semantic-kernel = ["nvidia-nat-semantic-kernel ~= 1.4.0"]
+strands = ["nvidia-nat-strands ~= 1.4.0"]
 telemetry = [
-  "nvidia-nat-data-flywheel == {version}",
-  "nvidia-nat-opentelemetry == {version}",
-  "nvidia-nat-phoenix == {version}",
-  "nvidia-nat-ragaai == {version}",
-  "nvidia-nat-weave == {version}",
+  "nvidia-nat-data-flywheel ~= 1.4.0",
+  "nvidia-nat-opentelemetry ~= 1.4.0",
+  "nvidia-nat-phoenix ~= 1.4.0",
+  "nvidia-nat-ragaai ~= 1.4.0",
+  "nvidia-nat-weave ~= 1.4.0",
 ]
-test = ["nvidia-nat-test == {version}"]
-vanna = ["nvidia-nat-vanna == {version}"]
-weave = ["nvidia-nat-weave == {version}"]
-zep-cloud = ["nvidia-nat-zep-cloud == {version}"]
-openpipe-art = ["nvidia-nat-openpipe-art == {version}"]
-nemo-customizer = ["nvidia-nat-nemo-customizer == {version}"]
+test = ["nvidia-nat-test ~= 1.4.0"]
+vanna = ["nvidia-nat-vanna ~= 1.4.0"]
+weave = ["nvidia-nat-weave ~= 1.4.0"]
+zep-cloud = ["nvidia-nat-zep-cloud ~= 1.4.0"]
+openpipe-art = ["nvidia-nat-openpipe-art ~= 1.4.0"]
+nemo-customizer = ["nvidia-nat-nemo-customizer ~= 1.4.0"]
 
 examples = [
   "nat_adk_demo",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,41 +91,41 @@ source = "https://github.com/NVIDIA/NeMo-Agent-Toolkit"
 [project.optional-dependencies]
 # Optional dependencies are things that users would want to install with NAT. i.e. `uv pip install "nvidia-nat[langchain]"`
 # Keep sorted!!!
-all = ["nvidia-nat-all"] # meta-package
-a2a = ["nvidia-nat-a2a"]
-adk = ["nvidia-nat-adk"]
-agno = ["nvidia-nat-agno"]
-autogen = ["nvidia-nat-autogen"]
-crewai = ["nvidia-nat-crewai"]
-data-flywheel = ["nvidia-nat-data-flywheel"]
-ingestion = ["nvidia-nat-ingestion"] # meta-package
-langchain = ["nvidia-nat-langchain"]
-llama-index = ["nvidia-nat-llama-index"]
-mcp = ["nvidia-nat-mcp"]
-mem0ai = ["nvidia-nat-mem0ai"]
-opentelemetry = ["nvidia-nat-opentelemetry"]
-phoenix = ["nvidia-nat-phoenix"]
-pii-defense = ["presidio-analyzer", "presidio-anonymizer"]
-profiling = ["nvidia-nat-profiling"] # meta-package
-ragaai = ["nvidia-nat-ragaai"]
-mysql = ["nvidia-nat-mysql"]
-redis = ["nvidia-nat-redis"]
-s3 = ["nvidia-nat-s3"]
-semantic-kernel = ["nvidia-nat-semantic-kernel"]
-strands = ["nvidia-nat-strands"]
+all = ["nvidia-nat-all == {version}"] # meta-package
+a2a = ["nvidia-nat-a2a == {version}"]
+adk = ["nvidia-nat-adk == {version}"]
+agno = ["nvidia-nat-agno == {version}"]
+autogen = ["nvidia-nat-autogen == {version}"]
+crewai = ["nvidia-nat-crewai == {version}"]
+data-flywheel = ["nvidia-nat-data-flywheel == {version}"]
+ingestion = ["nvidia-nat-ingestion == {version}"] # meta-package
+langchain = ["nvidia-nat-langchain == {version}"]
+llama-index = ["nvidia-nat-llama-index == {version}"]
+mcp = ["nvidia-nat-mcp == {version}"]
+mem0ai = ["nvidia-nat-mem0ai == {version}"]
+opentelemetry = ["nvidia-nat-opentelemetry == {version}"]
+phoenix = ["nvidia-nat-phoenix == {version}"]
+pii-defense = ["presidio-analyzer == {version}", "presidio-anonymizer == {version}"]
+profiling = ["nvidia-nat-profiling == {version}"] # meta-package
+ragaai = ["nvidia-nat-ragaai == {version}"]
+mysql = ["nvidia-nat-mysql == {version}"]
+redis = ["nvidia-nat-redis == {version}"]
+s3 = ["nvidia-nat-s3 == {version}"]
+semantic-kernel = ["nvidia-nat-semantic-kernel == {version}"]
+strands = ["nvidia-nat-strands == {version}"]
 telemetry = [
-  "nvidia-nat-data-flywheel",
-  "nvidia-nat-opentelemetry",
-  "nvidia-nat-phoenix",
-  "nvidia-nat-ragaai",
-  "nvidia-nat-weave",
+  "nvidia-nat-data-flywheel == {version}",
+  "nvidia-nat-opentelemetry == {version}",
+  "nvidia-nat-phoenix == {version}",
+  "nvidia-nat-ragaai == {version}",
+  "nvidia-nat-weave == {version}",
 ]
-test = ["nvidia-nat-test"]
-vanna = ["nvidia-nat-vanna"]
-weave = ["nvidia-nat-weave"]
-zep-cloud = ["nvidia-nat-zep-cloud"]
-openpipe-art = ["nvidia-nat-openpipe-art"]
-nemo-customizer = ["nvidia-nat-nemo-customizer"]
+test = ["nvidia-nat-test == {version}"]
+vanna = ["nvidia-nat-vanna == {version}"]
+weave = ["nvidia-nat-weave == {version}"]
+zep-cloud = ["nvidia-nat-zep-cloud == {version}"]
+openpipe-art = ["nvidia-nat-openpipe-art == {version}"]
+nemo-customizer = ["nvidia-nat-nemo-customizer == {version}"]
 
 examples = [
   "nat_adk_demo",


### PR DESCRIPTION
## Description

Extra packages never specified a version. This means that installing `nvidia-nat[langchain]~=1.4.0` could potentially resolve to install:
```
nvidia-nat==1.4.1
nvidia-nat-langchain==1.5.0
nvidia-nat-core==1.5.0
```

Fix/prevent this by explicitly specifying a version constraint for each extra.


## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated NVIDIA Dynamo support-matrix/getting-started links across integration and external guides to point to the v-0-7-0 pages.
  * Expanded link-check ignore rules to skip certain GitHub anchor fragments.

* **Chores**
  * Standardized optional dependency version constraints in project metadata to a consistent ~= 1.4.0 minor bound.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->