### PR TITLE
Fix default values for datetime fields in `JobInfo` objects

### DIFF
--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/async_jobs/job_store.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/async_jobs/job_store.py
@@ -121,10 +121,10 @@ class JobInfo(Base):
     output_path: Mapped[str] = mapped_column(nullable=True)
     # We shoud be able to use server_default=func.now() and server_onupdate=func.now() for the datetime fields
     # but in SQLite this results in timestamps with only second level precision
-    created_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now(UTC))
-    updated_at: Mapped[datetime] = mapped_column(
-        DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True),
+                                                 default=lambda: datetime.now(UTC),
+                                                 onupdate=lambda: datetime.now(UTC))
     expiry_seconds: Mapped[int]
     output: Mapped[str] = mapped_column(nullable=True)
     is_expired: Mapped[bool] = mapped_column(default=False, index=True)

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/async_jobs/job_store.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/async_jobs/job_store.py
@@ -119,10 +119,12 @@ class JobInfo(Base):
     config_file: Mapped[str] = mapped_column(nullable=True)
     error: Mapped[str] = mapped_column(nullable=True)
     output_path: Mapped[str] = mapped_column(nullable=True)
-    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.now(UTC))
-    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True),
-                                                 default=datetime.now(UTC),
-                                                 onupdate=datetime.now(UTC))
+    # We shoud be able to use server_default=func.now() and server_onupdate=func.now() for the datetime fields
+    # but in SQLite this results in timestamps with only second level precision
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC))
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=lambda: datetime.now(UTC), onupdate=lambda: datetime.now(UTC))
     expiry_seconds: Mapped[int]
     output: Mapped[str] = mapped_column(nullable=True)
     is_expired: Mapped[bool] = mapped_column(default=False, index=True)

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/async_jobs/job_store.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/async_jobs/job_store.py
@@ -119,7 +119,7 @@ class JobInfo(Base):
     config_file: Mapped[str] = mapped_column(nullable=True)
     error: Mapped[str] = mapped_column(nullable=True)
     output_path: Mapped[str] = mapped_column(nullable=True)
-    # We shoud be able to use server_default=func.now() and server_onupdate=func.now() for the datetime fields
+    # We should be able to use server_default=func.now() and server_onupdate=func.now() for the datetime fields
     # but in SQLite this results in timestamps with only second level precision
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=lambda: datetime.now(UTC))

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
@@ -17,7 +17,9 @@ import asyncio
 import json
 import os
 import typing
+from datetime import datetime
 from datetime import timedelta
+from datetime import UTC
 from pathlib import Path
 
 import pytest
