### PR TITLE
fix: pin liteLLM <=1.82.6 to mitigate TeamPCP supply chain attack

### DIFF
--- a/packages/nvidia_nat_adk/pyproject.toml
+++ b/packages/nvidia_nat_adk/pyproject.toml
@@ -55,7 +55,7 @@ dependencies = [
   # Keep sorted!!!
   "nvidia-nat-core == {version}",
   "google-adk~=1.18",
-  "litellm~=1.74",
+  "litellm>=1.74.0, <=1.82.6",
 ]
 
 [tool.setuptools_dynamic_dependencies.optional-dependencies]

--- a/packages/nvidia_nat_agno/pyproject.toml
+++ b/packages/nvidia_nat_agno/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
   "nvidia-nat-core == {version}",
   "agno>=1.2.3,<2.0.0",
   "google-search-results>=2.4.2,<3.0.0",
-  "litellm~=1.74",
+  "litellm>=1.74.0, <=1.82.6",
   "openai~=1.106",
 ]
 

--- a/packages/nvidia_nat_crewai/pyproject.toml
+++ b/packages/nvidia_nat_crewai/pyproject.toml
@@ -57,7 +57,7 @@ dependencies = [
   # Keep sorted!!!
   "nvidia-nat-core == {version}",
   "crewai>=0.193.2,<1.0.0",
-  "litellm~=1.74",
+  "litellm>=1.74.0, <=1.82.6",
 ]
 
 [tool.setuptools_dynamic_dependencies.optional-dependencies]


### PR DESCRIPTION
## Summary

liteLLM versions **1.82.7** and **1.82.8** were compromised by the **TeamPCP** group via a supply chain attack through Trivy. The current dependency constraint allows these malicious versions to be installed.

## Impact

The compromised versions steal sensitive credentials including SSH keys, AWS/GCP/K8s credentials, CI/CD tokens, and environment variables. Version 1.82.8 installs a `.pth` persistence mechanism that executes on every Python startup — even after liteLLM is uninstalled.

## Fix

This PR pins the upper bound of the liteLLM dependency to `<=1.82.6`, which is the last known safe version before the compromise. Once BerriAI publishes a verified clean release, this upper bound can be raised.

**Files changed (3 sub-packages):**
- `packages/nvidia_nat_adk/pyproject.toml`: `~=1.74` → `>=1.74.0, <=1.82.6`
- `packages/nvidia_nat_crewai/pyproject.toml`: `~=1.74` → `>=1.74.0, <=1.82.6`
- `packages/nvidia_nat_agno/pyproject.toml`: `~=1.74` → `>=1.74.0, <=1.82.6`

## References

- [BerriAI/litellm#24512](https://github.com/BerriAI/litellm/issues/24512) — Incident report
- [Wiz.io Analysis](https://www.wiz.io/blog/threes-a-crowd-teampcp-trojanizes-litellm-in-continuation-of-campaign) — Attack chain analysis
- [OSV: MAL-2026-2144](https://osv.dev/vulnerability/MAL-2026-2144) — Advisory

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `litellm` dependency constraints across packages to version range 1.74.0 to 1.82.6.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->