### PR TITLE
Fix: Exclude verify_ssl from ChatNVIDIA model_dump to prevent Azure rejection

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -195,10 +195,9 @@ async def nim_langchain(llm_config: NIMModelConfig, _builder: Builder):
         pass
 
     # prefer max_completion_tokens over max_tokens
-    # verify_ssl is a supported keyword parameter for the ChatNVIDIA client
     client = ChatNVIDIA(
         **llm_config.model_dump(
-            exclude={"type", "max_tokens", "thinking", "api_type"},
+            exclude={"type", "max_tokens", "thinking", "api_type", "verify_ssl"},
             by_alias=True,
             exclude_none=True,
             exclude_unset=True,

--- a/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
+++ b/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
@@ -74,13 +74,13 @@ class TestNimLangChain:
 
     @pytest.mark.parametrize("verify_ssl", [True, False], ids=["verify_ssl_true", "verify_ssl_false"])
     @patch("langchain_nvidia_ai_endpoints.ChatNVIDIA")
-    async def test_verify_ssl_passed_to_chat_nvidia(self, mock_chat, nim_cfg, mock_builder, verify_ssl):
-        """Test that verify_ssl is passed to ChatNVIDIA."""
+    async def test_verify_ssl_excluded_from_chat_nvidia(self, mock_chat, nim_cfg, mock_builder, verify_ssl):
+        """Test that verify_ssl is excluded from ChatNVIDIA kwargs to prevent Azure rejection."""
         nim_cfg.verify_ssl = verify_ssl
         async with nim_langchain(nim_cfg, mock_builder):
             pass
         mock_chat.assert_called_once()
-        assert mock_chat.call_args.kwargs["verify_ssl"] is verify_ssl
+        assert "verify_ssl" not in mock_chat.call_args.kwargs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Description
The NIM langchain client passes all config fields to ChatNVIDIA via model_dump(), but verify_ssl is not excluded. When the model routes through Azure (e.g. azure/openai/gpt-4o-mini), ChatNVIDIA forwards verify_ssl as a request argument to litellm, which sends it to Azure. Azure rejects it with "Unrecognized request argument supplied: verify_ssl".

The fix adds verify_ssl to the exclude set, matching the pattern already used by the azure_openai_langchain and openai_langchain clients.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed SSL verification handling in the LangChain integration: the SSL flag is no longer forwarded unexpectedly during client construction, preventing unintended SSL configuration from being applied. Updated tests to reflect the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->