### PR TITLE
add targeted MCP OAuth2 diagnostics for redirect URI mismatches

### DIFF
--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_flow_handler.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_flow_handler.py
@@ -17,6 +17,8 @@ import asyncio
 import logging
 import secrets
 import webbrowser
+from urllib.parse import parse_qs
+from urllib.parse import urlparse
 
 import pkce
 from authlib.integrations.httpx_client import AsyncOAuth2Client
@@ -92,7 +94,6 @@ class MCPAuthenticationFlowHandler(ConsoleAuthenticationFlowHandler):
         logger.info("Starting MCP OAuth2 authorization code flow")
 
         # Extract and validate host and port from redirect_uri for callback server
-        from urllib.parse import urlparse
         parsed_uri = urlparse(str(cfg.redirect_uri))
 
         # Validate scheme/host and choose a safe non-privileged bind port
@@ -133,12 +134,29 @@ class MCPAuthenticationFlowHandler(ConsoleAuthenticationFlowHandler):
             flow_state.challenge = challenge
             logger.debug("PKCE enabled for MCP authentication")
 
+        logger.debug("MCP OAuth authorize URL input: authorization_url=%s redirect_uri=%s",
+                     cfg.authorization_url,
+                     cfg.redirect_uri)
         auth_url, _ = client.create_authorization_url(
             cfg.authorization_url,
             state=state,
             code_verifier=flow_state.verifier if cfg.use_pkce else None,
             code_challenge=flow_state.challenge if cfg.use_pkce else None,
             **(cfg.authorization_kwargs or {})
+        )
+        parsed_auth_url = urlparse(auth_url)
+        parsed_auth_params = parse_qs(parsed_auth_url.query)
+        logger.debug(
+            "MCP OAuth authorize URL params: endpoint=%s://%s%s client_id=%s redirect_uri=%s scope=%s resource=%s "
+            "state_prefix=%s",
+            parsed_auth_url.scheme,
+            parsed_auth_url.netloc,
+            parsed_auth_url.path,
+            parsed_auth_params.get("client_id", [None])[0],
+            parsed_auth_params.get("redirect_uri", [None])[0],
+            parsed_auth_params.get("scope", [None])[0],
+            parsed_auth_params.get("resource", [None])[0],
+            state[:8],
         )
 
         async with self._server_lock:

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider.py
@@ -258,6 +258,14 @@ class DynamicClientRegistration:
             client_name=self.config.client_name or None,
         )
         payload = metadata.model_dump(by_alias=True, mode="json", exclude_none=True)
+        logger.debug(
+            "MCP DCR request: registration_url=%s server_url=%s redirect_uri=%s scopes=%s auth_method=%s",
+            registration_url,
+            self.config.server_url,
+            self.config.redirect_uri,
+            scopes,
+            getattr(self.config, "token_endpoint_auth_method", None) or "client_secret_post",
+        )
 
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.post(
@@ -279,6 +287,18 @@ class DynamicClientRegistration:
         if not info.client_id:
             raise RuntimeError("No client_id received from registration")
 
+        returned_redirect_uris = getattr(info, "redirect_uris", None)
+        returned_redirect_uris_str = ([str(uri) for uri in returned_redirect_uris] if returned_redirect_uris else None)
+        logger.debug("MCP DCR response: client_id=%s returned_redirect_uris=%s",
+                     info.client_id,
+                     returned_redirect_uris_str)
+        if returned_redirect_uris_str and str(self.config.redirect_uri) not in returned_redirect_uris_str:
+            logger.warning(
+                "MCP DCR redirect mismatch: requested_redirect_uri=%s returned_redirect_uris=%s client_id=%s",
+                self.config.redirect_uri,
+                returned_redirect_uris_str,
+                info.client_id,
+            )
         logger.info("Successfully registered OAuth2 client: %s", info.client_id)
         return OAuth2Credentials(client_id=info.client_id, client_secret=info.client_secret)
 
@@ -420,6 +440,15 @@ class MCPOAuth2Provider(AuthProviderBase[MCPOAuth2ProviderConfig]):
                 scopes=scopes,
                 use_pkce=bool(self.config.use_pkce),
                 authorization_kwargs={"resource": str(self.config.server_url)})
+            logger.debug(
+                "MCP OAuth authorize request inputs: authorization_url=%s client_id=%s redirect_uri=%s "
+                "resource=%s scopes=%s",
+                oauth2_config.authorization_url,
+                oauth2_config.client_id,
+                oauth2_config.redirect_uri,
+                oauth2_config.authorization_kwargs.get("resource") if oauth2_config.authorization_kwargs else None,
+                oauth2_config.scopes,
+            )
             self._auth_code_provider = OAuth2AuthCodeFlowProvider(oauth2_config, token_storage=self._token_storage)
 
             # Use MCP-specific authentication method if available

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider.py
@@ -289,9 +289,9 @@ class DynamicClientRegistration:
 
         returned_redirect_uris = getattr(info, "redirect_uris", None)
         returned_redirect_uris_str = ([str(uri) for uri in returned_redirect_uris] if returned_redirect_uris else None)
-        logger.debug("MCP DCR response: client_id=%s returned_redirect_uris=%s",
-                     info.client_id,
-                     returned_redirect_uris_str)
+        logger.info("MCP DCR response: client_id=%s returned_redirect_uris=%s",
+                    info.client_id,
+                    returned_redirect_uris_str)
         if returned_redirect_uris_str and str(self.config.redirect_uri) not in returned_redirect_uris_str:
             logger.warning(
                 "MCP DCR redirect mismatch: requested_redirect_uri=%s returned_redirect_uris=%s client_id=%s",
@@ -440,7 +440,7 @@ class MCPOAuth2Provider(AuthProviderBase[MCPOAuth2ProviderConfig]):
                 scopes=scopes,
                 use_pkce=bool(self.config.use_pkce),
                 authorization_kwargs={"resource": str(self.config.server_url)})
-            logger.debug(
+            logger.info(
                 "MCP OAuth authorize request inputs: authorization_url=%s client_id=%s redirect_uri=%s "
                 "resource=%s scopes=%s",
                 oauth2_config.authorization_url,


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Added focused auth logging in MCP OAuth flows to make redirect registration failures diagnosable without exposing secrets. This captures DCR request/response context (including normalized returned redirect URIs), authorize-request inputs, and callback bind details; true redirect mismatches remain warning while forensic details are logged at debug.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved debugging across OAuth flows with structured logging of authorization URL components and registration responses.
  * Added validation and warnings for redirect URI mismatches and clearer logging of client registration and authorization inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->