### PR TITLE
fix(fastapi): reject CORS wildcard origin combined with allow_credentials

### DIFF
--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_config.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_config.py
@@ -24,6 +24,7 @@ from pydantic import BaseModel
 from pydantic import Field
 from pydantic import SerializeAsAny
 from pydantic import field_validator
+from pydantic import model_validator
 
 from nat.data_models.component_ref import ObjectStoreRef
 from nat.data_models.evaluator import EvalInputItem
@@ -217,6 +218,36 @@ class FastApiFrontEndConfig(FrontEndBaseConfig, name="fastapi"):
             default=600,
             description="Sets a maximum time in seconds for browsers to cache CORS responses.",
         )
+
+        @model_validator(mode="after")
+        def _reject_wildcard_origin_with_credentials(self):
+            """Reject configs that pair wildcard origins with credentials.
+
+            Per the CORS spec (Fetch §3.2, MDN CORS), a response cannot set
+            Access-Control-Allow-Origin: * while Access-Control-Allow-Credentials
+            is true — browsers refuse such responses. Accepting the combination
+            in the config silently produces a server that looks permissive but
+            is broken in every browser, AND signals operator intent that would
+            be genuinely unsafe if the browser check were ever bypassed
+            (CVE-class misconfiguration). Fail fast with a clear error.
+
+            CWE-942 — Permissive Cross-domain Policy with Untrusted Domains.
+            """
+            if self.allow_credentials:
+                if self.allow_origins and "*" in self.allow_origins:
+                    raise ValueError(
+                        "CORS misconfiguration: 'allow_credentials=True' cannot be combined with "
+                        "'allow_origins=[\"*\"]'. Per the CORS spec, browsers reject responses that "
+                        "set Access-Control-Allow-Origin: * when credentials are allowed. "
+                        "Specify an explicit list of trusted origins (e.g. ['https://app.example.com']) "
+                        "or disable credentials.")
+                if self.allow_origin_regex and self.allow_origin_regex.strip() in (".*", ".+", "^.*$", "^.+$"):
+                    raise ValueError(
+                        "CORS misconfiguration: 'allow_credentials=True' cannot be combined with a "
+                        "match-everything 'allow_origin_regex' ({!r}). Use an explicit regex that "
+                        "matches only trusted origins (e.g. r'^https://(app|admin)\\.example\\.com$') "
+                        "or disable credentials.".format(self.allow_origin_regex))
+            return self
 
     root_path: str = Field(default="", description="The root path for the API")
     host: str = Field(default="localhost", description="Host to bind the server to")

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_fastapi_front_end_config.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_fastapi_front_end_config.py
@@ -141,3 +141,63 @@ def test_fast_api_front_end_config(config_kwargs: dict):
         assert isinstance(model.use_gunicorn, bool)
         assert (isinstance(model.runner_class, str) or model.runner_class is None)
         assert (isinstance(model.object_store, str) or model.object_store is None)
