### PR TITLE
fix(a2a): reject non-localhost bind without server_auth by default

### DIFF
--- a/packages/nvidia_nat_a2a/src/nat/plugins/a2a/server/front_end_config.py
+++ b/packages/nvidia_nat_a2a/src/nat/plugins/a2a/server/front_end_config.py
@@ -121,17 +121,46 @@ class A2AFrontEndConfig(FrontEndBaseConfig, name="a2a"):
                      "opaque token validation (via RFC 7662 introspection)."),
     )
 
+    # Explicit acknowledgement required to bind to a non-localhost interface without server_auth.
+    # Default is False: the validator below will reject the config rather than silently warning
+    # and proceeding. Operators who intentionally run A2A on a non-localhost interface behind
+    # an external auth layer (ingress, service mesh, network policy) can set this to True to
+    # override the check.
+    allow_unauthenticated_network_bind: bool = Field(
+        default=False,
+        description=("Explicit acknowledgement to allow binding to a non-localhost interface without "
+                     "server_auth configured. Required when host is not localhost/127.0.0.1/::1 and "
+                     "server_auth is None. Set this only when an external authentication layer "
+                     "(ingress, service mesh, mTLS, network policy) protects the A2A endpoint. "
+                     "Default: False (reject the config to prevent accidental unauthenticated exposure)."),
+    )
+
     @model_validator(mode="after")
     def validate_security_configuration(self):
-        """Validate security configuration to prevent accidental misconfigurations."""
-        # Check if server is bound to a non-localhost interface without authentication
+        """Validate security configuration to prevent accidental misconfigurations.
+
+        Reject any configuration that binds the A2A server to a non-localhost interface
+        without either (a) server_auth configured or (b) an explicit
+        allow_unauthenticated_network_bind acknowledgement. The previous behavior of
+        warn-and-proceed meant a single misconfiguration could silently expose an
+        unauthenticated A2A endpoint on the network. CWE-306.
+        """
         localhost_hosts = {"localhost", "127.0.0.1", "::1"}
         if self.host not in localhost_hosts and self.server_auth is None:
+            if not self.allow_unauthenticated_network_bind:
+                raise ValueError(
+                    f"A2A server is configured to bind to '{self.host}' without authentication. "
+                    "This would expose the server to unauthenticated network access. "
+                    "Fix one of the following:\n"
+                    "  (1) Bind to 'localhost', '127.0.0.1', or '::1' for local-only access.\n"
+                    "  (2) Configure 'server_auth' with OAuth2 token verification.\n"
+                    "  (3) If an external auth layer (ingress, service mesh, mTLS, network policy) "
+                    "protects this endpoint, set 'allow_unauthenticated_network_bind: true' to "
+                    "explicitly acknowledge the configuration.")
             logger.warning(
-                "A2A server is configured to bind to '%s' without authentication. "
-                "This may expose your server to unauthorized access. "
-                "Consider either: (1) binding to localhost for local-only access, "
-                "or (2) configuring server_auth for production deployments on public interfaces.",
+                "A2A server is bound to '%s' without server_auth; relying on "
+                "'allow_unauthenticated_network_bind=True'. Ensure an external authentication "
+                "layer is in place.",
                 self.host,
             )
 

--- a/packages/nvidia_nat_a2a/tests/server/test_agent_card_generation.py
+++ b/packages/nvidia_nat_a2a/tests/server/test_agent_card_generation.py
@@ -117,6 +117,9 @@ class TestAgentCardGeneration:
             port=10000,
             public_base_url="https://agents.example.com/calculator",
             version="1.0.0",
+            # Required for non-localhost bind without server_auth (see
+            # validate_security_configuration in front_end_config.py).
+            allow_unauthenticated_network_bind=True,
         )))
         worker = A2AFrontEndPluginWorker(config)
         agent_card = await worker.create_agent_card(mock_workflow_with_functions)

