### PR TITLE
fix(mcp-client): set proper httpx timeouts for streamable-http transport

### DIFF
--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
@@ -33,6 +33,9 @@ from mcp.client.sse import sse_client
 from mcp.client.stdio import StdioServerParameters
 from mcp.client.stdio import stdio_client
 from mcp.client.streamable_http import streamable_http_client
+from mcp.shared._httpx_utils import MCP_DEFAULT_SSE_READ_TIMEOUT
+from mcp.shared._httpx_utils import MCP_DEFAULT_TIMEOUT
+from mcp.shared._httpx_utils import create_mcp_http_client
 from mcp.types import TextContent
 from nat.authentication.interfaces import AuthenticatedContext
 from nat.authentication.interfaces import AuthFlowType
@@ -604,10 +607,29 @@ class MCPStreamableHTTPClient(MCPBaseClient):
         """
         Establish a session with an MCP server via streamable-http within an async context
         """
-        # Create httpx client with custom headers and auth
-        # streamable_http_client expects a pre-configured httpx.AsyncClient for headers/auth
-        http_client = httpx.AsyncClient(headers=self._custom_headers if self._custom_headers else None,
-                                        auth=self._httpx_auth)
+        # Create httpx client with custom headers and auth.
+        # streamable_http_client expects a pre-configured httpx.AsyncClient for headers/auth;
+        # when one is supplied, the SDK skips creating its own default client, so we must
+        # match its recommended timeouts here. Otherwise httpx falls back to its 5-second
+        # default read timeout and long-running MCP tool calls will hang / fail with
+        # ReadTimeout before producing a result.
+        #
+        # Use the SDK's own factory so we inherit follow_redirects + any future defaults,
+        # and extend the SSE read timeout to cover user-configured tool/auth timeouts so
+        # the httpx layer never cuts off before MCP-level timeouts do.
+        configured_timeouts_s = [
+            MCP_DEFAULT_SSE_READ_TIMEOUT,
+            self._tool_call_timeout.total_seconds(),
+            self._auth_flow_timeout.total_seconds(),
+        ]
+        sse_read_timeout_s = max(configured_timeouts_s)
+        timeout = httpx.Timeout(MCP_DEFAULT_TIMEOUT, read=sse_read_timeout_s)
+
+        http_client = create_mcp_http_client(
+            headers=self._custom_headers if self._custom_headers else None,
+            timeout=timeout,
+            auth=self._httpx_auth,
+        )
 
         try:
             async with http_client:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

Fixes MCP `streamable-http` tool calls hanging when a tool takes > 5 s to produce its first SSE byte (e.g. text2sql). Regression from #1500.
## Root cause
#1500 switched to `streamable_http_client(..., http_client=...)` and started passing a pre-built `httpx.AsyncClient(...)`. When a client is supplied, the MCP SDK skips its internal `create_mcp_http_client()` fallback (which sets `httpx.Timeout(30.0, read=300.0)` and `follow_redirects=True`). Our client was constructed with no `timeout=`, so httpx fell back to its 5-second default for every phase including `read`, causing slow tools to fail with `ReadTimeout` inside the transport task group.
## Fix
Build the `httpx.AsyncClient` via the SDK's own `create_mcp_http_client(...)` factory so we inherit its defaults, and pass an explicit `httpx.Timeout` whose read value is `max(MCP_DEFAULT_SSE_READ_TIMEOUT, tool_call_timeout, auth_flow_timeout)`. This both restores SDK parity and ensures users who raise `tool_call_timeout` for slow tools don't get cut off at the httpx layer.
Only `MCPStreamableHTTPClient` is affected.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed timeout behavior for long-running operations. Extended tool calls and authentication flows will no longer be prematurely interrupted by default read timeouts, ensuring these operations complete successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->