### PR TITLE
fix(github-files-tool): add optional allowed_repos allowlist

### DIFF
--- a/packages/nvidia_nat_core/src/nat/tool/github_tools.py
+++ b/packages/nvidia_nat_core/src/nat/tool/github_tools.py
@@ -372,6 +372,45 @@ async def github_tool(config: GithubGroupConfig, _builder: Builder):
 
 class GithubFilesGroupConfig(FunctionBaseConfig, name="github_files_tool"):
     timeout: int = Field(default=5, description="Timeout in seconds for HTTP requests")
+    allowed_repos: list[str] | None = Field(
+        default=None,
+        description=(
+            "Optional allowlist of GitHub repositories the tool may fetch from. "
+            "Each entry is either a full 'org/repo' or an 'org/*' wildcard. "
+            "When None (the default), any public GitHub repository is reachable — "
+            "which means a prompt-injected agent can read arbitrary public source "
+            "code (secrets in public forks, private PoC repos, etc.). Operators who "
+            "need a specific scope (e.g., only their own org) should set this to "
+            "['my-org/*'] or an explicit repo list. Matching is case-insensitive."),
+    )
+
+
+def _repo_path_is_allowed(repo_path: str, allowed_repos: list[str] | None) -> bool:
+    """Check whether a repo_path ('org/repo') matches the configured allowlist.
+
+    Returns True if:
+      - allowed_repos is None (no restriction — backward compatible default), or
+      - repo_path matches an explicit 'org/repo' entry (case-insensitive), or
+      - repo_path matches an 'org/*' wildcard entry (case-insensitive).
+
+    Returns False for any malformed entry or non-matching repo_path.
+    """
+    if allowed_repos is None:
+        return True
+    if not repo_path or "/" not in repo_path:
+        return False
+    repo_lower = repo_path.lower()
+    repo_org = repo_lower.split("/", 1)[0]
+    for entry in allowed_repos:
+        if not isinstance(entry, str) or "/" not in entry:
+            continue
+        entry_lower = entry.lower()
+        if entry_lower == repo_lower:
+            return True
+        entry_org, entry_repo = entry_lower.split("/", 1)
+        if entry_repo == "*" and entry_org == repo_org:
+            return True
+    return False
 
 
 @register_function(config_type=GithubFilesGroupConfig)
@@ -420,6 +459,15 @@ async def github_files_tool(config: GithubFilesGroupConfig, _builder: Builder):
                         "or 'https://github.com/org/repo/blob/main/README.md#L409-L417'")
 
             file_metadata = FileMetadata(**match.groupdict())
+
+            # Allowlist check: if the operator has configured `allowed_repos`, refuse
+            # URLs outside that scope. With no allowlist the default stays permissive
+            # for backward compatibility — the description on the config field calls
+            # out the security implication so the operator can decide.
+            if not _repo_path_is_allowed(file_metadata.repo_path, config.allowed_repos):
+                return (f"Repository '{file_metadata.repo_path}' is not in the configured "
+                        "allowed_repos list for this tool. Ask the operator to add it to "
+                        "the github_files_tool configuration if this fetch is expected.")
 
             # The following URL is the raw URL of the file. refs/heads/ always points to the top commit of the branch
             raw_url = f"https://raw.githubusercontent.com/{file_metadata.repo_path}/refs/heads/{file_metadata.file_path}"

--- a/packages/nvidia_nat_core/src/nat/tool/github_tools.py
+++ b/packages/nvidia_nat_core/src/nat/tool/github_tools.py
@@ -385,6 +385,30 @@ class GithubFilesGroupConfig(FunctionBaseConfig, name="github_files_tool"):
     )
 
 