--- a/packages/nvidia_nat_a2a/tests/server/test_front_end_config_security.py
+++ b/packages/nvidia_nat_a2a/tests/server/test_front_end_config_security.py
@@ -1,0 +1,63 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for A2A front-end security configuration validation.
+
+Covers the validator that rejects non-localhost binds without server_auth
+unless the operator sets allow_unauthenticated_network_bind explicitly.
+CWE-306 defense.
+"""
+
+import pytest
+from pydantic import ValidationError
+
+from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
+
+
+class TestNonLocalhostBindRequiresAuth:
+    """Validator must reject binding to a non-localhost host without authentication."""
+
+    @pytest.mark.parametrize("host", ["localhost", "127.0.0.1", "::1"])
+    def test_localhost_bind_without_auth_is_allowed(self, host):
+        """Localhost binds don't need server_auth — loopback is not network-accessible."""
+        cfg = A2AFrontEndConfig(host=host)
+        assert cfg.host == host
+        assert cfg.server_auth is None
+
+    def test_non_localhost_bind_without_auth_is_rejected(self):
+        """0.0.0.0 (or any non-loopback) without server_auth must fail validation."""
+        with pytest.raises(ValidationError) as exc_info:
+            A2AFrontEndConfig(host="0.0.0.0")
+        assert "without authentication" in str(exc_info.value)
+
+    def test_non_localhost_bind_rejects_named_host(self):
+        """A named host like 'agent.example.com' without server_auth also fails."""
+        with pytest.raises(ValidationError) as exc_info:
+            A2AFrontEndConfig(host="agent.example.com")
+        assert "without authentication" in str(exc_info.value)
+
+    def test_non_localhost_bind_allowed_with_explicit_ack(self):
+        """Operators who run behind an external auth layer can opt in explicitly."""
+        cfg = A2AFrontEndConfig(
+            host="0.0.0.0",
+            allow_unauthenticated_network_bind=True,
+        )
+        assert cfg.host == "0.0.0.0"
+        assert cfg.allow_unauthenticated_network_bind is True
+        assert cfg.server_auth is None
+
+    def test_allow_unauthenticated_network_bind_defaults_false(self):
+        """The opt-in acknowledgement must be off by default."""
+        cfg = A2AFrontEndConfig(host="localhost")
+        assert cfg.allow_unauthenticated_network_bind is False

--- a/packages/nvidia_nat_a2a/tests/server/test_front_end_config_security.py
+++ b/packages/nvidia_nat_a2a/tests/server/test_front_end_config_security.py
@@ -57,6 +57,21 @@ class TestNonLocalhostBindRequiresAuth:
         assert cfg.allow_unauthenticated_network_bind is True
         assert cfg.server_auth is None
 
+    def test_non_localhost_bind_allowed_with_server_auth(self):
+        """The primary intended path: non-localhost bind + configured server_auth = OK.
+
+        Closes the authenticated branch of the validator matrix — if someone
+        accidentally tightens the validator to reject server_auth too, this
+        test catches it.
+        """
+        from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
+        oauth = OAuth2ResourceServerConfig(issuer_url="https://auth.example.com")
+        cfg = A2AFrontEndConfig(host="0.0.0.0", server_auth=oauth)
+        assert cfg.host == "0.0.0.0"
+        assert cfg.server_auth is oauth
+        # The opt-in flag should NOT be needed when server_auth is present.
+        assert cfg.allow_unauthenticated_network_bind is False
+
     def test_allow_unauthenticated_network_bind_defaults_false(self):
         """The opt-in acknowledgement must be off by default."""
         cfg = A2AFrontEndConfig(host="localhost")

--- a/packages/nvidia_nat_a2a/tests/server/test_front_end_config_security.py
+++ b/packages/nvidia_nat_a2a/tests/server/test_front_end_config_security.py
@@ -19,10 +19,20 @@ unless the operator sets allow_unauthenticated_network_bind explicitly.
 CWE-306 defense.
 """
 
+import logging
+
 import pytest
 from pydantic import ValidationError
 
 from nat.plugins.a2a.server.front_end_config import A2AFrontEndConfig
+
+# Bind addresses are meaningful in these tests, not accidental. A single
+# module-level constant documents that intent and keeps Bandit's S104
+# (bind all interfaces) suppression localized to one place — the test
+# exists precisely to verify the behavior of binding "0.0.0.0" under
+# various auth configurations.
+WILDCARD_BIND = "0.0.0.0"  # noqa: S104
+NAMED_HOST_BIND = "agent.example.com"
 
 
 class TestNonLocalhostBindRequiresAuth:
@@ -38,24 +48,34 @@ class TestNonLocalhostBindRequiresAuth:
     def test_non_localhost_bind_without_auth_is_rejected(self):
         """0.0.0.0 (or any non-loopback) without server_auth must fail validation."""
         with pytest.raises(ValidationError) as exc_info:
-            A2AFrontEndConfig(host="0.0.0.0")
+            A2AFrontEndConfig(host=WILDCARD_BIND)
         assert "without authentication" in str(exc_info.value)
 
     def test_non_localhost_bind_rejects_named_host(self):
         """A named host like 'agent.example.com' without server_auth also fails."""
         with pytest.raises(ValidationError) as exc_info:
-            A2AFrontEndConfig(host="agent.example.com")
+            A2AFrontEndConfig(host=NAMED_HOST_BIND)
         assert "without authentication" in str(exc_info.value)
 
-    def test_non_localhost_bind_allowed_with_explicit_ack(self):
-        """Operators who run behind an external auth layer can opt in explicitly."""
-        cfg = A2AFrontEndConfig(
-            host="0.0.0.0",
-            allow_unauthenticated_network_bind=True,
-        )
-        assert cfg.host == "0.0.0.0"
+    def test_non_localhost_bind_allowed_with_explicit_ack(self, caplog):
+        """Operators who run behind an external auth layer can opt in explicitly.
+
+        This path must also emit a WARNING so operations teams still see the
+        event in logs even though the config was intentional.
+        """
+        with caplog.at_level(logging.WARNING, logger="nat.plugins.a2a.server.front_end_config"):
+            cfg = A2AFrontEndConfig(
+                host=WILDCARD_BIND,
+                allow_unauthenticated_network_bind=True,
+            )
+        assert cfg.host == WILDCARD_BIND
         assert cfg.allow_unauthenticated_network_bind is True
         assert cfg.server_auth is None
+        # The validator must emit a warning when the opt-in is exercised so
+        # operations still sees the event in logs.
+        combined = caplog.text
+        assert WILDCARD_BIND in combined
+        assert "allow_unauthenticated_network_bind" in combined
 
     def test_non_localhost_bind_allowed_with_server_auth(self):
         """The primary intended path: non-localhost bind + configured server_auth = OK.
