### PR TITLE
Misc test improvements and update model in the workflow template

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -130,7 +130,7 @@ test:python_tests:
       alias: mysql
       pull_policy: if-not-present
 
-    - name: arizephoenix/phoenix:latest
+    - name: arizephoenix/phoenix:13.22
       alias: phoenix
       pull_policy: if-not-present
 

--- a/examples/evaluation_and_profiling/simple_web_query_eval/tests/test_simple_web_query_eval.py
+++ b/examples/evaluation_and_profiling/simple_web_query_eval/tests/test_simple_web_query_eval.py
@@ -77,7 +77,7 @@ def validate_trajectory_accuracy(trajectory_output_file: Path):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key")
-async def test_eval():
+async def test_eval(tmp_path: Path):
     """
     1. nat-eval writes the workflow output to workflow_output.json
     2. nat-eval creates a file with scores for each evaluation metric.
@@ -85,16 +85,33 @@ async def test_eval():
        a. the rag accuracy metric
        b. the trajectory score (if present)
     """
+    import yaml
+
     import nat_simple_web_query_eval
 
     # Get config dynamically
     config_file: Path = locate_example_config(nat_simple_web_query_eval, "eval_config_llama33.yml")
 
+    # We don't need to run the full evaluation dataset, only a single entry is needed to verify that the workflow is
+    # functioning
+    with config_file.open(encoding="utf-8") as fh:
+        config_data = yaml.safe_load(fh)
+
+    dataset_file = Path(config_data['eval']['general']['dataset']['file_path'])
+
+    with dataset_file.open(encoding="utf-8") as fh:
+        dataset = json.load(fh)
+
+    dataset_slim_file = tmp_path / 'dataset.json'
+
+    with dataset_slim_file.open(mode="w", encoding="utf-8") as fh:
+        json.dump([dataset[0]], fh)
+
     # Create the configuration object for running the evaluation, single rep using the eval config in eval_config.yml
     # WIP: skip test if eval config is not present
     config = EvaluationRunConfig(
         config_file=config_file,
-        dataset=None,
+        dataset=dataset_slim_file.as_posix(),
         result_json_path="$",
         skip_workflow=False,
         skip_completed_entries=False,

--- a/examples/evaluation_and_profiling/simple_web_query_eval/tests/test_simple_web_query_eval.py
+++ b/examples/evaluation_and_profiling/simple_web_query_eval/tests/test_simple_web_query_eval.py
@@ -77,7 +77,7 @@ def validate_trajectory_accuracy(trajectory_output_file: Path):
 
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key")
-async def test_eval(tmp_path: Path):
+async def test_eval(tmp_path: Path, root_repo_dir: Path):
     """
     1. nat-eval writes the workflow output to workflow_output.json
     2. nat-eval creates a file with scores for each evaluation metric.
@@ -98,6 +98,9 @@ async def test_eval(tmp_path: Path):
         config_data = yaml.safe_load(fh)
 
     dataset_file = Path(config_data['eval']['general']['dataset']['file_path'])
+    if not dataset_file.is_absolute() and not dataset_file.exists():
+        # When these paths are relative, resolve them against the root repository directory
+        dataset_file = root_repo_dir / dataset_file
 
     with dataset_file.open(encoding="utf-8") as fh:
         dataset = json.load(fh)

--- a/packages/nvidia_nat_core/src/nat/cli/commands/workflow/templates/config.yml.j2
+++ b/packages/nvidia_nat_core/src/nat/cli/commands/workflow/templates/config.yml.j2
@@ -8,7 +8,7 @@ functions:
 llms:
   nim_llm:
     _type: nim
-    model_name: meta/llama-3.1-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
 
 workflow:

--- a/test_data/docker-compose.services.yml
+++ b/test_data/docker-compose.services.yml
@@ -101,6 +101,12 @@ services:
       REDIS_HOST: redis
       REDIS_PORT: 6379
       SALT: ${LANGFUSE_SALT:-mysalt}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3030/api/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
 
   langfuse-web:
@@ -119,6 +125,13 @@ services:
       LANGFUSE_INIT_USER_EMAIL: test@localhost.dev
       LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_USER_PW:-password123}
       NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:-mysecret}
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:3000/api/public/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
+
 
   local-sandbox:
     build:
@@ -178,6 +191,10 @@ services:
     environment:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-my_password}
     restart: unless-stopped
+    healthcheck:
+        test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
+        timeout: 20s
+        retries: 10
 
   nginx-rewrite-models:
     build: ./nginx
@@ -186,7 +203,6 @@ services:
       # This needs to include the port even if it is the default port for the protocol
       # ex: "https://some-server.com:443" and "http://some-server.com:80"
       - NAT_CI_PROXIED_OPENAI_BASE_URL
-
     ports:
       - 8088:8088
     restart: unless-stopped
@@ -231,11 +247,17 @@ services:
       - plugins.security.disabled=true
 
   phoenix:
-    image: arizephoenix/phoenix:latest
+    image: arizephoenix/phoenix:13.22
     container_name: test-phoenix
     ports:
       - "6006:6006"  # UI and OTLP HTTP collector
       - "4317:4317"  # OTLP gRPC collector
+    healthcheck:
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:6006/healthz')"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   postgres:
     container_name: test-postgres

--- a/test_data/docker-compose.services.yml
+++ b/test_data/docker-compose.services.yml
@@ -102,7 +102,7 @@ services:
       REDIS_PORT: 6379
       SALT: ${LANGFUSE_SALT:-mysalt}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3030/api/health"]
+      test: ["CMD-SHELL", "wget -q --spider http://$(hostname):3030/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -126,7 +126,7 @@ services:
       LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_USER_PW:-password123}
       NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:-mysecret}
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:3000/api/public/health"]
+      test: ["CMD-SHELL", "wget -q --spider http://$(hostname):3000/api/public/health"]
       interval: 30s
       timeout: 10s
       retries: 3
@@ -206,6 +206,11 @@ services:
     ports:
       - 8088:8088
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8088"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
 
   oauth2-server:
     build: ../examples/front_ends/simple_auth
@@ -245,6 +250,12 @@ services:
     environment:
       - discovery.type=single-node
       - plugins.security.disabled=true
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:9200/_cluster/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 30s
 
   phoenix:
     image: arizephoenix/phoenix:13.22

--- a/test_data/docker-compose.services.yml
+++ b/test_data/docker-compose.services.yml
@@ -102,6 +102,7 @@ services:
       REDIS_PORT: 6379
       SALT: ${LANGFUSE_SALT:-mysalt}
     healthcheck:
+      # Using $(hostname) since the service binds to the container id rather than localhost
       test: ["CMD-SHELL", "wget -q --spider http://$(hostname):3030/api/health"]
       interval: 30s
       timeout: 10s
@@ -126,6 +127,7 @@ services:
       LANGFUSE_INIT_USER_PASSWORD: ${LANGFUSE_USER_PW:-password123}
       NEXTAUTH_SECRET: ${LANGFUSE_NEXTAUTH_SECRET:-mysecret}
     healthcheck:
+      # Using $(hostname) since the service binds to the container id rather than localhost
       test: ["CMD-SHELL", "wget -q --spider http://$(hostname):3000/api/public/health"]
       interval: 30s
       timeout: 10s

--- a/test_data/docker-compose.services.yml
+++ b/test_data/docker-compose.services.yml
@@ -194,9 +194,9 @@ services:
       - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD:-my_password}
     restart: unless-stopped
     healthcheck:
-        test: ["CMD", "mysqladmin" ,"ping", "-h", "localhost"]
-        timeout: 20s
-        retries: 10
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 20s
+      retries: 10
 
   nginx-rewrite-models:
     build: ./nginx


### PR DESCRIPTION
## Description
* Change the default model in the `nat workflow create` template from `meta/llama-3.1-70b-instruct` to `nvidia/nemotron-3-nano-30b-a3b`.
  * The `getting_started_with_nat` notebook uses the default config from `nat workflow create` as-is and was having problems with being rate-limited. fixes
  * This is a bit of a heavy-handed way to fix a notebook, but I think we have been moving away from this model, and it is time to update our default config.

* Update `simple_web_query_eval` test to only perform evaluation over the first prompt in the eval dataset.
* Add healthchecks for each service in `test_data/docker-compose.services.yml`
* Test with the same version of the `arizephoenix/phoenix` container that we instruct users to use in documentation.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Phoenix service image to version 13.22 (CI and compose)
  * Added health checks for key services (web, worker, DB, search, proxy)
  * Updated default workflow model in templates

* **Tests**
  * Modified an integration test to use test fixtures and run on a temporary single-item dataset
<!-- end of auto-generated comment: release notes by coderabbit.ai -->