+def _split_org_repo(value: str) -> tuple[str, str] | None:
+    """Split a string into exactly two non-empty 'org' and 'repo' segments.
+
+    Returns None for anything that isn't strictly 'org/repo':
+      - missing '/'  ("NVIDIA")                -> None
+      - trailing '/' ("NVIDIA/")               -> None
+      - leading '/'  ("/repo")                 -> None
+      - extra segments ("NVIDIA/repo/extra")   -> None
+      - empty org or repo                      -> None
+
+    The previous `"/" in repo_path` check accepted all of the above, which
+    let malformed allowlist entries and malformed URLs partially match.
+    """
+    if not isinstance(value, str) or not value:
+        return None
+    parts = value.split("/")
+    if len(parts) != 2:
+        return None
+    org, repo = parts
+    if not org or not repo:
+        return None
+    return org, repo
+
+
 def _repo_path_is_allowed(repo_path: str, allowed_repos: list[str] | None) -> bool:
     """Check whether a repo_path ('org/repo') matches the configured allowlist.
 
@@ -393,22 +417,33 @@ def _repo_path_is_allowed(repo_path: str, allowed_repos: list[str] | None) -> bo
       - repo_path matches an explicit 'org/repo' entry (case-insensitive), or
       - repo_path matches an 'org/*' wildcard entry (case-insensitive).
 
-    Returns False for any malformed entry or non-matching repo_path.
+    Returns False for:
+      - any repo_path that isn't exactly 'org/repo' (two non-empty segments),
+      - any allowlist entry that isn't 'org/repo' or 'org/*' (two non-empty
+        segments with the second optionally '*').
     """
     if allowed_repos is None:
         return True
-    if not repo_path or "/" not in repo_path:
+
+    split = _split_org_repo(repo_path)
+    if split is None:
         return False
-    repo_lower = repo_path.lower()
-    repo_org = repo_lower.split("/", 1)[0]
+    repo_org_lower = split[0].lower()
+    repo_lower = f"{split[0]}/{split[1]}".lower()
+
     for entry in allowed_repos:
-        if not isinstance(entry, str) or "/" not in entry:
+        entry_split = _split_org_repo(entry) if isinstance(entry, str) else None
+        if entry_split is None:
+            # Malformed entry (missing or extra segments, empty parts, etc.)
+            # — ignore rather than accidentally matching.
             continue
-        entry_lower = entry.lower()
-        if entry_lower == repo_lower:
+        entry_org_lower = entry_split[0].lower()
+        entry_repo_lower = entry_split[1].lower()
+        # Exact match: 'org/repo'
+        if f"{entry_org_lower}/{entry_repo_lower}" == repo_lower:
             return True
-        entry_org, entry_repo = entry_lower.split("/", 1)
-        if entry_repo == "*" and entry_org == repo_org:
+        # Wildcard match: 'org/*'
+        if entry_repo_lower == "*" and entry_org_lower == repo_org_lower:
             return True
     return False
 

--- a/packages/nvidia_nat_core/tests/nat/tools/test_github_files_tool_allowlist.py
+++ b/packages/nvidia_nat_core/tests/nat/tools/test_github_files_tool_allowlist.py
@@ -62,15 +62,49 @@ class TestRepoPathAllowlist:
         assert _repo_path_is_allowed("custom-org/my-repo", allowlist) is True
         assert _repo_path_is_allowed("custom-org/OTHER", allowlist) is False
 
-    @pytest.mark.parametrize("bad_entry", ["", "no-slash", None, 123])
+    @pytest.mark.parametrize(
+        "bad_entry",
+        [
+            "",
+            "no-slash",
+            None,
+            123,
+            "/repo",           # empty org
+            "org/",            # empty repo
+            "org/repo/extra",  # three segments
+            "a/b/c/d",         # many segments
+            "//",              # all empty
+            "/",               # single slash, two empty sides
+        ],
+    )
     def test_malformed_allowlist_entries_are_ignored(self, bad_entry):
-        """A junk entry mixed in with valid ones must not short-circuit to True."""
+        """A malformed entry mixed in with valid ones must not short-circuit to True."""
         allowlist = [bad_entry, "NVIDIA/*"]
         assert _repo_path_is_allowed("NVIDIA/toolkit", allowlist) is True
         assert _repo_path_is_allowed("attacker/exfil", allowlist) is False
