### PR TITLE
Report installed packages when testing built wheels

### DIFF
--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -209,6 +209,14 @@ jobs:
         shell: bash
         run: ./nat/ci/scripts/github/build_wheel.sh
 
+      - name: Upload Package Reports
+        uses: actions/upload-artifact@v6
+        with:
+          name: "package_listings"
+          path: "${{ github.workspace }}/tmp/package_listings.tar.bz2"
+          if-no-files-found: error
+          compression-level: 0
+
       - name: Upload Wheels
         uses: actions/upload-artifact@v6
         with:

--- a/.github/workflows/ci_pipe.yml
+++ b/.github/workflows/ci_pipe.yml
@@ -211,6 +211,7 @@ jobs:
 
       - name: Upload Package Reports
         uses: actions/upload-artifact@v6
+        if: ${{ always() }}
         with:
           name: "package_listings"
           path: "${{ github.workspace }}/tmp/package_listings.tar.bz2"

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -59,6 +59,14 @@ deactivate
 TEMP_INSTALL_LOCATION="${WORKSPACE_TMP}/wheel_test_env"
 install_python_versions
 
+function create_package_report_tarball() {
+    local tarball_path="${WORKSPACE_TMP}/package_listings.tar.bz2"
+    tar -cjf "${tarball_path}" -C "${PIP_REPORTS_DIR}" .
+    echo "${tarball_path}"
+}
+
+trap create_package_report_tarball EXIT
+
 for whl in "${MOVED_WHEELS[@]}"; do
 
     for pyver in "${SUPPORTED_PYTHON_VERSIONS[@]}"; do

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -92,7 +92,7 @@ for whl in "${MOVED_WHEELS[@]}"; do
 
         # Report the packages in the environment regardless of install success
         rapids-logger "Installed wheel ${whl} with Python ${pyver}, pip install exit code ${INSTALL_RESULT}"
-        uv pip list --format json > ${PIP_REPORTS_DIR}/$(basename "${whl}" .whl)_py${pyver}_packages.json
+        uv pip list --format json > "${PIP_REPORTS_DIR}/$(basename "${whl}" .whl)_py${pyver}_packages.json"
 
         if [[ ${INSTALL_RESULT} -ne 0 ]]; then
             rapids-logger "Error, failed to install wheel ${whl} with Python ${pyver}"

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -133,3 +133,5 @@ for whl in "${MOVED_WHEELS[@]}"; do
         rm -rf "${TEMP_INSTALL_LOCATION}"
     done
 done
+
+exit 0

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -87,7 +87,7 @@ for whl in "${MOVED_WHEELS[@]}"; do
         INSTALL_RESULT=$?
 
         # Report the packages in the environment regardless of install success
-        rapids-logger "Installed wheel ${whl} with Python ${pyver}, pip install exit code ${INSTALL_RESULT}, installed packages:"
+        rapids-logger "Installed wheel ${whl} with Python ${pyver}, pip install exit code ${INSTALL_RESULT}"
         uv pip list --format json > ${PIP_REPORTS_DIR}/$(basename "${whl}" .whl)_py${pyver}_packages.json
 
         if [[ ${INSTALL_RESULT} -ne 0 ]]; then

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -21,6 +21,8 @@ GITHUB_SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd 
 source ${GITHUB_SCRIPT_DIR}/common.sh
 WHEELS_BASE_DIR="${WORKSPACE_TMP}/wheels"
 WHEELS_DIR="${WHEELS_BASE_DIR}/nvidia-nat"
+PIP_REPORTS_DIR="${WORKSPACE_TMP}/pip_reports"
+mkdir -p "${PIP_REPORTS_DIR}"
 
 GIT_TAG=$(get_git_tag)
 rapids-logger "Git Version: ${GIT_TAG}"
@@ -78,7 +80,7 @@ for whl in "${MOVED_WHEELS[@]}"; do
 
         # Report the packages in the environment regardless of install success
         rapids-logger "Installed wheel ${whl} with Python ${pyver}, pip install exit code ${INSTALL_RESULT}, installed packages:"
-        uv pip list
+        uv pip list --format json > ${PIP_REPORTS_DIR}/$(basename "${whl}" .whl)_py${pyver}_packages.json
 
         if [[ ${INSTALL_RESULT} -ne 0 ]]; then
             rapids-logger "Error, failed to install wheel ${whl} with Python ${pyver}"

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -62,6 +62,10 @@ install_python_versions
 function create_package_report_tarball() {
     local tarball_path="${WORKSPACE_TMP}/package_listings.tar.bz2"
     tar -cjf "${tarball_path}" -C "${PIP_REPORTS_DIR}" .
+
+    # Clean out the reports directory, in CI this doesn't have an impact, but if running locally it prevents old
+    # reports from being included in future tarballs
+    rm -rf "${PIP_REPORTS_DIR}"
     echo "${tarball_path}"
 }
 

--- a/ci/scripts/github/build_wheel.sh
+++ b/ci/scripts/github/build_wheel.sh
@@ -76,6 +76,10 @@ for whl in "${MOVED_WHEELS[@]}"; do
         UV_PIP_OUT=$(uv pip install -q --prerelease=allow --find-links "${WHEELS_BASE_DIR}" "${whl}" 2>&1)
         INSTALL_RESULT=$?
 
+        # Report the packages in the environment regardless of install success
+        rapids-logger "Installed wheel ${whl} with Python ${pyver}, pip install exit code ${INSTALL_RESULT}, installed packages:"
+        uv pip list
+
         if [[ ${INSTALL_RESULT} -ne 0 ]]; then
             rapids-logger "Error, failed to install wheel ${whl} with Python ${pyver}"
             echo "${UV_PIP_OUT}"


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced CI to always collect and archive per-build diagnostic package listings and per-test reports, improving post-build debugging and visibility even when individual test steps fail.
  * Added guaranteed report generation and artifact upload at pipeline completion to make build outputs more discoverable and reliable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->