@@ -66,8 +86,8 @@ class TestNonLocalhostBindRequiresAuth:
         """
         from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
         oauth = OAuth2ResourceServerConfig(issuer_url="https://auth.example.com")
-        cfg = A2AFrontEndConfig(host="0.0.0.0", server_auth=oauth)
-        assert cfg.host == "0.0.0.0"
+        cfg = A2AFrontEndConfig(host=WILDCARD_BIND, server_auth=oauth)
+        assert cfg.host == WILDCARD_BIND
         assert cfg.server_auth is oauth
         # The opt-in flag should NOT be needed when server_auth is present.
         assert cfg.allow_unauthenticated_network_bind is False


### PR DESCRIPTION
## Summary
\`A2AFrontEndConfig.validate_security_configuration\` previously **warned but proceeded** when \`host\` was non-localhost and \`server_auth\` was \`None\`. A warning is easy to miss in production and the resulting deployment exposes an unauthenticated A2A endpoint to the network.

Promote the check from a log warning to a validator error. Operators who legitimately run A2A behind an external auth layer (ingress, service mesh, mTLS, network policy) can opt in with a new \`allow_unauthenticated_network_bind: bool\` field, which defaults to \`False\`.

## CWE
CWE-306 — Missing Authentication for Critical Function

## Behavior change matrix

| host                     | server_auth | allow_unauthenticated_network_bind | result       |
|--------------------------|-------------|------------------------------------|--------------|
| localhost/127.0.0.1/::1  | any         | any                                | ✅ allow     |
| non-localhost            | configured  | any                                | ✅ allow     |
| non-localhost            | None        | \`True\`                           | ✅ allow + warn |
| non-localhost            | None        | \`False\` (default)                | ❌ reject    |

## Why this matters
LLM-driven agent endpoints exposed without authentication are a common mistake and a high-consequence one — any caller can invoke the agent, consume resources, and trigger downstream tool calls. Making the insecure case require an explicit acknowledgement turns the deployment-time misconfiguration from silent into loud.

## Escape hatch
Deployments that *do* have authentication out-of-process (Istio, nginx-ingress with OAuth2 proxy, mTLS, cluster-local-only service, etc.) can set:

\`\`\`yaml
front_end:
  _type: a2a
  host: 0.0.0.0
  allow_unauthenticated_network_bind: true
\`\`\`

## Files changed
- \`packages/nvidia_nat_a2a/src/nat/plugins/a2a/server/front_end_config.py\` — add \`allow_unauthenticated_network_bind\` field; validator now raises \`ValueError\` when misconfigured
- \`packages/nvidia_nat_a2a/tests/server/test_front_end_config_security.py\` — new regression tests for all four rows of the matrix above
- \`packages/nvidia_nat_a2a/tests/server/test_agent_card_generation.py\` — update the existing 0.0.0.0 public-URL test to set the new flag so coverage keeps passing

## Test plan
- [x] \`localhost\`, \`127.0.0.1\`, \`::1\` without auth: allowed (parametrized test)
- [x] \`0.0.0.0\` without auth, no opt-in: rejected with clear error message
- [x] named host without auth, no opt-in: rejected
- [x] \`0.0.0.0\` without auth, \`allow_unauthenticated_network_bind=True\`: allowed + warning logged
- [x] Existing \`test_agent_card_url_uses_public_base_url_when_configured\` updated to set the flag
- [x] Syntax-checked (couldn't run pytest locally — my env is missing \`pytest-asyncio\`; CI will run it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Strengthened network-binding validation: non-localhost hosts now require authentication unless explicitly allowed; misconfigurations that previously only warned are rejected by default.

* **New Features**
  * Added an opt-in flag to permit unauthenticated network binding (default: false); enabling it permits non-localhost binds without auth and is logged.

* **Tests**
  * Added tests covering localhost vs non-localhost binding, opt-in behavior, logging, and validation error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->