@@ -117,6 +119,28 @@ async def test_create_job_default_params(db_engine: "AsyncEngine", dask_schedule
     assert job.expiry_seconds == JobStore.DEFAULT_EXPIRY
     assert job.is_expired is False
 
+@pytest.mark.usefixtures("setup_db")
+@pytest.mark.asyncio
+async def test_job_info_default_params(db_engine: "AsyncEngine", dask_scheduler_address: str):
+    """Test job creation with default parameters."""
+    from nat.front_ends.fastapi.async_jobs import JobInfo
+    from nat.front_ends.fastapi.async_jobs import JobStatus
+    from nat.front_ends.fastapi.async_jobs import JobStore
+
+    job_store = JobStore(scheduler_address=dask_scheduler_address, db_engine=db_engine)
+
+    test_start_time = datetime.now(UTC)
+    job_id = job_store.ensure_job_id(None)
+    job = JobInfo(job_id=job_id,
+                  status=JobStatus.SUBMITTED,
+                  expiry_seconds=30)
+
+    async with job_store.session() as session:
+        session.add(job)
+
+    job = await job_store.get_job(job_id)
+    assert job.created_at.replace(tzinfo=UTC) >= test_start_time
+    assert job.updated_at.replace(tzinfo=UTC) >= test_start_time
 
 @pytest.mark.usefixtures("setup_db")
 @pytest.mark.asyncio

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
@@ -728,7 +728,7 @@ async def test_session_context_manager(db_engine: "AsyncEngine", dask_scheduler_
 
 @pytest.mark.usefixtures("setup_db")
 async def test_job_info_default_time_fields(db_engine: "AsyncEngine", dask_scheduler_address: str):
-    """Test job creation with default parameters."""
+    """Test to ensure that datetime fields in JobInfo are set correctly on job creation and update."""
     from nat.front_ends.fastapi.async_jobs import JobInfo
     from nat.front_ends.fastapi.async_jobs import JobStatus
     from nat.front_ends.fastapi.async_jobs import JobStore

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
@@ -45,7 +45,7 @@ async def failing_job_function() -> None:
     raise ValueError("This job is designed to fail")
 
 
-@pytest.mark.asyncio
+
 async def test_job_store_init_with_engine(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test JobStore initialization with provided database engine."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -56,7 +56,7 @@ async def test_job_store_init_with_engine(db_engine: "AsyncEngine", dask_schedul
     assert job_store._session is not None
 
 
-@pytest.mark.asyncio
+
 async def test_job_store_init_with_db_url(db_url: str, dask_scheduler_address: str):
     """Test JobStore initialization with database URL."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -99,7 +99,6 @@ def test_ensure_job_id_generates_new_id(db_engine: "AsyncEngine", dask_scheduler
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_create_job_default_params(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test job creation with default parameters."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -121,39 +120,6 @@ async def test_create_job_default_params(db_engine: "AsyncEngine", dask_schedule
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
-async def test_job_info_default_time_fields(db_engine: "AsyncEngine", dask_scheduler_address: str):
-    """Test job creation with default parameters."""
-    from nat.front_ends.fastapi.async_jobs import JobInfo
-    from nat.front_ends.fastapi.async_jobs import JobStatus
-    from nat.front_ends.fastapi.async_jobs import JobStore
-
-    job_store = JobStore(scheduler_address=dask_scheduler_address, db_engine=db_engine)
-
-    test_start_time = datetime.now(UTC)
-    job_id = job_store.ensure_job_id(None)
-    job = JobInfo(job_id=job_id, status=JobStatus.SUBMITTED, expiry_seconds=30)
-
-    async with job_store.session() as session:
-        session.add(job)
-
-    job = await job_store.get_job(job_id)
-    assert job.created_at.replace(tzinfo=UTC) > test_start_time
-    assert job.updated_at.replace(tzinfo=UTC) > test_start_time
-
-    # Verify that updated_at changes on status update
-    initial_updated_at = job.updated_at
-    async with job_store.session() as session:
-        job.status = JobStatus.RUNNING
-        session.add(job)
-
-    job = await job_store.get_job(job_id)
-    assert job.status == JobStatus.RUNNING
-    assert job.updated_at > initial_updated_at
-
-
-@pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_create_job_with_params(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test job creation with custom parameters."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -175,7 +141,6 @@ async def test_create_job_with_params(db_engine: "AsyncEngine", dask_scheduler_a
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_create_job_clamps_expiry(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test job creation clamps expiry seconds to valid range."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -196,7 +161,6 @@ async def test_create_job_clamps_expiry(db_engine: "AsyncEngine", dask_scheduler
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_submit_job_success(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test successful job submission."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -216,7 +180,6 @@ async def test_submit_job_success(db_engine: "AsyncEngine", dask_scheduler_addre
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_submit_job_with_sync_timeout(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test job submission with sync timeout to get immediate result."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -235,7 +198,6 @@ async def test_submit_job_with_sync_timeout(db_engine: "AsyncEngine", dask_sched
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_submit_job_with_kwargs(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test job submission with keyword arguments."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -256,7 +218,6 @@ async def test_submit_job_with_kwargs(db_engine: "AsyncEngine", dask_scheduler_a
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_update_status_basic(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test basic status update."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -282,7 +243,6 @@ async def test_update_status_basic(db_engine: "AsyncEngine", dask_scheduler_addr
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_update_status_with_error(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test status update with error message."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -302,7 +262,6 @@ async def test_update_status_with_error(db_engine: "AsyncEngine", dask_scheduler
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_update_status_with_pydantic_output(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test status update with Pydantic model output."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -326,7 +285,6 @@ async def test_update_status_with_pydantic_output(db_engine: "AsyncEngine", dask
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_update_status_with_dict_output(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test status update with dictionary output."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -350,7 +308,6 @@ async def test_update_status_with_dict_output(db_engine: "AsyncEngine", dask_sch
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_update_status_nonexistent_job(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test updating status of non-existent job raises error."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -363,7 +320,6 @@ async def test_update_status_nonexistent_job(db_engine: "AsyncEngine", dask_sche
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_job_existing(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test getting an existing job."""
     from nat.front_ends.fastapi.async_jobs import JobInfo
@@ -380,7 +336,6 @@ async def test_get_job_existing(db_engine: "AsyncEngine", dask_scheduler_address
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_job_nonexistent(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test getting a non-existent job returns None."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -392,7 +347,6 @@ async def test_get_job_nonexistent(db_engine: "AsyncEngine", dask_scheduler_addr
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_status_existing(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test getting status of an existing job."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -407,7 +361,6 @@ async def test_get_status_existing(db_engine: "AsyncEngine", dask_scheduler_addr
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_status_nonexistent(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test getting status of non-existent job returns NOT_FOUND."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -420,7 +373,6 @@ async def test_get_status_nonexistent(db_engine: "AsyncEngine", dask_scheduler_a
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_all_jobs_empty(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test getting all jobs when database is empty."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -432,7 +384,6 @@ async def test_get_all_jobs_empty(db_engine: "AsyncEngine", dask_scheduler_addre
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_all_jobs_multiple(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test getting all jobs with multiple jobs in database."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -452,7 +403,6 @@ async def test_get_all_jobs_multiple(db_engine: "AsyncEngine", dask_scheduler_ad
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_last_job_empty(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test getting last job when database is empty."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -464,7 +414,6 @@ async def test_get_last_job_empty(db_engine: "AsyncEngine", dask_scheduler_addre
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_last_job_multiple(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test getting last job with multiple jobs in database."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -484,7 +433,6 @@ async def test_get_last_job_multiple(db_engine: "AsyncEngine", dask_scheduler_ad
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_jobs_by_status(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test filtering jobs by status."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -519,7 +467,6 @@ async def test_get_jobs_by_status(db_engine: "AsyncEngine", dask_scheduler_addre
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_expires_at_active_job(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test get_expires_at for active jobs returns None."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -545,7 +492,6 @@ async def test_get_expires_at_active_job(db_engine: "AsyncEngine", dask_schedule
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_get_expires_at_finished_job(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test get_expires_at for finished jobs returns correct expiry time."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -574,7 +520,6 @@ async def test_get_expires_at_finished_job(db_engine: "AsyncEngine", dask_schedu
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_cleanup_expired_jobs_no_expired(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test cleanup when no jobs are expired."""
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -603,7 +548,6 @@ async def test_cleanup_expired_jobs_no_expired(db_engine: "AsyncEngine", dask_sc
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_cleanup_expired_jobs_with_output_files(db_engine: "AsyncEngine",
                                                       dask_scheduler_address: str,
                                                       tmp_path: Path,
@@ -657,7 +601,6 @@ async def test_cleanup_expired_jobs_with_output_files(db_engine: "AsyncEngine",
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_cleanup_expired_jobs_keeps_active(db_engine: "AsyncEngine",
                                                  dask_scheduler_address: str,
                                                  monkeypatch: pytest.MonkeyPatch):
@@ -769,7 +712,6 @@ def test_job_store_dask_client_property(dask_client: "DaskClient",
 
 
 @pytest.mark.usefixtures("setup_db")
-@pytest.mark.asyncio
 async def test_session_context_manager(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test the session context manager works correctly."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -782,3 +724,34 @@ async def test_session_context_manager(db_engine: "AsyncEngine", dask_scheduler_
         from sqlalchemy import text
         result = await session.execute(text("SELECT 1"))
         assert result is not None
+
+
+@pytest.mark.usefixtures("setup_db")
+async def test_job_info_default_time_fields(db_engine: "AsyncEngine", dask_scheduler_address: str):
+    """Test job creation with default parameters."""
+    from nat.front_ends.fastapi.async_jobs import JobInfo
+    from nat.front_ends.fastapi.async_jobs import JobStatus
+    from nat.front_ends.fastapi.async_jobs import JobStore
+
+    job_store = JobStore(scheduler_address=dask_scheduler_address, db_engine=db_engine)
+
+    test_start_time = datetime.now(UTC)
+    job_id = job_store.ensure_job_id(None)
+    job = JobInfo(job_id=job_id, status=JobStatus.SUBMITTED, expiry_seconds=30)
+
+    async with job_store.session() as session:
+        session.add(job)
+
+    job = await job_store.get_job(job_id)
+    assert job.created_at.replace(tzinfo=UTC) > test_start_time
+    assert job.updated_at.replace(tzinfo=UTC) > test_start_time
+
+    # Verify that updated_at changes on status update
+    initial_updated_at = job.updated_at
+    async with job_store.session() as session:
+        job.status = JobStatus.RUNNING
+        session.add(job)
+
+    job = await job_store.get_job(job_id)
+    assert job.status == JobStatus.RUNNING
+    assert job.updated_at > initial_updated_at

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
@@ -121,7 +121,7 @@ async def test_create_job_default_params(db_engine: "AsyncEngine", dask_schedule
 
 @pytest.mark.usefixtures("setup_db")
 @pytest.mark.asyncio
-async def test_job_info_default_params(db_engine: "AsyncEngine", dask_scheduler_address: str):
+async def test_job_info_default_time_fields(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test job creation with default parameters."""
     from nat.front_ends.fastapi.async_jobs import JobInfo
     from nat.front_ends.fastapi.async_jobs import JobStatus
@@ -139,8 +139,18 @@ async def test_job_info_default_params(db_engine: "AsyncEngine", dask_scheduler_
         session.add(job)
 
     job = await job_store.get_job(job_id)
-    assert job.created_at.replace(tzinfo=UTC) >= test_start_time
-    assert job.updated_at.replace(tzinfo=UTC) >= test_start_time
+    assert job.created_at.replace(tzinfo=UTC) > test_start_time
+    assert job.updated_at.replace(tzinfo=UTC) > test_start_time
+
+    # Verify that updated_at changes on status update
+    initial_updated_at = job.updated_at
+    async with job_store.session() as session:
+        job.status = JobStatus.RUNNING
+        session.add(job)
+    
+    job = await job_store.get_job(job_id)
+    assert job.status == JobStatus.RUNNING
+    assert job.updated_at > initial_updated_at
 
 @pytest.mark.usefixtures("setup_db")
 @pytest.mark.asyncio

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
@@ -17,9 +17,9 @@ import asyncio
 import json
 import os
 import typing
+from datetime import UTC
 from datetime import datetime
 from datetime import timedelta
-from datetime import UTC
 from pathlib import Path
 
 import pytest
@@ -119,6 +119,7 @@ async def test_create_job_default_params(db_engine: "AsyncEngine", dask_schedule
     assert job.expiry_seconds == JobStore.DEFAULT_EXPIRY
     assert job.is_expired is False
 
+
 @pytest.mark.usefixtures("setup_db")
 @pytest.mark.asyncio
 async def test_job_info_default_time_fields(db_engine: "AsyncEngine", dask_scheduler_address: str):
@@ -131,9 +132,7 @@ async def test_job_info_default_time_fields(db_engine: "AsyncEngine", dask_sched
 
     test_start_time = datetime.now(UTC)
     job_id = job_store.ensure_job_id(None)
-    job = JobInfo(job_id=job_id,
-                  status=JobStatus.SUBMITTED,
-                  expiry_seconds=30)
+    job = JobInfo(job_id=job_id, status=JobStatus.SUBMITTED, expiry_seconds=30)
 
     async with job_store.session() as session:
         session.add(job)
@@ -147,10 +146,11 @@ async def test_job_info_default_time_fields(db_engine: "AsyncEngine", dask_sched
     async with job_store.session() as session:
         job.status = JobStatus.RUNNING
         session.add(job)
-    
+
     job = await job_store.get_job(job_id)
     assert job.status == JobStatus.RUNNING
     assert job.updated_at > initial_updated_at
+
 
 @pytest.mark.usefixtures("setup_db")
 @pytest.mark.asyncio

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
@@ -45,7 +45,6 @@ async def failing_job_function() -> None:
     raise ValueError("This job is designed to fail")
 
 
-
 async def test_job_store_init_with_engine(db_engine: "AsyncEngine", dask_scheduler_address: str):
     """Test JobStore initialization with provided database engine."""
     from nat.front_ends.fastapi.async_jobs import JobStore
@@ -54,7 +53,6 @@ async def test_job_store_init_with_engine(db_engine: "AsyncEngine", dask_schedul
 
     assert job_store._scheduler_address == dask_scheduler_address
     assert job_store._session is not None
-
 
 
 async def test_job_store_init_with_db_url(db_url: str, dask_scheduler_address: str):


### PR DESCRIPTION
## Description
* Fixes a bug where `default=datetime.now(UTC)` was being evaluated at Python parse time. Anytime that a `JobInfo` object was updated and an explicit value wasn't being set for the `updated_at` field, the default was used.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Job timestamps are now computed at creation/update so created_at and updated_at reflect actual event times.

* **Tests**
  * Added tests verifying timestamps on creation and that updated_at advances after status changes; test suite updated for async handling and timezone normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->