+        # The bad entry alone should not match anything.
+        assert _repo_path_is_allowed("NVIDIA/toolkit", [bad_entry]) is False
 
-    @pytest.mark.parametrize("bad_path", ["", "orgonly", "/repo", "org/"])
+    @pytest.mark.parametrize(
+        "bad_path",
+        [
+            "",
+            "orgonly",
+            "/repo",
+            "org/",
+            "org/repo/extra",  # previously accepted by the 'contains /' check
+            "a/b/c/d",         # previously accepted by the 'contains /' check
+            "//",
+            "/",
+        ],
+    )
     def test_malformed_repo_path_is_rejected(self, bad_path):
+        """Tighter validation: repo_path must be exactly 'org/repo'.
+
+        The earlier 'contains /' check accepted 'org/repo/extra' and 'org/'
+        as partial matches against allowlist prefixes — a narrow but real
+        scope-widening bug. Now split+segment-count enforces the intent.
+        """
         assert _repo_path_is_allowed(bad_path, ["NVIDIA/*"]) is False
 
     def test_empty_allowlist_blocks_everything(self):

--- a/packages/nvidia_nat_core/tests/nat/tools/test_github_files_tool_allowlist.py
+++ b/packages/nvidia_nat_core/tests/nat/tools/test_github_files_tool_allowlist.py
@@ -12,12 +12,12 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for the github_files_tool allowed_repos allowlist.
+"""Tests for the `github_files_tool` `allowed_repos` allowlist.
 
-Direct unit coverage of the _repo_path_is_allowed helper plus the
-GithubFilesGroupConfig shape. End-to-end test_tool coverage of the get()
-closure is more involved (requires a mock httpx transport) and is out of
-scope for this defensive hardening PR.
+Direct unit coverage of the `_repo_path_is_allowed` helper plus the
+`GithubFilesGroupConfig` shape. End-to-end `test_tool` coverage of the
+`get()` closure is more involved (requires a mock `httpx` transport) and
+is out of scope for this defensive hardening PR.
 """
 
 import pytest
@@ -27,10 +27,10 @@ from nat.tool.github_tools import _repo_path_is_allowed
 
 
 class TestRepoPathAllowlist:
-    """_repo_path_is_allowed should pass with no allowlist and enforce scope when set."""
+    """`_repo_path_is_allowed` should pass with no allowlist and enforce scope when set."""
 
     def test_none_allowlist_permits_everything(self):
-        """Backward compat: allowed_repos=None keeps the current permissive default."""
+        """Backward compat: `allowed_repos=None` keeps the current permissive default."""
         assert _repo_path_is_allowed("NVIDIA/NeMo-Agent-Toolkit", None) is True
         assert _repo_path_is_allowed("any-org/any-repo", None) is True
 
@@ -99,7 +99,7 @@ class TestRepoPathAllowlist:
         ],
     )
     def test_malformed_repo_path_is_rejected(self, bad_path):
-        """Tighter validation: repo_path must be exactly 'org/repo'.
+        """Tighter validation: `repo_path` must be exactly `'org/repo'`.
 
         The earlier 'contains /' check accepted 'org/repo/extra' and 'org/'
         as partial matches against allowlist prefixes — a narrow but real
@@ -114,7 +114,7 @@ class TestRepoPathAllowlist:
 
 
 class TestGithubFilesGroupConfigShape:
-    """Config must expose the allowed_repos field and default it to None."""
+    """Config must expose the `allowed_repos` field and default it to `None`."""
 
     def test_default_allowed_repos_is_none(self):
         cfg = GithubFilesGroupConfig()

