### PR TITLE
Support client-id-only MCP OAuth2 and refine Outlook auth example config

### DIFF
--- a/examples/MCP/simple_auth_mcp/configs/config-mcp-auth-outlook.yml
+++ b/examples/MCP/simple_auth_mcp/configs/config-mcp-auth-outlook.yml
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/examples/MCP/simple_auth_mcp/configs/config-mcp-auth-outlook.yml
+++ b/examples/MCP/simple_auth_mcp/configs/config-mcp-auth-outlook.yml
@@ -16,7 +16,7 @@
 
 # This is a static OAuth2 example for Outlook MCP authentication.
 # It demonstrates manual OAuth2 (no DCR) using a pre-registered client_id.
-# Ensure NAT_REDIRECT_URI is registered/allowlisted for NAT_CORPORATE_MCP_OUTLOOK_CLIENT_ID,
+# Ensure NAT_REDIRECT_URI is registered or allowlisted for NAT_CORPORATE_MCP_OUTLOOK_CLIENT_ID,
 # or the OAuth flow will fail with "redirect_uri not allowed for this client".
 
 function_groups:

--- a/examples/MCP/simple_auth_mcp/configs/config-mcp-auth-outlook.yml
+++ b/examples/MCP/simple_auth_mcp/configs/config-mcp-auth-outlook.yml
@@ -1,0 +1,52 @@
+# SPDX-FileCopyrightText: Copyright (c) 2024-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# This is a static OAuth2 example for Outlook MCP authentication.
+# It demonstrates manual OAuth2 (no DCR) using a pre-registered client_id.
+# Ensure NAT_REDIRECT_URI is registered/allowlisted for NAT_CORPORATE_MCP_OUTLOOK_CLIENT_ID,
+# or the OAuth flow will fail with "redirect_uri not allowed for this client".
+
+function_groups:
+  mcp_outlook:
+    _type: per_user_mcp_client
+    server:
+      url: ${NAT_CORPORATE_MCP_OUTLOOK_URL}
+      auth_provider: mcp_oauth2_outlook
+
+authentication:
+  mcp_oauth2_outlook:
+    _type: mcp_oauth2
+    server_url: ${NAT_CORPORATE_MCP_OUTLOOK_URL}
+    redirect_uri: ${NAT_REDIRECT_URI:-http://localhost:8000/auth/redirect}
+    client_id: ${NAT_CORPORATE_MCP_OUTLOOK_CLIENT_ID}
+
+llms:
+  nim_llm:
+    _type: nim
+    model_name: nvidia/nemotron-3-nano-30b-a3b
+    temperature: 0.0
+    max_tokens: 1024
+    chat_template_kwargs:
+      enable_thinking: false
+
+workflow:
+  _type: per_user_react_agent
+  tool_names:
+    - mcp_outlook
+  llm_name: nim_llm
+  verbose: true
+  retry_parsing_errors: true
+  max_retries: 3

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider_config.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider_config.py
@@ -28,7 +28,11 @@ class MCPOAuth2ProviderConfig(AuthProviderBaseConfig, name="mcp_oauth2"):
 
     Supported modes:
       - Endpoints discovery + Dynamic Client Registration (DCR) (enable_dynamic_registration=True, no client_id)
-      - Endpoints discovery + Manual Client Registration (client_id + client_secret provided)
+      - Endpoints discovery + Manual Client Registration (client_id with optional client_secret)
+
+    Precedence:
+      - If client_id is provided, manual registration mode is used even when
+        enable_dynamic_registration is True.
     """
     server_url: HttpUrl = Field(
         ...,
@@ -39,8 +43,10 @@ class MCPOAuth2ProviderConfig(AuthProviderBaseConfig, name="mcp_oauth2"):
     client_id: str | None = Field(default=None, description="OAuth2 client ID for pre-registered clients")
     client_secret: OptionalSecretStr = Field(default=None,
                                              description="OAuth2 client secret for pre-registered clients")
-    enable_dynamic_registration: bool = Field(default=True,
-                                              description="Enable OAuth2 Dynamic Client Registration (RFC 7591)")
+    enable_dynamic_registration: bool = Field(
+        default=True,
+        description=
+        "Enable OAuth2 Dynamic Client Registration (RFC 7591). Ignored when client_id is provided.")
     client_name: str = Field(default="NAT MCP Client", description="OAuth2 client name for dynamic registration")
 
     # OAuth2 flow configuration
@@ -74,20 +80,20 @@ class MCPOAuth2ProviderConfig(AuthProviderBaseConfig, name="mcp_oauth2"):
         # if default_user_id is not provided, use the server_url as the default user id
         if not self.default_user_id:
             self.default_user_id = str(self.server_url)
-        # Dynamic registration + MCP discovery
-        if self.enable_dynamic_registration and not self.client_id:
-            # Pure dynamic registration - no explicit credentials needed
+        # Manual registration + MCP discovery (public and confidential clients).
+        # NOTE: client_id takes precedence over enable_dynamic_registration.
+        if self.client_id:
+            # Has pre-registered client ID; client_secret is optional.
             pass
-
-        # Manual registration + MCP discovery
-        elif self.client_id and self.client_secret:
-            # Has credentials but will discover URLs from MCP server
+        # Dynamic registration + MCP discovery
+        elif self.enable_dynamic_registration:
+            # Pure dynamic registration - no explicit credentials needed
             pass
 
         # Invalid configuration
         else:
             raise ValueError("Must provide either: "
-                             "1) enable_dynamic_registration=True (dynamic), or "
-                             "2) client_id + client_secret (hybrid)")
+                             "1) enable_dynamic_registration=True without client_id (dynamic), or "
+                             "2) client_id with optional client_secret (manual)")
 
         return self

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider_config.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider_config.py
@@ -45,8 +45,7 @@ class MCPOAuth2ProviderConfig(AuthProviderBaseConfig, name="mcp_oauth2"):
                                              description="OAuth2 client secret for pre-registered clients")
     enable_dynamic_registration: bool = Field(
         default=True,
-        description=
-        "Enable OAuth2 Dynamic Client Registration (RFC 7591). Ignored when client_id is provided.")
+        description="Enable OAuth2 Dynamic Client Registration (RFC 7591). Ignored when client_id is provided.")
     client_name: str = Field(default="NAT MCP Client", description="OAuth2 client name for dynamic registration")
 
     # OAuth2 flow configuration

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_config.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_config.py
@@ -40,7 +40,8 @@ class MCPServerConfig(BaseModel):
     streamable-http is the recommended default for HTTP-based connections.
     """
     transport: Literal["stdio", "sse", "streamable-http"] = Field(
-        ..., description="Transport type to connect to the MCP server (stdio, sse, or streamable-http)")
+        default="streamable-http",
+        description="Transport type to connect to the MCP server (stdio, sse, or streamable-http)")
     url: HttpUrl | None = Field(default=None,
                                 description="URL of the MCP server (for sse or streamable-http transport)")
     command: str | None = Field(default=None,

--- a/packages/nvidia_nat_mcp/tests/client/test_mcp_auth_provider.py
+++ b/packages/nvidia_nat_mcp/tests/client/test_mcp_auth_provider.py
@@ -79,6 +79,35 @@ def mock_credentials() -> OAuth2Credentials:
 
 
 # --------------------------------------------------------------------------- #
+# MCPOAuth2ProviderConfig Tests
+# --------------------------------------------------------------------------- #
+
+
+class TestMCPOAuth2ProviderConfig:
+    """Test MCP OAuth2 provider config validation."""
+
+    def test_validate_allows_public_client_without_secret(self):
+        """Manual mode should allow a pre-registered public client without client_secret."""
+        config = MCPOAuth2ProviderConfig(
+            server_url="https://example.com/mcp",  # type: ignore
+            redirect_uri="https://example.com/callback",  # type: ignore
+            client_id="public_client_id",
+            enable_dynamic_registration=False,
+        )
+
+        assert config.client_id == "public_client_id"
+
+    def test_validate_rejects_no_client_id_when_dynamic_registration_disabled(self):
+        """Validation should fail when DCR is disabled and no client_id is provided."""
+        with pytest.raises(ValueError, match="enable_dynamic_registration=True without client_id"):
+            MCPOAuth2ProviderConfig(
+                server_url="https://example.com/mcp",  # type: ignore
+                redirect_uri="https://example.com/callback",  # type: ignore
+                enable_dynamic_registration=False,
+            )
+
+
+# --------------------------------------------------------------------------- #
 # DiscoverOAuth2Endpoints Tests
 # --------------------------------------------------------------------------- #
 

--- a/packages/nvidia_nat_mcp/tests/client/test_mcp_client_base.py
+++ b/packages/nvidia_nat_mcp/tests/client/test_mcp_client_base.py
@@ -825,6 +825,14 @@ class TestMCPServerConfigCustomHeaders:
 
         assert config.custom_headers is None
 
+    def test_transport_defaults_to_streamable_http(self):
+        """Test that transport defaults to streamable-http when omitted."""
+        from nat.plugins.mcp.client.client_config import MCPServerConfig
+
+        config = MCPServerConfig(url="http://localhost:8080/mcp")
+
+        assert config.transport == "streamable-http"
+
 
 if __name__ == "__main__":
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This PR improves MCP OAuth2 manual authentication and adds as Outlook auth example configuration using static client registration.
- Optional client secret in manual OAuth2
  - mcp_oauth2 now allows manual mode with client_id and optional client_secret (public-client compatible).
  - Runtime behavior remains consistent: when client_id is provided, manual registration is used instead of dynamic registration.
  - Added explicit config documentation that client_id takes precedence over dynamic registration.
- Makes streamable-http the default transport
- Adds an Outlook MCP auth example config file as a quick reference.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Outlook OAuth2 example configuration for per-user MCP authentication and a new default LLM/workflow example.
  * MCP server transport now defaults to "streamable-http", reducing required configuration.

* **Behavior Changes**
  * OAuth2 validation updated so a provided client_id takes precedence and allows manual registration without requiring a client_secret.

* **Tests**
  * Added unit tests validating the OAuth2 validation behavior and the new transport default.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->