+
+
+class TestCorsWildcardCredentialsValidator:
+    """The CORS validator must reject wildcard origin combined with credentials."""
+
+    def test_wildcard_origin_with_credentials_is_rejected(self):
+        """allow_origins=['*'] + allow_credentials=True must fail validation.
+
+        Per the CORS spec, browsers reject this combination. Accepting it in
+        config silently produces a server that looks permissive but is broken
+        in every browser, and signals operator intent that would be genuinely
+        unsafe if the browser check were bypassed. CWE-942.
+        """
+        with pytest.raises(ValueError, match="cannot be combined"):
+            FastApiFrontEndConfig.CrossOriginResourceSharing(
+                allow_origins=["*"],
+                allow_credentials=True,
+            )
+
+    def test_wildcard_origin_without_credentials_is_allowed(self):
+        """Wildcard origin alone (no credentials) is a valid CORS config."""
+        cors = FastApiFrontEndConfig.CrossOriginResourceSharing(
+            allow_origins=["*"],
+            allow_credentials=False,
+        )
+        assert cors.allow_origins == ["*"]
+        assert cors.allow_credentials is False
+
+    def test_explicit_origins_with_credentials_is_allowed(self):
+        """Explicit origin list + credentials is the intended pattern for authenticated CORS."""
+        cors = FastApiFrontEndConfig.CrossOriginResourceSharing(
+            allow_origins=["https://app.example.com"],
+            allow_credentials=True,
+        )
+        assert cors.allow_credentials is True
+
+    @pytest.mark.parametrize("regex", [".*", ".+", "^.*$", "^.+$"])
+    def test_match_everything_regex_with_credentials_is_rejected(self, regex):
+        """A match-everything regex + credentials is the same foot-gun as '*'."""
+        with pytest.raises(ValueError, match="match-everything"):
+            FastApiFrontEndConfig.CrossOriginResourceSharing(
+                allow_origin_regex=regex,
+                allow_credentials=True,
+            )
+
+    def test_specific_regex_with_credentials_is_allowed(self):
+        """A bounded regex that matches specific origins + credentials is allowed."""
+        cors = FastApiFrontEndConfig.CrossOriginResourceSharing(
+            allow_origin_regex=r"^https://(app|admin)\.example\.com$",
+            allow_credentials=True,
+        )
+        assert cors.allow_credentials is True
+
+    def test_wildcard_origin_in_list_with_credentials_is_rejected(self):
+        """Wildcard mixed with explicit origins + credentials also fails."""
+        with pytest.raises(ValueError, match="cannot be combined"):
+            FastApiFrontEndConfig.CrossOriginResourceSharing(
+                allow_origins=["*", "https://app.example.com"],
+                allow_credentials=True,
+            )


### PR DESCRIPTION
## Summary
`FastApiFrontEndConfig.CrossOriginResourceSharing` silently accepted `allow_origins=["*"]` with `allow_credentials=True`. Per the CORS spec (Fetch §3.2, MDN CORS), browsers reject responses that set `Access-Control-Allow-Origin: *` when credentials are allowed — so the combination produces a server that looks permissive but is broken in every browser, and signals operator intent that would be unsafe if the browser check were ever bypassed.

Promote the check to a `model_validator` that rejects the combination at config-load time with an actionable error pointing at the two correct fixes.

## CWE
CWE-942 — Permissive Cross-domain Policy with Untrusted Domains

## Behavior change

| allow_origins | allow_origin_regex | allow_credentials | result |
|---|---|---|---|
| `["*"]` | — | `True` | ❌ rejected |
| `["*", "https://app.ex.com"]` | — | `True` | ❌ rejected |
| `["*"]` | — | `False` | ✅ allowed |
| `["https://app.ex.com"]` | — | `True` | ✅ allowed (intended) |
| — | `.*` / `.+` / `^.*$` / `^.+$` | `True` | ❌ rejected |
| — | `^https://(app\|admin)\.example\.com$` | `True` | ✅ allowed |

## Why this matters
The combination is cheap to misconfigure and carries production risk. Failing fast at config-load time prevents shipping a service that is simultaneously (a) broken in browsers and (b) a vulnerability waiting to surface via any non-browser client that doesn't enforce the browser-side check.

## Files changed
- `packages/nvidia_nat_core/src/nat/front_ends/fastapi/fastapi_front_end_config.py` — add `model_validator` on `CrossOriginResourceSharing`
- `packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_fastapi_front_end_config.py` — new `TestCorsWildcardCredentialsValidator` class

## Test plan
- [x] Wildcard origin + credentials → rejected
- [x] Wildcard origin alone → allowed
- [x] Explicit origin allowlist + credentials → allowed (intended pattern)
- [x] Match-everything regex (`.*`, `.+`, `^.*$`, `^.+$`) + credentials → rejected (parametrized)
- [x] Bounded regex + credentials → allowed
- [x] Mixed wildcard + explicit list + credentials → rejected

Signed-off-by: Colin McDonough <cmcdonough@50words.com>