--- a/packages/nvidia_nat_core/tests/nat/tools/test_github_files_tool_allowlist.py
+++ b/packages/nvidia_nat_core/tests/nat/tools/test_github_files_tool_allowlist.py
@@ -1,0 +1,99 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the github_files_tool allowed_repos allowlist.
+
+Direct unit coverage of the _repo_path_is_allowed helper plus the
+GithubFilesGroupConfig shape. End-to-end test_tool coverage of the get()
+closure is more involved (requires a mock httpx transport) and is out of
+scope for this defensive hardening PR.
+"""
+
+import pytest
+
+from nat.tool.github_tools import GithubFilesGroupConfig
+from nat.tool.github_tools import _repo_path_is_allowed
+
+
+class TestRepoPathAllowlist:
+    """_repo_path_is_allowed should pass with no allowlist and enforce scope when set."""
+
+    def test_none_allowlist_permits_everything(self):
+        """Backward compat: allowed_repos=None keeps the current permissive default."""
+        assert _repo_path_is_allowed("NVIDIA/NeMo-Agent-Toolkit", None) is True
+        assert _repo_path_is_allowed("any-org/any-repo", None) is True
+
+    @pytest.mark.parametrize(
+        "repo_path,allowlist,expected",
+        [
+            ("NVIDIA/NeMo-Agent-Toolkit", ["NVIDIA/NeMo-Agent-Toolkit"], True),
+            ("NVIDIA/NeMo-Agent-Toolkit", ["NVIDIA/*"], True),
+            ("nvidia/nemo-agent-toolkit", ["NVIDIA/*"], True),
+            ("NVIDIA/Other-Repo", ["NVIDIA/*"], True),
+            ("NVIDIA/Other-Repo", ["NVIDIA/NeMo-Agent-Toolkit"], False),
+            ("attacker/exfil", ["NVIDIA/*"], False),
+            ("attacker/exfil", ["NVIDIA/NeMo-Agent-Toolkit"], False),
+        ],
+    )
+    def test_explicit_and_wildcard_matches(self, repo_path, allowlist, expected):
+        assert _repo_path_is_allowed(repo_path, allowlist) is expected
+
+    def test_case_insensitive_match(self):
+        """Operator can write 'NVIDIA/Repo' and still match the lower-case URL form."""
+        assert _repo_path_is_allowed("nvidia/repo", ["NVIDIA/Repo"]) is True
+        assert _repo_path_is_allowed("NVIDIA/REPO", ["nvidia/repo"]) is True
+
+    def test_multiple_entries_are_or(self):
+        """Any one matching entry is sufficient to allow the repo."""
+        allowlist = ["NVIDIA/*", "apache/spark", "custom-org/my-repo"]
+        assert _repo_path_is_allowed("NVIDIA/x", allowlist) is True
+        assert _repo_path_is_allowed("apache/spark", allowlist) is True
+        assert _repo_path_is_allowed("custom-org/my-repo", allowlist) is True
+        assert _repo_path_is_allowed("custom-org/OTHER", allowlist) is False
+
+    @pytest.mark.parametrize("bad_entry", ["", "no-slash", None, 123])
+    def test_malformed_allowlist_entries_are_ignored(self, bad_entry):
+        """A junk entry mixed in with valid ones must not short-circuit to True."""
+        allowlist = [bad_entry, "NVIDIA/*"]
+        assert _repo_path_is_allowed("NVIDIA/toolkit", allowlist) is True
+        assert _repo_path_is_allowed("attacker/exfil", allowlist) is False
+
+    @pytest.mark.parametrize("bad_path", ["", "orgonly", "/repo", "org/"])
+    def test_malformed_repo_path_is_rejected(self, bad_path):
+        assert _repo_path_is_allowed(bad_path, ["NVIDIA/*"]) is False
+
+    def test_empty_allowlist_blocks_everything(self):
+        """Explicit empty list means 'no repos allowed' — an explicit deny-all."""
+        assert _repo_path_is_allowed("NVIDIA/toolkit", []) is False
+        assert _repo_path_is_allowed("any/any", []) is False
+
+
+class TestGithubFilesGroupConfigShape:
+    """Config must expose the allowed_repos field and default it to None."""
+
+    def test_default_allowed_repos_is_none(self):
+        cfg = GithubFilesGroupConfig()
+        assert cfg.allowed_repos is None
+
+    def test_accepts_explicit_repo_list(self):
+        cfg = GithubFilesGroupConfig(allowed_repos=["NVIDIA/NeMo-Agent-Toolkit"])
+        assert cfg.allowed_repos == ["NVIDIA/NeMo-Agent-Toolkit"]
+
+    def test_accepts_wildcard_entry(self):
+        cfg = GithubFilesGroupConfig(allowed_repos=["NVIDIA/*"])
+        assert cfg.allowed_repos == ["NVIDIA/*"]
+
+    def test_accepts_empty_list_deny_all(self):
+        cfg = GithubFilesGroupConfig(allowed_repos=[])
+        assert cfg.allowed_repos == []


### PR DESCRIPTION
## Summary
\`github_files_tool\` previously accepted any URL matching \`github.com/<org>/<repo>/blob/...\` — meaning a prompt-injected agent (or a user following a crafted prompt) could have the tool fetch arbitrary public source from any repo on GitHub. That reaches into:

- Secrets / misconfigured credentials committed to public forks
- Private-research PoC repos that were later made public
- Any cross-org code the agent's operator never intended to expose

Add an optional \`allowed_repos\` field to \`GithubFilesGroupConfig\`. Entries are either \`'org/repo'\` (exact) or \`'org/*'\` (wildcard), matched case-insensitively. When set, URLs outside the allowlist return a clear \`"not in the configured allowed_repos list"\` error instead of fetching. **Default remains \`None\` (permissive) for backward compatibility**, with the docstring on the field calling out the security implication so operators can decide.

## CWE
CWE-284 — Improper Access Control (broad exposure scope on an external data source)

## Behavior matrix

| \`allowed_repos\` | URL fetched? |
|---|---|
| \`None\` (default) | ✅ any github.com repo (backward compat) |
| \`[]\` | ❌ deny-all (explicit) |
| \`["NVIDIA/NeMo-Agent-Toolkit"]\` | ✅ exact match only |
| \`["NVIDIA/*"]\` | ✅ any repo under NVIDIA org |
| \`["NVIDIA/*", "apache/spark"]\` | ✅ OR-combined |

Matching is case-insensitive; malformed entries (missing \`/\`, non-strings, empty) are ignored without false-positive matches.

## Why not change the default to strict
Flipping the default breaks every existing config that uses the tool without setting the field. Opt-in allowlist with a prominent docstring is the backward-compatible hardening: operators who want scope get it, operators who rely on current behavior are unchanged.

## Files changed
- \`packages/nvidia_nat_core/src/nat/tool/github_tools.py\`
  - \`GithubFilesGroupConfig.allowed_repos: list[str] | None\` (default None)
  - New \`_repo_path_is_allowed\` helper
  - \`get()\` closure returns a scoped-out error message when the repo_path fails the allowlist
- \`packages/nvidia_nat_core/tests/nat/tools/test_github_files_tool_allowlist.py\` — direct unit coverage of the helper + config shape (12 parametrized cases)

## Test plan
- [x] \`allowed_repos=None\` → any repo allowed
- [x] Explicit \`"org/repo"\` and \`"org/*"\` wildcard matches (parametrized)
- [x] Case-insensitive matching (operator can write \`"NVIDIA/Repo"\`, URL can use lowercase)
- [x] Multiple allowlist entries OR-combined
- [x] Malformed entries (\`""\`, \`None\`, non-strings, missing \`/\`) ignored without false-positives
- [x] Malformed \`repo_path\` rejected
- [x] Empty list = explicit deny-all
- [x] Syntax-checked locally; pytest deferred to CI

End-to-end coverage of the \`get()\` closure needs a mocked httpx transport and is out of scope for this defensive hardening PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional repository allowlist to restrict GitHub file access to specific repositories, supporting exact repo matches and org-level wildcards (e.g., org/*) with case-insensitive matching.

* **Tests**
  * Added comprehensive tests for allowlist behavior: defaults, wildcard and exact-match semantics, case-insensitivity, defensive handling of malformed entries, and empty-allowlist blocking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->