### PR TITLE
Experimental: Hermes + Harbor + NeMo-Flow E2E smoke (CLI gateway alignment)

### DIFF
--- a/packages/nvidia_nat_atif/src/nat/atof/scripts/atof_to_atif_converter.py
+++ b/packages/nvidia_nat_atif/src/nat/atof/scripts/atof_to_atif_converter.py
@@ -549,6 +549,20 @@ def _events_to_step_dicts(
         if isinstance(tool_call_id, str) and tool_call_id
     }
 
+    def is_lossy_llm_summary(event: Event) -> bool:
+        metadata = event.metadata or {}
+        if metadata.get("provider_payload_exact") is False:
+            return True
+        if metadata.get("fidelity_source") == "hermes_api_hooks":
+            return True
+        data = event.data if isinstance(event.data, dict) else {}
+        content = data.get("content")
+        if isinstance(content, dict):
+            fidelity = content.get("fidelity")
+            if isinstance(fidelity, dict) and fidelity.get("provider_payload_exact") is False:
+                return True
+        return False
+
     def flush_observations() -> None:
         """Attach buffered observations to the preceding agent step (R4 drain).
 
@@ -628,6 +642,8 @@ def _events_to_step_dicts(
             llm_extractor = resolve_llm_extractor(event.data_schema)
             messages = llm_extractor.extract_input_messages(data)
             if data and not messages:
+                if is_lossy_llm_summary(event):
+                    continue
                 raise ShapeMismatchError(
                     kind="llm_input",
                     uuid=event.uuid,
@@ -717,13 +733,17 @@ def _events_to_step_dicts(
             # would drop the producer's response entirely. A payload with
             # only tool_calls (no content) or only content (no tool_calls)
             # is legitimate and not an error.
+            metrics = _metrics_from_usage(raw_data.get("usage"))
             if raw_data and not agent_msg and not tool_call_dicts:
-                raise ShapeMismatchError(
-                    kind="llm_output",
-                    uuid=event.uuid,
-                    data_schema=event.data_schema,
-                    data_keys=sorted(raw_data.keys()),
-                )
+                if is_lossy_llm_summary(event):
+                    continue
+                if metrics is None:
+                    raise ShapeMismatchError(
+                        kind="llm_output",
+                        uuid=event.uuid,
+                        data_schema=event.data_schema,
+                        data_keys=sorted(raw_data.keys()),
+                    )
             function_ancestry = _build_ancestry(event.uuid, event.name, event.parent_uuid, name_map)
 
             start_micros = start_ts_map.get(event.uuid)
@@ -763,7 +783,6 @@ def _events_to_step_dicts(
             }
             if tool_call_dicts:
                 step_dict["tool_calls"] = tool_call_dicts
-            metrics = _metrics_from_usage(raw_data.get("usage"))
             if metrics:
                 step_dict["metrics"] = metrics
 

--- a/packages/nvidia_nat_atif/src/nat/atof/scripts/atof_to_atif_converter.py
+++ b/packages/nvidia_nat_atif/src/nat/atof/scripts/atof_to_atif_converter.py
@@ -563,6 +563,34 @@ def _events_to_step_dicts(
                 return True
         return False
 
+    def is_empty_assistant_message(event: Event) -> bool:
+        data = event.data if isinstance(event.data, dict) else {}
+        role = data.get("role")
+        if role not in {"assistant", "model"}:
+            return False
+        if data.get("content") not in {None, ""}:
+            return False
+
+        for key, value in data.items():
+            if key in {"role", "content"}:
+                continue
+            if key == "tool_calls" and (value is None or value == ()):
+                continue
+            if key == "tool_calls" and isinstance(value, list) and not value:
+                continue
+            if key == "usage" and not value:
+                continue
+            return False
+        return True
+
+    def is_synthetic_tool_cleanup(event: Event) -> bool:
+        metadata = event.metadata or {}
+        if metadata.get("status") == "closed_by_agent_end":
+            return True
+        if isinstance(event.data, dict) and event.data.get("status") == "closed_by_agent_end":
+            return True
+        return False
+
     def flush_observations() -> None:
         """Attach buffered observations to the preceding agent step (R4 drain).
 
@@ -737,6 +765,8 @@ def _events_to_step_dicts(
             if raw_data and not agent_msg and not tool_call_dicts:
                 if is_lossy_llm_summary(event):
                     continue
+                if metrics is None and is_empty_assistant_message(event):
+                    continue
                 if metrics is None:
                     raise ShapeMismatchError(
                         kind="llm_output",
@@ -790,6 +820,8 @@ def _events_to_step_dicts(
             current_agent_step_idx = len(step_dicts) - 1
 
         elif _is_scope_end(event) and event.category == "tool":
+            if is_synthetic_tool_cleanup(event):
+                continue
             tool_call_id = (event.category_profile or {}).get("tool_call_id")
             if pending_obs_timestamp is None:
                 pending_obs_timestamp = event.timestamp

--- a/packages/nvidia_nat_atif/tests/test_sidecar_openai_conversion.py
+++ b/packages/nvidia_nat_atif/tests/test_sidecar_openai_conversion.py
@@ -288,9 +288,7 @@ def test_sidecar_openai_conversion_ignores_agent_end_tool_cleanup() -> None:
     trajectory = convert(events)
 
     source_call_ids = [
-        result.source_call_id
-        for step in trajectory.steps
-        if step.observation is not None
+        result.source_call_id for step in trajectory.steps if step.observation is not None
         for result in step.observation.results
     ]
     assert "call_1" in source_call_ids
@@ -330,9 +328,10 @@ def test_sidecar_openai_conversion_skips_empty_assistant_noop_turn() -> None:
     events = _sidecar_stream_without_tool_scopes()
     events.insert(
         -1,
-        _llm_start("llm-noop", "2026-05-12T22:00:05.500Z", [{
-            "role": "assistant", "content": "Previous assistant message."
-        }]),
+        _llm_start("llm-noop",
+                   "2026-05-12T22:00:05.500Z", [{
+                       "role": "assistant", "content": "Previous assistant message."
+                   }]),
     )
     events.insert(
         -1,
@@ -344,7 +343,9 @@ def test_sidecar_openai_conversion_skips_empty_assistant_noop_turn() -> None:
             name="openai.chat_completions",
             category="llm",
             category_profile={"model_name": "qwen3.6:35b"},
-            data={"role": "assistant", "content": None},
+            data={
+                "role": "assistant", "content": None
+            },
         ),
     )
 

--- a/packages/nvidia_nat_atif/tests/test_sidecar_openai_conversion.py
+++ b/packages/nvidia_nat_atif/tests/test_sidecar_openai_conversion.py
@@ -73,6 +73,57 @@ def _llm_end(
     )
 
 
+def _lossy_hermes_api_hook_pair() -> list[ScopeEvent]:
+    return [
+        ScopeEvent(
+            scope_category="start",
+            uuid="lossy-llm-001",
+            parent_uuid="gateway-001",
+            timestamp="2026-05-12T22:00:00.500Z",
+            name="custom",
+            category="llm",
+            category_profile={"model_name": "qwen3.6:35b"},
+            data={
+                "content": {
+                    "api_call_count": 1,
+                    "message_count": 2,
+                    "model": "qwen3.6:35b",
+                    "fidelity": {
+                        "provider_payload_exact": False, "source": "hermes_pre_api_request"
+                    },
+                },
+                "headers": {},
+            },
+            metadata={
+                "fidelity_source": "hermes_api_hooks",
+                "provider_payload_exact": False,
+            },
+        ),
+        ScopeEvent(
+            scope_category="end",
+            uuid="lossy-llm-001",
+            parent_uuid="gateway-001",
+            timestamp="2026-05-12T22:00:00.900Z",
+            name="custom",
+            category="llm",
+            category_profile={"model_name": "qwen3.6:35b"},
+            data={
+                "api_call_count": 1,
+                "assistant_content_chars": 12,
+                "message_count": 2,
+                "model": "qwen3.6:35b",
+                "usage": {
+                    "prompt_tokens": 99, "completion_tokens": 3, "total_tokens": 102
+                },
+            },
+            metadata={
+                "fidelity_source": "hermes_api_hooks",
+                "provider_payload_exact": False,
+            },
+        ),
+    ]
+
+
 def _sidecar_stream_without_tool_scopes() -> list[ScopeEvent]:
     system = {"role": "system", "content": "You are Hermes Agent."}
     user = {"role": "user", "content": "Find the answer."}
@@ -182,3 +233,44 @@ def test_sidecar_openai_history_recovers_observations_metrics_and_metadata() -> 
     assert trajectory.final_metrics.total_prompt_tokens == 30
     assert trajectory.final_metrics.total_completion_tokens == 5
     assert trajectory.final_metrics.extra == {"total_tokens": 35}
+
+
+def test_sidecar_openai_conversion_ignores_lossy_hermes_hook_summaries() -> None:
+    events = _sidecar_stream_without_tool_scopes()
+    events[1:1] = _lossy_hermes_api_hook_pair()
+
+    trajectory = convert(events)
+
+    assert [step.source for step in trajectory.steps] == ["system", "user", "agent", "agent"]
+    assert trajectory.final_metrics is not None
+    assert trajectory.final_metrics.total_prompt_tokens == 30
+    assert trajectory.final_metrics.total_completion_tokens == 5
+
+
+def test_sidecar_openai_conversion_keeps_usage_only_empty_assistant_turn() -> None:
+    events = _sidecar_stream_without_tool_scopes()
+    events.insert(
+        -1,
+        _llm_start("llm-empty", "2026-05-12T22:00:05.500Z", [{
+            "role": "user", "content": "No-op."
+        }]),
+    )
+    events.insert(
+        -1,
+        _llm_end(
+            "llm-empty",
+            "2026-05-12T22:00:05.900Z",
+            content="",
+            usage={
+                "prompt_tokens": 7, "completion_tokens": 1, "total_tokens": 8
+            },
+        ),
+    )
+
+    trajectory = convert(events)
+
+    assert trajectory.steps[-1].source == "agent"
+    assert trajectory.steps[-1].message == ""
+    assert trajectory.steps[-1].metrics is not None
+    assert trajectory.steps[-1].metrics.prompt_tokens == 7
+    assert trajectory.steps[-1].metrics.completion_tokens == 1

--- a/packages/nvidia_nat_atif/tests/test_sidecar_openai_conversion.py
+++ b/packages/nvidia_nat_atif/tests/test_sidecar_openai_conversion.py
@@ -247,6 +247,56 @@ def test_sidecar_openai_conversion_ignores_lossy_hermes_hook_summaries() -> None
     assert trajectory.final_metrics.total_completion_tokens == 5
 
 
+def test_sidecar_openai_conversion_ignores_agent_end_tool_cleanup() -> None:
+    events = _sidecar_stream_without_tool_scopes()
+    events.extend([
+        ScopeEvent(
+            scope_category="start",
+            uuid="fallback-tool-001",
+            parent_uuid="gateway-001",
+            timestamp="2026-05-12T22:00:05.200Z",
+            name="patch",
+            category="tool",
+            category_profile={"tool_call_id": "tool-fallback-001"},
+            data={
+                "path": "/testbed/file.py",
+                "old_string": "before",
+                "new_string": "after",
+            },
+            metadata={
+                "hook_event_name": "pre_tool_call",
+                "tool_correlation_status": "agent_fallback",
+            },
+        ),
+        ScopeEvent(
+            scope_category="end",
+            uuid="fallback-tool-001",
+            parent_uuid="gateway-001",
+            timestamp="2026-05-12T22:00:05.800Z",
+            name="patch",
+            category="tool",
+            category_profile={"tool_call_id": "tool-fallback-001"},
+            data={"status": "closed_by_agent_end"},
+            metadata={
+                "hook_event_name": "pre_tool_call",
+                "status": "closed_by_agent_end",
+                "tool_correlation_status": "agent_fallback",
+            },
+        ),
+    ])
+
+    trajectory = convert(events)
+
+    source_call_ids = [
+        result.source_call_id
+        for step in trajectory.steps
+        if step.observation is not None
+        for result in step.observation.results
+    ]
+    assert "call_1" in source_call_ids
+    assert "tool-fallback-001" not in source_call_ids
+
+
 def test_sidecar_openai_conversion_keeps_usage_only_empty_assistant_turn() -> None:
     events = _sidecar_stream_without_tool_scopes()
     events.insert(
@@ -274,3 +324,36 @@ def test_sidecar_openai_conversion_keeps_usage_only_empty_assistant_turn() -> No
     assert trajectory.steps[-1].metrics is not None
     assert trajectory.steps[-1].metrics.prompt_tokens == 7
     assert trajectory.steps[-1].metrics.completion_tokens == 1
+
+
+def test_sidecar_openai_conversion_skips_empty_assistant_noop_turn() -> None:
+    events = _sidecar_stream_without_tool_scopes()
+    events.insert(
+        -1,
+        _llm_start("llm-noop", "2026-05-12T22:00:05.500Z", [{
+            "role": "assistant", "content": "Previous assistant message."
+        }]),
+    )
+    events.insert(
+        -1,
+        ScopeEvent(
+            scope_category="end",
+            uuid="llm-noop",
+            parent_uuid="gateway-001",
+            timestamp="2026-05-12T22:00:05.900Z",
+            name="openai.chat_completions",
+            category="llm",
+            category_profile={"model_name": "qwen3.6:35b"},
+            data={"role": "assistant", "content": None},
+        ),
+    )
+
+    trajectory = convert(events)
+
+    assert [step.source for step in trajectory.steps] == ["system", "user", "agent", "agent"]
+    assert [step.message for step in trajectory.steps] == [
+        "You are Hermes Agent.",
+        "Find the answer.",
+        "[tool call]",
+        "Done.",
+    ]

--- a/packages/nvidia_nat_harbor/README.md
+++ b/packages/nvidia_nat_harbor/README.md
@@ -30,6 +30,9 @@ see [`harbor-library-mode.md`](./harbor-library-mode.md).
 This package provides:
 
 - A NeMo Agent Toolkit-backed Harbor agent (`NemoAgent`)
+- Experimental coding-agent smoke wrappers for NeMo-Flow instrumentation, including
+  [`OpenCodeNeMoFlow`](./opencode-nemoflow-smoke.md) and
+  [`HermesNeMoFlow`](./hermes-nemoflow-smoke.md)
 - A host-local Harbor environment implementation (`LocalEnvironment`)
 - An inline ATIF verifier class for Harbor verifier import hooks (`ATIFInlineVerifier`)
 - ATIF verifier bridge utilities for script-based compatibility (`nat_harbor.verifier.bridge_runner`)

--- a/packages/nvidia_nat_harbor/data/hermes-nemoflow-smoke/native-hermes-trajectory.json
+++ b/packages/nvidia_nat_harbor/data/hermes-nemoflow-smoke/native-hermes-trajectory.json
@@ -1,0 +1,744 @@
+{
+  "schema_version": "ATIF-v1.2",
+  "session_id": "48b8e2c5-7f1e-4236-97a5-5796c6d40483",
+  "agent": {
+    "name": "hermes",
+    "version": "Hermes Agent v0.13.0 (2026.5.7)\nProject: /usr/local/lib/hermes-agent\nPython: 3.11.5\nOpenAI SDK: 2.24.0\nUp to date",
+    "model_name": "openai/qwen3.6:35b"
+  },
+  "steps": [
+    {
+      "step_id": 1,
+      "source": "user",
+      "message": "Set disabled prop on ReadOnlyPasswordHashField\nDescription\n\nCurrently the django.contrib.auth.forms.UserChangeForm defines a clean_password method that returns the initial password value to prevent (accidental) changes to the password value. It is also documented that custom forms for the User model need to define this method: \u200bhttps://docs.djangoproject.com/en/3.1/topics/auth/customizing/#a-full-example\nA while ago the forms.Field base class gained the \u200bdisabled argument to:\n[disable] a form field using the disabled HTML attribute so that it won\u2019t be editable by users. Even if a user tampers with the field\u2019s value submitted to the server, it will be ignored in favor of the value from the form\u2019s initial data.\nIt seems to me that this property could be set to True be default on the ReadOnlyPasswordHashField used to display the password hash. This way the clean_password is no longer necessary and the potential pitfall when using the ReadOnlyPasswordHashField without implementing clean_password is removed.\n"
+    },
+    {
+      "step_id": 2,
+      "source": "agent",
+      "message": "I'll explore the Django codebase to understand the current implementation of `ReadOnlyPasswordHashField` and `UserChangeForm`.",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_gi06g0vd",
+          "function_name": "search_files",
+          "arguments": {
+            "pattern": "ReadOnlyPasswordHashField",
+            "output_mode": "files_only"
+          }
+        },
+        {
+          "tool_call_id": "call_ug6k81mw",
+          "function_name": "search_files",
+          "arguments": {
+            "pattern": "UserChangeForm",
+            "output_mode": "files_only"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_gi06g0vd",
+            "content": "{\"total_count\": 3, \"files\": [\"./tests/auth_tests/test_forms.py\", \"./django/contrib/auth/forms.py\", \"./docs/topics/auth/customizing.txt\"]}"
+          },
+          {
+            "source_call_id": "call_ug6k81mw",
+            "content": "{\"total_count\": 7, \"files\": [\"./tests/auth_tests/test_forms.py\", \"./django/contrib/auth/forms.py\", \"./django/contrib/auth/admin.py\", \"./docs/releases/2.0.txt\", \"./docs/releases/3.1.txt\", \"./docs/topics/auth/default.txt\", \"./docs/topics/auth/customizing.txt\"]}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 3,
+      "source": "agent",
+      "message": "[tool call]",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_922zw7y9",
+          "function_name": "read_file",
+          "arguments": {
+            "path": "./django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_922zw7y9",
+            "content": "{\"content\": \"     1|import unicodedata\\n     2|\\n     3|from django import forms\\n     4|from django.contrib.auth import (\\n     5|    authenticate, get_user_model, password_validation,\\n     6|)\\n     7|from django.contrib.auth.hashers import (\\n     8|    UNUSABLE_PASSWORD_PREFIX, identify_hasher,\\n     9|)\\n    10|from django.contrib.auth.models import User\\n    11|from django.contrib.auth.tokens import default_token_generator\\n    12|from django.contrib.sites.shortcuts import get_current_site\\n    13|from django.core.exceptions import ValidationError\\n    14|from django.core.mail import EmailMultiAlternatives\\n    15|from django.template import loader\\n    16|from django.utils.encoding import force_bytes\\n    17|from django.utils.http import urlsafe_base64_encode\\n    18|from django.utils.text import capfirst\\n    19|from django.utils.translation import gettext, gettext_lazy as _\\n    20|\\n    21|UserModel = get_user_model()\\n    22|\\n    23|\\n    24|def _unicode_ci_compare(s1, s2):\\n    25|    \\\"\\\"\\\"\\n    26|    Perform case-insensitive comparison of two identifiers, using the\\n    27|    recommended algorithm from Unicode Technical Report 36, section\\n    28|    2.11.2(B)(2).\\n    29|    \\\"\\\"\\\"\\n    30|    return unicodedata.normalize('NFKC', s1).casefold() == unicodedata.normalize('NFKC', s2).casefold()\\n    31|\\n    32|\\n    33|class ReadOnlyPasswordHashWidget(forms.Widget):\\n    34|    template_name = 'auth/widgets/read_only_password_hash.html'\\n    35|    read_only = True\\n    36|\\n    37|    def get_context(self, name, value, attrs):\\n    38|        context = super().get_context(name, value, attrs)\\n    39|        summary = []\\n    40|        if not value or value.startswith(UNUSABLE_PASSWORD_PREFIX):\\n    41|            summary.append({'label': gettext(\\\"No password set.\\\")})\\n    42|        else:\\n    43|            try:\\n    44|                hasher = identify_hasher(value)\\n    45|            except ValueError:\\n    46|                summary.append({'label': gettext(\\\"Invalid password format or unknown hashing algorithm.\\\")})\\n    47|            else:\\n    48|                for key, value_ in hasher.safe_summary(value).items():\\n    49|                    summary.append({'label': gettext(key), 'value': value_})\\n    50|        context['summary'] = summary\\n    51|        return context\\n    52|\\n    53|\\n    54|class ReadOnlyPasswordHashField(forms.Field):\\n    55|    widget = ReadOnlyPasswordHashWidget\\n    56|\\n    57|    def __init__(self, *args, **kwargs):\\n    58|        kwargs.setdefault(\\\"required\\\", False)\\n    59|        super().__init__(*args, **kwargs)\\n    60|\\n    61|    def bound_data(self, data, initial):\\n    62|        # Always return initial because the widget doesn't\\n    63|        # render an input field.\\n    64|        return initial\\n    65|\\n    66|    def has_changed(self, initial, data):\\n    67|        return False\\n    68|\\n    69|\\n    70|class UsernameField(forms.CharField):\\n    71|    def to_python(self, value):\\n    72|        return unicodedata.normalize('NFKC', super().to_python(value))\\n    73|\\n    74|    def widget_attrs(self, widget):\\n    75|        return {\\n    76|            **super().widget_attrs(widget),\\n    77|            'autocapitalize': 'none',\\n    78|            'autocomplete': 'username',\\n    79|        }\\n    80|\\n    81|\\n    82|class UserCreationForm(forms.ModelForm):\\n    83|    \\\"\\\"\\\"\\n    84|    A form that creates a user, with no privileges, from the given username and\\n    85|    password.\\n    86|    \\\"\\\"\\\"\\n    87|    error_messages = {\\n    88|        'password_mismatch': _('The two password fields didn\u2019t match.'),\\n    89|    }\\n    90|    password1 = forms.CharField(\\n    91|        label=_(\\\"Password\\\"),\\n    92|        strip=False,\\n    93|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),\\n    94|        help_text=password_validation.password_validators_help_text_html(),\\n    95|    )\\n    96|    password2 = forms.CharField(\\n    97|        label=_(\\\"Password confirmation\\\"),\\n    98|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),\\n    99|        strip=False,\\n   100|        help_text=_(\\\"Enter the same password as before, for verification.\\\"),\\n   101|    )\\n   102|\\n   103|    class Meta:\\n   104|        model = User\\n   105|        fields = (\\\"username\\\",)\\n   106|        field_classes = {'username': UsernameField}\\n   107|\\n   108|    def __init__(self, *args, **kwargs):\\n   109|        super().__init__(*args, **kwargs)\\n   110|        if self._meta.model.USERNAME_FIELD in self.fields:\\n   111|            self.fields[self._meta.model.USERNAME_FIELD].widget.attrs['autofocus'] = True\\n   112|\\n   113|    def clean_password2(self):\\n   114|        password1 = self.cleaned_data.get(\\\"password1\\\")\\n   115|        password2 = self.cleaned_data.get(\\\"password2\\\")\\n   116|        if password1 and password2 and password1 != password2:\\n   117|            raise ValidationError(\\n   118|                self.error_messages['password_mismatch'],\\n   119|                code='password_mismatch',\\n   120|            )\\n   121|        return password2\\n   122|\\n   123|    def _post_clean(self):\\n   124|        super()._post_clean()\\n   125|        # Validate the password after self.instance is updated with form data\\n   126|        # by super().\\n   127|        password = self.cleaned_data.get('password2')\\n   128|        if password:\\n   129|            try:\\n   130|                password_validation.validate_password(password, self.instance)\\n   131|            except ValidationError as error:\\n   132|                self.add_error('password2', error)\\n   133|\\n   134|    def save(self, commit=True):\\n   135|        user = super().save(commit=False)\\n   136|        user.set_password(self.cleaned_data[\\\"password1\\\"])\\n   137|        if commit:\\n   138|            user.save()\\n   139|        return user\\n   140|\\n   141|\\n   142|class UserChangeForm(forms.ModelForm):\\n   143|    password = ReadOnlyPasswordHashField(\\n   144|        label=_(\\\"Password\\\"),\\n   145|        help_text=_(\\n   146|            'Raw passwords are not stored, so there is no way to see this '\\n   147|            'user\u2019s password, but you can change the password using '\\n   148|            '<a href=\\\"{}\\\">this form</a>.'\\n   149|        ),\\n   150|    )\\n   151|\\n   152|    class Meta:\\n   153|        model = User\\n   154|        fields = '__all__'\\n   155|        field_classes = {'username': UsernameField}\\n   156|\\n   157|    def __init__(self, *args, **kwargs):\\n   158|        super().__init__(*args, **kwargs)\\n   159|        password = self.fields.get('password')\\n   160|        if password:\\n   161|            password.help_text = password.help_text.format('../password/')\\n   162|        user_permissions = self.fields.get('user_permissions')\\n   163|        if user_permissions:\\n   164|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n   165|\\n   166|    def clean_password(self):\\n   167|        # Regardless of what the user provides, return the initial value.\\n   168|        # This is done here, rather than on the field, because the\\n   169|        # field does not have access to the initial value\\n   170|        return self.initial.get('password')\\n   171|\\n   172|\\n   173|class AuthenticationForm(forms.Form):\\n   174|    \\\"\\\"\\\"\\n   175|    Base class for authenticating users. Extend this to get a form that accepts\\n   176|    username/password logins.\\n   177|    \\\"\\\"\\\"\\n   178|    username = UsernameField(widget=forms.TextInput(attrs={'autofocus': True}))\\n   179|    password = forms.CharField(\\n   180|        label=_(\\\"Password\\\"),\\n   181|        strip=False,\\n   182|        widget=forms.PasswordInput(attrs={'autocomplete': 'current-password'}),\\n   183|    )\\n   184|\\n   185|    error_messages = {\\n   186|        'invalid_login': _(\\n   187|            \\\"Please enter a correct %(username)s and password. Note that both \\\"\\n   188|            \\\"fields may be case-sensitive.\\\"\\n   189|        ),\\n   190|        'inactive': _(\\\"This account is inactive.\\\"),\\n   191|    }\\n   192|\\n   193|    def __init__(self, request=None, *args, **kwargs):\\n   194|        \\\"\\\"\\\"\\n   195|        The 'request' parameter is set for custom auth use by subclasses.\\n   196|        The form data comes in via the standard 'data' kwarg.\\n   197|        \\\"\\\"\\\"\\n   198|        self.request = request\\n   199|        self.user_cache = None\\n   200|        super().__init__(*args, **kwargs)\\n   201|\\n   202|        # Set the max length and label for the \\\"username\\\" field.\\n   203|        self.username_field = UserModel._meta.get_field(UserModel.USERNAME_FIELD)\\n   204|        username_max_length = self.username_field.max_length or 254\\n   205|        self.fields['username'].max_length = username_max_length\\n   206|        self.fields['username'].widget.attrs['maxlength'] = username_max_length\\n   207|        if self.fields['username'].label is None:\\n   208|            self.fields['username'].label = capfirst(self.username_field.verbose_name)\\n   209|\\n   210|    def clean(self):\\n   211|        username = self.cleaned_data.get('username')\\n   212|        password = self.cleaned_data.get('password')\\n   213|\\n   214|        if username is not None and password:\\n   215|            self.user_cache = authenticate(self.request, username=username, password=password)\\n   216|            if self.user_cache is None:\\n   217|                raise self.get_invalid_login_error()\\n   218|            else:\\n   219|                self.confirm_login_allowed(self.user_cache)\\n   220|\\n   221|        return self.cleaned_data\\n   222|\\n   223|    def confirm_login_allowed(self, user):\\n   224|        \\\"\\\"\\\"\\n   225|        Controls whether the given User may log in. This is a policy setting,\\n   226|        independent of end-user authentication. This default behavior is to\\n   227|        allow login by active users, and reject login by inactive users.\\n   228|\\n   229|        If the given user cannot log in, this method should raise a\\n   230|        ``ValidationError``.\\n   231|\\n   232|        If the given user may log in, this method should return None.\\n   233|        \\\"\\\"\\\"\\n   234|        if not user.is_active:\\n   235|            raise ValidationError(\\n   236|                self.error_messages['inactive'],\\n   237|                code='inactive',\\n   238|            )\\n   239|\\n   240|    def get_user(self):\\n   241|        return self.user_cache\\n   242|\\n   243|    def get_invalid_login_error(self):\\n   244|        return ValidationError(\\n   245|            self.error_messages['invalid_login'],\\n   246|            code='invalid_login',\\n   247|            params={'username': self.username_field.verbose_name},\\n   248|        )\\n   249|\\n   250|\\n   251|class PasswordResetForm(forms.Form):\\n   252|    email = forms.EmailField(\\n   253|        label=_(\\\"Email\\\"),\\n   254|        max_length=254,\\n   255|        widget=forms.EmailInput(attrs={'autocomplete': 'email'})\\n   256|    )\\n   257|\\n   258|    def send_mail(self, subject_template_name, email_template_name,\\n   259|                  context, from_email, to_email, html_email_template_name=None):\\n   260|        \\\"\\\"\\\"\\n   261|        Send a django.core.mail.EmailMultiAlternatives to `to_email`.\\n   262|        \\\"\\\"\\\"\\n   263|        subject = loader.render_to_string(subject_template_name, context)\\n   264|        # Email subject *must not* contain newlines\\n   265|        subject = ''.join(subject.splitlines())\\n   266|        body = loader.render_to_string(email_template_name, context)\\n   267|\\n   268|        email_message = EmailMultiAlternatives(subject, body, from_email, [to_email])\\n   269|        if html_email_template_name is not None:\\n   270|            html_email = loader.render_to_string(html_email_template_name, context)\\n   271|            email_message.attach_alternative(html_email, 'text/html')\\n   272|\\n   273|        email_message.send()\\n   274|\\n   275|    def get_users(self, email):\\n   276|        \\\"\\\"\\\"Given an email, return matching user(s) who should receive a reset.\\n   277|\\n   278|        This allows subclasses to more easily customize the default policies\\n   279|        that prevent inactive users and users with unusable passwords from\\n   280|        resetting their password.\\n   281|        \\\"\\\"\\\"\\n   282|        email_field_name = UserModel.get_email_field_name()\\n   283|        active_users = UserModel._default_manager.filter(**{\\n   284|            '%s__iexact' % email_field_name: email,\\n   285|            'is_active': True,\\n   286|        })\\n   287|        return (\\n   288|            u for u in active_users\\n   289|            if u.has_usable_password() and\\n   290|            _unicode_ci_compare(email, getattr(u, email_field_name))\\n   291|        )\\n   292|\\n   293|    def save(self, domain_override=None,\\n   294|             subject_template_name='registration/password_reset_subject.txt',\\n   295|             email_template_name='registration/password_reset_email.html',\\n   296|             use_https=False, token_generator=default_token_generator,\\n   297|             from_email=None, request=None, html_email_template_name=None,\\n   298|             extra_email_context=None):\\n   299|        \\\"\\\"\\\"\\n   300|        Generate a one-use only link for resetting password and send it to the\\n   301|        user.\\n   302|        \\\"\\\"\\\"\\n   303|        email = self.cleaned_data[\\\"email\\\"]\\n   304|        if not domain_override:\\n   305|            current_site = get_current_site(request)\\n   306|            site_name = current_site.name\\n   307|            domain = current_site.domain\\n   308|        else:\\n   309|            site_name = domain = domain_override\\n   310|        email_field_name = UserModel.get_email_field_name()\\n   311|        for user in self.get_users(email):\\n   312|            user_email = getattr(user, email_field_name)\\n   313|            context = {\\n   314|                'email': user_email,\\n   315|                'domain': domain,\\n   316|                'site_name': site_name,\\n   317|                'uid': urlsafe_base64_encode(force_bytes(user.pk)),\\n   318|                'user': user,\\n   319|                'token': token_generator.make_token(user),\\n   320|                'protocol': 'https' if use_https else 'http',\\n   321|                **(extra_email_context or {}),\\n   322|            }\\n   323|            self.send_mail(\\n   324|                subject_template_name, email_template_name, context, from_email,\\n   325|                user_email, html_email_template_name=html_email_template_name,\\n   326|            )\\n   327|\\n   328|\\n   329|class SetPasswordForm(forms.Form):\\n   330|    \\\"\\\"\\\"\\n   331|    A form that lets a user change set their password without entering the old\\n   332|    password\\n   333|    \\\"\\\"\\\"\\n   334|    error_messages = {\\n   335|        'password_mismatch': _('The two password fields didn\u2019t match.'),\\n   336|    }\\n   337|    new_password1 = forms.CharField(\\n   338|        label=_(\\\"New password\\\"),\\n   339|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),\\n   340|        strip=False,\\n   341|        help_text=password_validation.password_validators_help_text_html(),\\n   342|    )\\n   343|    new_password2 = forms.CharField(\\n   344|        label=_(\\\"New password confirmation\\\"),\\n   345|        strip=False,\\n   346|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),\\n   347|    )\\n   348|\\n   349|    def __init__(self, user, *args, **kwargs):\\n   350|        self.user = user\\n   351|        super().__init__(*args, **kwargs)\\n   352|\\n   353|    def clean_new_password2(self):\\n   354|        password1 = self.cleaned_data.get('new_password1')\\n   355|        password2 = self.cleaned_data.get('new_password2')\\n   356|        if password1 and password2:\\n   357|            if password1 != password2:\\n   358|                raise ValidationError(\\n   359|                    self.error_messages['password_mismatch'],\\n   360|                    code='password_mismatch',\\n   361|                )\\n   362|        password_validation.validate_password(password2, self.user)\\n   363|        return password2\\n   364|\\n   365|    def save(self, commit=True):\\n   366|        password = self.cleaned_data[\\\"new_password1\\\"]\\n   367|        self.user.set_password(password)\\n   368|        if commit:\\n   369|            self.user.save()\\n   370|        return self.user\\n   371|\\n   372|\\n   373|class PasswordChangeForm(SetPasswordForm):\\n   374|    \\\"\\\"\\\"\\n   375|    A form that lets a user change their password by entering their old\\n   376|    password.\\n   377|    \\\"\\\"\\\"\\n   378|    error_messages = {\\n   379|        **SetPasswordForm.error_messages,\\n   380|        'password_incorrect': _(\\\"Your old password was entered incorrectly. Please enter it again.\\\"),\\n   381|    }\\n   382|    old_password = forms.CharField(\\n   383|        label=_(\\\"Old password\\\"),\\n   384|        strip=False,\\n   385|        widget=forms.PasswordInput(attrs={'autocomplete': 'current-password', 'autofocus': True}),\\n   386|    )\\n   387|\\n   388|    field_order = ['old_password', 'new_password1', 'new_password2']\\n   389|\\n   390|    def clean_old_password(self):\\n   391|        \\\"\\\"\\\"\\n   392|        Validate that the old_password field is correct.\\n   393|        \\\"\\\"\\\"\\n   394|        old_password = self.cleaned_data[\\\"old_password\\\"]\\n   395|        if not self.user.check_password(old_password):\\n   396|            raise ValidationError(\\n   397|                self.error_messages['password_incorrect'],\\n   398|                code='password_incorrect',\\n   399|            )\\n   400|        return old_password\\n   401|\\n   402|\\n   403|class AdminPasswordChangeForm(forms.Form):\\n   404|    \\\"\\\"\\\"\\n   405|    A form used to change the password of a user in the admin interface.\\n   406|    \\\"\\\"\\\"\\n   407|    error_messages = {\\n   408|        'password_mismatch': _('The two password fields didn\u2019t match.'),\\n   409|    }\\n   410|    required_css_class = 'required'\\n   411|    password1 = forms.CharField(\\n   412|        label=_(\\\"Password\\\"),\\n   413|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password', 'autofocus': True}),\\n   414|        strip=False,\\n   415|        help_text=password_validation.password_validators_help_text_html(),\\n   416|    )\\n   417|    password2 = forms.CharField(\\n   418|        label=_(\\\"Password (again)\\\"),\\n   419|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),\\n   420|        strip=False,\\n   421|        help_text=_(\\\"Enter the same password as before, for verification.\\\"),\\n   422|    )\\n   423|\\n   424|    def __init__(self, user, *args, **kwargs):\\n   425|        self.user = user\\n   426|        super().__init__(*args, **kwargs)\\n   427|\\n   428|    def clean_password2(self):\\n   429|        password1 = self.cleaned_data.get('password1')\\n   430|        password2 = self.cleaned_data.get('password2')\\n   431|        if password1 and password2 and password1 != password2:\\n   432|            raise ValidationError(\\n   433|                self.error_messages['password_mismatch'],\\n   434|                code='password_mismatch',\\n   435|            )\\n   436|        password_validation.validate_password(password2, self.user)\\n   437|        return password2\\n   438|\\n   439|    def save(self, commit=True):\\n   440|        \\\"\\\"\\\"Save the new password.\\\"\\\"\\\"\\n   441|        password = self.cleaned_data[\\\"password1\\\"]\\n   442|        self.user.set_password(password)\\n   443|        if commit:\\n   444|            self.user.save()\\n   445|        return self.user\\n   446|\\n   447|    @property\\n   448|    def changed_data(self):\\n   449|        data = super().changed_data\\n   450|        for name in self.fields:\\n   451|            if name not in data:\\n   452|                return []\\n   453|        return ['password']\\n   454|\", \"total_lines\": 453, \"file_size\": 16311, \"truncated\": false, \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 4,
+      "source": "agent",
+      "message": "Now let me check the tests and the docs that reference `clean_password`:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_rntyhigl",
+          "function_name": "search_files",
+          "arguments": {
+            "output_mode": "content",
+            "path": "./tests/auth_tests",
+            "pattern": "clean_password"
+          }
+        },
+        {
+          "tool_call_id": "call_3jhj2k7c",
+          "function_name": "search_files",
+          "arguments": {
+            "output_mode": "content",
+            "path": "./docs/topics/auth",
+            "pattern": "clean_password"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_rntyhigl",
+            "content": "{\"total_count\": 0}"
+          },
+          {
+            "source_call_id": "call_3jhj2k7c",
+            "content": "{\"total_count\": 2, \"matches\": [{\"path\": \"./docs/topics/auth/customizing.txt\", \"line\": 1112, \"content\": \"        def clean_password2(self):\"}, {\"path\": \"./docs/topics/auth/customizing.txt\", \"line\": 1140, \"content\": \"        def clean_password(self):\"}]}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 5,
+      "source": "agent",
+      "message": "[tool call]",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_89pm5vx6",
+          "function_name": "read_file",
+          "arguments": {
+            "offset": 1100,
+            "limit": 80,
+            "path": "./docs/topics/auth/customizing.txt"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_89pm5vx6",
+            "content": "{\"content\": \"  1100|\\n  1101|\\n  1102|    class UserCreationForm(forms.ModelForm):\\n  1103|        \\\"\\\"\\\"A form for creating new users. Includes all the required\\n  1104|        fields, plus a repeated password.\\\"\\\"\\\"\\n  1105|        password1 = forms.CharField(label='Password', widget=forms.PasswordInput)\\n  1106|        password2 = forms.CharField(label='Password confirmation', widget=forms.PasswordInput)\\n  1107|\\n  1108|        class Meta:\\n  1109|            model = MyUser\\n  1110|            fields = ('email', 'date_of_birth')\\n  1111|\\n  1112|        def clean_password2(self):\\n  1113|            # Check that the two password entries match\\n  1114|            password1 = self.cleaned_data.get(\\\"password1\\\")\\n  1115|            password2 = self.cleaned_data.get(\\\"password2\\\")\\n  1116|            if password1 and password2 and password1 != password2:\\n  1117|                raise ValidationError(\\\"Passwords don't match\\\")\\n  1118|            return password2\\n  1119|\\n  1120|        def save(self, commit=True):\\n  1121|            # Save the provided password in hashed format\\n  1122|            user = super().save(commit=False)\\n  1123|            user.set_password(self.cleaned_data[\\\"password1\\\"])\\n  1124|            if commit:\\n  1125|                user.save()\\n  1126|            return user\\n  1127|\\n  1128|\\n  1129|    class UserChangeForm(forms.ModelForm):\\n  1130|        \\\"\\\"\\\"A form for updating users. Includes all the fields on\\n  1131|        the user, but replaces the password field with admin's\\n  1132|        password hash display field.\\n  1133|        \\\"\\\"\\\"\\n  1134|        password = ReadOnlyPasswordHashField()\\n  1135|\\n  1136|        class Meta:\\n  1137|            model = MyUser\\n  1138|            fields = ('email', 'password', 'date_of_birth', 'is_active', 'is_admin')\\n  1139|\\n  1140|        def clean_password(self):\\n  1141|            # Regardless of what the user provides, return the initial value.\\n  1142|            # This is done here, rather than on the field, because the\\n  1143|            # field does not have access to the initial value\\n  1144|            return self.initial[\\\"password\\\"]\\n  1145|\\n  1146|\\n  1147|    class UserAdmin(BaseUserAdmin):\\n  1148|        # The forms to add and change user instances\\n  1149|        form = UserChangeForm\\n  1150|        add_form = UserCreationForm\\n  1151|\\n  1152|        # The fields to be used in displaying the User model.\\n  1153|        # These override the definitions on the base UserAdmin\\n  1154|        # that reference specific fields on auth.User.\\n  1155|        list_display = ('email', 'date_of_birth', 'is_admin')\\n  1156|        list_filter = ('is_admin',)\\n  1157|        fieldsets = (\\n  1158|            (None, {'fields': ('email', 'password')}),\\n  1159|            ('Personal info', {'fields': ('date_of_birth',)}),\\n  1160|            ('Permissions', {'fields': ('is_admin',)}),\\n  1161|        )\\n  1162|        # add_fieldsets is not a standard ModelAdmin attribute. UserAdmin\\n  1163|        # overrides get_fieldsets to use this attribute when creating a user.\\n  1164|        add_fieldsets = (\\n  1165|            (None, {\\n  1166|                'classes': ('wide',),\\n  1167|                'fields': ('email', 'date_of_birth', 'password1', 'password2'),\\n  1168|            }),\\n  1169|        )\\n  1170|        search_fields = ('email',)\\n  1171|        ordering = ('email',)\\n  1172|        filter_horizontal = ()\\n  1173|\\n  1174|\\n  1175|    # Now register the new UserAdmin...\\n  1176|    admin.site.register(MyUser, UserAdmin)\\n  1177|    # ... and, since we're not using Django's built-in permissions,\\n  1178|    # unregister the Group model from admin.\\n  1179|    admin.site.unregister(Group)\\n  1180|\", \"total_lines\": 1184, \"file_size\": 49492, \"truncated\": true, \"hint\": \"Use offset=1180 to continue reading (showing 1100-1179 of 1184 lines)\", \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 6,
+      "source": "agent",
+      "message": "Let me check the existing tests for `UserChangeForm`:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_do5cz4pw",
+          "function_name": "search_files",
+          "arguments": {
+            "output_mode": "content",
+            "path": "./tests/auth_tests/test_forms.py",
+            "pattern": "password",
+            "context": 5
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_do5cz4pw",
+            "content": "{\"total_count\": 245, \"matches\": [{\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 29, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 30, \"content\": \"class TestDataMixin:\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 31, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 32, \"content\": \"    @classmethod\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 33, \"content\": \"    def setUpTestData(cls):\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 34, \"content\": \"        cls.u1 = User.objects.create_user(username='testclient', password='password', email='testclient@example.com')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 35, \"content\": \"        cls.u2 = User.objects.create_user(username='inactive', password='password', is_active=False)\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 36, \"content\": \"        cls.u3 = User.objects.create_user(username='staff', password='password')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 37, \"content\": \"        cls.u4 = User.objects.create(username='empty_password', password='')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 38, \"content\": \"        cls.u5 = User.objects.create(username='unmanageable_password', password='$')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 39, \"content\": \"        cls.u6 = User.objects.create(username='unknown_password', password='foo$bar')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 40, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 41, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 42, \"content\": \"class UserCreationFormTest(TestDataMixin, TestCase):\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 43, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 44, \"content\": \"    def test_user_already_exists(self):\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 45, \"content\": \"        data = {\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 46, \"content\": \"            'username': 'testclient',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 47, \"content\": \"            'password1': 'test123',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 48, \"content\": \"            'password2': 'test123',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 49, \"content\": \"        }\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 50, \"content\": \"        form = UserCreationForm(data)\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 51, \"content\": \"        self.assertFalse(form.is_valid())\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 52, \"content\": \"        self.assertEqual(form[\\\"username\\\"].errors,\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 53, \"content\": \"                         [str(User._meta.get_field('username').error_messages['unique'])])\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 54, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 55, \"content\": \"    def test_invalid_data(self):\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 56, \"content\": \"        data = {\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 57, \"content\": \"            'username': 'jsmith!',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 58, \"content\": \"            'password1': 'test123',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 59, \"content\": \"            'password2': 'test123',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 60, \"content\": \"        }\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 61, \"content\": \"        form = UserCreationForm(data)\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 62, \"content\": \"        self.assertFalse(form.is_valid())\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 63, \"content\": \"        validator = next(v for v in User._meta.get_field('username').validators if v.code == 'invalid')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 64, \"content\": \"        self.assertEqual(form[\\\"username\\\"].errors, [str(validator.message)])\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 65, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 66, \"content\": \"    def test_password_verification(self):\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 67, \"content\": \"        # The verification password is incorrect.\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 68, \"content\": \"        data = {\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 69, \"content\": \"            'username': 'jsmith',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 70, \"content\": \"            'password1': 'test123',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 71, \"content\": \"            'password2': 'test',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 72, \"content\": \"        }\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 73, \"content\": \"        form = UserCreationForm(data)\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 74, \"content\": \"        self.assertFalse(form.is_valid())\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 75, \"content\": \"        self.assertEqual(form[\\\"password2\\\"].errors,\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 76, \"content\": \"                         [str(form.error_messages['password_mismatch'])])\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 77, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 78, \"content\": \"    def test_both_passwords(self):\"}], \"truncated\": true}\n\n[Hint: Results truncated. Use offset=50 to see more, or narrow with a more specific pattern or file_glob.]"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 7,
+      "source": "agent",
+      "message": "Now I have a clear picture. Let me implement the change.\n\nThe fix is straightforward: add `disabled=True` to the `ReadOnlyPasswordHashField` field definition in `UserChangeForm` and remove the now-unnecessary `clean_password` method.",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_588dvlm1",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "path": "./django/contrib/auth/forms.py",
+            "old_string": "class UserChangeForm(forms.ModelForm):\n    password = ReadOnlyPasswordHashField(\n        label=_(\"Password\"),\n        help_text=_(\n            'Raw passwords are not stored, so there is no way to see this '\n            'user's password, but you can change the password using '\n            '<a href=\"{}\">this form</a>.'\n        ),\n    )",
+            "new_string": "class UserChangeForm(forms.ModelForm):\n    password = ReadOnlyPasswordHashField(\n        label=_(\"Password\"),\n        disabled=True,\n        help_text=_(\n            'Raw passwords are not stored, so there is no way to see this '\n            'user's password, but you can change the password using '\n            '<a href=\"{}\">this form</a>.'\n        ),\n    )"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_588dvlm1",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -142,9 +142,10 @@\\n class UserChangeForm(forms.ModelForm):\\n     password = ReadOnlyPasswordHashField(\\n         label=_(\\\"Password\\\"),\\n+        disabled=True,\\n         help_text=_(\\n             'Raw passwords are not stored, so there is no way to see this '\\n-            'user\u2019s password, but you can change the password using '\\n+            'user's password, but you can change the password using '\\n             '<a href=\\\"{}\\\">this form</a>.'\\n         ),\\n     )\\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"error\", \"output\": \"SyntaxError: unterminated string literal (detected at line 148) (line 148, column 69)\"}}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 8,
+      "source": "agent",
+      "message": "The patch introduced an encoding issue. Let me read the current state and fix it:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_3ev8gxr9",
+          "function_name": "read_file",
+          "arguments": {
+            "limit": 15,
+            "offset": 142,
+            "path": "./django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_3ev8gxr9",
+            "content": "{\"content\": \"   142|class UserChangeForm(forms.ModelForm):\\n   143|    password = ReadOnlyPasswordHashField(\\n   144|        label=_(\\\"Password\\\"),\\n   145|        disabled=True,\\n   146|        help_text=_(\\n   147|            'Raw passwords are not stored, so there is no way to see this '\\n   148|            'user's password, but you can change the password using '\\n   149|            '<a href=\\\"{}\\\">this form</a>.'\\n   150|        ),\\n   151|    )\\n   152|\\n   153|    class Meta:\\n   154|        model = User\\n   155|        fields = '__all__'\\n   156|        field_classes = {'username': UsernameField}\\n   157|\", \"total_lines\": 454, \"file_size\": 16332, \"truncated\": true, \"hint\": \"Use offset=157 to continue reading (showing 142-156 of 454 lines)\", \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 9,
+      "source": "agent",
+      "message": "The curly apostrophe in the original text was converted to `'` which breaks the string. Let me fix it:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_8lrexjko",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "path": "./django/contrib/auth/forms.py",
+            "old_string": "        help_text=_(\n            'Raw passwords are not stored, so there is no way to see this '\n            'user's password, but you can change the password using '\n            '<a href=\"{}\">this form</a>.'\n        ),",
+            "new_string": "        help_text=_(\n            \"Raw passwords are not stored, so there is no way to see this \"\n            \"user's password, but you can change the password using \"\n            \"<a href=\\\"{}\\\">this form</a>.\"\n        ),"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_8lrexjko",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -144,9 +144,9 @@\\n         label=_(\\\"Password\\\"),\\n         disabled=True,\\n         help_text=_(\\n-            'Raw passwords are not stored, so there is no way to see this '\\n-            'user's password, but you can change the password using '\\n-            '<a href=\\\"{}\\\">this form</a>.'\\n+            \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n+            \\\"user's password, but you can change the password using \\\"\\n+            \\\"<a href=\\\\\\\"{}\\\\\\\">this form</a>.\\\"\\n         ),\\n     )\\n \\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"ok\", \"output\": \"\"}, \"_warning\": \"/testbed/django/contrib/auth/forms.py was last read with offset/limit pagination (partial view). Re-read the whole file before overwriting it.\"}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 10,
+      "source": "agent",
+      "message": "The escaping looks wrong. Let me re-read and fix properly:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_apcd6m2h",
+          "function_name": "read_file",
+          "arguments": {
+            "limit": 20,
+            "offset": 142,
+            "path": "./django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_apcd6m2h",
+            "content": "{\"content\": \"   142|class UserChangeForm(forms.ModelForm):\\n   143|    password = ReadOnlyPasswordHashField(\\n   144|        label=_(\\\"Password\\\"),\\n   145|        disabled=True,\\n   146|        help_text=_(\\n   147|            \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n   148|            \\\"user's password, but you can change the password using \\\"\\n   149|            \\\"<a href=\\\\\\\"{}\\\\\\\">this form</a>.\\\"\\n   150|        ),\\n   151|    )\\n   152|\\n   153|    class Meta:\\n   154|        model = User\\n   155|        fields = '__all__'\\n   156|        field_classes = {'username': UsernameField}\\n   157|\\n   158|    def __init__(self, *args, **kwargs):\\n   159|        super().__init__(*args, **kwargs)\\n   160|        password = self.fields.get('password')\\n   161|        if password:\\n   162|\", \"total_lines\": 454, \"file_size\": 16334, \"truncated\": true, \"hint\": \"Use offset=162 to continue reading (showing 142-161 of 454 lines)\", \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 11,
+      "source": "agent",
+      "message": "The escaping on line 149 is incorrect. Let me fix that, and also now remove the `clean_password` method since it's no longer needed:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_jomhje2z",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "path": "./django/contrib/auth/forms.py",
+            "old_string": "            \"<a href=\\\\\"{}\\\\\">this form</a>.\"",
+            "new_string": "            '<a href=\"{}\">this form</a>.'"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_jomhje2z",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -146,7 +146,7 @@\\n         help_text=_(\\n             \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n             \\\"user's password, but you can change the password using \\\"\\n-            \\\"<a href=\\\\\\\"{}\\\\\\\">this form</a>.\\\"\\n+            '<a href=\\\"{}\\\">this form</a>.'\\n         ),\\n     )\\n \\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"ok\", \"output\": \"\"}, \"_warning\": \"/testbed/django/contrib/auth/forms.py was last read with offset/limit pagination (partial view). Re-read the whole file before overwriting it.\"}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 12,
+      "source": "agent",
+      "message": "Let me start fresh and rewrite the entire `UserChangeForm` class properly.",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_igvwuti8",
+          "function_name": "read_file",
+          "arguments": {
+            "offset": 142,
+            "limit": 30,
+            "path": "./django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_igvwuti8",
+            "content": "{\"content\": \"   142|class UserChangeForm(forms.ModelForm):\\n   143|    password = ReadOnlyPasswordHashField(\\n   144|        label=_(\\\"Password\\\"),\\n   145|        disabled=True,\\n   146|        help_text=_(\\n   147|            \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n   148|            \\\"user's password, but you can change the password using \\\"\\n   149|            '<a href=\\\"{}\\\">this form</a>.'\\n   150|        ),\\n   151|    )\\n   152|\\n   153|    class Meta:\\n   154|        model = User\\n   155|        fields = '__all__'\\n   156|        field_classes = {'username': UsernameField}\\n   157|\\n   158|    def __init__(self, *args, **kwargs):\\n   159|        super().__init__(*args, **kwargs)\\n   160|        password = self.fields.get('password')\\n   161|        if password:\\n   162|            password.help_text = password.help_text.format('../password/')\\n   163|        user_permissions = self.fields.get('user_permissions')\\n   164|        if user_permissions:\\n   165|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n   166|\\n   167|    def clean_password(self):\\n   168|        # Regardless of what the user provides, return the initial value.\\n   169|        # This is done here, rather than on the field, because the\\n   170|        # field does not have access to the initial value\\n   171|        return self.initial.get('password')\\n   172|\", \"total_lines\": 454, \"file_size\": 16332, \"truncated\": true, \"hint\": \"Use offset=172 to continue reading (showing 142-171 of 454 lines)\", \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 13,
+      "source": "agent",
+      "message": "The help_text has odd quote mixing but is valid Python. The real remaining change is to remove the `clean_password` method. But first, let me fix the help_text quotes to be clean, then remove `clean_password`:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_t878z9ul",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "new_string": "class UserChangeForm(forms.ModelForm):\n    password = ReadOnlyPasswordHashField(\n        label=_(\"Password\"),\n        disabled=True,\n        help_text=_(\n            \"Raw passwords are not stored, so there is no way to see this \"\n            \"user's password, but you can change the password using \"\n            '<a href=\"{}\">this form</a>.'\n        ),\n    )\n\n    class Meta:\n        model = User\n        fields = '__all__'\n        field_classes = {'username': UsernameField}\n\n    def __init__(self, *args, **kwargs):\n        super().__init__(*args, **kwargs)\n        password = self.fields.get('password')\n        if password:\n            password.help_text = password.help_text.format('../password/')\n        user_permissions = self.fields.get('user_permissions')\n        if user_permissions:\n            user_permissions.queryset = user_permissions.queryset.select_related('content_type')",
+            "old_string": "class UserChangeForm(forms.ModelForm):\n    password = ReadOnlyPasswordHashField(\n        label=_(\"Password\"),\n        disabled=True,\n        help_text=_(\n            \"Raw passwords are not stored, so there is no way to see this \"\n            \"user's password, but you can change the password using \"\n            '<a href=\"{}\">this form</a>.'\n        ),\n    )\n\n    class Meta:\n        model = User\n        fields = '__all__'\n        field_classes = {'username': UsernameField}\n\n    def __init__(self, *args, **kwargs):\n        super().__init__(*args, **kwargs)\n        password = self.fields.get('password')\n        if password:\n            password.help_text = password.help_text.format('../password/')\n        user_permissions = self.fields.get('user_permissions')\n        if user_permissions:\n            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\n\n    def clean_password(self):\n        # Regardless of what the user provides, return the initial value.\n        # This is done here, rather than on the field, because the\n        # field does not have access to the initial value\n        return self.initial.get('password')",
+            "path": "./django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_t878z9ul",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -163,12 +163,6 @@\\n         user_permissions = self.fields.get('user_permissions')\\n         if user_permissions:\\n             user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n-\\n-    def clean_password(self):\\n-        # Regardless of what the user provides, return the initial value.\\n-        # This is done here, rather than on the field, because the\\n-        # field does not have access to the initial value\\n-        return self.initial.get('password')\\n \\n \\n class AuthenticationForm(forms.Form):\\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"ok\", \"output\": \"\"}, \"_warning\": \"/testbed/django/contrib/auth/forms.py was last read with offset/limit pagination (partial view). Re-read the whole file before overwriting it.\"}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 14,
+      "source": "agent",
+      "message": "The `clean_password` method is now removed. Let me verify the final state of the file looks correct:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_jlg04i2d",
+          "function_name": "read_file",
+          "arguments": {
+            "limit": 30,
+            "offset": 142,
+            "path": "./django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_jlg04i2d",
+            "content": "{\"content\": \"   142|class UserChangeForm(forms.ModelForm):\\n   143|    password = ReadOnlyPasswordHashField(\\n   144|        label=_(\\\"Password\\\"),\\n   145|        disabled=True,\\n   146|        help_text=_(\\n   147|            \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n   148|            \\\"user's password, but you can change the password using \\\"\\n   149|            '<a href=\\\"{}\\\">this form</a>.'\\n   150|        ),\\n   151|    )\\n   152|\\n   153|    class Meta:\\n   154|        model = User\\n   155|        fields = '__all__'\\n   156|        field_classes = {'username': UsernameField}\\n   157|\\n   158|    def __init__(self, *args, **kwargs):\\n   159|        super().__init__(*args, **kwargs)\\n   160|        password = self.fields.get('password')\\n   161|        if password:\\n   162|            password.help_text = password.help_text.format('../password/')\\n   163|        user_permissions = self.fields.get('user_permissions')\\n   164|        if user_permissions:\\n   165|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n   166|\\n   167|\\n   168|class AuthenticationForm(forms.Form):\\n   169|    \\\"\\\"\\\"\\n   170|    Base class for authenticating users. Extend this to get a form that accepts\\n   171|    username/password logins.\\n   172|\", \"total_lines\": 448, \"file_size\": 16058, \"truncated\": true, \"hint\": \"Use offset=172 to continue reading (showing 142-171 of 448 lines)\", \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 15,
+      "source": "agent",
+      "message": "Let me fix the mixed quotes in the help_text for consistency:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_rctd2l1c",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "new_string": "        help_text=_(\n            'Raw passwords are not stored, so there is no way to see this '\n            'user's password, but you can change the password using '\n            '<a href=\"{}\">this form</a>.'\n        ),",
+            "old_string": "        help_text=_(\n            \"Raw passwords are not stored, so there is no way to see this \"\n            \"user's password, but you can change the password using \"\n            '<a href=\"{}\">this form</a>.'\n        ),",
+            "path": "./django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_rctd2l1c",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -144,8 +144,8 @@\\n         label=_(\\\"Password\\\"),\\n         disabled=True,\\n         help_text=_(\\n-            \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n-            \\\"user's password, but you can change the password using \\\"\\n+            'Raw passwords are not stored, so there is no way to see this '\\n+            'user's password, but you can change the password using '\\n             '<a href=\\\"{}\\\">this form</a>.'\\n         ),\\n     )\\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"error\", \"output\": \"SyntaxError: unterminated string literal (detected at line 148) (line 148, column 69)\"}, \"_warning\": \"/testbed/django/contrib/auth/forms.py was last read with offset/limit pagination (partial view). Re-read the whole file before overwriting it.\"}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 16,
+      "source": "agent",
+      "message": "The problem is the apostrophe in \"user's\" conflicting with single quotes. Let me read the original version of this file from git:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_kfot9kqo",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "git diff HEAD -- django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_kfot9kqo",
+            "content": "{\"output\": \"diff --git a/django/contrib/auth/forms.py b/django/contrib/auth/forms.py\\nindex b9eb33329f..b890d12e7e 100644\\n--- a/django/contrib/auth/forms.py\\n+++ b/django/contrib/auth/forms.py\\n@@ -142,9 +142,10 @@ class UserCreationForm(forms.ModelForm):\\n class UserChangeForm(forms.ModelForm):\\n     password = ReadOnlyPasswordHashField(\\n         label=_(\\\"Password\\\"),\\n+        disabled=True,\\n         help_text=_(\\n             'Raw passwords are not stored, so there is no way to see this '\\n-            'user\u2019s password, but you can change the password using '\\n+            'user's password, but you can change the password using '\\n             '<a href=\\\"{}\\\">this form</a>.'\\n         ),\\n     )\\n@@ -163,12 +164,6 @@ class UserChangeForm(forms.ModelForm):\\n         if user_permissions:\\n             user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n \\n-    def clean_password(self):\\n-        # Regardless of what the user provides, return the initial value.\\n-        # This is done here, rather than on the field, because the\\n-        # field does not have access to the initial value\\n-        return self.initial.get('password')\\n-\\n \\n class AuthenticationForm(forms.Form):\\n     \\\"\\\"\\\"\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 17,
+      "source": "agent",
+      "message": "The original file uses a curly/smart apostrophe (') in \"user's\", not an ASCII apostrophe. Let me reset and redo this cleanly:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_16np6w11",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "git checkout -- django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_16np6w11",
+            "content": "{\"output\": \"\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 18,
+      "source": "agent",
+      "message": "Now let me use Python to make the edit properly:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_5uo0t4qb",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"r\") as f:\n    content = f.read()\n\n# Add disabled=True to ReadOnlyPasswordHashField\ncontent = content.replace(\n    \"\"\"password = ReadOnlyPasswordHashField(\n        label=_(\\\"Password\\\"),\n        help_text=(\"\"\",\n    \"\"\"password = ReadOnlyPasswordHashField(\n        label=_(\\\"Password\\\"),\n        disabled=True,\n        help_text=(\"\"\",\n)\n\n# Remove the clean_password method from UserChangeForm\nold_clean = \"\"\"    def clean_password(self):\n        # Regardless of what the user provides, return the initial value.\n        # This is done here, rather than on the field, because the\n        # field does not have access to the initial value\n        return self.initial.get('password')\n\"\"\"\n\ncontent = content.replace(old_clean, \"\")\n\nwith open(path, \"w\") as f:\n    f.write(content)\n\n# Verify\nwith open(path, \"r\") as f:\n    lines = f.readlines()\n\n# Print the UserChangeForm class\nfor i, line in enumerate(lines):\n    if 'class UserChangeForm' in line:\n        for j in range(i, min(i+30, len(lines))):\n            print(f\"{j+1:4d}|{lines[j]}\", end='')\n        break\n"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_5uo0t4qb",
+            "content": "{\"status\": \"success\", \"output\": \" 142|class UserChangeForm(forms.ModelForm):\\n 143|    password = ReadOnlyPasswordHashField(\\n 144|        label=_(\\\"Password\\\"),\\n 145|        help_text=_(\\n 146|            'Raw passwords are not stored, so there is no way to see this '\\n 147|            'user\u2019s password, but you can change the password using '\\n 148|            '<a href=\\\"{}\\\">this form</a>.'\\n 149|        ),\\n 150|    )\\n 151|\\n 152|    class Meta:\\n 153|        model = User\\n 154|        fields = '__all__'\\n 155|        field_classes = {'username': UsernameField}\\n 156|\\n 157|    def __init__(self, *args, **kwargs):\\n 158|        super().__init__(*args, **kwargs)\\n 159|        password = self.fields.get('password')\\n 160|        if password:\\n 161|            password.help_text = password.help_text.format('../password/')\\n 162|        user_permissions = self.fields.get('user_permissions')\\n 163|        if user_permissions:\\n 164|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n 165|\\n 166|\\n 167|\\n 168|class AuthenticationForm(forms.Form):\\n 169|    \\\"\\\"\\\"\\n 170|    Base class for authenticating users. Extend this to get a form that accepts\\n 171|    username/password logins.\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.23}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 19,
+      "source": "agent",
+      "message": "The `disabled=True` wasn't inserted. Let me debug:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_t3tuiyds",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "git diff HEAD -- django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_t3tuiyds",
+            "content": "{\"output\": \"diff --git a/django/contrib/auth/forms.py b/django/contrib/auth/forms.py\\nindex b9eb33329f..12c9e0c925 100644\\n--- a/django/contrib/auth/forms.py\\n+++ b/django/contrib/auth/forms.py\\n@@ -163,11 +163,6 @@ class UserChangeForm(forms.ModelForm):\\n         if user_permissions:\\n             user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n \\n-    def clean_password(self):\\n-        # Regardless of what the user provides, return the initial value.\\n-        # This is done here, rather than on the field, because the\\n-        # field does not have access to the initial value\\n-        return self.initial.get('password')\\n \\n \\n class AuthenticationForm(forms.Form):\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 20,
+      "source": "agent",
+      "message": "Good, `clean_password` is removed. Now let me check why `disabled=True` wasn't inserted:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_978wtkkb",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"rb\") as f:\n    content = f.read()\n\n# Check the exact bytes around the label line\nidx = content.find(b'label=_(b\"Password\")')\nif idx == -1:\n    idx = content.find(b'label=_(\\'Password\\'')\n    print(f\"label pattern 2 found at: {idx}\")\n    print(f\"Context: {content[idx-5:idx+50]}\")\n\n# Show what we're looking for\nsearch = b'label=_(\\\"Password\\\"),\\n        help_text='\nidx = content.find(search)\nprint(f\"Exact search found at: {idx}\")\nif idx > 0:\n    print(f\"Context: {content[idx-10:idx+60]}\")\n"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_978wtkkb",
+            "content": "{\"status\": \"success\", \"output\": \"label pattern 2 found at: -1\\nContext: b''\\nExact search found at: 4881\\nContext: b'(\\\\n        label=_(\\\"Password\\\"),\\\\n        help_text=_(\\\\n            \\\\'Raw p'\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.21}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 21,
+      "source": "agent",
+      "message": "The `clean_password` was removed but `disabled=True` wasn't added because the original file has a Unicode curly quote that made my Python string differ. Let me add `disabled=True` now:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_rjgp7pp9",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"r\", encoding=\"utf-8\") as f:\n    content = f.read()\n\n# Find the exact text to replace - use bytes to be precise\nwith open(path, \"rb\") as f:\n    raw = f.read()\n\n# Show bytes around 'label=_(\\\"Password\\\"),'\nidx = raw.find(b'label=(\"Password\"),')\nprint(f\"Search target bytes: {raw[idx:idx+50]}\")\n\n# Replace label=_(\\\"Password\\\"), with label=_(\\\"Password\\\"),\\n        disabled=True,\nold = b'label=_(\\\"Password\\\"),\\n        help_text=('\nnew = b'label=_(\\\"Password\\\"),\\n        disabled=True,\\n        help_text=('\ncontent_bytes = raw.replace(old, new)\n\nwith open(path, \"w\", encoding=\"utf-8\") as f:\n    f.write(content_bytes.decode(\"utf-8\"))\n\nprint(\"Done. Verifying:\")\nwith open(path, \"r\", encoding=\"utf-8\") as f:\n    lines = f.readlines()\nfor i, line in enumerate(lines):\n    if 'class UserChangeForm' in line:\n        for j in range(i, min(i+30, len(lines))):\n            print(f\"{j+1:4d}|{lines[j]}\", end='')\n        break\n"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_rjgp7pp9",
+            "content": "{\"status\": \"success\", \"output\": \"Search target bytes: b''\\nDone. Verifying:\\n 142|class UserChangeForm(forms.ModelForm):\\n 143|    password = ReadOnlyPasswordHashField(\\n 144|        label=_(\\\"Password\\\"),\\n 145|        help_text=_(\\n 146|            'Raw passwords are not stored, so there is no way to see this '\\n 147|            'user\u2019s password, but you can change the password using '\\n 148|            '<a href=\\\"{}\\\">this form</a>.'\\n 149|        ),\\n 150|    )\\n 151|\\n 152|    class Meta:\\n 153|        model = User\\n 154|        fields = '__all__'\\n 155|        field_classes = {'username': UsernameField}\\n 156|\\n 157|    def __init__(self, *args, **kwargs):\\n 158|        super().__init__(*args, **kwargs)\\n 159|        password = self.fields.get('password')\\n 160|        if password:\\n 161|            password.help_text = password.help_text.format('../password/')\\n 162|        user_permissions = self.fields.get('user_permissions')\\n 163|        if user_permissions:\\n 164|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n 165|\\n 166|\\n 167|\\n 168|class AuthenticationForm(forms.Form):\\n 169|    \\\"\\\"\\\"\\n 170|    Base class for authenticating users. Extend this to get a form that accepts\\n 171|    username/password logins.\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.22}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 22,
+      "source": "agent",
+      "message": "[tool call]",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_glckjhb5",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"rb\") as f:\n    raw = f.read()\n\n# Find the label line for UserChangeForm (not UserCreationForm)\nidx = raw.find(b'class UserChangeForm')\nprint(f\"Found UserChangeForm at: {idx}\")\nchunk = raw[idx:idx+500]\nfor i, b in enumerate(chunk):\n    print(f\"  byte {i}: {hex(b)} = {chr(b) if 32 <= b < 127 else '?'}\")\n"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_glckjhb5",
+            "content": "{\"status\": \"success\", \"output\": \"Found UserChangeForm at: 4792\\n  byte 0: 0x63 = c\\n  byte 1: 0x6c = l\\n  byte 2: 0x61 = a\\n  byte 3: 0x73 = s\\n  byte 4: 0x73 = s\\n  byte 5: 0x20 =  \\n  byte 6: 0x55 = U\\n  byte 7: 0x73 = s\\n  byte 8: 0x65 = e\\n  byte 9: 0x72 = r\\n  byte 10: 0x43 = C\\n  byte 11: 0x68 = h\\n  byte 12: 0x61 = a\\n  byte 13: 0x6e = n\\n  byte 14: 0x67 = g\\n  byte 15: 0x65 = e\\n  byte 16: 0x46 = F\\n  byte 17: 0x6f = o\\n  byte 18: 0x72 = r\\n  byte 19: 0x6d = m\\n  byte 20: 0x28 = (\\n  byte 21: 0x66 = f\\n  byte 22: 0x6f = o\\n  byte 23: 0x72 = r\\n  byte 24: 0x6d = m\\n  byte 25: 0x73 = s\\n  byte 26: 0x2e = .\\n  byte 27: 0x4d = M\\n  byte 28: 0x6f = o\\n  byte 29: 0x64 = d\\n  byte 30: 0x65 = e\\n  byte 31: 0x6c = l\\n  byte 32: 0x46 = F\\n  byte 33: 0x6f = o\\n  byte 34: 0x72 = r\\n  byte 35: 0x6d = m\\n  byte 36: 0x29 = )\\n  byte 37: 0x3a = :\\n  byte 38: 0xa = ?\\n  byte 39: 0x20 =  \\n  byte 40: 0x20 =  \\n  byte 41: 0x20 =  \\n  byte 42: 0x20 =  \\n  byte 43: 0x70 = p\\n  byte 44: 0x61 = a\\n  byte 45: 0x73 = s\\n  byte 46: 0x73 = s\\n  byte 47: 0x77 = w\\n  byte 48: 0x6f = o\\n  byte 49: 0x72 = r\\n  byte 50: 0x64 = d\\n  byte 51: 0x20 =  \\n  byte 52: 0x3d = =\\n  byte 53: 0x20 =  \\n  byte 54: 0x52 = R\\n  byte 55: 0x65 = e\\n  byte 56: 0x61 = a\\n  byte 57: 0x64 = d\\n  byte 58: 0x4f = O\\n  byte 59: 0x6e = n\\n  byte 60: 0x6c = l\\n  byte 61: 0x79 = y\\n  byte 62: 0x50 = P\\n  byte 63: 0x61 = a\\n  byte 64: 0x73 = s\\n  byte 65: 0x73 = s\\n  byte 66: 0x77 = w\\n  byte 67: 0x6f = o\\n  byte 68: 0x72 = r\\n  byte 69: 0x64 = d\\n  byte 70: 0x48 = H\\n  byte 71: 0x61 = a\\n  byte 72: 0x73 = s\\n  byte 73: 0x68 = h\\n  byte 74: 0x46 = F\\n  byte 75: 0x69 = i\\n  byte 76: 0x65 = e\\n  byte 77: 0x6c = l\\n  byte 78: 0x64 = d\\n  byte 79: 0x28 = (\\n  byte 80: 0xa = ?\\n  byte 81: 0x20 =  \\n  byte 82: 0x20 =  \\n  byte 83: 0x20 =  \\n  byte 84: 0x20 =  \\n  byte 85: 0x20 =  \\n  byte 86: 0x20 =  \\n  byte 87: 0x20 =  \\n  byte 88: 0x20 =  \\n  byte 89: 0x6c = l\\n  byte 90: 0x61 = a\\n  byte 91: 0x62 = b\\n  byte 92: 0x65 = e\\n  byte 93: 0x6c = l\\n  byte 94: 0x3d = =\\n  byte 95: 0x5f = _\\n  byte 96: 0x28 = (\\n  byte 97: 0x22 = \\\"\\n  byte 98: 0x50 = P\\n  byte 99: 0x61 = a\\n  byte 100: 0x73 = s\\n  byte 101: 0x73 = s\\n  byte 102: 0x77 = w\\n  byte 103: 0x6f = o\\n  byte 104: 0x72 = r\\n  byte 105: 0x64 = d\\n  byte 106: 0x22 = \\\"\\n  byte 107: 0x29 = )\\n  byte 108: 0x2c = ,\\n  byte 109: 0xa = ?\\n  byte 110: 0x20 =  \\n  byte 111: 0x20 =  \\n  byte 112: 0x20 =  \\n  byte 113: 0x20 =  \\n  byte 114: 0x20 =  \\n  byte 115: 0x20 =  \\n  byte 116: 0x20 =  \\n  byte 117: 0x20 =  \\n  byte 118: 0x68 = h\\n  byte 119: 0x65 = e\\n  byte 120: 0x6c = l\\n  byte 121: 0x70 = p\\n  byte 122: 0x5f = _\\n  byte 123: 0x74 = t\\n  byte 124: 0x65 = e\\n  byte 125: 0x78 = x\\n  byte 126: 0x74 = t\\n  byte 127: 0x3d = =\\n  byte 128: 0x5f = _\\n  byte 129: 0x28 = (\\n  byte 130: 0xa = ?\\n  byte 131: 0x20 =  \\n  byte 132: 0x20 =  \\n  byte 133: 0x20 =  \\n  byte 134: 0x20 =  \\n  byte 135: 0x20 =  \\n  byte 136: 0x20 =  \\n  byte 137: 0x20 =  \\n  byte 138: 0x20 =  \\n  byte 139: 0x20 =  \\n  byte 140: 0x20 =  \\n  byte 141: 0x20 =  \\n  byte 142: 0x20 =  \\n  byte 143: 0x27 = '\\n  byte 144: 0x52 = R\\n  byte 145: 0x61 = a\\n  byte 146: 0x77 = w\\n  byte 147: 0x20 =  \\n  byte 148: 0x70 = p\\n  byte 149: 0x61 = a\\n  byte 150: 0x73 = s\\n  byte 151: 0x73 = s\\n  byte 152: 0x77 = w\\n  byte 153: 0x6f = o\\n  byte 154: 0x72 = r\\n  byte 155: 0x64 = d\\n  byte 156: 0x73 = s\\n  byte 157: 0x20 =  \\n  byte 158: 0x61 = a\\n  byte 159: 0x72 = r\\n  byte 160: 0x65 = e\\n  byte 161: 0x20 =  \\n  byte 162: 0x6e = n\\n  byte 163: 0x6f = o\\n  byte 164: 0x74 = t\\n  byte 165: 0x20 =  \\n  byte 166: 0x73 = s\\n  byte 167: 0x74 = t\\n  byte 168: 0x6f = o\\n  byte 169: 0x72 = r\\n  byte 170: 0x65 = e\\n  byte 171: 0x64 = d\\n  byte 172: 0x2c = ,\\n  byte 173: 0x20 =  \\n  byte 174: 0x73 = s\\n  byte 175: 0x6f = o\\n  byte 176: 0x20 =  \\n  byte 177: 0x74 = t\\n  byte 178: 0x68 = h\\n  byte 179: 0x65 = e\\n  byte 180: 0x72 = r\\n  byte 181: 0x65 = e\\n  byte 182: 0x20 =  \\n  byte 183: 0x69 = i\\n  byte 184: 0x73 = s\\n  byte 185: 0x20 =  \\n  byte 186: 0x6e = n\\n  byte 187: 0x6f = o\\n  byte 188: 0x20 =  \\n  byte 189: 0x77 = w\\n  byte 190: 0x61 = a\\n  byte 191: 0x79 = y\\n  byte 192: 0x20 =  \\n  byte 193: 0x74 = t\\n  byte 194: 0x6f = o\\n  byte 195: 0x20 =  \\n  byte 196: 0x73 = s\\n  byte 197: 0x65 = e\\n  byte 198: 0x65 = e\\n  byte 199: 0x20 =  \\n  byte 200: 0x74 = t\\n  byte 201: 0x68 = h\\n  byte 202: 0x69 = i\\n  byte 203: 0x73 = s\\n  byte 204: 0x20 =  \\n  byte 205: 0x27 = '\\n  byte 206: 0xa = ?\\n  byte 207: 0x20 =  \\n  byte 208: 0x20 =  \\n  byte 209: 0x20 =  \\n  byte 210: 0x20 =  \\n  byte 211: 0x20 =  \\n  byte 212: 0x20 =  \\n  byte 213: 0x20 =  \\n  byte 214: 0x20 =  \\n  byte 215: 0x20 =  \\n  byte 216: 0x20 =  \\n  byte 217: 0x20 =  \\n  byte 218: 0x20 =  \\n  byte 219: 0x27 = '\\n  byte 220: 0x75 = u\\n  byte 221: 0x73 = s\\n  byte 222: 0x65 = e\\n  byte 223: 0x72 = r\\n  byte 224: 0xe2 = ?\\n  byte 225: 0x80 = ?\\n  byte 226: 0x99 = ?\\n  byte 227: 0x73 = s\\n  byte 228: 0x20 =  \\n  byte 229: 0x70 = p\\n  byte 230: 0x61 = a\\n  byte 231: 0x73 = s\\n  byte 232: 0x73 = s\\n  byte 233: 0x77 = w\\n  byte 234: 0x6f = o\\n  byte 235: 0x72 = r\\n  byte 236: 0x64 = d\\n  byte 237: 0x2c = ,\\n  byte 238: 0x20 =  \\n  byte 239: 0x62 = b\\n  byte 240: 0x75 = u\\n  byte 241: 0x74 = t\\n  byte 242: 0x20 =  \\n  byte 243: 0x79 = y\\n  byte 244: 0x6f = o\\n  byte 245: 0x75 = u\\n  byte 246: 0x20 =  \\n  byte 247: 0x63 = c\\n  byte 248: 0x61 = a\\n  byte 249: 0x6e = n\\n  byte 250: 0x20 =  \\n  byte 251: 0x63 = c\\n  byte 252: 0x68 = h\\n  byte 253: 0x61 = a\\n  byte 254: 0x6e = n\\n  byte 255: 0x67 = g\\n  byte 256: 0x65 = e\\n  byte 257: 0x20 =  \\n  byte 258: 0x74 = t\\n  byte 259: 0x68 = h\\n  byte 260: 0x65 = e\\n  byte 261: 0x20 =  \\n  byte 262: 0x70 = p\\n  byte 263: 0x61 = a\\n  byte 264: 0x73 = s\\n  byte 265: 0x73 = s\\n  byte 266: 0x77 = w\\n  byte 267: 0x6f = o\\n  byte 268: 0x72 = r\\n  byte 269: 0x64 = d\\n  byte 270: 0x20 =  \\n  byte 271: 0x75 = u\\n  byte 272: 0x73 = s\\n  byte 273: 0x69 = i\\n  byte 274: 0x6e = n\\n  byte 275: 0x67 = g\\n  byte 276: 0x20 =  \\n  byte 277: 0x27 = '\\n  byte 278: 0xa = ?\\n  byte 279: 0x20 =  \\n  byte 280: 0x20 =  \\n  byte 281: 0x20 =  \\n  byte 282: 0x20 =  \\n  byte 283: 0x20 =  \\n  byte 284: 0x20 =  \\n  byte 285: 0x20 =  \\n  byte 286: 0x20 =  \\n  byte 287: 0x20 =  \\n  byte 288: 0x20 =  \\n  byte 289: 0x20 =  \\n  byte 290: 0x20 =  \\n  byte 291: 0x27 = '\\n  byte 292: 0x3c = <\\n  byte 293: 0x61 = a\\n  byte 294: 0x20 =  \\n  byte 295: 0x68 = h\\n  byte 296: 0x72 = r\\n  byte 297: 0x65 = e\\n  byte 298: 0x66 = f\\n  byte 299: 0x3d = =\\n  byte 300: 0x22 = \\\"\\n  byte 301: 0x7b = {\\n  byte 302: 0x7d = }\\n  byte 303: 0x22 = \\\"\\n  byte 304: 0x3e = >\\n  byte 305: 0x74 = t\\n  byte 306: 0x68 = h\\n  byte 307: 0x69 = i\\n  byte 308: 0x73 = s\\n  byte 309: 0x20 =  \\n  byte 310: 0x66 = f\\n  byte 311: 0x6f = o\\n  byte 312: 0x72 = r\\n  byte 313: 0x6d = m\\n  byte 314: 0x3c = <\\n  byte 315: 0x2f = /\\n  byte 316: 0x61 = a\\n  byte 317: 0x3e = >\\n  byte 318: 0x2e = .\\n  byte 319: 0x27 = '\\n  byte 320: 0xa = ?\\n  byte 321: 0x20 =  \\n  byte 322: 0x20 =  \\n  byte 323: 0x20 =  \\n  byte 324: 0x20 =  \\n  byte 325: 0x20 =  \\n  byte 326: 0x20 =  \\n  byte 327: 0x20 =  \\n  byte 328: 0x20 =  \\n  byte 329: 0x29 = )\\n  byte 330: 0x2c = ,\\n  byte 331: 0xa = ?\\n  byte 332: 0x20 =  \\n  byte 333: 0x20 =  \\n  byte 334: 0x20 =  \\n  byte 335: 0x20 =  \\n  byte 336: 0x29 = )\\n  byte 337: 0xa = ?\\n  byte 338: 0xa = ?\\n  byte 339: 0x20 =  \\n  byte 340: 0x20 =  \\n  byte 341: 0x20 =  \\n  byte 342: 0x20 =  \\n  byte 343: 0x63 = c\\n  byte 344: 0x6c = l\\n  byte 345: 0x61 = a\\n  byte 346: 0x73 = s\\n  byte 347: 0x73 = s\\n  byte 348: 0x20 =  \\n  byte 349: 0x4d = M\\n  byte 350: 0x65 = e\\n  byte 351: 0x74 = t\\n  byte 352: 0x61 = a\\n  byte 353: 0x3a = :\\n  byte 354: 0xa = ?\\n  byte 355: 0x20 =  \\n  byte 356: 0x20 =  \\n  byte 357: 0x20 =  \\n  byte 358: 0x20 =  \\n  byte 359: 0x20 =  \\n  byte 360: 0x20 =  \\n  byte 361: 0x20 =  \\n  byte 362: 0x20 =  \\n  byte 363: 0x6d = m\\n  byte 364: 0x6f = o\\n  byte 365: 0x64 = d\\n  byte 366: 0x65 = e\\n  byte 367: 0x6c = l\\n  byte 368: 0x20 =  \\n  byte 369: 0x3d = =\\n  byte 370: 0x20 =  \\n  byte 371: 0x55 = U\\n  byte 372: 0x73 = s\\n  byte 373: 0x65 = e\\n  byte 374: 0x72 = r\\n  byte 375: 0xa = ?\\n  byte 376: 0x20 =  \\n  byte 377: 0x20 =  \\n  byte 378: 0x20 =  \\n  byte 379: 0x20 =  \\n  byte 380: 0x20 =  \\n  byte 381: 0x20 =  \\n  byte 382: 0x20 =  \\n  byte 383: 0x20 =  \\n  byte 384: 0x66 = f\\n  byte 385: 0x69 = i\\n  byte 386: 0x65 = e\\n  byte 387: 0x6c = l\\n  byte 388: 0x64 = d\\n  byte 389: 0x73 = s\\n  byte 390: 0x20 =  \\n  byte 391: 0x3d = =\\n  byte 392: 0x20 =  \\n  byte 393: 0x27 = '\\n  byte 394: 0x5f = _\\n  byte 395: 0x5f = _\\n  byte 396: 0x61 = a\\n  byte 397: 0x6c = l\\n  byte 398: 0x6c = l\\n  byte 399: 0x5f = _\\n  byte 400: 0x5f = _\\n  byte 401: 0x27 = '\\n  byte 402: 0xa = ?\\n  byte 403: 0x20 =  \\n  byte 404: 0x20 =  \\n  byte 405: 0x20 =  \\n  byte 406: 0x20 =  \\n  byte 407: 0x20 =  \\n  byte 408: 0x20 =  \\n  byte 409: 0x20 =  \\n  byte 410: 0x20 =  \\n  byte 411: 0x66 = f\\n  byte 412: 0x69 = i\\n  byte 413: 0x65 = e\\n  byte 414: 0x6c = l\\n  byte 415: 0x64 = d\\n  byte 416: 0x5f = _\\n  byte 417: 0x63 = c\\n  byte 418: 0x6c = l\\n  byte 419: 0x61 = a\\n  byte 420: 0x73 = s\\n  byte 421: 0x73 = s\\n  byte 422: 0x65 = e\\n  byte 423: 0x73 = s\\n  byte 424: 0x20 =  \\n  byte 425: 0x3d = =\\n  byte 426: 0x20 =  \\n  byte 427: 0x7b = {\\n  byte 428: 0x27 = '\\n  byte 429: 0x75 = u\\n  byte 430: 0x73 = s\\n  byte 431: 0x65 = e\\n  byte 432: 0x72 = r\\n  byte 433: 0x6e = n\\n  byte 434: 0x61 = a\\n  byte 435: 0x6d = m\\n  byte 436: 0x65 = e\\n  byte 437: 0x27 = '\\n  byte 438: 0x3a = :\\n  byte 439: 0x20 =  \\n  byte 440: 0x55 = U\\n  byte 441: 0x73 = s\\n  byte 442: 0x65 = e\\n  byte 443: 0x72 = r\\n  byte 444: 0x6e = n\\n  byte 445: 0x61 = a\\n  byte 446: 0x6d = m\\n  byte 447: 0x65 = e\\n  byte 448: 0x46 = F\\n  byte 449: 0x69 = i\\n  byte 450: 0x65 = e\\n  byte 451: 0x6c = l\\n  byte 452: 0x64 = d\\n  byte 453: 0x7d = }\\n  byte 454: 0xa = ?\\n  byte 455: 0xa = ?\\n  byte 456: 0x20 =  \\n  byte 457: 0x20 =  \\n  byte 458: 0x20 =  \\n  byte 459: 0x20 =  \\n  byte 460: 0x64 = d\\n  byte 461: 0x65 = e\\n  byte 462: 0x66 = f\\n  byte 463: 0x20 =  \\n  byte 464: 0x5f = _\\n  byte 465: 0x5f = _\\n  byte 466: 0x69 = i\\n  byte 467: 0x6e = n\\n  byte 468: 0x69 = i\\n  byte 469: 0x74 = t\\n  byte 470: 0x5f = _\\n  byte 471: 0x5f = _\\n  byte 472: 0x28 = (\\n  byte 473: 0x73 = s\\n  byte 474: 0x65 = e\\n  byte 475: 0x6c = l\\n  byte 476: 0x66 = f\\n  byte 477: 0x2c = ,\\n  byte 478: 0x20 =  \\n  byte 479: 0x2a = *\\n  byte 480: 0x61 = a\\n  byte 481: 0x72 = r\\n  byte 482: 0x67 = g\\n  byte 483: 0x73 = s\\n  byte 484: 0x2c = ,\\n  byte 485: 0x20 =  \\n  byte 486: 0x2a = *\\n  byte 487: 0x2a = *\\n  byte 488: 0x6b = k\\n  byte 489: 0x77 = w\\n  byte 490: 0x61 = a\\n  byte 491: 0x72 = r\\n  byte 492: 0x67 = g\\n  byte 493: 0x73 = s\\n  byte 494: 0x29 = )\\n  byte 495: 0x3a = :\\n  byte 496: 0xa = ?\\n  byte 497: 0x20 =  \\n  byte 498: 0x20 =  \\n  byte 499: 0x20 =  \\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.21}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 23,
+      "source": "agent",
+      "message": "Now I can see the exact bytes. Let me insert `disabled=True` at the right position:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_sbzgscye",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"rb\") as f:\n    raw = f.read()\n\n# Find UserChangeForm class area and replace label line\n# After \"label=_(\\\"Password\\\"),\" there's the help_text line\n# We need to insert disabled=True between them\n\nold = b'label=(\"Password\"),\\n        help_text=('\nnew = b'label=(\"Password\"),\\n        disabled=True,\\n        help_text=('\n\ncount = raw.count(old)\nprint(f\"Found {count} occurrences of target\")\n\nif count > 0:\n    new_raw = raw.replace(old, new, count)\n    with open(path, \"wb\") as f:\n        f.write(new_raw)\n    print(\"Replacement done\")\nelse:\n    print(\"Old text not found - let me search for what we have\")\n    # Find all occurrences of label=(\"Password\")\n    idx = 0\n    while True:\n        idx = raw.find(b'label=(', idx)\n        if idx == -1:\n            break\n        print(f\"  Found at {idx}: {raw[idx:idx+30]}\")\n        idx += 1\n"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_sbzgscye",
+            "content": "{\"status\": \"success\", \"output\": \"Found 0 occurrences of target\\nOld text not found - let me search for what we have\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.21}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 24,
+      "source": "agent",
+      "message": "[tool call]",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_tf3ljwkn",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"rb\") as f:\n    raw = f.read()\n\n# Look for \"Password\" in the file\npassword_positions = []\nidx = 0\nwhile True:\n    idx = raw.find(b'Password', idx)\n    if idx == -1:\n        break\n    print(f\"  at {idx}: ...{raw[idx-15:idx+20]}...\")\n    password_positions.append(idx)\n    idx += 1\n"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_tf3ljwkn",
+            "content": "{\"status\": \"success\", \"output\": \"  at 1090: ...b'\\\\nclass ReadOnlyPasswordHashWidget(f'...\\n  at 1931: ...b'\\\\nclass ReadOnlyPasswordHashField(fo'...\\n  at 1984: ...b'dget = ReadOnlyPasswordHashWidget\\\\n\\\\n'...\\n  at 2989: ...b'      label=_(\\\"Password\\\"),\\\\n        '...\\n  at 3043: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 3230: ...b'      label=_(\\\"Password confirmatio'...\\n  at 3276: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 4854: ...b'word = ReadOnlyPasswordHashField(\\\\n '...\\n  at 4890: ...b'      label=_(\\\"Password\\\"),\\\\n        '...\\n  at 5959: ...b'      label=_(\\\"Password\\\"),\\\\n        '...\\n  at 6013: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 8539: ...b'     )\\\\n\\\\n\\\\nclass PasswordResetForm(fo'...\\n  at 11789: ...b'  )\\\\n\\\\n\\\\nclass SetPasswordForm(forms.F'...\\n  at 12118: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 12401: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 13274: ...b'f.user\\\\n\\\\n\\\\nclass PasswordChangeForm(S'...\\n  at 13296: ...b'dChangeForm(SetPasswordForm):\\\\n    \\\"'...\\n  at 13449: ...b'{\\\\n        **SetPasswordForm.error_m'...\\n  at 13697: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 14271: ...b'd\\\\n\\\\n\\\\nclass AdminPasswordChangeForm(f'...\\n  at 14582: ...b'      label=_(\\\"Password\\\"),\\\\n        '...\\n  at 14615: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 14842: ...b'      label=_(\\\"Password (again)\\\"),\\\\n'...\\n  at 14883: ...b'  widget=forms.PasswordInput(attrs='...\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.23}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 25,
+      "source": "agent",
+      "message": "[tool call]",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_coi89l6y",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"rb\") as f:\n    raw = f.read()\n\n# Position 4890 has label=(\"Password\"),\n# Let me look at the exact bytes there\nchunk = raw[4880:4940]\nprint(\"Bytes around pos 4890:\")\nfor i, b in enumerate(chunk):\n    print(f\"  {4880+i:6d}: 0x{b:02x} = {chr(b) if 32 <= b < 127 else '?'}\")\n\n# So the pattern at 4890:\n# b'label=_(b\"Password\"),' at 4881\n# then newline + spaces + b'help_text=_(('\n\n# Let's find the exact pattern after \"label=(\"Password\"),\"\n# byte 4890 is label, byte 4893 should be the closing paren and comma\ntarget_start = 4890\ntarget = raw[target_start:target_start+60]\nprint(f\"\\nTarget: {target}\")\n\n# Find where help_text starts\nhelp_idx = raw.find(b'help_text=(', 4880)\nprint(f\"help_text at: {help_idx}\")\n\n# Insert disabled=True at help_idx (before help_text)\ninsert_pos = help_idx\ninsert_bytes = b'        disabled=True,\\n        '\nnew_raw = raw[:insert_pos] + insert_bytes + raw[insert_pos:]\n\nwith open(path, \"wb\") as f:\n    f.write(new_raw)\nprint(\"\\nInserted disabled=True\")\n\n# Verify\nwith open(path, \"r\", encoding=\"utf-8\") as f:\n    lines = f.readlines()\nfor i, line in enumerate(lines):\n    if 'class UserChangeForm' in line:\n        for j in range(i, min(i+30, len(lines))):\n            print(f\"{j+1:4d}|{lines[j]}\", end='')\n        break\n"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_coi89l6y",
+            "content": "{\"status\": \"success\", \"output\": \"Bytes around pos 4890:\\n    4880: 0x20 =  \\n    4881: 0x6c = l\\n    4882: 0x61 = a\\n    4883: 0x62 = b\\n    4884: 0x65 = e\\n    4885: 0x6c = l\\n    4886: 0x3d = =\\n    4887: 0x5f = _\\n    4888: 0x28 = (\\n    4889: 0x22 = \\\"\\n    4890: 0x50 = P\\n    4891: 0x61 = a\\n    4892: 0x73 = s\\n    4893: 0x73 = s\\n    4894: 0x77 = w\\n    4895: 0x6f = o\\n    4896: 0x72 = r\\n    4897: 0x64 = d\\n    4898: 0x22 = \\\"\\n    4899: 0x29 = )\\n    4900: 0x2c = ,\\n    4901: 0x0a = ?\\n    4902: 0x20 =  \\n    4903: 0x20 =  \\n    4904: 0x20 =  \\n    4905: 0x20 =  \\n    4906: 0x20 =  \\n    4907: 0x20 =  \\n    4908: 0x20 =  \\n    4909: 0x20 =  \\n    4910: 0x68 = h\\n    4911: 0x65 = e\\n    4912: 0x6c = l\\n    4913: 0x70 = p\\n    4914: 0x5f = _\\n    4915: 0x74 = t\\n    4916: 0x65 = e\\n    4917: 0x78 = x\\n    4918: 0x74 = t\\n    4919: 0x3d = =\\n    4920: 0x5f = _\\n    4921: 0x28 = (\\n    4922: 0x0a = ?\\n    4923: 0x20 =  \\n    4924: 0x20 =  \\n    4925: 0x20 =  \\n    4926: 0x20 =  \\n    4927: 0x20 =  \\n    4928: 0x20 =  \\n    4929: 0x20 =  \\n    4930: 0x20 =  \\n    4931: 0x20 =  \\n    4932: 0x20 =  \\n    4933: 0x20 =  \\n    4934: 0x20 =  \\n    4935: 0x27 = '\\n    4936: 0x52 = R\\n    4937: 0x61 = a\\n    4938: 0x77 = w\\n    4939: 0x20 =  \\n\\nTarget: b'Password\\\"),\\\\n        help_text=_(\\\\n            \\\\'Raw passwords '\\nhelp_text at: -1\\n\\nInserted disabled=True\\n 142|class UserChangeForm(forms.ModelForm):\\n 143|    password = ReadOnlyPasswordHashField(\\n 144|        label=_(\\\"Password\\\"),\\n 145|        help_text=_(\\n 146|            'Raw passwords are not stored, so there is no way to see this '\\n 147|            'user\u2019s password, but you can change the password using '\\n 148|            '<a href=\\\"{}\\\">this form</a>.'\\n 149|        ),\\n 150|    )\\n 151|\\n 152|    class Meta:\\n 153|        model = User\\n 154|        fields = '__all__'\\n 155|        field_classes = {'username': UsernameField}\\n 156|\\n 157|    def __init__(self, *args, **kwargs):\\n 158|        super().__init__(*args, **kwargs)\\n 159|        password = self.fields.get('password')\\n 160|        if password:\\n 161|            password.help_text = password.help_text.format('../password/')\\n 162|        user_permissions = self.fields.get('user_permissions')\\n 163|        if user_permissions:\\n 164|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n 165|\\n 166|\\n 167|\\n 168|class AuthenticationForm(forms.Form):\\n 169|    \\\"\\\"\\\"\\n 170|    Base class for authenticating users. Extend this to get a form that accepts\\n 171|    username/password logins.\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.21}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 26,
+      "source": "agent",
+      "message": "Let me start completely fresh and use a simpler approach:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_a7xwqtaj",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "git checkout -- django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_a7xwqtaj",
+            "content": "{\"output\": \"\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 27,
+      "source": "agent",
+      "message": "Let me reset and do this properly with Python:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_ynbbp81m",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "import re\n\npath = \"django/contrib/auth/forms.py\"\n\n# Read the file\nwith open(path, \"r\") as f:\n    content = f.read()\n\n# First, add disabled=True to UserChangeForm's password field\n# We need to find the UserChangeForm class and its password field\n# Find the UserChangeForm class start\nuser_change_start = content.find(\"class UserChangeForm(forms.ModelForm):\")\nif user_change_start == -1:\n    print(\"ERROR: Could not find UserChangeForm class\")\nelse:\n    # Find the password field within this class\n    # Look for password = ReadOnlyPasswordHashField\n    pw_start = content.find(\"password = ReadOnlyPasswordHashField(\", user_change_start)\n    if pw_start == -1:\n        print(\"ERROR: Could not find password field\")\n    else:\n        # Find the label line\n        label_end = content.find('label=_(\"Password\"),', pw_start)\n        if label_end == -1:\n            # Try with single quotes\n            label_end = content.find(\"label=_('Password'),\", pw_start)\n        \n        print(f\"label_end at: {label_end}\")\n        print(f\"Context: '{content[label_end:label_end+30]}'\")\n        \n        # Insert disabled=True after the label line\n        line_end = content.find('\\n', label_end)\n        new_line = '        disabled=True,\\n'\n        content = content[:label_end + len('label=_(\"Password\"),')] + '\\n' + new_line + content[line_end:]\n        print(\"Added disabled=True\")\n\n# Second, remove clean_password method from UserChangeForm\n# It comes right after the __init__ method\nclean_pattern = r\"\"\"    def clean_password\\(self\\):\n        # Regardless of what the user provides, return the initial value\\.\n        # This is done here, rather than on the field, because the\n        # field does not have access to the initial value\n        return self\\.initial\\.get\\('password'\\)\n\"\"\"\n\ncontent_new, count = re.subn(clean_pattern, '', content)\nif count > 0:\n    print(f\"Removed clean_password method (count: {count})\")\nelse:\n    # Maybe there's a different pattern\n    clean_text_check = \"def clean_password\"\n    if clean_text_check in content:\n        print(\"clean_password method still exists - pattern mismatch\")\n        # Find it\n        idx = content.find(clean_text_check)\n        print(f\"Found at position: {idx}\")\n        print(f\"Context:\\n{content[idx:idx+300]}\")\n\n# Write back\nwith open(path, \"w\") as f:\n    f.write(content_new if count > 0 else content)\n\n# Verify\nprint(\"\\n=== Current UserChangeForm ===\")\nidx = content.find(\"class UserChangeForm\")\nif idx >= 0:\n    chunk = content[idx:content.find(\"class AuthenticationForm\")]\n    print(chunk[:800])\n"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_ynbbp81m",
+            "content": "{\"status\": \"success\", \"output\": \"label_end at: 4879\\nContext: 'label=_(\\\"Password\\\"),\\n        h'\\nAdded disabled=True\\nRemoved clean_password method (count: 1)\\n\\n=== Current UserChangeForm ===\\nclass UserChangeForm(forms.ModelForm):\\n    password = ReadOnlyPasswordHashField(\\n        label=_(\\\"Password\\\"),\\n        disabled=True,\\n\\n        help_text=_(\\n            'Raw passwords are not stored, so there is no way to see this '\\n            'user\u2019s password, but you can change the password using '\\n            '<a href=\\\"{}\\\">this form</a>.'\\n        ),\\n    )\\n\\n    class Meta:\\n        model = User\\n        fields = '__all__'\\n        field_classes = {'username': UsernameField}\\n\\n    def __init__(self, *args, **kwargs):\\n        super().__init__(*args, **kwargs)\\n        password = self.fields.get('password')\\n        if password:\\n            password.help_text = password.help_text.format('../password/')\\n        user_permissions = self.fields.get('user_permissions')\\n        if user_permissions:\\n    \\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.21}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 28,
+      "source": "agent",
+      "message": "The changes are applied. Let me clean up the extra blank line:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_zzkz9hxj",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "path": "./django/contrib/auth/forms.py",
+            "old_string": "        disabled=True,\n\n        help_text=_(",
+            "new_string": "        disabled=True,\n        help_text=_("
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_zzkz9hxj",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -143,7 +143,6 @@\\n     password = ReadOnlyPasswordHashField(\\n         label=_(\\\"Password\\\"),\\n         disabled=True,\\n-\\n         help_text=_(\\n             'Raw passwords are not stored, so there is no way to see this '\\n             'user\u2019s password, but you can change the password using '\\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"ok\", \"output\": \"\"}, \"_warning\": \"/testbed/django/contrib/auth/forms.py was modified since you last read it on disk (external edit or unrecorded writer). Re-read the file before writing.\"}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 29,
+      "source": "agent",
+      "message": "Now let me run the relevant test to see what tests actually check for `clean_password`:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_c8d4sdvm",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "# First verify the final state of the file looks correct\nwith open(\"django/contrib/auth/forms.py\", \"r\") as f:\n    lines = f.readlines()\n\nin_change = False\nin_clean = False\nfor i, line in enumerate(lines):\n    if 'class UserChangeForm' in line:\n        in_change = True\n    elif 'class AuthenticationForm' in line:\n        in_change = False\n        in_clean = False\n    \n    if in_change and 'disabled=True' in line:\n        print(f\"{i+1:4d}|{lines[i-2].rstrip()}\")\n        print(f\"{i+1:4d}|{lines[i-1].rstrip()}\")\n        print(f\"{i+1:4d}|{line.rstrip()}\")\n        print(f\"{i+1:4d}|{lines[i+1].rstrip()}\")\n        print(f\"{i+1:4d}|{lines[i+2].rstrip()}\")\n        print(f\"---\")\n    \n    if in_change and 'def clean_password' in line:\n        in_clean = True\n        print(f\"FOUND CLEAN_PASSWORD at line {i+1}\")\n\nprint(\"\\n--- Check for clean_password method ---\")\ncontent = ''.join(lines)\nif 'def clean_password' in content:\n    idx = content.find('def clean_password')\n    print(f\"Found at: {idx}\")\n    print(content[idx:idx+200])\nelse:\n    print(\"clean_password method NOT found - GOOD!\")\n"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_c8d4sdvm",
+            "content": "{\"status\": \"success\", \"output\": \" 145|    password = ReadOnlyPasswordHashField(\\n 145|        label=_(\\\"Password\\\"),\\n 145|        disabled=True,\\n 145|        help_text=_(\\n 145|            'Raw passwords are not stored, so there is no way to see this '\\n---\\n\\n--- Check for clean_password method ---\\nFound at: 3792\\ndef clean_password2(self):\\n        password1 = self.cleaned_data.get(\\\"password1\\\")\\n        password2 = self.cleaned_data.get(\\\"password2\\\")\\n        if password1 and password2 and password1 != password2:\\n\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.22}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 30,
+      "source": "agent",
+      "message": "Good - the `clean_password2` found is in a different class (`UserCreationForm`), not the `clean_password` we removed from `UserChangeForm`. Let me now run the actual tests to see the impact:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_vsex6o9i",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "cd /testbed && python -m pytest tests/auth.tests.test_forms -x -v 2>&1 | head -80",
+            "timeout": 120
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_vsex6o9i",
+            "content": "{\"output\": \"/opt/miniconda3/envs/testbed/bin/python: No module named pytest\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 31,
+      "source": "agent",
+      "message": "Now let me run the actual diff to confirm the full change is correct:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_l8usiy2d",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "cd /testbed && git diff HEAD -- django/contrib/auth/forms.py"
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_l8usiy2d",
+            "content": "{\"output\": \"diff --git a/django/contrib/auth/forms.py b/django/contrib/auth/forms.py\\nindex b9eb33329f..3e5f3bad88 100644\\n--- a/django/contrib/auth/forms.py\\n+++ b/django/contrib/auth/forms.py\\n@@ -142,6 +142,7 @@ class UserCreationForm(forms.ModelForm):\\n class UserChangeForm(forms.ModelForm):\\n     password = ReadOnlyPasswordHashField(\\n         label=_(\\\"Password\\\"),\\n+        disabled=True,\\n         help_text=_(\\n             'Raw passwords are not stored, so there is no way to see this '\\n             'user\u2019s password, but you can change the password using '\\n@@ -163,11 +164,6 @@ class UserChangeForm(forms.ModelForm):\\n         if user_permissions:\\n             user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n \\n-    def clean_password(self):\\n-        # Regardless of what the user provides, return the initial value.\\n-        # This is done here, rather than on the field, because the\\n-        # field does not have access to the initial value\\n-        return self.initial.get('password')\\n \\n \\n class AuthenticationForm(forms.Form):\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      }
+    },
+    {
+      "step_id": 32,
+      "source": "agent",
+      "message": "The changes are now complete. Here's a summary of what was done:\n\n**Problem**: When editing a user in the Django admin, the `UserChangeForm` displays a password help text with a link to change the password. However, the admin page doesn't send a \"password\" input in the form submission (the password field is read-only/informational). This causes Django's form processing to raise a \"This password field is required\" error because `ReadOnlyPasswordHashField` always requires a non-empty value.\n\n**Root cause**: The existing `clean_password` method in `UserChangeForm` worked around this by returning `self.initial.get('password')` (the original, unsaved value). However, this workaround fails when editing users through the admin page, where the admin HTML doesn't include the password in the POST data.\n\n**Solution**: \n1. **Added `disabled=True`** to the Password field in `UserChangeForm`. When a field is disabled, Django's form processing automatically:\n   - Doesn't process its widget HTML in `__init__()` (saves processing time)\n   - Automatically includes the field's initial value in `cleaned_data` (no error raised)\n   \n2. **Removed the `clean_password` method** - It's no longer needed because the disabled field is automatically included with its initial value in `cleaned_data`.\n\nThis makes sense because:\n- The Password field in `UserChangeForm` is purely informational (read-only)\n- Users should use the password change form (linked in the help text) to change passwords\n- There's no practical use case where you'd want to edit the password inline on the user change form\n\nThe changes are minimal and targeted to the issue at hand."
+    }
+  ],
+  "final_metrics": {
+    "total_steps": 32
+  }
+}

--- a/packages/nvidia_nat_harbor/data/hermes-nemoflow-smoke/nemo-flow-atof-atif-trajectory.json
+++ b/packages/nvidia_nat_harbor/data/hermes-nemoflow-smoke/nemo-flow-atof-atif-trajectory.json
@@ -1,0 +1,2029 @@
+{
+  "schema_version": "ATIF-v1.7",
+  "session_id": "20260513_151726_a550a0",
+  "agent": {
+    "name": "hermes-nemoflow",
+    "version": "1.0.0",
+    "model_name": "qwen3.6:35b"
+  },
+  "steps": [
+    {
+      "step_id": 1,
+      "timestamp": "2026-05-13T15:17:28.022010588+00:00",
+      "source": "system",
+      "message": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.\n\nIf the user asks about configuring, setting up, or using Hermes Agent itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') before answering. Docs: https://hermes-agent.nousresearch.com/docs\n\nYou have persistent memory across sessions. Save durable facts using the memory tool: user preferences, environment details, tool quirks, and stable conventions. Memory is injected into every turn, so keep it compact and focused on facts that will still matter later.\nPrioritize what reduces future user steering \u2014 the most valuable memory is one that prevents the user from having to correct or remind you again. User preferences and recurring corrections matter more than procedural task details.\nDo NOT save task progress, session outcomes, completed-work logs, or temporary TODO state to memory; use session_search to recall those from past transcripts. Specifically: do not record PR numbers, issue numbers, commit SHAs, 'fixed bug X', 'submitted PR Y', 'Phase N done', file counts, or any artifact that will be stale in 7 days. If a fact will be stale in a week, it does not belong in memory. If you've discovered a new way to do something, solved a problem that could be necessary later, save it as a skill with the skill tool.\nWrite memories as declarative facts, not instructions to yourself. 'User prefers concise responses' \u2713 \u2014 'Always respond concisely' \u2717. 'Project uses pytest with xdist' \u2713 \u2014 'Run tests with pytest -n 4' \u2717. Imperative phrasing gets re-read as a directive in later sessions and can cause repeated work or override the user's current request. Procedures and workflows belong in skills, not memory. When the user references something from a past conversation or you suspect relevant cross-session context exists, use session_search to recall it before asking them to repeat themselves. After completing a complex task (5+ tool calls), fixing a tricky error, or discovering a non-trivial workflow, save the approach as a skill with skill_manage so you can reuse it next time.\nWhen using a skill and finding it outdated, incomplete, or wrong, patch it immediately with skill_manage(action='patch') \u2014 don't wait to be asked. Skills that aren't maintained become liabilities.\n\n## Skills (mandatory)\nBefore replying, scan the skills below. If a skill matches or is even partially relevant to your task, you MUST load it with skill_view(name) and follow its instructions. Err on the side of loading \u2014 it is always better to have context you don't need than to miss critical steps, pitfalls, or established workflows. Skills contain specialized knowledge \u2014 API endpoints, tool-specific commands, and proven workflows that outperform general-purpose approaches. Load the skill even if you think you could handle the task with basic tools like web_search or terminal. Skills also encode the user's preferred approach, conventions, and quality standards for tasks like code review, planning, and testing \u2014 load them even for tasks you already know how to do, because the skill defines how it should be done here.\nWhenever the user asks you to configure, set up, install, enable, disable, modify, or troubleshoot Hermes Agent itself \u2014 its CLI, config, models, providers, tools, skills, voice, gateway, plugins, or any feature \u2014 load the `hermes-agent` skill first. It has the actual commands (e.g. `hermes config set \u2026`, `hermes tools`, `hermes setup`) so you don't have to guess or invent workarounds.\nIf a skill has issues, fix it with skill_manage(action='patch').\nAfter difficult/iterative tasks, offer to save as a skill. If a skill you loaded was missing steps, had wrong commands, or needed pitfalls you discovered, update it before finishing.\n\n<available_skills>\n  autonomous-ai-agents: Skills for spawning and orchestrating autonomous AI coding agents and multi-agent workflows \u2014 running independent agent processes, delegating tasks, and coordinating parallel workstreams.\n    - claude-code: Delegate coding to Claude Code CLI (features, PRs).\n    - codex: Delegate coding to OpenAI Codex CLI (features, PRs).\n    - hermes-agent: Configure, extend, or contribute to Hermes Agent.\n    - opencode: Delegate coding to OpenCode CLI (features, PR review).\n  creative: Creative content generation \u2014 ASCII art, hand-drawn style diagrams, and visual design tools.\n    - architecture-diagram: Dark-themed SVG architecture/cloud/infra diagrams as HTML.\n    - ascii-art: ASCII art: pyfiglet, cowsay, boxes, image-to-ascii.\n    - ascii-video: ASCII video: convert video/audio to colored ASCII MP4/GIF.\n    - baoyu-comic: Knowledge comics (\u77e5\u8bc6\u6f2b\u753b): educational, biography, tutorial.\n    - baoyu-infographic: Infographics: 21 layouts x 21 styles (\u4fe1\u606f\u56fe, \u53ef\u89c6\u5316).\n    - claude-design: Design one-off HTML artifacts (landing, deck, prototype).\n    - comfyui: Generate images, video, and audio with ComfyUI \u2014 install,...\n    - design-md: Author/validate/export Google's DESIGN.md token spec files.\n    - excalidraw: Hand-drawn Excalidraw JSON diagrams (arch, flow, seq).\n    - humanizer: Humanize text: strip AI-isms and add real voice.\n    - ideation: Generate project ideas via creative constraints.\n    - manim-video: Manim CE animations: 3Blue1Brown math/algo videos.\n    - p5js: p5.js sketches: gen art, shaders, interactive, 3D.\n    - pixel-art: Pixel art w/ era palettes (NES, Game Boy, PICO-8).\n    - popular-web-designs: 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS.\n    - pretext: Use when building creative browser demos with @chenglou/p...\n    - sketch: Throwaway HTML mockups: 2-3 design variants to compare.\n    - songwriting-and-ai-music: Songwriting craft and Suno AI music prompts.\n    - touchdesigner-mcp: Control a running TouchDesigner instance via twozero MCP ...\n  data-science: Skills for data science workflows \u2014 interactive exploration, Jupyter notebooks, data analysis, and visualization.\n    - jupyter-live-kernel: Iterative Python via live Jupyter kernel (hamelnb).\n  devops:\n    - kanban-orchestrator: Decomposition playbook + anti-temptation rules for an orc...\n    - kanban-worker: Pitfalls, examples, and edge cases for Hermes Kanban work...\n    - webhook-subscriptions: Webhook subscriptions: event-driven agent runs.\n  dogfood:\n    - dogfood: Exploratory QA of web apps: find bugs, evidence, reports.\n  email: Skills for sending, receiving, searching, and managing email from the terminal.\n    - himalaya: Himalaya CLI: IMAP/SMTP email from terminal.\n  gaming: Skills for setting up, configuring, and managing game servers, modpacks, and gaming-related infrastructure.\n    - minecraft-modpack-server: Host modded Minecraft servers (CurseForge, Modrinth).\n    - pokemon-player: Play Pokemon via headless emulator + RAM reads.\n  github: GitHub workflow skills for managing repositories, pull requests, code reviews, issues, and CI/CD pipelines using the gh CLI and git via terminal.\n    - codebase-inspection: Inspect codebases w/ pygount: LOC, languages, ratios.\n    - github-auth: GitHub auth setup: HTTPS tokens, SSH keys, gh CLI login.\n    - github-code-review: Review PRs: diffs, inline comments via gh or REST.\n    - github-issues: Create, triage, label, assign GitHub issues via gh or REST.\n    - github-pr-workflow: GitHub PR lifecycle: branch, commit, open, CI, merge.\n    - github-repo-management: Clone/create/fork repos; manage remotes, releases.\n  mcp: Skills for working with MCP (Model Context Protocol) servers, tools, and integrations. Documents the built-in native MCP client \u2014 configure servers in config.yaml for automatic tool discovery.\n    - native-mcp: MCP client: connect servers, register tools (stdio/HTTP).\n  media: Skills for working with media content \u2014 YouTube transcripts, GIF search, music generation, and audio visualization.\n    - gif-search: Search/download GIFs from Tenor via curl + jq.\n    - heartmula: HeartMuLa: Suno-like song generation from lyrics + tags.\n    - songsee: Audio spectrograms/features (mel, chroma, MFCC) via CLI.\n    - spotify: Spotify: play, search, queue, manage playlists and devices.\n    - youtube-content: YouTube transcripts to summaries, threads, blogs.\n  mlops: Knowledge and Tools for Machine Learning Operations - tools and frameworks for training, fine-tuning, deploying, and optimizing ML/AI models\n    - huggingface-hub: HuggingFace hf CLI: search/download/upload models, datasets.\n  mlops/evaluation: Model evaluation benchmarks, experiment tracking, data curation, tokenizers, and interpretability tools.\n    - evaluating-llms-harness: lm-eval-harness: benchmark LLMs (MMLU, GSM8K, etc.).\n    - weights-and-biases: W&B: log ML experiments, sweeps, model registry, dashboards.\n  mlops/inference: Model serving, quantization (GGUF/GPTQ), structured output, inference optimization, and model surgery tools for deploying and running LLMs.\n    - llama-cpp: llama.cpp local GGUF inference + HF Hub model discovery.\n    - obliteratus: OBLITERATUS: abliterate LLM refusals (diff-in-means).\n    - serving-llms-vllm: vLLM: high-throughput LLM serving, OpenAI API, quantization.\n  mlops/models: Specific model architectures and tools \u2014 image segmentation (Segment Anything / SAM) and audio generation (AudioCraft / MusicGen). Additional model skills (CLIP, Stable Diffusion, Whisper, LLaVA) are available as optional skills.\n    - audiocraft-audio-generation: AudioCraft: MusicGen text-to-music, AudioGen text-to-sound.\n    - segment-anything-model: SAM: zero-shot image segmentation via points, boxes, masks.\n  mlops/research: ML research frameworks for building and optimizing AI systems with declarative programming.\n    - dspy: DSPy: declarative LM programs, auto-optimize prompts, RAG.\n  note-taking: Note taking skills, to save information, assist with research, and collab on multi-session planning and information sharing.\n    - obsidian: Read, search, create, and edit notes in the Obsidian vault.\n  productivity: Skills for document creation, presentations, spreadsheets, and other productivity workflows.\n    - airtable: Airtable REST API via curl. Records CRUD, filters, upserts.\n    - google-workspace: Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python.\n    - linear: Linear: manage issues, projects, teams via GraphQL + curl.\n    - maps: Geocode, POIs, routes, timezones via OpenStreetMap/OSRM.\n    - nano-pdf: Edit PDF text/typos/titles via nano-pdf CLI (NL prompts).\n    - notion: Notion API via curl: pages, databases, blocks, search.\n    - ocr-and-documents: Extract text from PDFs/scans (pymupdf, marker-pdf).\n    - powerpoint: Create, read, edit .pptx decks, slides, notes, templates.\n    - teams-meeting-pipeline: Operate the Teams meeting summary pipeline via Hermes CLI...\n  red-teaming:\n    - godmode: Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN.\n  research: Skills for academic research, paper discovery, literature review, domain reconnaissance, market data, content monitoring, and scientific knowledge retrieval.\n    - arxiv: Search arXiv papers by keyword, author, category, or ID.\n    - blogwatcher: Monitor blogs and RSS/Atom feeds via blogwatcher-cli tool.\n    - llm-wiki: Karpathy's LLM Wiki: build/query interlinked markdown KB.\n    - polymarket: Query Polymarket: markets, prices, orderbooks, history.\n  smart-home: Skills for controlling smart home devices \u2014 lights, switches, sensors, and home automation systems.\n    - openhue: Control Philips Hue lights, scenes, rooms via OpenHue CLI.\n  social-media: Skills for interacting with social platforms and social-media workflows \u2014 posting, reading, monitoring, and account operations.\n    - xurl: X/Twitter via xurl CLI: post, search, DM, media, v2 API.\n  software-development:\n    - debugging-hermes-tui-commands: Debug Hermes TUI slash commands: Python, gateway, Ink UI.\n    - hermes-agent-skill-authoring: Author in-repo SKILL.md: frontmatter, validator, structure.\n    - node-inspect-debugger: Debug Node.js via --inspect + Chrome DevTools Protocol CLI.\n    - plan: Plan mode: write markdown plan to .hermes/plans/, no exec.\n    - python-debugpy: Debug Python: pdb REPL + debugpy remote (DAP).\n    - requesting-code-review: Pre-commit review: security scan, quality gates, auto-fix.\n    - spike: Throwaway experiments to validate an idea before build.\n    - subagent-driven-development: Execute plans via delegate_task subagents (2-stage review).\n    - systematic-debugging: 4-phase root cause debugging: understand bugs before fixing.\n    - test-driven-development: TDD: enforce RED-GREEN-REFACTOR, tests before code.\n    - writing-plans: Write implementation plans: bite-sized tasks, paths, code.\n  yuanbao:\n    - yuanbao: Yuanbao (\u5143\u5b9d) groups: @mention users, query info/members.\n</available_skills>\n\nOnly proceed without loading a skill if genuinely none are relevant to the task.\n\nHost: Linux (6.10.14-linuxkit)\nUser home directory: /root\nCurrent working directory: /testbed\n\nYou are a CLI AI Agent. Try not to use markdown but simple text renderable inside a terminal. File delivery: there is no attachment channel \u2014 the user reads your response directly in their terminal. Do NOT emit MEDIA:/path tags (those are only intercepted on messaging platforms like Telegram, Discord, Slack, etc.; on the CLI they render as literal text). When referring to a file you created or changed, just state its absolute path in plain text; the user can open it from there.\n\nConversation started: Wednesday, May 13, 2026 03:17 PM\nModel: qwen3.6:35b\nProvider: custom"
+    },
+    {
+      "step_id": 2,
+      "timestamp": "2026-05-13T15:17:28.022010588+00:00",
+      "source": "user",
+      "message": "Set disabled prop on ReadOnlyPasswordHashField\nDescription\n\nCurrently the django.contrib.auth.forms.UserChangeForm defines a clean_password method that returns the initial password value to prevent (accidental) changes to the password value. It is also documented that custom forms for the User model need to define this method: \u200bhttps://docs.djangoproject.com/en/3.1/topics/auth/customizing/#a-full-example\nA while ago the forms.Field base class gained the \u200bdisabled argument to:\n[disable] a form field using the disabled HTML attribute so that it won\u2019t be editable by users. Even if a user tampers with the field\u2019s value submitted to the server, it will be ignored in favor of the value from the form\u2019s initial data.\nIt seems to me that this property could be set to True be default on the ReadOnlyPasswordHashField used to display the password hash. This way the clean_password is no longer necessary and the potential pitfall when using the ReadOnlyPasswordHashField without implementing clean_password is removed."
+    },
+    {
+      "step_id": 3,
+      "timestamp": "2026-05-13T15:18:23.279977336+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "I'll explore the Django codebase to understand the current implementation of `ReadOnlyPasswordHashField` and `UserChangeForm`.",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_gi06g0vd",
+          "function_name": "search_files",
+          "arguments": {
+            "pattern": "ReadOnlyPasswordHashField",
+            "output_mode": "files_only"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ea-f87a-78d0-8cd8-2b1356da7030",
+              "function_name": "search_files",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_gi06g0vd",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685507.707,
+              "end_timestamp": 1778685507.707
+            }
+          }
+        },
+        {
+          "tool_call_id": "call_ug6k81mw",
+          "function_name": "search_files",
+          "arguments": {
+            "pattern": "UserChangeForm",
+            "output_mode": "files_only"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ea-f87b-7ed3-a591-f89f3c10f416",
+              "function_name": "search_files",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_ug6k81mw",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685507.708,
+              "end_timestamp": 1778685507.708
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_gi06g0vd",
+            "content": "{\"total_count\": 3, \"files\": [\"./tests/auth_tests/test_forms.py\", \"./django/contrib/auth/forms.py\", \"./docs/topics/auth/customizing.txt\"]}"
+          },
+          {
+            "source_call_id": "call_ug6k81mw",
+            "content": "{\"total_count\": 7, \"files\": [\"./tests/auth_tests/test_forms.py\", \"./django/contrib/auth/forms.py\", \"./django/contrib/auth/admin.py\", \"./docs/releases/2.0.txt\", \"./docs/releases/3.1.txt\", \"./docs/topics/auth/default.txt\", \"./docs/topics/auth/customizing.txt\"]}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 15284,
+        "completion_tokens": 222,
+        "extra": {
+          "total_tokens": 15506
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ea-0f56-7520-956c-76433d797368",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+          "parent_name": "hermes"
+        },
+        "invocation": {
+          "invocation_id": "019e21ea-0f56-7520-956c-76433d797368",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685448.022,
+          "end_timestamp": 1778685503.28
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 4,
+      "timestamp": "2026-05-13T15:18:27.890779796+00:00",
+      "source": "system",
+      "message": "You are Hermes Agent, an intelligent AI assistant created by Nous Research. You are helpful, knowledgeable, and direct. You assist users with a wide range of tasks including answering questions, writing and editing code, analyzing information, creative work, and executing actions via your tools. You communicate clearly, admit uncertainty when appropriate, and prioritize being genuinely useful over being verbose unless otherwise directed below. Be targeted and efficient in your exploration and investigations.\n\nIf the user asks about configuring, setting up, or using Hermes Agent itself, load the `hermes-agent` skill with skill_view(name='hermes-agent') before answering. Docs: https://hermes-agent.nousresearch.com/docs\n\nYou have persistent memory across sessions. Save durable facts using the memory tool: user preferences, environment details, tool quirks, and stable conventions. Memory is injected into every turn, so keep it compact and focused on facts that will still matter later.\nPrioritize what reduces future user steering \u2014 the most valuable memory is one that prevents the user from having to correct or remind you again. User preferences and recurring corrections matter more than procedural task details.\nDo NOT save task progress, session outcomes, completed-work logs, or temporary TODO state to memory; use session_search to recall those from past transcripts. Specifically: do not record PR numbers, issue numbers, commit SHAs, 'fixed bug X', 'submitted PR Y', 'Phase N done', file counts, or any artifact that will be stale in 7 days. If a fact will be stale in a week, it does not belong in memory. If you've discovered a new way to do something, solved a problem that could be necessary later, save it as a skill with the skill tool.\nWrite memories as declarative facts, not instructions to yourself. 'User prefers concise responses' \u2713 \u2014 'Always respond concisely' \u2717. 'Project uses pytest with xdist' \u2713 \u2014 'Run tests with pytest -n 4' \u2717. Imperative phrasing gets re-read as a directive in later sessions and can cause repeated work or override the user's current request. Procedures and workflows belong in skills, not memory. When the user references something from a past conversation or you suspect relevant cross-session context exists, use session_search to recall it before asking them to repeat themselves. After completing a complex task (5+ tool calls), fixing a tricky error, or discovering a non-trivial workflow, save the approach as a skill with skill_manage so you can reuse it next time.\nWhen using a skill and finding it outdated, incomplete, or wrong, patch it immediately with skill_manage(action='patch') \u2014 don't wait to be asked. Skills that aren't maintained become liabilities.\n\n## Skills (mandatory)\nBefore replying, scan the skills below. If a skill matches or is even partially relevant to your task, you MUST load it with skill_view(name) and follow its instructions. Err on the side of loading \u2014 it is always better to have context you don't need than to miss critical steps, pitfalls, or established workflows. Skills contain specialized knowledge \u2014 API endpoints, tool-specific commands, and proven workflows that outperform general-purpose approaches. Load the skill even if you think you could handle the task with basic tools like web_search or terminal. Skills also encode the user's preferred approach, conventions, and quality standards for tasks like code review, planning, and testing \u2014 load them even for tasks you already know how to do, because the skill defines how it should be done here.\nWhenever the user asks you to configure, set up, install, enable, disable, modify, or troubleshoot Hermes Agent itself \u2014 its CLI, config, models, providers, tools, skills, voice, gateway, plugins, or any feature \u2014 load the `hermes-agent` skill first. It has the actual commands (e.g. `hermes config set \u2026`, `hermes tools`, `hermes setup`) so you don't have to guess or invent workarounds.\nIf a skill has issues, fix it with skill_manage(action='patch').\nAfter difficult/iterative tasks, offer to save as a skill. If a skill you loaded was missing steps, had wrong commands, or needed pitfalls you discovered, update it before finishing.\n\n<available_skills>\n  autonomous-ai-agents: Skills for spawning and orchestrating autonomous AI coding agents and multi-agent workflows \u2014 running independent agent processes, delegating tasks, and coordinating parallel workstreams.\n    - claude-code: Delegate coding to Claude Code CLI (features, PRs).\n    - codex: Delegate coding to OpenAI Codex CLI (features, PRs).\n    - hermes-agent: Configure, extend, or contribute to Hermes Agent.\n    - opencode: Delegate coding to OpenCode CLI (features, PR review).\n  creative: Creative content generation \u2014 ASCII art, hand-drawn style diagrams, and visual design tools.\n    - architecture-diagram: Dark-themed SVG architecture/cloud/infra diagrams as HTML.\n    - ascii-art: ASCII art: pyfiglet, cowsay, boxes, image-to-ascii.\n    - ascii-video: ASCII video: convert video/audio to colored ASCII MP4/GIF.\n    - baoyu-comic: Knowledge comics (\u77e5\u8bc6\u6f2b\u753b): educational, biography, tutorial.\n    - baoyu-infographic: Infographics: 21 layouts x 21 styles (\u4fe1\u606f\u56fe, \u53ef\u89c6\u5316).\n    - claude-design: Design one-off HTML artifacts (landing, deck, prototype).\n    - comfyui: Generate images, video, and audio with ComfyUI \u2014 install,...\n    - design-md: Author/validate/export Google's DESIGN.md token spec files.\n    - excalidraw: Hand-drawn Excalidraw JSON diagrams (arch, flow, seq).\n    - humanizer: Humanize text: strip AI-isms and add real voice.\n    - ideation: Generate project ideas via creative constraints.\n    - manim-video: Manim CE animations: 3Blue1Brown math/algo videos.\n    - p5js: p5.js sketches: gen art, shaders, interactive, 3D.\n    - pixel-art: Pixel art w/ era palettes (NES, Game Boy, PICO-8).\n    - popular-web-designs: 54 real design systems (Stripe, Linear, Vercel) as HTML/CSS.\n    - pretext: Use when building creative browser demos with @chenglou/p...\n    - sketch: Throwaway HTML mockups: 2-3 design variants to compare.\n    - songwriting-and-ai-music: Songwriting craft and Suno AI music prompts.\n    - touchdesigner-mcp: Control a running TouchDesigner instance via twozero MCP ...\n  data-science: Skills for data science workflows \u2014 interactive exploration, Jupyter notebooks, data analysis, and visualization.\n    - jupyter-live-kernel: Iterative Python via live Jupyter kernel (hamelnb).\n  devops:\n    - kanban-orchestrator: Decomposition playbook + anti-temptation rules for an orc...\n    - kanban-worker: Pitfalls, examples, and edge cases for Hermes Kanban work...\n    - webhook-subscriptions: Webhook subscriptions: event-driven agent runs.\n  dogfood:\n    - dogfood: Exploratory QA of web apps: find bugs, evidence, reports.\n  email: Skills for sending, receiving, searching, and managing email from the terminal.\n    - himalaya: Himalaya CLI: IMAP/SMTP email from terminal.\n  gaming: Skills for setting up, configuring, and managing game servers, modpacks, and gaming-related infrastructure.\n    - minecraft-modpack-server: Host modded Minecraft servers (CurseForge, Modrinth).\n    - pokemon-player: Play Pokemon via headless emulator + RAM reads.\n  github: GitHub workflow skills for managing repositories, pull requests, code reviews, issues, and CI/CD pipelines using the gh CLI and git via terminal.\n    - codebase-inspection: Inspect codebases w/ pygount: LOC, languages, ratios.\n    - github-auth: GitHub auth setup: HTTPS tokens, SSH keys, gh CLI login.\n    - github-code-review: Review PRs: diffs, inline comments via gh or REST.\n    - github-issues: Create, triage, label, assign GitHub issues via gh or REST.\n    - github-pr-workflow: GitHub PR lifecycle: branch, commit, open, CI, merge.\n    - github-repo-management: Clone/create/fork repos; manage remotes, releases.\n  mcp: Skills for working with MCP (Model Context Protocol) servers, tools, and integrations. Documents the built-in native MCP client \u2014 configure servers in config.yaml for automatic tool discovery.\n    - native-mcp: MCP client: connect servers, register tools (stdio/HTTP).\n  media: Skills for working with media content \u2014 YouTube transcripts, GIF search, music generation, and audio visualization.\n    - gif-search: Search/download GIFs from Tenor via curl + jq.\n    - heartmula: HeartMuLa: Suno-like song generation from lyrics + tags.\n    - songsee: Audio spectrograms/features (mel, chroma, MFCC) via CLI.\n    - spotify: Spotify: play, search, queue, manage playlists and devices.\n    - youtube-content: YouTube transcripts to summaries, threads, blogs.\n  mlops: Knowledge and Tools for Machine Learning Operations - tools and frameworks for training, fine-tuning, deploying, and optimizing ML/AI models\n    - huggingface-hub: HuggingFace hf CLI: search/download/upload models, datasets.\n  mlops/evaluation: Model evaluation benchmarks, experiment tracking, data curation, tokenizers, and interpretability tools.\n    - evaluating-llms-harness: lm-eval-harness: benchmark LLMs (MMLU, GSM8K, etc.).\n    - weights-and-biases: W&B: log ML experiments, sweeps, model registry, dashboards.\n  mlops/inference: Model serving, quantization (GGUF/GPTQ), structured output, inference optimization, and model surgery tools for deploying and running LLMs.\n    - llama-cpp: llama.cpp local GGUF inference + HF Hub model discovery.\n    - obliteratus: OBLITERATUS: abliterate LLM refusals (diff-in-means).\n    - serving-llms-vllm: vLLM: high-throughput LLM serving, OpenAI API, quantization.\n  mlops/models: Specific model architectures and tools \u2014 image segmentation (Segment Anything / SAM) and audio generation (AudioCraft / MusicGen). Additional model skills (CLIP, Stable Diffusion, Whisper, LLaVA) are available as optional skills.\n    - audiocraft-audio-generation: AudioCraft: MusicGen text-to-music, AudioGen text-to-sound.\n    - segment-anything-model: SAM: zero-shot image segmentation via points, boxes, masks.\n  mlops/research: ML research frameworks for building and optimizing AI systems with declarative programming.\n    - dspy: DSPy: declarative LM programs, auto-optimize prompts, RAG.\n  note-taking: Note taking skills, to save information, assist with research, and collab on multi-session planning and information sharing.\n    - obsidian: Read, search, create, and edit notes in the Obsidian vault.\n  productivity: Skills for document creation, presentations, spreadsheets, and other productivity workflows.\n    - airtable: Airtable REST API via curl. Records CRUD, filters, upserts.\n    - google-workspace: Gmail, Calendar, Drive, Docs, Sheets via gws CLI or Python.\n    - linear: Linear: manage issues, projects, teams via GraphQL + curl.\n    - maps: Geocode, POIs, routes, timezones via OpenStreetMap/OSRM.\n    - nano-pdf: Edit PDF text/typos/titles via nano-pdf CLI (NL prompts).\n    - notion: Notion API via curl: pages, databases, blocks, search.\n    - ocr-and-documents: Extract text from PDFs/scans (pymupdf, marker-pdf).\n    - powerpoint: Create, read, edit .pptx decks, slides, notes, templates.\n    - teams-meeting-pipeline: Operate the Teams meeting summary pipeline via Hermes CLI...\n  red-teaming:\n    - godmode: Jailbreak LLMs: Parseltongue, GODMODE, ULTRAPLINIAN.\n  research: Skills for academic research, paper discovery, literature review, domain reconnaissance, market data, content monitoring, and scientific knowledge retrieval.\n    - arxiv: Search arXiv papers by keyword, author, category, or ID.\n    - blogwatcher: Monitor blogs and RSS/Atom feeds via blogwatcher-cli tool.\n    - llm-wiki: Karpathy's LLM Wiki: build/query interlinked markdown KB.\n    - polymarket: Query Polymarket: markets, prices, orderbooks, history.\n  smart-home: Skills for controlling smart home devices \u2014 lights, switches, sensors, and home automation systems.\n    - openhue: Control Philips Hue lights, scenes, rooms via OpenHue CLI.\n  social-media: Skills for interacting with social platforms and social-media workflows \u2014 posting, reading, monitoring, and account operations.\n    - xurl: X/Twitter via xurl CLI: post, search, DM, media, v2 API.\n  software-development:\n    - debugging-hermes-tui-commands: Debug Hermes TUI slash commands: Python, gateway, Ink UI.\n    - hermes-agent-skill-authoring: Author in-repo SKILL.md: frontmatter, validator, structure.\n    - node-inspect-debugger: Debug Node.js via --inspect + Chrome DevTools Protocol CLI.\n    - plan: Plan mode: write markdown plan to .hermes/plans/, no exec.\n    - python-debugpy: Debug Python: pdb REPL + debugpy remote (DAP).\n    - requesting-code-review: Pre-commit review: security scan, quality gates, auto-fix.\n    - spike: Throwaway experiments to validate an idea before build.\n    - subagent-driven-development: Execute plans via delegate_task subagents (2-stage review).\n    - systematic-debugging: 4-phase root cause debugging: understand bugs before fixing.\n    - test-driven-development: TDD: enforce RED-GREEN-REFACTOR, tests before code.\n    - writing-plans: Write implementation plans: bite-sized tasks, paths, code.\n  yuanbao:\n    - yuanbao: Yuanbao (\u5143\u5b9d) groups: @mention users, query info/members.\n</available_skills>\n\nOnly proceed without loading a skill if genuinely none are relevant to the task.\n\nHost: Linux (6.10.14-linuxkit)\nUser home directory: /root\nCurrent working directory: /testbed\n\nYou are a CLI AI Agent. Try not to use markdown but simple text renderable inside a terminal. File delivery: there is no attachment channel \u2014 the user reads your response directly in their terminal. Do NOT emit MEDIA:/path tags (those are only intercepted on messaging platforms like Telegram, Discord, Slack, etc.; on the CLI they render as literal text). When referring to a file you created or changed, just state its absolute path in plain text; the user can open it from there.\n\nConversation started: Wednesday, May 13, 2026 03:17 PM\nModel: qwen3.6:35b\nProvider: custom"
+    },
+    {
+      "step_id": 5,
+      "timestamp": "2026-05-13T15:18:27.890779796+00:00",
+      "source": "user",
+      "message": "Set disabled prop on ReadOnlyPasswordHashField\nDescription\n\nCurrently the django.contrib.auth.forms.UserChangeForm defines a clean_password method that returns the initial password value to prevent (accidental) changes to the password value. It is also documented that custom forms for the User model need to define this method: \u200bhttps://docs.djangoproject.com/en/3.1/topics/auth/customizing/#a-full-example\nA while ago the forms.Field base class gained the \u200bdisabled argument to:\n[disable] a form field using the disabled HTML attribute so that it won\u2019t be editable by users. Even if a user tampers with the field\u2019s value submitted to the server, it will be ignored in favor of the value from the form\u2019s initial data.\nIt seems to me that this property could be set to True be default on the ReadOnlyPasswordHashField used to display the password hash. This way the clean_password is no longer necessary and the potential pitfall when using the ReadOnlyPasswordHashField without implementing clean_password is removed."
+    },
+    {
+      "step_id": 6,
+      "timestamp": "2026-05-13T15:18:31.282761881+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_922zw7y9",
+          "function_name": "read_file",
+          "arguments": {
+            "path": "./django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21eb-0ab6-7c80-b022-59f646cc00e6",
+              "function_name": "read_file",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_922zw7y9",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685512.374,
+              "end_timestamp": 1778685512.374
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_922zw7y9",
+            "content": "{\"content\": \"     1|import unicodedata\\n     2|\\n     3|from django import forms\\n     4|from django.contrib.auth import (\\n     5|    authenticate, get_user_model, password_validation,\\n     6|)\\n     7|from django.contrib.auth.hashers import (\\n     8|    UNUSABLE_PASSWORD_PREFIX, identify_hasher,\\n     9|)\\n    10|from django.contrib.auth.models import User\\n    11|from django.contrib.auth.tokens import default_token_generator\\n    12|from django.contrib.sites.shortcuts import get_current_site\\n    13|from django.core.exceptions import ValidationError\\n    14|from django.core.mail import EmailMultiAlternatives\\n    15|from django.template import loader\\n    16|from django.utils.encoding import force_bytes\\n    17|from django.utils.http import urlsafe_base64_encode\\n    18|from django.utils.text import capfirst\\n    19|from django.utils.translation import gettext, gettext_lazy as _\\n    20|\\n    21|UserModel = get_user_model()\\n    22|\\n    23|\\n    24|def _unicode_ci_compare(s1, s2):\\n    25|    \\\"\\\"\\\"\\n    26|    Perform case-insensitive comparison of two identifiers, using the\\n    27|    recommended algorithm from Unicode Technical Report 36, section\\n    28|    2.11.2(B)(2).\\n    29|    \\\"\\\"\\\"\\n    30|    return unicodedata.normalize('NFKC', s1).casefold() == unicodedata.normalize('NFKC', s2).casefold()\\n    31|\\n    32|\\n    33|class ReadOnlyPasswordHashWidget(forms.Widget):\\n    34|    template_name = 'auth/widgets/read_only_password_hash.html'\\n    35|    read_only = True\\n    36|\\n    37|    def get_context(self, name, value, attrs):\\n    38|        context = super().get_context(name, value, attrs)\\n    39|        summary = []\\n    40|        if not value or value.startswith(UNUSABLE_PASSWORD_PREFIX):\\n    41|            summary.append({'label': gettext(\\\"No password set.\\\")})\\n    42|        else:\\n    43|            try:\\n    44|                hasher = identify_hasher(value)\\n    45|            except ValueError:\\n    46|                summary.append({'label': gettext(\\\"Invalid password format or unknown hashing algorithm.\\\")})\\n    47|            else:\\n    48|                for key, value_ in hasher.safe_summary(value).items():\\n    49|                    summary.append({'label': gettext(key), 'value': value_})\\n    50|        context['summary'] = summary\\n    51|        return context\\n    52|\\n    53|\\n    54|class ReadOnlyPasswordHashField(forms.Field):\\n    55|    widget = ReadOnlyPasswordHashWidget\\n    56|\\n    57|    def __init__(self, *args, **kwargs):\\n    58|        kwargs.setdefault(\\\"required\\\", False)\\n    59|        super().__init__(*args, **kwargs)\\n    60|\\n    61|    def bound_data(self, data, initial):\\n    62|        # Always return initial because the widget doesn't\\n    63|        # render an input field.\\n    64|        return initial\\n    65|\\n    66|    def has_changed(self, initial, data):\\n    67|        return False\\n    68|\\n    69|\\n    70|class UsernameField(forms.CharField):\\n    71|    def to_python(self, value):\\n    72|        return unicodedata.normalize('NFKC', super().to_python(value))\\n    73|\\n    74|    def widget_attrs(self, widget):\\n    75|        return {\\n    76|            **super().widget_attrs(widget),\\n    77|            'autocapitalize': 'none',\\n    78|            'autocomplete': 'username',\\n    79|        }\\n    80|\\n    81|\\n    82|class UserCreationForm(forms.ModelForm):\\n    83|    \\\"\\\"\\\"\\n    84|    A form that creates a user, with no privileges, from the given username and\\n    85|    password.\\n    86|    \\\"\\\"\\\"\\n    87|    error_messages = {\\n    88|        'password_mismatch': _('The two password fields didn\u2019t match.'),\\n    89|    }\\n    90|    password1 = forms.CharField(\\n    91|        label=_(\\\"Password\\\"),\\n    92|        strip=False,\\n    93|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),\\n    94|        help_text=password_validation.password_validators_help_text_html(),\\n    95|    )\\n    96|    password2 = forms.CharField(\\n    97|        label=_(\\\"Password confirmation\\\"),\\n    98|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),\\n    99|        strip=False,\\n   100|        help_text=_(\\\"Enter the same password as before, for verification.\\\"),\\n   101|    )\\n   102|\\n   103|    class Meta:\\n   104|        model = User\\n   105|        fields = (\\\"username\\\",)\\n   106|        field_classes = {'username': UsernameField}\\n   107|\\n   108|    def __init__(self, *args, **kwargs):\\n   109|        super().__init__(*args, **kwargs)\\n   110|        if self._meta.model.USERNAME_FIELD in self.fields:\\n   111|            self.fields[self._meta.model.USERNAME_FIELD].widget.attrs['autofocus'] = True\\n   112|\\n   113|    def clean_password2(self):\\n   114|        password1 = self.cleaned_data.get(\\\"password1\\\")\\n   115|        password2 = self.cleaned_data.get(\\\"password2\\\")\\n   116|        if password1 and password2 and password1 != password2:\\n   117|            raise ValidationError(\\n   118|                self.error_messages['password_mismatch'],\\n   119|                code='password_mismatch',\\n   120|            )\\n   121|        return password2\\n   122|\\n   123|    def _post_clean(self):\\n   124|        super()._post_clean()\\n   125|        # Validate the password after self.instance is updated with form data\\n   126|        # by super().\\n   127|        password = self.cleaned_data.get('password2')\\n   128|        if password:\\n   129|            try:\\n   130|                password_validation.validate_password(password, self.instance)\\n   131|            except ValidationError as error:\\n   132|                self.add_error('password2', error)\\n   133|\\n   134|    def save(self, commit=True):\\n   135|        user = super().save(commit=False)\\n   136|        user.set_password(self.cleaned_data[\\\"password1\\\"])\\n   137|        if commit:\\n   138|            user.save()\\n   139|        return user\\n   140|\\n   141|\\n   142|class UserChangeForm(forms.ModelForm):\\n   143|    password = ReadOnlyPasswordHashField(\\n   144|        label=_(\\\"Password\\\"),\\n   145|        help_text=_(\\n   146|            'Raw passwords are not stored, so there is no way to see this '\\n   147|            'user\u2019s password, but you can change the password using '\\n   148|            '<a href=\\\"{}\\\">this form</a>.'\\n   149|        ),\\n   150|    )\\n   151|\\n   152|    class Meta:\\n   153|        model = User\\n   154|        fields = '__all__'\\n   155|        field_classes = {'username': UsernameField}\\n   156|\\n   157|    def __init__(self, *args, **kwargs):\\n   158|        super().__init__(*args, **kwargs)\\n   159|        password = self.fields.get('password')\\n   160|        if password:\\n   161|            password.help_text = password.help_text.format('../password/')\\n   162|        user_permissions = self.fields.get('user_permissions')\\n   163|        if user_permissions:\\n   164|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n   165|\\n   166|    def clean_password(self):\\n   167|        # Regardless of what the user provides, return the initial value.\\n   168|        # This is done here, rather than on the field, because the\\n   169|        # field does not have access to the initial value\\n   170|        return self.initial.get('password')\\n   171|\\n   172|\\n   173|class AuthenticationForm(forms.Form):\\n   174|    \\\"\\\"\\\"\\n   175|    Base class for authenticating users. Extend this to get a form that accepts\\n   176|    username/password logins.\\n   177|    \\\"\\\"\\\"\\n   178|    username = UsernameField(widget=forms.TextInput(attrs={'autofocus': True}))\\n   179|    password = forms.CharField(\\n   180|        label=_(\\\"Password\\\"),\\n   181|        strip=False,\\n   182|        widget=forms.PasswordInput(attrs={'autocomplete': 'current-password'}),\\n   183|    )\\n   184|\\n   185|    error_messages = {\\n   186|        'invalid_login': _(\\n   187|            \\\"Please enter a correct %(username)s and password. Note that both \\\"\\n   188|            \\\"fields may be case-sensitive.\\\"\\n   189|        ),\\n   190|        'inactive': _(\\\"This account is inactive.\\\"),\\n   191|    }\\n   192|\\n   193|    def __init__(self, request=None, *args, **kwargs):\\n   194|        \\\"\\\"\\\"\\n   195|        The 'request' parameter is set for custom auth use by subclasses.\\n   196|        The form data comes in via the standard 'data' kwarg.\\n   197|        \\\"\\\"\\\"\\n   198|        self.request = request\\n   199|        self.user_cache = None\\n   200|        super().__init__(*args, **kwargs)\\n   201|\\n   202|        # Set the max length and label for the \\\"username\\\" field.\\n   203|        self.username_field = UserModel._meta.get_field(UserModel.USERNAME_FIELD)\\n   204|        username_max_length = self.username_field.max_length or 254\\n   205|        self.fields['username'].max_length = username_max_length\\n   206|        self.fields['username'].widget.attrs['maxlength'] = username_max_length\\n   207|        if self.fields['username'].label is None:\\n   208|            self.fields['username'].label = capfirst(self.username_field.verbose_name)\\n   209|\\n   210|    def clean(self):\\n   211|        username = self.cleaned_data.get('username')\\n   212|        password = self.cleaned_data.get('password')\\n   213|\\n   214|        if username is not None and password:\\n   215|            self.user_cache = authenticate(self.request, username=username, password=password)\\n   216|            if self.user_cache is None:\\n   217|                raise self.get_invalid_login_error()\\n   218|            else:\\n   219|                self.confirm_login_allowed(self.user_cache)\\n   220|\\n   221|        return self.cleaned_data\\n   222|\\n   223|    def confirm_login_allowed(self, user):\\n   224|        \\\"\\\"\\\"\\n   225|        Controls whether the given User may log in. This is a policy setting,\\n   226|        independent of end-user authentication. This default behavior is to\\n   227|        allow login by active users, and reject login by inactive users.\\n   228|\\n   229|        If the given user cannot log in, this method should raise a\\n   230|        ``ValidationError``.\\n   231|\\n   232|        If the given user may log in, this method should return None.\\n   233|        \\\"\\\"\\\"\\n   234|        if not user.is_active:\\n   235|            raise ValidationError(\\n   236|                self.error_messages['inactive'],\\n   237|                code='inactive',\\n   238|            )\\n   239|\\n   240|    def get_user(self):\\n   241|        return self.user_cache\\n   242|\\n   243|    def get_invalid_login_error(self):\\n   244|        return ValidationError(\\n   245|            self.error_messages['invalid_login'],\\n   246|            code='invalid_login',\\n   247|            params={'username': self.username_field.verbose_name},\\n   248|        )\\n   249|\\n   250|\\n   251|class PasswordResetForm(forms.Form):\\n   252|    email = forms.EmailField(\\n   253|        label=_(\\\"Email\\\"),\\n   254|        max_length=254,\\n   255|        widget=forms.EmailInput(attrs={'autocomplete': 'email'})\\n   256|    )\\n   257|\\n   258|    def send_mail(self, subject_template_name, email_template_name,\\n   259|                  context, from_email, to_email, html_email_template_name=None):\\n   260|        \\\"\\\"\\\"\\n   261|        Send a django.core.mail.EmailMultiAlternatives to `to_email`.\\n   262|        \\\"\\\"\\\"\\n   263|        subject = loader.render_to_string(subject_template_name, context)\\n   264|        # Email subject *must not* contain newlines\\n   265|        subject = ''.join(subject.splitlines())\\n   266|        body = loader.render_to_string(email_template_name, context)\\n   267|\\n   268|        email_message = EmailMultiAlternatives(subject, body, from_email, [to_email])\\n   269|        if html_email_template_name is not None:\\n   270|            html_email = loader.render_to_string(html_email_template_name, context)\\n   271|            email_message.attach_alternative(html_email, 'text/html')\\n   272|\\n   273|        email_message.send()\\n   274|\\n   275|    def get_users(self, email):\\n   276|        \\\"\\\"\\\"Given an email, return matching user(s) who should receive a reset.\\n   277|\\n   278|        This allows subclasses to more easily customize the default policies\\n   279|        that prevent inactive users and users with unusable passwords from\\n   280|        resetting their password.\\n   281|        \\\"\\\"\\\"\\n   282|        email_field_name = UserModel.get_email_field_name()\\n   283|        active_users = UserModel._default_manager.filter(**{\\n   284|            '%s__iexact' % email_field_name: email,\\n   285|            'is_active': True,\\n   286|        })\\n   287|        return (\\n   288|            u for u in active_users\\n   289|            if u.has_usable_password() and\\n   290|            _unicode_ci_compare(email, getattr(u, email_field_name))\\n   291|        )\\n   292|\\n   293|    def save(self, domain_override=None,\\n   294|             subject_template_name='registration/password_reset_subject.txt',\\n   295|             email_template_name='registration/password_reset_email.html',\\n   296|             use_https=False, token_generator=default_token_generator,\\n   297|             from_email=None, request=None, html_email_template_name=None,\\n   298|             extra_email_context=None):\\n   299|        \\\"\\\"\\\"\\n   300|        Generate a one-use only link for resetting password and send it to the\\n   301|        user.\\n   302|        \\\"\\\"\\\"\\n   303|        email = self.cleaned_data[\\\"email\\\"]\\n   304|        if not domain_override:\\n   305|            current_site = get_current_site(request)\\n   306|            site_name = current_site.name\\n   307|            domain = current_site.domain\\n   308|        else:\\n   309|            site_name = domain = domain_override\\n   310|        email_field_name = UserModel.get_email_field_name()\\n   311|        for user in self.get_users(email):\\n   312|            user_email = getattr(user, email_field_name)\\n   313|            context = {\\n   314|                'email': user_email,\\n   315|                'domain': domain,\\n   316|                'site_name': site_name,\\n   317|                'uid': urlsafe_base64_encode(force_bytes(user.pk)),\\n   318|                'user': user,\\n   319|                'token': token_generator.make_token(user),\\n   320|                'protocol': 'https' if use_https else 'http',\\n   321|                **(extra_email_context or {}),\\n   322|            }\\n   323|            self.send_mail(\\n   324|                subject_template_name, email_template_name, context, from_email,\\n   325|                user_email, html_email_template_name=html_email_template_name,\\n   326|            )\\n   327|\\n   328|\\n   329|class SetPasswordForm(forms.Form):\\n   330|    \\\"\\\"\\\"\\n   331|    A form that lets a user change set their password without entering the old\\n   332|    password\\n   333|    \\\"\\\"\\\"\\n   334|    error_messages = {\\n   335|        'password_mismatch': _('The two password fields didn\u2019t match.'),\\n   336|    }\\n   337|    new_password1 = forms.CharField(\\n   338|        label=_(\\\"New password\\\"),\\n   339|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),\\n   340|        strip=False,\\n   341|        help_text=password_validation.password_validators_help_text_html(),\\n   342|    )\\n   343|    new_password2 = forms.CharField(\\n   344|        label=_(\\\"New password confirmation\\\"),\\n   345|        strip=False,\\n   346|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),\\n   347|    )\\n   348|\\n   349|    def __init__(self, user, *args, **kwargs):\\n   350|        self.user = user\\n   351|        super().__init__(*args, **kwargs)\\n   352|\\n   353|    def clean_new_password2(self):\\n   354|        password1 = self.cleaned_data.get('new_password1')\\n   355|        password2 = self.cleaned_data.get('new_password2')\\n   356|        if password1 and password2:\\n   357|            if password1 != password2:\\n   358|                raise ValidationError(\\n   359|                    self.error_messages['password_mismatch'],\\n   360|                    code='password_mismatch',\\n   361|                )\\n   362|        password_validation.validate_password(password2, self.user)\\n   363|        return password2\\n   364|\\n   365|    def save(self, commit=True):\\n   366|        password = self.cleaned_data[\\\"new_password1\\\"]\\n   367|        self.user.set_password(password)\\n   368|        if commit:\\n   369|            self.user.save()\\n   370|        return self.user\\n   371|\\n   372|\\n   373|class PasswordChangeForm(SetPasswordForm):\\n   374|    \\\"\\\"\\\"\\n   375|    A form that lets a user change their password by entering their old\\n   376|    password.\\n   377|    \\\"\\\"\\\"\\n   378|    error_messages = {\\n   379|        **SetPasswordForm.error_messages,\\n   380|        'password_incorrect': _(\\\"Your old password was entered incorrectly. Please enter it again.\\\"),\\n   381|    }\\n   382|    old_password = forms.CharField(\\n   383|        label=_(\\\"Old password\\\"),\\n   384|        strip=False,\\n   385|        widget=forms.PasswordInput(attrs={'autocomplete': 'current-password', 'autofocus': True}),\\n   386|    )\\n   387|\\n   388|    field_order = ['old_password', 'new_password1', 'new_password2']\\n   389|\\n   390|    def clean_old_password(self):\\n   391|        \\\"\\\"\\\"\\n   392|        Validate that the old_password field is correct.\\n   393|        \\\"\\\"\\\"\\n   394|        old_password = self.cleaned_data[\\\"old_password\\\"]\\n   395|        if not self.user.check_password(old_password):\\n   396|            raise ValidationError(\\n   397|                self.error_messages['password_incorrect'],\\n   398|                code='password_incorrect',\\n   399|            )\\n   400|        return old_password\\n   401|\\n   402|\\n   403|class AdminPasswordChangeForm(forms.Form):\\n   404|    \\\"\\\"\\\"\\n   405|    A form used to change the password of a user in the admin interface.\\n   406|    \\\"\\\"\\\"\\n   407|    error_messages = {\\n   408|        'password_mismatch': _('The two password fields didn\u2019t match.'),\\n   409|    }\\n   410|    required_css_class = 'required'\\n   411|    password1 = forms.CharField(\\n   412|        label=_(\\\"Password\\\"),\\n   413|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password', 'autofocus': True}),\\n   414|        strip=False,\\n   415|        help_text=password_validation.password_validators_help_text_html(),\\n   416|    )\\n   417|    password2 = forms.CharField(\\n   418|        label=_(\\\"Password (again)\\\"),\\n   419|        widget=forms.PasswordInput(attrs={'autocomplete': 'new-password'}),\\n   420|        strip=False,\\n   421|        help_text=_(\\\"Enter the same password as before, for verification.\\\"),\\n   422|    )\\n   423|\\n   424|    def __init__(self, user, *args, **kwargs):\\n   425|        self.user = user\\n   426|        super().__init__(*args, **kwargs)\\n   427|\\n   428|    def clean_password2(self):\\n   429|        password1 = self.cleaned_data.get('password1')\\n   430|        password2 = self.cleaned_data.get('password2')\\n   431|        if password1 and password2 and password1 != password2:\\n   432|            raise ValidationError(\\n   433|                self.error_messages['password_mismatch'],\\n   434|                code='password_mismatch',\\n   435|            )\\n   436|        password_validation.validate_password(password2, self.user)\\n   437|        return password2\\n   438|\\n   439|    def save(self, commit=True):\\n   440|        \\\"\\\"\\\"Save the new password.\\\"\\\"\\\"\\n   441|        password = self.cleaned_data[\\\"password1\\\"]\\n   442|        self.user.set_password(password)\\n   443|        if commit:\\n   444|            self.user.save()\\n   445|        return self.user\\n   446|\\n   447|    @property\\n   448|    def changed_data(self):\\n   449|        data = super().changed_data\\n   450|        for name in self.fields:\\n   451|            if name not in data:\\n   452|                return []\\n   453|        return ['password']\\n   454|\", \"total_lines\": 453, \"file_size\": 16311, \"truncated\": false, \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 15518,
+        "completion_tokens": 41,
+        "extra": {
+          "total_tokens": 15559
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ea-f932-7c81-9890-4d6965b56b4a",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ea-f932-7c81-9890-4d6965b56b4a",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685507.891,
+          "end_timestamp": 1778685511.283
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 7,
+      "timestamp": "2026-05-13T15:19:07.846486551+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Now let me check the tests and the docs that reference `clean_password`:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_rntyhigl",
+          "function_name": "search_files",
+          "arguments": {
+            "output_mode": "content",
+            "path": "./tests/auth_tests",
+            "pattern": "clean_password"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21eb-990e-7881-83c5-61a81f5b21ea",
+              "function_name": "search_files",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_rntyhigl",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685548.814,
+              "end_timestamp": 1778685548.815
+            }
+          }
+        },
+        {
+          "tool_call_id": "call_3jhj2k7c",
+          "function_name": "search_files",
+          "arguments": {
+            "output_mode": "content",
+            "path": "./docs/topics/auth",
+            "pattern": "clean_password"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21eb-995d-74c0-85bc-3c8c9d756844",
+              "function_name": "search_files",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_3jhj2k7c",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685548.894,
+              "end_timestamp": 1778685548.894
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_rntyhigl",
+            "content": "{\"total_count\": 0}"
+          },
+          {
+            "source_call_id": "call_3jhj2k7c",
+            "content": "{\"total_count\": 2, \"matches\": [{\"path\": \"./docs/topics/auth/customizing.txt\", \"line\": 1112, \"content\": \"        def clean_password2(self):\"}, {\"path\": \"./docs/topics/auth/customizing.txt\", \"line\": 1140, \"content\": \"        def clean_password(self):\"}]}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 22053,
+        "completion_tokens": 453,
+        "extra": {
+          "total_tokens": 22506
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21eb-0b29-78d2-ad61-351af3deb59f",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21eb-0b29-78d2-ad61-351af3deb59f",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685512.49,
+          "end_timestamp": 1778685547.846
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 8,
+      "timestamp": "2026-05-13T15:19:15.581116138+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_89pm5vx6",
+          "function_name": "read_file",
+          "arguments": {
+            "offset": 1100,
+            "limit": 80,
+            "path": "./docs/topics/auth/customizing.txt"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21eb-b7ab-7a21-a910-ed34b279b072",
+              "function_name": "read_file",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_89pm5vx6",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685556.652,
+              "end_timestamp": 1778685556.652
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_89pm5vx6",
+            "content": "{\"content\": \"  1100|\\n  1101|\\n  1102|    class UserCreationForm(forms.ModelForm):\\n  1103|        \\\"\\\"\\\"A form for creating new users. Includes all the required\\n  1104|        fields, plus a repeated password.\\\"\\\"\\\"\\n  1105|        password1 = forms.CharField(label='Password', widget=forms.PasswordInput)\\n  1106|        password2 = forms.CharField(label='Password confirmation', widget=forms.PasswordInput)\\n  1107|\\n  1108|        class Meta:\\n  1109|            model = MyUser\\n  1110|            fields = ('email', 'date_of_birth')\\n  1111|\\n  1112|        def clean_password2(self):\\n  1113|            # Check that the two password entries match\\n  1114|            password1 = self.cleaned_data.get(\\\"password1\\\")\\n  1115|            password2 = self.cleaned_data.get(\\\"password2\\\")\\n  1116|            if password1 and password2 and password1 != password2:\\n  1117|                raise ValidationError(\\\"Passwords don't match\\\")\\n  1118|            return password2\\n  1119|\\n  1120|        def save(self, commit=True):\\n  1121|            # Save the provided password in hashed format\\n  1122|            user = super().save(commit=False)\\n  1123|            user.set_password(self.cleaned_data[\\\"password1\\\"])\\n  1124|            if commit:\\n  1125|                user.save()\\n  1126|            return user\\n  1127|\\n  1128|\\n  1129|    class UserChangeForm(forms.ModelForm):\\n  1130|        \\\"\\\"\\\"A form for updating users. Includes all the fields on\\n  1131|        the user, but replaces the password field with admin's\\n  1132|        password hash display field.\\n  1133|        \\\"\\\"\\\"\\n  1134|        password = ReadOnlyPasswordHashField()\\n  1135|\\n  1136|        class Meta:\\n  1137|            model = MyUser\\n  1138|            fields = ('email', 'password', 'date_of_birth', 'is_active', 'is_admin')\\n  1139|\\n  1140|        def clean_password(self):\\n  1141|            # Regardless of what the user provides, return the initial value.\\n  1142|            # This is done here, rather than on the field, because the\\n  1143|            # field does not have access to the initial value\\n  1144|            return self.initial[\\\"password\\\"]\\n  1145|\\n  1146|\\n  1147|    class UserAdmin(BaseUserAdmin):\\n  1148|        # The forms to add and change user instances\\n  1149|        form = UserChangeForm\\n  1150|        add_form = UserCreationForm\\n  1151|\\n  1152|        # The fields to be used in displaying the User model.\\n  1153|        # These override the definitions on the base UserAdmin\\n  1154|        # that reference specific fields on auth.User.\\n  1155|        list_display = ('email', 'date_of_birth', 'is_admin')\\n  1156|        list_filter = ('is_admin',)\\n  1157|        fieldsets = (\\n  1158|            (None, {'fields': ('email', 'password')}),\\n  1159|            ('Personal info', {'fields': ('date_of_birth',)}),\\n  1160|            ('Permissions', {'fields': ('is_admin',)}),\\n  1161|        )\\n  1162|        # add_fieldsets is not a standard ModelAdmin attribute. UserAdmin\\n  1163|        # overrides get_fieldsets to use this attribute when creating a user.\\n  1164|        add_fieldsets = (\\n  1165|            (None, {\\n  1166|                'classes': ('wide',),\\n  1167|                'fields': ('email', 'date_of_birth', 'password1', 'password2'),\\n  1168|            }),\\n  1169|        )\\n  1170|        search_fields = ('email',)\\n  1171|        ordering = ('email',)\\n  1172|        filter_horizontal = ()\\n  1173|\\n  1174|\\n  1175|    # Now register the new UserAdmin...\\n  1176|    admin.site.register(MyUser, UserAdmin)\\n  1177|    # ... and, since we're not using Django's built-in permissions,\\n  1178|    # unregister the Group model from admin.\\n  1179|    admin.site.unregister(Group)\\n  1180|\", \"total_lines\": 1184, \"file_size\": 49492, \"truncated\": true, \"hint\": \"Use offset=1180 to continue reading (showing 1100-1179 of 1184 lines)\", \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 22278,
+        "completion_tokens": 77,
+        "extra": {
+          "total_tokens": 22355
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21eb-99ea-74d2-a1ab-82b8f238d3d3",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21eb-99ea-74d2-a1ab-82b8f238d3d3",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685549.035,
+          "end_timestamp": 1778685555.581
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 9,
+      "timestamp": "2026-05-13T15:19:38.691625218+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Let me check the existing tests for `UserChangeForm`:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_do5cz4pw",
+          "function_name": "search_files",
+          "arguments": {
+            "output_mode": "content",
+            "path": "./tests/auth_tests/test_forms.py",
+            "pattern": "password",
+            "context": 5
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ec-1082-7943-bf28-61dbc141a7d8",
+              "function_name": "search_files",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_do5cz4pw",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685579.395,
+              "end_timestamp": 1778685579.395
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_do5cz4pw",
+            "content": "{\"total_count\": 245, \"matches\": [{\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 29, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 30, \"content\": \"class TestDataMixin:\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 31, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 32, \"content\": \"    @classmethod\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 33, \"content\": \"    def setUpTestData(cls):\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 34, \"content\": \"        cls.u1 = User.objects.create_user(username='testclient', password='password', email='testclient@example.com')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 35, \"content\": \"        cls.u2 = User.objects.create_user(username='inactive', password='password', is_active=False)\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 36, \"content\": \"        cls.u3 = User.objects.create_user(username='staff', password='password')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 37, \"content\": \"        cls.u4 = User.objects.create(username='empty_password', password='')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 38, \"content\": \"        cls.u5 = User.objects.create(username='unmanageable_password', password='$')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 39, \"content\": \"        cls.u6 = User.objects.create(username='unknown_password', password='foo$bar')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 40, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 41, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 42, \"content\": \"class UserCreationFormTest(TestDataMixin, TestCase):\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 43, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 44, \"content\": \"    def test_user_already_exists(self):\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 45, \"content\": \"        data = {\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 46, \"content\": \"            'username': 'testclient',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 47, \"content\": \"            'password1': 'test123',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 48, \"content\": \"            'password2': 'test123',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 49, \"content\": \"        }\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 50, \"content\": \"        form = UserCreationForm(data)\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 51, \"content\": \"        self.assertFalse(form.is_valid())\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 52, \"content\": \"        self.assertEqual(form[\\\"username\\\"].errors,\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 53, \"content\": \"                         [str(User._meta.get_field('username').error_messages['unique'])])\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 54, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 55, \"content\": \"    def test_invalid_data(self):\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 56, \"content\": \"        data = {\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 57, \"content\": \"            'username': 'jsmith!',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 58, \"content\": \"            'password1': 'test123',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 59, \"content\": \"            'password2': 'test123',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 60, \"content\": \"        }\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 61, \"content\": \"        form = UserCreationForm(data)\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 62, \"content\": \"        self.assertFalse(form.is_valid())\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 63, \"content\": \"        validator = next(v for v in User._meta.get_field('username').validators if v.code == 'invalid')\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 64, \"content\": \"        self.assertEqual(form[\\\"username\\\"].errors, [str(validator.message)])\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 65, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 66, \"content\": \"    def test_password_verification(self):\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 67, \"content\": \"        # The verification password is incorrect.\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 68, \"content\": \"        data = {\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 69, \"content\": \"            'username': 'jsmith',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 70, \"content\": \"            'password1': 'test123',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 71, \"content\": \"            'password2': 'test',\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 72, \"content\": \"        }\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 73, \"content\": \"        form = UserCreationForm(data)\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 74, \"content\": \"        self.assertFalse(form.is_valid())\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 75, \"content\": \"        self.assertEqual(form[\\\"password2\\\"].errors,\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 76, \"content\": \"                         [str(form.error_messages['password_mismatch'])])\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 77, \"content\": \"\"}, {\"path\": \"./tests/auth_tests/test_forms.py\", \"line\": 78, \"content\": \"    def test_both_passwords(self):\"}], \"truncated\": true}\n\n[Hint: Results truncated. Use offset=50 to see more, or narrow with a more specific pattern or file_glob.]"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 23717,
+        "completion_tokens": 366,
+        "extra": {
+          "total_tokens": 24083
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21eb-b80e-7c62-baa3-94d714c0df4a",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21eb-b80e-7c62-baa3-94d714c0df4a",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685556.751,
+          "end_timestamp": 1778685578.692
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 10,
+      "timestamp": "2026-05-13T15:19:58.587602713+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Now I have a clear picture. Let me implement the change.\n\nThe fix is straightforward: add `disabled=True` to the `ReadOnlyPasswordHashField` field definition in `UserChangeForm` and remove the now-unnecessary `clean_password` method.",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_588dvlm1",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "path": "./django/contrib/auth/forms.py",
+            "old_string": "class UserChangeForm(forms.ModelForm):\n    password = ReadOnlyPasswordHashField(\n        label=_(\"Password\"),\n        help_text=_(\n            'Raw passwords are not stored, so there is no way to see this '\n            'user's password, but you can change the password using '\n            '<a href=\"{}\">this form</a>.'\n        ),\n    )",
+            "new_string": "class UserChangeForm(forms.ModelForm):\n    password = ReadOnlyPasswordHashField(\n        label=_(\"Password\"),\n        disabled=True,\n        help_text=_(\n            'Raw passwords are not stored, so there is no way to see this '\n            'user's password, but you can change the password using '\n            '<a href=\"{}\">this form</a>.'\n        ),\n    )"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ec-8573-7fa0-a466-e088d33e1b0f",
+              "function_name": "patch",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_588dvlm1",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685609.332,
+              "end_timestamp": 1778685609.332
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_588dvlm1",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -142,9 +142,10 @@\\n class UserChangeForm(forms.ModelForm):\\n     password = ReadOnlyPasswordHashField(\\n         label=_(\\\"Password\\\"),\\n+        disabled=True,\\n         help_text=_(\\n             'Raw passwords are not stored, so there is no way to see this '\\n-            'user\u2019s password, but you can change the password using '\\n+            'user's password, but you can change the password using '\\n             '<a href=\\\"{}\\\">this form</a>.'\\n         ),\\n     )\\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"error\", \"output\": \"SyntaxError: unterminated string literal (detected at line 148) (line 148, column 69)\"}}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 25429,
+        "completion_tokens": 290,
+        "extra": {
+          "total_tokens": 25719
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ec-1108-7d60-98bc-64a7670d5971",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ec-1108-7d60-98bc-64a7670d5971",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685579.528,
+          "end_timestamp": 1778685598.588
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 11,
+      "timestamp": "2026-05-13T15:20:17.116962916+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The patch introduced an encoding issue. Let me read the current state and fix it:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_3ev8gxr9",
+          "function_name": "read_file",
+          "arguments": {
+            "limit": 15,
+            "offset": 142,
+            "path": "./django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ec-a82b-7453-9f2e-0d806fa09e5b",
+              "function_name": "read_file",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_3ev8gxr9",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685618.219,
+              "end_timestamp": 1778685618.219
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_3ev8gxr9",
+            "content": "{\"content\": \"   142|class UserChangeForm(forms.ModelForm):\\n   143|    password = ReadOnlyPasswordHashField(\\n   144|        label=_(\\\"Password\\\"),\\n   145|        disabled=True,\\n   146|        help_text=_(\\n   147|            'Raw passwords are not stored, so there is no way to see this '\\n   148|            'user's password, but you can change the password using '\\n   149|            '<a href=\\\"{}\\\">this form</a>.'\\n   150|        ),\\n   151|    )\\n   152|\\n   153|    class Meta:\\n   154|        model = User\\n   155|        fields = '__all__'\\n   156|        field_classes = {'username': UsernameField}\\n   157|\", \"total_lines\": 454, \"file_size\": 16332, \"truncated\": true, \"hint\": \"Use offset=157 to continue reading (showing 142-156 of 454 lines)\", \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 25950,
+        "completion_tokens": 127,
+        "extra": {
+          "total_tokens": 26077
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ec-8624-7931-acd9-e9bc751e1f3b",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ec-8624-7931-acd9-e9bc751e1f3b",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685609.508,
+          "end_timestamp": 1778685617.117
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 12,
+      "timestamp": "2026-05-13T15:20:31.892332632+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The curly apostrophe in the original text was converted to `'` which breaks the string. Let me fix it:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_8lrexjko",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "path": "./django/contrib/auth/forms.py",
+            "old_string": "        help_text=_(\n            'Raw passwords are not stored, so there is no way to see this '\n            'user's password, but you can change the password using '\n            '<a href=\"{}\">this form</a>.'\n        ),",
+            "new_string": "        help_text=_(\n            \"Raw passwords are not stored, so there is no way to see this \"\n            \"user's password, but you can change the password using \"\n            \"<a href=\\\"{}\\\">this form</a>.\"\n        ),"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ec-e3bb-7d61-99c2-1f541041da65",
+              "function_name": "patch",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_8lrexjko",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685633.468,
+              "end_timestamp": 1778685633.468
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_8lrexjko",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -144,9 +144,9 @@\\n         label=_(\\\"Password\\\"),\\n         disabled=True,\\n         help_text=_(\\n-            'Raw passwords are not stored, so there is no way to see this '\\n-            'user's password, but you can change the password using '\\n-            '<a href=\\\"{}\\\">this form</a>.'\\n+            \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n+            \\\"user's password, but you can change the password using \\\"\\n+            \\\"<a href=\\\\\\\"{}\\\\\\\">this form</a>.\\\"\\n         ),\\n     )\\n \\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"ok\", \"output\": \"\"}, \"_warning\": \"/testbed/django/contrib/auth/forms.py was last read with offset/limit pagination (partial view). Re-read the whole file before overwriting it.\"}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 26338,
+        "completion_tokens": 244,
+        "extra": {
+          "total_tokens": 26582
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ec-a89d-71f2-b79c-3b4127589f7d",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ec-a89d-71f2-b79c-3b4127589f7d",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685618.334,
+          "end_timestamp": 1778685631.892
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 13,
+      "timestamp": "2026-05-13T15:20:42.414247845+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The escaping looks wrong. Let me re-read and fix properly:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_apcd6m2h",
+          "function_name": "read_file",
+          "arguments": {
+            "limit": 20,
+            "offset": 142,
+            "path": "./django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ed-0b19-7d00-8c18-20a722b86497",
+              "function_name": "read_file",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_apcd6m2h",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685643.546,
+              "end_timestamp": 1778685643.546
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_apcd6m2h",
+            "content": "{\"content\": \"   142|class UserChangeForm(forms.ModelForm):\\n   143|    password = ReadOnlyPasswordHashField(\\n   144|        label=_(\\\"Password\\\"),\\n   145|        disabled=True,\\n   146|        help_text=_(\\n   147|            \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n   148|            \\\"user's password, but you can change the password using \\\"\\n   149|            \\\"<a href=\\\\\\\"{}\\\\\\\">this form</a>.\\\"\\n   150|        ),\\n   151|    )\\n   152|\\n   153|    class Meta:\\n   154|        model = User\\n   155|        fields = '__all__'\\n   156|        field_classes = {'username': UsernameField}\\n   157|\\n   158|    def __init__(self, *args, **kwargs):\\n   159|        super().__init__(*args, **kwargs)\\n   160|        password = self.fields.get('password')\\n   161|        if password:\\n   162|\", \"total_lines\": 454, \"file_size\": 16334, \"truncated\": true, \"hint\": \"Use offset=162 to continue reading (showing 142-161 of 454 lines)\", \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 26804,
+        "completion_tokens": 92,
+        "extra": {
+          "total_tokens": 26896
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ec-e445-73d0-becb-c54881e0fe41",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ec-e445-73d0-becb-c54881e0fe41",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685633.605,
+          "end_timestamp": 1778685642.414
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 14,
+      "timestamp": "2026-05-13T15:20:56.820049171+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The escaping on line 149 is incorrect. Let me fix that, and also now remove the `clean_password` method since it's no longer needed:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_jomhje2z",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "path": "./django/contrib/auth/forms.py",
+            "old_string": "            \"<a href=\\\\\"{}\\\\\">this form</a>.\"",
+            "new_string": "            '<a href=\"{}\">this form</a>.'"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ed-4536-77c0-80be-2084e6e9c13c",
+              "function_name": "patch",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_jomhje2z",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685658.423,
+              "end_timestamp": 1778685658.423
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_jomhje2z",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -146,7 +146,7 @@\\n         help_text=_(\\n             \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n             \\\"user's password, but you can change the password using \\\"\\n-            \\\"<a href=\\\\\\\"{}\\\\\\\">this form</a>.\\\"\\n+            '<a href=\\\"{}\\\">this form</a>.'\\n         ),\\n     )\\n \\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"ok\", \"output\": \"\"}, \"_warning\": \"/testbed/django/contrib/auth/forms.py was last read with offset/limit pagination (partial view). Re-read the whole file before overwriting it.\"}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 27265,
+        "completion_tokens": 157,
+        "extra": {
+          "total_tokens": 27422
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ed-0b9f-74c1-95f8-4688d5eadbb3",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ed-0b9f-74c1-95f8-4688d5eadbb3",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685643.68,
+          "end_timestamp": 1778685656.82
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 15,
+      "timestamp": "2026-05-13T15:21:04.139834549+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Let me start fresh and rewrite the entire `UserChangeForm` class properly.",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_igvwuti8",
+          "function_name": "read_file",
+          "arguments": {
+            "offset": 142,
+            "limit": 30,
+            "path": "./django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ed-5feb-7140-a94b-cd2b2ce322c9",
+              "function_name": "read_file",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_igvwuti8",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685665.26,
+              "end_timestamp": 1778685665.26
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_igvwuti8",
+            "content": "{\"content\": \"   142|class UserChangeForm(forms.ModelForm):\\n   143|    password = ReadOnlyPasswordHashField(\\n   144|        label=_(\\\"Password\\\"),\\n   145|        disabled=True,\\n   146|        help_text=_(\\n   147|            \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n   148|            \\\"user's password, but you can change the password using \\\"\\n   149|            '<a href=\\\"{}\\\">this form</a>.'\\n   150|        ),\\n   151|    )\\n   152|\\n   153|    class Meta:\\n   154|        model = User\\n   155|        fields = '__all__'\\n   156|        field_classes = {'username': UsernameField}\\n   157|\\n   158|    def __init__(self, *args, **kwargs):\\n   159|        super().__init__(*args, **kwargs)\\n   160|        password = self.fields.get('password')\\n   161|        if password:\\n   162|            password.help_text = password.help_text.format('../password/')\\n   163|        user_permissions = self.fields.get('user_permissions')\\n   164|        if user_permissions:\\n   165|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n   166|\\n   167|    def clean_password(self):\\n   168|        # Regardless of what the user provides, return the initial value.\\n   169|        # This is done here, rather than on the field, because the\\n   170|        # field does not have access to the initial value\\n   171|        return self.initial.get('password')\\n   172|\", \"total_lines\": 454, \"file_size\": 16332, \"truncated\": true, \"hint\": \"Use offset=172 to continue reading (showing 142-171 of 454 lines)\", \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 27607,
+        "completion_tokens": 93,
+        "extra": {
+          "total_tokens": 27700
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ed-45d0-7cd2-8fe6-f7f73d3c8082",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ed-45d0-7cd2-8fe6-f7f73d3c8082",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685658.576,
+          "end_timestamp": 1778685664.14
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 16,
+      "timestamp": "2026-05-13T15:21:36.332872509+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The help_text has odd quote mixing but is valid Python. The real remaining change is to remove the `clean_password` method. But first, let me fix the help_text quotes to be clean, then remove `clean_password`:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_t878z9ul",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "new_string": "class UserChangeForm(forms.ModelForm):\n    password = ReadOnlyPasswordHashField(\n        label=_(\"Password\"),\n        disabled=True,\n        help_text=_(\n            \"Raw passwords are not stored, so there is no way to see this \"\n            \"user's password, but you can change the password using \"\n            '<a href=\"{}\">this form</a>.'\n        ),\n    )\n\n    class Meta:\n        model = User\n        fields = '__all__'\n        field_classes = {'username': UsernameField}\n\n    def __init__(self, *args, **kwargs):\n        super().__init__(*args, **kwargs)\n        password = self.fields.get('password')\n        if password:\n            password.help_text = password.help_text.format('../password/')\n        user_permissions = self.fields.get('user_permissions')\n        if user_permissions:\n            user_permissions.queryset = user_permissions.queryset.select_related('content_type')",
+            "old_string": "class UserChangeForm(forms.ModelForm):\n    password = ReadOnlyPasswordHashField(\n        label=_(\"Password\"),\n        disabled=True,\n        help_text=_(\n            \"Raw passwords are not stored, so there is no way to see this \"\n            \"user's password, but you can change the password using \"\n            '<a href=\"{}\">this form</a>.'\n        ),\n    )\n\n    class Meta:\n        model = User\n        fields = '__all__'\n        field_classes = {'username': UsernameField}\n\n    def __init__(self, *args, **kwargs):\n        super().__init__(*args, **kwargs)\n        password = self.fields.get('password')\n        if password:\n            password.help_text = password.help_text.format('../password/')\n        user_permissions = self.fields.get('user_permissions')\n        if user_permissions:\n            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\n\n    def clean_password(self):\n        # Regardless of what the user provides, return the initial value.\n        # This is done here, rather than on the field, because the\n        # field does not have access to the initial value\n        return self.initial.get('password')",
+            "path": "./django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ed-dfa0-7440-889d-bb7e34c6899b",
+              "function_name": "patch",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_t878z9ul",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685697.953,
+              "end_timestamp": 1778685697.953
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_t878z9ul",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -163,12 +163,6 @@\\n         user_permissions = self.fields.get('user_permissions')\\n         if user_permissions:\\n             user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n-\\n-    def clean_password(self):\\n-        # Regardless of what the user provides, return the initial value.\\n-        # This is done here, rather than on the field, because the\\n-        # field does not have access to the initial value\\n-        return self.initial.get('password')\\n \\n \\n class AuthenticationForm(forms.Form):\\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"ok\", \"output\": \"\"}, \"_warning\": \"/testbed/django/contrib/auth/forms.py was last read with offset/limit pagination (partial view). Re-read the whole file before overwriting it.\"}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 28240,
+        "completion_tokens": 665,
+        "extra": {
+          "total_tokens": 28905
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ed-6070-7f20-899d-18e1024f17c7",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ed-6070-7f20-899d-18e1024f17c7",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685665.393,
+          "end_timestamp": 1778685696.333
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 17,
+      "timestamp": "2026-05-13T15:21:48.292911292+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The `clean_password` method is now removed. Let me verify the final state of the file looks correct:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_jlg04i2d",
+          "function_name": "read_file",
+          "arguments": {
+            "limit": 30,
+            "offset": 142,
+            "path": "./django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ee-0c66-7cf1-b242-9de5ac7aec10",
+              "function_name": "read_file",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_jlg04i2d",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685709.415,
+              "end_timestamp": 1778685709.415
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_jlg04i2d",
+            "content": "{\"content\": \"   142|class UserChangeForm(forms.ModelForm):\\n   143|    password = ReadOnlyPasswordHashField(\\n   144|        label=_(\\\"Password\\\"),\\n   145|        disabled=True,\\n   146|        help_text=_(\\n   147|            \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n   148|            \\\"user's password, but you can change the password using \\\"\\n   149|            '<a href=\\\"{}\\\">this form</a>.'\\n   150|        ),\\n   151|    )\\n   152|\\n   153|    class Meta:\\n   154|        model = User\\n   155|        fields = '__all__'\\n   156|        field_classes = {'username': UsernameField}\\n   157|\\n   158|    def __init__(self, *args, **kwargs):\\n   159|        super().__init__(*args, **kwargs)\\n   160|        password = self.fields.get('password')\\n   161|        if password:\\n   162|            password.help_text = password.help_text.format('../password/')\\n   163|        user_permissions = self.fields.get('user_permissions')\\n   164|        if user_permissions:\\n   165|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n   166|\\n   167|\\n   168|class AuthenticationForm(forms.Form):\\n   169|    \\\"\\\"\\\"\\n   170|    Base class for authenticating users. Extend this to get a form that accepts\\n   171|    username/password logins.\\n   172|\", \"total_lines\": 448, \"file_size\": 16058, \"truncated\": true, \"hint\": \"Use offset=172 to continue reading (showing 142-171 of 448 lines)\", \"is_binary\": false, \"is_image\": false}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 29061,
+        "completion_tokens": 84,
+        "extra": {
+          "total_tokens": 29145
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ed-e047-7ef2-b129-668082699c17",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ed-e047-7ef2-b129-668082699c17",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685698.12,
+          "end_timestamp": 1778685708.293
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 18,
+      "timestamp": "2026-05-13T15:22:07.724355968+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Let me fix the mixed quotes in the help_text for consistency:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_rctd2l1c",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "new_string": "        help_text=_(\n            'Raw passwords are not stored, so there is no way to see this '\n            'user's password, but you can change the password using '\n            '<a href=\"{}\">this form</a>.'\n        ),",
+            "old_string": "        help_text=_(\n            \"Raw passwords are not stored, so there is no way to see this \"\n            \"user's password, but you can change the password using \"\n            '<a href=\"{}\">this form</a>.'\n        ),",
+            "path": "./django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ee-59fe-7542-a147-31ddb554edda",
+              "function_name": "patch",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_rctd2l1c",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685729.278,
+              "end_timestamp": 1778685729.279
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_rctd2l1c",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -144,8 +144,8 @@\\n         label=_(\\\"Password\\\"),\\n         disabled=True,\\n         help_text=_(\\n-            \\\"Raw passwords are not stored, so there is no way to see this \\\"\\n-            \\\"user's password, but you can change the password using \\\"\\n+            'Raw passwords are not stored, so there is no way to see this '\\n+            'user's password, but you can change the password using '\\n             '<a href=\\\"{}\\\">this form</a>.'\\n         ),\\n     )\\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"error\", \"output\": \"SyntaxError: unterminated string literal (detected at line 148) (line 148, column 69)\"}, \"_warning\": \"/testbed/django/contrib/auth/forms.py was last read with offset/limit pagination (partial view). Re-read the whole file before overwriting it.\"}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 29677,
+        "completion_tokens": 254,
+        "extra": {
+          "total_tokens": 29931
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ee-0ce0-70d0-a864-dcd3a545ddf3",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ee-0ce0-70d0-a864-dcd3a545ddf3",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685709.537,
+          "end_timestamp": 1778685727.724
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 19,
+      "timestamp": "2026-05-13T15:22:17.511656833+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The problem is the apostrophe in \"user's\" conflicting with single quotes. Let me read the original version of this file from git:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_kfot9kqo",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "git diff HEAD -- django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ee-7be7-7a52-b083-a73aa7ec82fc",
+              "function_name": "terminal",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_kfot9kqo",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685737.959,
+              "end_timestamp": 1778685737.959
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_kfot9kqo",
+            "content": "{\"output\": \"diff --git a/django/contrib/auth/forms.py b/django/contrib/auth/forms.py\\nindex b9eb33329f..b890d12e7e 100644\\n--- a/django/contrib/auth/forms.py\\n+++ b/django/contrib/auth/forms.py\\n@@ -142,9 +142,10 @@ class UserCreationForm(forms.ModelForm):\\n class UserChangeForm(forms.ModelForm):\\n     password = ReadOnlyPasswordHashField(\\n         label=_(\\\"Password\\\"),\\n+        disabled=True,\\n         help_text=_(\\n             'Raw passwords are not stored, so there is no way to see this '\\n-            'user\u2019s password, but you can change the password using '\\n+            'user's password, but you can change the password using '\\n             '<a href=\\\"{}\\\">this form</a>.'\\n         ),\\n     )\\n@@ -163,12 +164,6 @@ class UserChangeForm(forms.ModelForm):\\n         if user_permissions:\\n             user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n \\n-    def clean_password(self):\\n-        # Regardless of what the user provides, return the initial value.\\n-        # This is done here, rather than on the field, because the\\n-        # field does not have access to the initial value\\n-        return self.initial.get('password')\\n-\\n \\n class AuthenticationForm(forms.Form):\\n     \\\"\\\"\\\"\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 30140,
+        "completion_tokens": 115,
+        "extra": {
+          "total_tokens": 30255
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ee-5a89-73c0-bb26-2b45d4b33c35",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ee-5a89-73c0-bb26-2b45d4b33c35",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685729.417,
+          "end_timestamp": 1778685737.512
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 20,
+      "timestamp": "2026-05-13T15:22:32.121974965+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The original file uses a curly/smart apostrophe (') in \"user's\", not an ASCII apostrophe. Let me reset and redo this cleanly:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_16np6w11",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "git checkout -- django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ee-b561-7e73-b7e9-c2f70449bd46",
+              "function_name": "terminal",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_16np6w11",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685752.673,
+              "end_timestamp": 1778685752.674
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_16np6w11",
+            "content": "{\"output\": \"\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 30571,
+        "completion_tokens": 208,
+        "extra": {
+          "total_tokens": 30779
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ee-7c4f-7b33-a092-d76cda4d3221",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ee-7c4f-7b33-a092-d76cda4d3221",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685738.064,
+          "end_timestamp": 1778685752.122
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 21,
+      "timestamp": "2026-05-13T15:22:51.464632460+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Now let me use Python to make the edit properly:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_5uo0t4qb",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"r\") as f:\n    content = f.read()\n\n# Add disabled=True to ReadOnlyPasswordHashField\ncontent = content.replace(\n    \"\"\"password = ReadOnlyPasswordHashField(\n        label=_(\\\"Password\\\"),\n        help_text=(\"\"\",\n    \"\"\"password = ReadOnlyPasswordHashField(\n        label=_(\\\"Password\\\"),\n        disabled=True,\n        help_text=(\"\"\",\n)\n\n# Remove the clean_password method from UserChangeForm\nold_clean = \"\"\"    def clean_password(self):\n        # Regardless of what the user provides, return the initial value.\n        # This is done here, rather than on the field, because the\n        # field does not have access to the initial value\n        return self.initial.get('password')\n\"\"\"\n\ncontent = content.replace(old_clean, \"\")\n\nwith open(path, \"w\") as f:\n    f.write(content)\n\n# Verify\nwith open(path, \"r\") as f:\n    lines = f.readlines()\n\n# Print the UserChangeForm class\nfor i, line in enumerate(lines):\n    if 'class UserChangeForm' in line:\n        for j in range(i, min(i+30, len(lines))):\n            print(f\"{j+1:4d}|{lines[j]}\", end='')\n        break\n"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ef-0c72-7a60-af03-78b6891de1c4",
+              "function_name": "execute_code",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_5uo0t4qb",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685774.962,
+              "end_timestamp": 1778685774.962
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_5uo0t4qb",
+            "content": "{\"status\": \"success\", \"output\": \" 142|class UserChangeForm(forms.ModelForm):\\n 143|    password = ReadOnlyPasswordHashField(\\n 144|        label=_(\\\"Password\\\"),\\n 145|        help_text=_(\\n 146|            'Raw passwords are not stored, so there is no way to see this '\\n 147|            'user\u2019s password, but you can change the password using '\\n 148|            '<a href=\\\"{}\\\">this form</a>.'\\n 149|        ),\\n 150|    )\\n 151|\\n 152|    class Meta:\\n 153|        model = User\\n 154|        fields = '__all__'\\n 155|        field_classes = {'username': UsernameField}\\n 156|\\n 157|    def __init__(self, *args, **kwargs):\\n 158|        super().__init__(*args, **kwargs)\\n 159|        password = self.fields.get('password')\\n 160|        if password:\\n 161|            password.help_text = password.help_text.format('../password/')\\n 162|        user_permissions = self.fields.get('user_permissions')\\n 163|        if user_permissions:\\n 164|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n 165|\\n 166|\\n 167|\\n 168|class AuthenticationForm(forms.Form):\\n 169|    \\\"\\\"\\\"\\n 170|    Base class for authenticating users. Extend this to get a form that accepts\\n 171|    username/password logins.\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.23}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 30670,
+        "completion_tokens": 335,
+        "extra": {
+          "total_tokens": 31005
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ee-b5dc-7003-8d3f-73e3aad9482e",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ee-b5dc-7003-8d3f-73e3aad9482e",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685752.796,
+          "end_timestamp": 1778685771.465
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 22,
+      "timestamp": "2026-05-13T15:23:05.864575050+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The `disabled=True` wasn't inserted. Let me debug:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_t3tuiyds",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "git diff HEAD -- django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ef-38c6-7ea2-9a45-9b4e018bfa54",
+              "function_name": "terminal",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_t3tuiyds",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685786.311,
+              "end_timestamp": 1778685786.311
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_t3tuiyds",
+            "content": "{\"output\": \"diff --git a/django/contrib/auth/forms.py b/django/contrib/auth/forms.py\\nindex b9eb33329f..12c9e0c925 100644\\n--- a/django/contrib/auth/forms.py\\n+++ b/django/contrib/auth/forms.py\\n@@ -163,11 +163,6 @@ class UserChangeForm(forms.ModelForm):\\n         if user_permissions:\\n             user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n \\n-    def clean_password(self):\\n-        # Regardless of what the user provides, return the initial value.\\n-        # This is done here, rather than on the field, because the\\n-        # field does not have access to the initial value\\n-        return self.initial.get('password')\\n \\n \\n class AuthenticationForm(forms.Form):\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 31452,
+        "completion_tokens": 74,
+        "extra": {
+          "total_tokens": 31526
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ef-0cfe-72b1-9fdc-95dd34213bae",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ef-0cfe-72b1-9fdc-95dd34213bae",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685775.102,
+          "end_timestamp": 1778685785.865
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 23,
+      "timestamp": "2026-05-13T15:23:20.055242084+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Good, `clean_password` is removed. Now let me check why `disabled=True` wasn't inserted:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_978wtkkb",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"rb\") as f:\n    content = f.read()\n\n# Check the exact bytes around the label line\nidx = content.find(b'label=_(b\"Password\")')\nif idx == -1:\n    idx = content.find(b'label=_(\\'Password\\'')\n    print(f\"label pattern 2 found at: {idx}\")\n    print(f\"Context: {content[idx-5:idx+50]}\")\n\n# Show what we're looking for\nsearch = b'label=_(\\\"Password\\\"),\\n        help_text='\nidx = content.find(search)\nprint(f\"Exact search found at: {idx}\")\nif idx > 0:\n    print(f\"Context: {content[idx-10:idx+60]}\")\n"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ef-7c4b-77d1-b777-1b7d31b09285",
+              "function_name": "execute_code",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_978wtkkb",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685803.595,
+              "end_timestamp": 1778685803.595
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_978wtkkb",
+            "content": "{\"status\": \"success\", \"output\": \"label pattern 2 found at: -1\\nContext: b''\\nExact search found at: 4881\\nContext: b'(\\\\n        label=_(\\\"Password\\\"),\\\\n        help_text=_(\\\\n            \\\\'Raw p'\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.21}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 31728,
+        "completion_tokens": 271,
+        "extra": {
+          "total_tokens": 31999
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ef-393d-7250-b8a5-d1f4b1a1f1af",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ef-393d-7250-b8a5-d1f4b1a1f1af",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685786.429,
+          "end_timestamp": 1778685800.055
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 24,
+      "timestamp": "2026-05-13T15:23:43.805456596+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The `clean_password` was removed but `disabled=True` wasn't added because the original file has a Unicode curly quote that made my Python string differ. Let me add `disabled=True` now:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_rjgp7pp9",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"r\", encoding=\"utf-8\") as f:\n    content = f.read()\n\n# Find the exact text to replace - use bytes to be precise\nwith open(path, \"rb\") as f:\n    raw = f.read()\n\n# Show bytes around 'label=_(\\\"Password\\\"),'\nidx = raw.find(b'label=(\"Password\"),')\nprint(f\"Search target bytes: {raw[idx:idx+50]}\")\n\n# Replace label=_(\\\"Password\\\"), with label=_(\\\"Password\\\"),\\n        disabled=True,\nold = b'label=_(\\\"Password\\\"),\\n        help_text=('\nnew = b'label=_(\\\"Password\\\"),\\n        disabled=True,\\n        help_text=('\ncontent_bytes = raw.replace(old, new)\n\nwith open(path, \"w\", encoding=\"utf-8\") as f:\n    f.write(content_bytes.decode(\"utf-8\"))\n\nprint(\"Done. Verifying:\")\nwith open(path, \"r\", encoding=\"utf-8\") as f:\n    lines = f.readlines()\nfor i, line in enumerate(lines):\n    if 'class UserChangeForm' in line:\n        for j in range(i, min(i+30, len(lines))):\n            print(f\"{j+1:4d}|{lines[j]}\", end='')\n        break\n"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21ef-d8ee-7601-8298-45677082e89c",
+              "function_name": "execute_code",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_rjgp7pp9",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685827.31,
+              "end_timestamp": 1778685827.311
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_rjgp7pp9",
+            "content": "{\"status\": \"success\", \"output\": \"Search target bytes: b''\\nDone. Verifying:\\n 142|class UserChangeForm(forms.ModelForm):\\n 143|    password = ReadOnlyPasswordHashField(\\n 144|        label=_(\\\"Password\\\"),\\n 145|        help_text=_(\\n 146|            'Raw passwords are not stored, so there is no way to see this '\\n 147|            'user\u2019s password, but you can change the password using '\\n 148|            '<a href=\\\"{}\\\">this form</a>.'\\n 149|        ),\\n 150|    )\\n 151|\\n 152|    class Meta:\\n 153|        model = User\\n 154|        fields = '__all__'\\n 155|        field_classes = {'username': UsernameField}\\n 156|\\n 157|    def __init__(self, *args, **kwargs):\\n 158|        super().__init__(*args, **kwargs)\\n 159|        password = self.fields.get('password')\\n 160|        if password:\\n 161|            password.help_text = password.help_text.format('../password/')\\n 162|        user_permissions = self.fields.get('user_permissions')\\n 163|        if user_permissions:\\n 164|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n 165|\\n 166|\\n 167|\\n 168|class AuthenticationForm(forms.Form):\\n 169|    \\\"\\\"\\\"\\n 170|    Base class for authenticating users. Extend this to get a form that accepts\\n 171|    username/password logins.\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.22}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 32058,
+        "completion_tokens": 414,
+        "extra": {
+          "total_tokens": 32472
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ef-7cd7-7213-80bf-bd773270acdf",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ef-7cd7-7213-80bf-bd773270acdf",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685803.735,
+          "end_timestamp": 1778685823.805
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 25,
+      "timestamp": "2026-05-13T15:25:20.222996709+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_glckjhb5",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"rb\") as f:\n    raw = f.read()\n\n# Find the label line for UserChangeForm (not UserCreationForm)\nidx = raw.find(b'class UserChangeForm')\nprint(f\"Found UserChangeForm at: {idx}\")\nchunk = raw[idx:idx+500]\nfor i, b in enumerate(chunk):\n    print(f\"  byte {i}: {hex(b)} = {chr(b) if 32 <= b < 127 else '?'}\")\n"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21f1-518b-7e50-8177-705ccb96b9ac",
+              "function_name": "execute_code",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_glckjhb5",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778685923.724,
+              "end_timestamp": 1778685923.724
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_glckjhb5",
+            "content": "{\"status\": \"success\", \"output\": \"Found UserChangeForm at: 4792\\n  byte 0: 0x63 = c\\n  byte 1: 0x6c = l\\n  byte 2: 0x61 = a\\n  byte 3: 0x73 = s\\n  byte 4: 0x73 = s\\n  byte 5: 0x20 =  \\n  byte 6: 0x55 = U\\n  byte 7: 0x73 = s\\n  byte 8: 0x65 = e\\n  byte 9: 0x72 = r\\n  byte 10: 0x43 = C\\n  byte 11: 0x68 = h\\n  byte 12: 0x61 = a\\n  byte 13: 0x6e = n\\n  byte 14: 0x67 = g\\n  byte 15: 0x65 = e\\n  byte 16: 0x46 = F\\n  byte 17: 0x6f = o\\n  byte 18: 0x72 = r\\n  byte 19: 0x6d = m\\n  byte 20: 0x28 = (\\n  byte 21: 0x66 = f\\n  byte 22: 0x6f = o\\n  byte 23: 0x72 = r\\n  byte 24: 0x6d = m\\n  byte 25: 0x73 = s\\n  byte 26: 0x2e = .\\n  byte 27: 0x4d = M\\n  byte 28: 0x6f = o\\n  byte 29: 0x64 = d\\n  byte 30: 0x65 = e\\n  byte 31: 0x6c = l\\n  byte 32: 0x46 = F\\n  byte 33: 0x6f = o\\n  byte 34: 0x72 = r\\n  byte 35: 0x6d = m\\n  byte 36: 0x29 = )\\n  byte 37: 0x3a = :\\n  byte 38: 0xa = ?\\n  byte 39: 0x20 =  \\n  byte 40: 0x20 =  \\n  byte 41: 0x20 =  \\n  byte 42: 0x20 =  \\n  byte 43: 0x70 = p\\n  byte 44: 0x61 = a\\n  byte 45: 0x73 = s\\n  byte 46: 0x73 = s\\n  byte 47: 0x77 = w\\n  byte 48: 0x6f = o\\n  byte 49: 0x72 = r\\n  byte 50: 0x64 = d\\n  byte 51: 0x20 =  \\n  byte 52: 0x3d = =\\n  byte 53: 0x20 =  \\n  byte 54: 0x52 = R\\n  byte 55: 0x65 = e\\n  byte 56: 0x61 = a\\n  byte 57: 0x64 = d\\n  byte 58: 0x4f = O\\n  byte 59: 0x6e = n\\n  byte 60: 0x6c = l\\n  byte 61: 0x79 = y\\n  byte 62: 0x50 = P\\n  byte 63: 0x61 = a\\n  byte 64: 0x73 = s\\n  byte 65: 0x73 = s\\n  byte 66: 0x77 = w\\n  byte 67: 0x6f = o\\n  byte 68: 0x72 = r\\n  byte 69: 0x64 = d\\n  byte 70: 0x48 = H\\n  byte 71: 0x61 = a\\n  byte 72: 0x73 = s\\n  byte 73: 0x68 = h\\n  byte 74: 0x46 = F\\n  byte 75: 0x69 = i\\n  byte 76: 0x65 = e\\n  byte 77: 0x6c = l\\n  byte 78: 0x64 = d\\n  byte 79: 0x28 = (\\n  byte 80: 0xa = ?\\n  byte 81: 0x20 =  \\n  byte 82: 0x20 =  \\n  byte 83: 0x20 =  \\n  byte 84: 0x20 =  \\n  byte 85: 0x20 =  \\n  byte 86: 0x20 =  \\n  byte 87: 0x20 =  \\n  byte 88: 0x20 =  \\n  byte 89: 0x6c = l\\n  byte 90: 0x61 = a\\n  byte 91: 0x62 = b\\n  byte 92: 0x65 = e\\n  byte 93: 0x6c = l\\n  byte 94: 0x3d = =\\n  byte 95: 0x5f = _\\n  byte 96: 0x28 = (\\n  byte 97: 0x22 = \\\"\\n  byte 98: 0x50 = P\\n  byte 99: 0x61 = a\\n  byte 100: 0x73 = s\\n  byte 101: 0x73 = s\\n  byte 102: 0x77 = w\\n  byte 103: 0x6f = o\\n  byte 104: 0x72 = r\\n  byte 105: 0x64 = d\\n  byte 106: 0x22 = \\\"\\n  byte 107: 0x29 = )\\n  byte 108: 0x2c = ,\\n  byte 109: 0xa = ?\\n  byte 110: 0x20 =  \\n  byte 111: 0x20 =  \\n  byte 112: 0x20 =  \\n  byte 113: 0x20 =  \\n  byte 114: 0x20 =  \\n  byte 115: 0x20 =  \\n  byte 116: 0x20 =  \\n  byte 117: 0x20 =  \\n  byte 118: 0x68 = h\\n  byte 119: 0x65 = e\\n  byte 120: 0x6c = l\\n  byte 121: 0x70 = p\\n  byte 122: 0x5f = _\\n  byte 123: 0x74 = t\\n  byte 124: 0x65 = e\\n  byte 125: 0x78 = x\\n  byte 126: 0x74 = t\\n  byte 127: 0x3d = =\\n  byte 128: 0x5f = _\\n  byte 129: 0x28 = (\\n  byte 130: 0xa = ?\\n  byte 131: 0x20 =  \\n  byte 132: 0x20 =  \\n  byte 133: 0x20 =  \\n  byte 134: 0x20 =  \\n  byte 135: 0x20 =  \\n  byte 136: 0x20 =  \\n  byte 137: 0x20 =  \\n  byte 138: 0x20 =  \\n  byte 139: 0x20 =  \\n  byte 140: 0x20 =  \\n  byte 141: 0x20 =  \\n  byte 142: 0x20 =  \\n  byte 143: 0x27 = '\\n  byte 144: 0x52 = R\\n  byte 145: 0x61 = a\\n  byte 146: 0x77 = w\\n  byte 147: 0x20 =  \\n  byte 148: 0x70 = p\\n  byte 149: 0x61 = a\\n  byte 150: 0x73 = s\\n  byte 151: 0x73 = s\\n  byte 152: 0x77 = w\\n  byte 153: 0x6f = o\\n  byte 154: 0x72 = r\\n  byte 155: 0x64 = d\\n  byte 156: 0x73 = s\\n  byte 157: 0x20 =  \\n  byte 158: 0x61 = a\\n  byte 159: 0x72 = r\\n  byte 160: 0x65 = e\\n  byte 161: 0x20 =  \\n  byte 162: 0x6e = n\\n  byte 163: 0x6f = o\\n  byte 164: 0x74 = t\\n  byte 165: 0x20 =  \\n  byte 166: 0x73 = s\\n  byte 167: 0x74 = t\\n  byte 168: 0x6f = o\\n  byte 169: 0x72 = r\\n  byte 170: 0x65 = e\\n  byte 171: 0x64 = d\\n  byte 172: 0x2c = ,\\n  byte 173: 0x20 =  \\n  byte 174: 0x73 = s\\n  byte 175: 0x6f = o\\n  byte 176: 0x20 =  \\n  byte 177: 0x74 = t\\n  byte 178: 0x68 = h\\n  byte 179: 0x65 = e\\n  byte 180: 0x72 = r\\n  byte 181: 0x65 = e\\n  byte 182: 0x20 =  \\n  byte 183: 0x69 = i\\n  byte 184: 0x73 = s\\n  byte 185: 0x20 =  \\n  byte 186: 0x6e = n\\n  byte 187: 0x6f = o\\n  byte 188: 0x20 =  \\n  byte 189: 0x77 = w\\n  byte 190: 0x61 = a\\n  byte 191: 0x79 = y\\n  byte 192: 0x20 =  \\n  byte 193: 0x74 = t\\n  byte 194: 0x6f = o\\n  byte 195: 0x20 =  \\n  byte 196: 0x73 = s\\n  byte 197: 0x65 = e\\n  byte 198: 0x65 = e\\n  byte 199: 0x20 =  \\n  byte 200: 0x74 = t\\n  byte 201: 0x68 = h\\n  byte 202: 0x69 = i\\n  byte 203: 0x73 = s\\n  byte 204: 0x20 =  \\n  byte 205: 0x27 = '\\n  byte 206: 0xa = ?\\n  byte 207: 0x20 =  \\n  byte 208: 0x20 =  \\n  byte 209: 0x20 =  \\n  byte 210: 0x20 =  \\n  byte 211: 0x20 =  \\n  byte 212: 0x20 =  \\n  byte 213: 0x20 =  \\n  byte 214: 0x20 =  \\n  byte 215: 0x20 =  \\n  byte 216: 0x20 =  \\n  byte 217: 0x20 =  \\n  byte 218: 0x20 =  \\n  byte 219: 0x27 = '\\n  byte 220: 0x75 = u\\n  byte 221: 0x73 = s\\n  byte 222: 0x65 = e\\n  byte 223: 0x72 = r\\n  byte 224: 0xe2 = ?\\n  byte 225: 0x80 = ?\\n  byte 226: 0x99 = ?\\n  byte 227: 0x73 = s\\n  byte 228: 0x20 =  \\n  byte 229: 0x70 = p\\n  byte 230: 0x61 = a\\n  byte 231: 0x73 = s\\n  byte 232: 0x73 = s\\n  byte 233: 0x77 = w\\n  byte 234: 0x6f = o\\n  byte 235: 0x72 = r\\n  byte 236: 0x64 = d\\n  byte 237: 0x2c = ,\\n  byte 238: 0x20 =  \\n  byte 239: 0x62 = b\\n  byte 240: 0x75 = u\\n  byte 241: 0x74 = t\\n  byte 242: 0x20 =  \\n  byte 243: 0x79 = y\\n  byte 244: 0x6f = o\\n  byte 245: 0x75 = u\\n  byte 246: 0x20 =  \\n  byte 247: 0x63 = c\\n  byte 248: 0x61 = a\\n  byte 249: 0x6e = n\\n  byte 250: 0x20 =  \\n  byte 251: 0x63 = c\\n  byte 252: 0x68 = h\\n  byte 253: 0x61 = a\\n  byte 254: 0x6e = n\\n  byte 255: 0x67 = g\\n  byte 256: 0x65 = e\\n  byte 257: 0x20 =  \\n  byte 258: 0x74 = t\\n  byte 259: 0x68 = h\\n  byte 260: 0x65 = e\\n  byte 261: 0x20 =  \\n  byte 262: 0x70 = p\\n  byte 263: 0x61 = a\\n  byte 264: 0x73 = s\\n  byte 265: 0x73 = s\\n  byte 266: 0x77 = w\\n  byte 267: 0x6f = o\\n  byte 268: 0x72 = r\\n  byte 269: 0x64 = d\\n  byte 270: 0x20 =  \\n  byte 271: 0x75 = u\\n  byte 272: 0x73 = s\\n  byte 273: 0x69 = i\\n  byte 274: 0x6e = n\\n  byte 275: 0x67 = g\\n  byte 276: 0x20 =  \\n  byte 277: 0x27 = '\\n  byte 278: 0xa = ?\\n  byte 279: 0x20 =  \\n  byte 280: 0x20 =  \\n  byte 281: 0x20 =  \\n  byte 282: 0x20 =  \\n  byte 283: 0x20 =  \\n  byte 284: 0x20 =  \\n  byte 285: 0x20 =  \\n  byte 286: 0x20 =  \\n  byte 287: 0x20 =  \\n  byte 288: 0x20 =  \\n  byte 289: 0x20 =  \\n  byte 290: 0x20 =  \\n  byte 291: 0x27 = '\\n  byte 292: 0x3c = <\\n  byte 293: 0x61 = a\\n  byte 294: 0x20 =  \\n  byte 295: 0x68 = h\\n  byte 296: 0x72 = r\\n  byte 297: 0x65 = e\\n  byte 298: 0x66 = f\\n  byte 299: 0x3d = =\\n  byte 300: 0x22 = \\\"\\n  byte 301: 0x7b = {\\n  byte 302: 0x7d = }\\n  byte 303: 0x22 = \\\"\\n  byte 304: 0x3e = >\\n  byte 305: 0x74 = t\\n  byte 306: 0x68 = h\\n  byte 307: 0x69 = i\\n  byte 308: 0x73 = s\\n  byte 309: 0x20 =  \\n  byte 310: 0x66 = f\\n  byte 311: 0x6f = o\\n  byte 312: 0x72 = r\\n  byte 313: 0x6d = m\\n  byte 314: 0x3c = <\\n  byte 315: 0x2f = /\\n  byte 316: 0x61 = a\\n  byte 317: 0x3e = >\\n  byte 318: 0x2e = .\\n  byte 319: 0x27 = '\\n  byte 320: 0xa = ?\\n  byte 321: 0x20 =  \\n  byte 322: 0x20 =  \\n  byte 323: 0x20 =  \\n  byte 324: 0x20 =  \\n  byte 325: 0x20 =  \\n  byte 326: 0x20 =  \\n  byte 327: 0x20 =  \\n  byte 328: 0x20 =  \\n  byte 329: 0x29 = )\\n  byte 330: 0x2c = ,\\n  byte 331: 0xa = ?\\n  byte 332: 0x20 =  \\n  byte 333: 0x20 =  \\n  byte 334: 0x20 =  \\n  byte 335: 0x20 =  \\n  byte 336: 0x29 = )\\n  byte 337: 0xa = ?\\n  byte 338: 0xa = ?\\n  byte 339: 0x20 =  \\n  byte 340: 0x20 =  \\n  byte 341: 0x20 =  \\n  byte 342: 0x20 =  \\n  byte 343: 0x63 = c\\n  byte 344: 0x6c = l\\n  byte 345: 0x61 = a\\n  byte 346: 0x73 = s\\n  byte 347: 0x73 = s\\n  byte 348: 0x20 =  \\n  byte 349: 0x4d = M\\n  byte 350: 0x65 = e\\n  byte 351: 0x74 = t\\n  byte 352: 0x61 = a\\n  byte 353: 0x3a = :\\n  byte 354: 0xa = ?\\n  byte 355: 0x20 =  \\n  byte 356: 0x20 =  \\n  byte 357: 0x20 =  \\n  byte 358: 0x20 =  \\n  byte 359: 0x20 =  \\n  byte 360: 0x20 =  \\n  byte 361: 0x20 =  \\n  byte 362: 0x20 =  \\n  byte 363: 0x6d = m\\n  byte 364: 0x6f = o\\n  byte 365: 0x64 = d\\n  byte 366: 0x65 = e\\n  byte 367: 0x6c = l\\n  byte 368: 0x20 =  \\n  byte 369: 0x3d = =\\n  byte 370: 0x20 =  \\n  byte 371: 0x55 = U\\n  byte 372: 0x73 = s\\n  byte 373: 0x65 = e\\n  byte 374: 0x72 = r\\n  byte 375: 0xa = ?\\n  byte 376: 0x20 =  \\n  byte 377: 0x20 =  \\n  byte 378: 0x20 =  \\n  byte 379: 0x20 =  \\n  byte 380: 0x20 =  \\n  byte 381: 0x20 =  \\n  byte 382: 0x20 =  \\n  byte 383: 0x20 =  \\n  byte 384: 0x66 = f\\n  byte 385: 0x69 = i\\n  byte 386: 0x65 = e\\n  byte 387: 0x6c = l\\n  byte 388: 0x64 = d\\n  byte 389: 0x73 = s\\n  byte 390: 0x20 =  \\n  byte 391: 0x3d = =\\n  byte 392: 0x20 =  \\n  byte 393: 0x27 = '\\n  byte 394: 0x5f = _\\n  byte 395: 0x5f = _\\n  byte 396: 0x61 = a\\n  byte 397: 0x6c = l\\n  byte 398: 0x6c = l\\n  byte 399: 0x5f = _\\n  byte 400: 0x5f = _\\n  byte 401: 0x27 = '\\n  byte 402: 0xa = ?\\n  byte 403: 0x20 =  \\n  byte 404: 0x20 =  \\n  byte 405: 0x20 =  \\n  byte 406: 0x20 =  \\n  byte 407: 0x20 =  \\n  byte 408: 0x20 =  \\n  byte 409: 0x20 =  \\n  byte 410: 0x20 =  \\n  byte 411: 0x66 = f\\n  byte 412: 0x69 = i\\n  byte 413: 0x65 = e\\n  byte 414: 0x6c = l\\n  byte 415: 0x64 = d\\n  byte 416: 0x5f = _\\n  byte 417: 0x63 = c\\n  byte 418: 0x6c = l\\n  byte 419: 0x61 = a\\n  byte 420: 0x73 = s\\n  byte 421: 0x73 = s\\n  byte 422: 0x65 = e\\n  byte 423: 0x73 = s\\n  byte 424: 0x20 =  \\n  byte 425: 0x3d = =\\n  byte 426: 0x20 =  \\n  byte 427: 0x7b = {\\n  byte 428: 0x27 = '\\n  byte 429: 0x75 = u\\n  byte 430: 0x73 = s\\n  byte 431: 0x65 = e\\n  byte 432: 0x72 = r\\n  byte 433: 0x6e = n\\n  byte 434: 0x61 = a\\n  byte 435: 0x6d = m\\n  byte 436: 0x65 = e\\n  byte 437: 0x27 = '\\n  byte 438: 0x3a = :\\n  byte 439: 0x20 =  \\n  byte 440: 0x55 = U\\n  byte 441: 0x73 = s\\n  byte 442: 0x65 = e\\n  byte 443: 0x72 = r\\n  byte 444: 0x6e = n\\n  byte 445: 0x61 = a\\n  byte 446: 0x6d = m\\n  byte 447: 0x65 = e\\n  byte 448: 0x46 = F\\n  byte 449: 0x69 = i\\n  byte 450: 0x65 = e\\n  byte 451: 0x6c = l\\n  byte 452: 0x64 = d\\n  byte 453: 0x7d = }\\n  byte 454: 0xa = ?\\n  byte 455: 0xa = ?\\n  byte 456: 0x20 =  \\n  byte 457: 0x20 =  \\n  byte 458: 0x20 =  \\n  byte 459: 0x20 =  \\n  byte 460: 0x64 = d\\n  byte 461: 0x65 = e\\n  byte 462: 0x66 = f\\n  byte 463: 0x20 =  \\n  byte 464: 0x5f = _\\n  byte 465: 0x5f = _\\n  byte 466: 0x69 = i\\n  byte 467: 0x6e = n\\n  byte 468: 0x69 = i\\n  byte 469: 0x74 = t\\n  byte 470: 0x5f = _\\n  byte 471: 0x5f = _\\n  byte 472: 0x28 = (\\n  byte 473: 0x73 = s\\n  byte 474: 0x65 = e\\n  byte 475: 0x6c = l\\n  byte 476: 0x66 = f\\n  byte 477: 0x2c = ,\\n  byte 478: 0x20 =  \\n  byte 479: 0x2a = *\\n  byte 480: 0x61 = a\\n  byte 481: 0x72 = r\\n  byte 482: 0x67 = g\\n  byte 483: 0x73 = s\\n  byte 484: 0x2c = ,\\n  byte 485: 0x20 =  \\n  byte 486: 0x2a = *\\n  byte 487: 0x2a = *\\n  byte 488: 0x6b = k\\n  byte 489: 0x77 = w\\n  byte 490: 0x61 = a\\n  byte 491: 0x72 = r\\n  byte 492: 0x67 = g\\n  byte 493: 0x73 = s\\n  byte 494: 0x29 = )\\n  byte 495: 0x3a = :\\n  byte 496: 0xa = ?\\n  byte 497: 0x20 =  \\n  byte 498: 0x20 =  \\n  byte 499: 0x20 =  \\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.21}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 32601,
+        "completion_tokens": 169,
+        "extra": {
+          "total_tokens": 32770
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21ef-d96f-7d42-a749-db02322f7583",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21ef-d96f-7d42-a749-db02322f7583",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685827.439,
+          "end_timestamp": 1778685920.223
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 26,
+      "timestamp": "2026-05-13T15:26:59.152883047+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Now I can see the exact bytes. Let me insert `disabled=True` at the right position:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_sbzgscye",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"rb\") as f:\n    raw = f.read()\n\n# Find UserChangeForm class area and replace label line\n# After \"label=_(\\\"Password\\\"),\" there's the help_text line\n# We need to insert disabled=True between them\n\nold = b'label=(\"Password\"),\\n        help_text=('\nnew = b'label=(\"Password\"),\\n        disabled=True,\\n        help_text=('\n\ncount = raw.count(old)\nprint(f\"Found {count} occurrences of target\")\n\nif count > 0:\n    new_raw = raw.replace(old, new, count)\n    with open(path, \"wb\") as f:\n        f.write(new_raw)\n    print(\"Replacement done\")\nelse:\n    print(\"Old text not found - let me search for what we have\")\n    # Find all occurrences of label=(\"Password\")\n    idx = 0\n    while True:\n        idx = raw.find(b'label=(', idx)\n        if idx == -1:\n            break\n        print(f\"  Found at {idx}: {raw[idx:idx+30]}\")\n        idx += 1\n"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21f2-d3f4-7131-a8b3-42c53fc4ed17",
+              "function_name": "execute_code",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_sbzgscye",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778686022.644,
+              "end_timestamp": 1778686022.645
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_sbzgscye",
+            "content": "{\"status\": \"success\", \"output\": \"Found 0 occurrences of target\\nOld text not found - let me search for what we have\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.21}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 31945,
+        "completion_tokens": 394,
+        "extra": {
+          "total_tokens": 32339
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21f1-5215-74b1-9535-cbf59509baa8",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21f1-5215-74b1-9535-cbf59509baa8",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778685923.862,
+          "end_timestamp": 1778686019.153
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 27,
+      "timestamp": "2026-05-13T15:27:13.550645929+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_tf3ljwkn",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"rb\") as f:\n    raw = f.read()\n\n# Look for \"Password\" in the file\npassword_positions = []\nidx = 0\nwhile True:\n    idx = raw.find(b'Password', idx)\n    if idx == -1:\n        break\n    print(f\"  at {idx}: ...{raw[idx-15:idx+20]}...\")\n    password_positions.append(idx)\n    idx += 1\n"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21f3-0c43-7dc1-a79b-3e47917ac33b",
+              "function_name": "execute_code",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_tf3ljwkn",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778686037.059,
+              "end_timestamp": 1778686037.059
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_tf3ljwkn",
+            "content": "{\"status\": \"success\", \"output\": \"  at 1090: ...b'\\\\nclass ReadOnlyPasswordHashWidget(f'...\\n  at 1931: ...b'\\\\nclass ReadOnlyPasswordHashField(fo'...\\n  at 1984: ...b'dget = ReadOnlyPasswordHashWidget\\\\n\\\\n'...\\n  at 2989: ...b'      label=_(\\\"Password\\\"),\\\\n        '...\\n  at 3043: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 3230: ...b'      label=_(\\\"Password confirmatio'...\\n  at 3276: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 4854: ...b'word = ReadOnlyPasswordHashField(\\\\n '...\\n  at 4890: ...b'      label=_(\\\"Password\\\"),\\\\n        '...\\n  at 5959: ...b'      label=_(\\\"Password\\\"),\\\\n        '...\\n  at 6013: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 8539: ...b'     )\\\\n\\\\n\\\\nclass PasswordResetForm(fo'...\\n  at 11789: ...b'  )\\\\n\\\\n\\\\nclass SetPasswordForm(forms.F'...\\n  at 12118: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 12401: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 13274: ...b'f.user\\\\n\\\\n\\\\nclass PasswordChangeForm(S'...\\n  at 13296: ...b'dChangeForm(SetPasswordForm):\\\\n    \\\"'...\\n  at 13449: ...b'{\\\\n        **SetPasswordForm.error_m'...\\n  at 13697: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 14271: ...b'd\\\\n\\\\n\\\\nclass AdminPasswordChangeForm(f'...\\n  at 14582: ...b'      label=_(\\\"Password\\\"),\\\\n        '...\\n  at 14615: ...b'  widget=forms.PasswordInput(attrs='...\\n  at 14842: ...b'      label=_(\\\"Password (again)\\\"),\\\\n'...\\n  at 14883: ...b'  widget=forms.PasswordInput(attrs='...\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.23}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 32312,
+        "completion_tokens": 162,
+        "extra": {
+          "total_tokens": 32474
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21f2-d493-7340-adf5-dea4adf4a3c7",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21f2-d493-7340-adf5-dea4adf4a3c7",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778686022.804,
+          "end_timestamp": 1778686033.551
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 28,
+      "timestamp": "2026-05-13T15:28:23.077958461+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_coi89l6y",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "path = \"django/contrib/auth/forms.py\"\nwith open(path, \"rb\") as f:\n    raw = f.read()\n\n# Position 4890 has label=(\"Password\"),\n# Let me look at the exact bytes there\nchunk = raw[4880:4940]\nprint(\"Bytes around pos 4890:\")\nfor i, b in enumerate(chunk):\n    print(f\"  {4880+i:6d}: 0x{b:02x} = {chr(b) if 32 <= b < 127 else '?'}\")\n\n# So the pattern at 4890:\n# b'label=_(b\"Password\"),' at 4881\n# then newline + spaces + b'help_text=_(('\n\n# Let's find the exact pattern after \"label=(\"Password\"),\"\n# byte 4890 is label, byte 4893 should be the closing paren and comma\ntarget_start = 4890\ntarget = raw[target_start:target_start+60]\nprint(f\"\\nTarget: {target}\")\n\n# Find where help_text starts\nhelp_idx = raw.find(b'help_text=(', 4880)\nprint(f\"help_text at: {help_idx}\")\n\n# Insert disabled=True at help_idx (before help_text)\ninsert_pos = help_idx\ninsert_bytes = b'        disabled=True,\\n        '\nnew_raw = raw[:insert_pos] + insert_bytes + raw[insert_pos:]\n\nwith open(path, \"wb\") as f:\n    f.write(new_raw)\nprint(\"\\nInserted disabled=True\")\n\n# Verify\nwith open(path, \"r\", encoding=\"utf-8\") as f:\n    lines = f.readlines()\nfor i, line in enumerate(lines):\n    if 'class UserChangeForm' in line:\n        for j in range(i, min(i+30, len(lines))):\n            print(f\"{j+1:4d}|{lines[j]}\", end='')\n        break\n"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21f4-1bfb-7bc0-bf7b-109e2f1bb669",
+              "function_name": "execute_code",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_coi89l6y",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778686106.619,
+              "end_timestamp": 1778686106.619
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_coi89l6y",
+            "content": "{\"status\": \"success\", \"output\": \"Bytes around pos 4890:\\n    4880: 0x20 =  \\n    4881: 0x6c = l\\n    4882: 0x61 = a\\n    4883: 0x62 = b\\n    4884: 0x65 = e\\n    4885: 0x6c = l\\n    4886: 0x3d = =\\n    4887: 0x5f = _\\n    4888: 0x28 = (\\n    4889: 0x22 = \\\"\\n    4890: 0x50 = P\\n    4891: 0x61 = a\\n    4892: 0x73 = s\\n    4893: 0x73 = s\\n    4894: 0x77 = w\\n    4895: 0x6f = o\\n    4896: 0x72 = r\\n    4897: 0x64 = d\\n    4898: 0x22 = \\\"\\n    4899: 0x29 = )\\n    4900: 0x2c = ,\\n    4901: 0x0a = ?\\n    4902: 0x20 =  \\n    4903: 0x20 =  \\n    4904: 0x20 =  \\n    4905: 0x20 =  \\n    4906: 0x20 =  \\n    4907: 0x20 =  \\n    4908: 0x20 =  \\n    4909: 0x20 =  \\n    4910: 0x68 = h\\n    4911: 0x65 = e\\n    4912: 0x6c = l\\n    4913: 0x70 = p\\n    4914: 0x5f = _\\n    4915: 0x74 = t\\n    4916: 0x65 = e\\n    4917: 0x78 = x\\n    4918: 0x74 = t\\n    4919: 0x3d = =\\n    4920: 0x5f = _\\n    4921: 0x28 = (\\n    4922: 0x0a = ?\\n    4923: 0x20 =  \\n    4924: 0x20 =  \\n    4925: 0x20 =  \\n    4926: 0x20 =  \\n    4927: 0x20 =  \\n    4928: 0x20 =  \\n    4929: 0x20 =  \\n    4930: 0x20 =  \\n    4931: 0x20 =  \\n    4932: 0x20 =  \\n    4933: 0x20 =  \\n    4934: 0x20 =  \\n    4935: 0x27 = '\\n    4936: 0x52 = R\\n    4937: 0x61 = a\\n    4938: 0x77 = w\\n    4939: 0x20 =  \\n\\nTarget: b'Password\\\"),\\\\n        help_text=_(\\\\n            \\\\'Raw passwords '\\nhelp_text at: -1\\n\\nInserted disabled=True\\n 142|class UserChangeForm(forms.ModelForm):\\n 143|    password = ReadOnlyPasswordHashField(\\n 144|        label=_(\\\"Password\\\"),\\n 145|        help_text=_(\\n 146|            'Raw passwords are not stored, so there is no way to see this '\\n 147|            'user\u2019s password, but you can change the password using '\\n 148|            '<a href=\\\"{}\\\">this form</a>.'\\n 149|        ),\\n 150|    )\\n 151|\\n 152|    class Meta:\\n 153|        model = User\\n 154|        fields = '__all__'\\n 155|        field_classes = {'username': UsernameField}\\n 156|\\n 157|    def __init__(self, *args, **kwargs):\\n 158|        super().__init__(*args, **kwargs)\\n 159|        password = self.fields.get('password')\\n 160|        if password:\\n 161|            password.help_text = password.help_text.format('../password/')\\n 162|        user_permissions = self.fields.get('user_permissions')\\n 163|        if user_permissions:\\n 164|            user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n 165|\\n 166|\\n 167|\\n 168|class AuthenticationForm(forms.Form):\\n 169|    \\\"\\\"\\\"\\n 170|    Base class for authenticating users. Extend this to get a form that accepts\\n 171|    username/password logins.\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.21}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 31355,
+        "completion_tokens": 503,
+        "extra": {
+          "total_tokens": 31858
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21f3-0cce-76c3-8bc9-a04aea4fe72c",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21f3-0cce-76c3-8bc9-a04aea4fe72c",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778686037.198,
+          "end_timestamp": 1778686103.078
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 29,
+      "timestamp": "2026-05-13T15:29:56.692264962+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Let me start completely fresh and use a simpler approach:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_a7xwqtaj",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "git checkout -- django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21f5-8123-75b0-8a98-822ff2be2451",
+              "function_name": "terminal",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_a7xwqtaj",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778686198.052,
+              "end_timestamp": 1778686198.052
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_a7xwqtaj",
+            "content": "{\"output\": \"\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 32735,
+        "completion_tokens": 97,
+        "extra": {
+          "total_tokens": 32832
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21f4-1c80-7ca3-9c8e-9986facd1c73",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21f4-1c80-7ca3-9c8e-9986facd1c73",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778686106.752,
+          "end_timestamp": 1778686196.692
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 30,
+      "timestamp": "2026-05-13T15:32:24.611938336+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Let me reset and do this properly with Python:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_ynbbp81m",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "import re\n\npath = \"django/contrib/auth/forms.py\"\n\n# Read the file\nwith open(path, \"r\") as f:\n    content = f.read()\n\n# First, add disabled=True to UserChangeForm's password field\n# We need to find the UserChangeForm class and its password field\n# Find the UserChangeForm class start\nuser_change_start = content.find(\"class UserChangeForm(forms.ModelForm):\")\nif user_change_start == -1:\n    print(\"ERROR: Could not find UserChangeForm class\")\nelse:\n    # Find the password field within this class\n    # Look for password = ReadOnlyPasswordHashField\n    pw_start = content.find(\"password = ReadOnlyPasswordHashField(\", user_change_start)\n    if pw_start == -1:\n        print(\"ERROR: Could not find password field\")\n    else:\n        # Find the label line\n        label_end = content.find('label=_(\"Password\"),', pw_start)\n        if label_end == -1:\n            # Try with single quotes\n            label_end = content.find(\"label=_('Password'),\", pw_start)\n        \n        print(f\"label_end at: {label_end}\")\n        print(f\"Context: '{content[label_end:label_end+30]}'\")\n        \n        # Insert disabled=True after the label line\n        line_end = content.find('\\n', label_end)\n        new_line = '        disabled=True,\\n'\n        content = content[:label_end + len('label=_(\"Password\"),')] + '\\n' + new_line + content[line_end:]\n        print(\"Added disabled=True\")\n\n# Second, remove clean_password method from UserChangeForm\n# It comes right after the __init__ method\nclean_pattern = r\"\"\"    def clean_password\\(self\\):\n        # Regardless of what the user provides, return the initial value\\.\n        # This is done here, rather than on the field, because the\n        # field does not have access to the initial value\n        return self\\.initial\\.get\\('password'\\)\n\"\"\"\n\ncontent_new, count = re.subn(clean_pattern, '', content)\nif count > 0:\n    print(f\"Removed clean_password method (count: {count})\")\nelse:\n    # Maybe there's a different pattern\n    clean_text_check = \"def clean_password\"\n    if clean_text_check in content:\n        print(\"clean_password method still exists - pattern mismatch\")\n        # Find it\n        idx = content.find(clean_text_check)\n        print(f\"Found at position: {idx}\")\n        print(f\"Context:\\n{content[idx:idx+300]}\")\n\n# Write back\nwith open(path, \"w\") as f:\n    f.write(content_new if count > 0 else content)\n\n# Verify\nprint(\"\\n=== Current UserChangeForm ===\")\nidx = content.find(\"class UserChangeForm\")\nif idx >= 0:\n    chunk = content[idx:content.find(\"class AuthenticationForm\")]\n    print(chunk[:800])\n"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21f7-cb36-78e0-92b5-9a99058ee75a",
+              "function_name": "execute_code",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_ynbbp81m",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778686348.086,
+              "end_timestamp": 1778686348.086
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_ynbbp81m",
+            "content": "{\"status\": \"success\", \"output\": \"label_end at: 4879\\nContext: 'label=_(\\\"Password\\\"),\\n        h'\\nAdded disabled=True\\nRemoved clean_password method (count: 1)\\n\\n=== Current UserChangeForm ===\\nclass UserChangeForm(forms.ModelForm):\\n    password = ReadOnlyPasswordHashField(\\n        label=_(\\\"Password\\\"),\\n        disabled=True,\\n\\n        help_text=_(\\n            'Raw passwords are not stored, so there is no way to see this '\\n            'user\u2019s password, but you can change the password using '\\n            '<a href=\\\"{}\\\">this form</a>.'\\n        ),\\n    )\\n\\n    class Meta:\\n        model = User\\n        fields = '__all__'\\n        field_classes = {'username': UsernameField}\\n\\n    def __init__(self, *args, **kwargs):\\n        super().__init__(*args, **kwargs)\\n        password = self.fields.get('password')\\n        if password:\\n            password.help_text = password.help_text.format('../password/')\\n        user_permissions = self.fields.get('user_permissions')\\n        if user_permissions:\\n    \\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.21}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 32730,
+        "completion_tokens": 719,
+        "extra": {
+          "total_tokens": 33449
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21f5-8212-77c3-b82b-881393b670b1",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21f5-8212-77c3-b82b-881393b670b1",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778686198.291,
+          "end_timestamp": 1778686344.612
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 31,
+      "timestamp": "2026-05-13T15:33:57.377810421+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The changes are applied. Let me clean up the extra blank line:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_zzkz9hxj",
+          "function_name": "patch",
+          "arguments": {
+            "mode": "replace",
+            "path": "./django/contrib/auth/forms.py",
+            "old_string": "        disabled=True,\n\n        help_text=_(",
+            "new_string": "        disabled=True,\n        help_text=_("
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21f9-2e5e-7333-9403-b19da0cad83f",
+              "function_name": "patch",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_zzkz9hxj",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778686439.007,
+              "end_timestamp": 1778686439.007
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_zzkz9hxj",
+            "content": "{\"success\": true, \"diff\": \"--- a/./django/contrib/auth/forms.py\\n+++ b/./django/contrib/auth/forms.py\\n@@ -143,7 +143,6 @@\\n     password = ReadOnlyPasswordHashField(\\n         label=_(\\\"Password\\\"),\\n         disabled=True,\\n-\\n         help_text=_(\\n             'Raw passwords are not stored, so there is no way to see this '\\n             'user\u2019s password, but you can change the password using '\\n\", \"files_modified\": [\"./django/contrib/auth/forms.py\"], \"lint\": {\"status\": \"ok\", \"output\": \"\"}, \"_warning\": \"/testbed/django/contrib/auth/forms.py was modified since you last read it on disk (external edit or unrecorded writer). Re-read the file before writing.\"}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 32490,
+        "completion_tokens": 141,
+        "extra": {
+          "total_tokens": 32631
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21f7-cbbb-7093-9d0c-6bcbb8888efd",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21f7-cbbb-7093-9d0c-6bcbb8888efd",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778686348.219,
+          "end_timestamp": 1778686437.378
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 32,
+      "timestamp": "2026-05-13T15:35:42.432574678+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Now let me run the relevant test to see what tests actually check for `clean_password`:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_c8d4sdvm",
+          "function_name": "execute_code",
+          "arguments": {
+            "code": "# First verify the final state of the file looks correct\nwith open(\"django/contrib/auth/forms.py\", \"r\") as f:\n    lines = f.readlines()\n\nin_change = False\nin_clean = False\nfor i, line in enumerate(lines):\n    if 'class UserChangeForm' in line:\n        in_change = True\n    elif 'class AuthenticationForm' in line:\n        in_change = False\n        in_clean = False\n    \n    if in_change and 'disabled=True' in line:\n        print(f\"{i+1:4d}|{lines[i-2].rstrip()}\")\n        print(f\"{i+1:4d}|{lines[i-1].rstrip()}\")\n        print(f\"{i+1:4d}|{line.rstrip()}\")\n        print(f\"{i+1:4d}|{lines[i+1].rstrip()}\")\n        print(f\"{i+1:4d}|{lines[i+2].rstrip()}\")\n        print(f\"---\")\n    \n    if in_change and 'def clean_password' in line:\n        in_clean = True\n        print(f\"FOUND CLEAN_PASSWORD at line {i+1}\")\n\nprint(\"\\n--- Check for clean_password method ---\")\ncontent = ''.join(lines)\nif 'def clean_password' in content:\n    idx = content.find('def clean_password')\n    print(f\"Found at: {idx}\")\n    print(content[idx:idx+200])\nelse:\n    print(\"clean_password method NOT found - GOOD!\")\n"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21fa-d054-7393-b801-e6452a3f17ba",
+              "function_name": "execute_code",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_c8d4sdvm",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778686546.005,
+              "end_timestamp": 1778686546.005
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_c8d4sdvm",
+            "content": "{\"status\": \"success\", \"output\": \" 145|    password = ReadOnlyPasswordHashField(\\n 145|        label=_(\\\"Password\\\"),\\n 145|        disabled=True,\\n 145|        help_text=_(\\n 145|            'Raw passwords are not stored, so there is no way to see this '\\n---\\n\\n--- Check for clean_password method ---\\nFound at: 3792\\ndef clean_password2(self):\\n        password1 = self.cleaned_data.get(\\\"password1\\\")\\n        password2 = self.cleaned_data.get(\\\"password2\\\")\\n        if password1 and password2 and password1 != password2:\\n\\n\", \"tool_calls_made\": 0, \"duration_seconds\": 0.22}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 32651,
+        "completion_tokens": 397,
+        "extra": {
+          "total_tokens": 33048
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21f9-2ef4-73e0-b145-f7f4a9dac013",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21f9-2ef4-73e0-b145-f7f4a9dac013",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778686439.157,
+          "end_timestamp": 1778686542.433
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 33,
+      "timestamp": "2026-05-13T15:37:15.899040388+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Good - the `clean_password2` found is in a different class (`UserCreationForm`), not the `clean_password` we removed from `UserChangeForm`. Let me now run the actual tests to see the impact:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_vsex6o9i",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "cd /testbed && python -m pytest tests/auth.tests.test_forms -x -v 2>&1 | head -80",
+            "timeout": 120
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21fc-3148-7a20-8078-96cecc2e08c7",
+              "function_name": "terminal",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_vsex6o9i",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778686636.361,
+              "end_timestamp": 1778686636.361
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_vsex6o9i",
+            "content": "{\"output\": \"/opt/miniconda3/envs/testbed/bin/python: No module named pytest\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 32381,
+        "completion_tokens": 165,
+        "extra": {
+          "total_tokens": 32546
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21fa-d0e3-7550-bc6a-69f0fdee39b2",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21fa-d0e3-7550-bc6a-69f0fdee39b2",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778686546.148,
+          "end_timestamp": 1778686635.899
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 34,
+      "timestamp": "2026-05-13T15:37:26.219542795+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "Now let me run the actual diff to confirm the full change is correct:",
+      "tool_calls": [
+        {
+          "tool_call_id": "call_l8usiy2d",
+          "function_name": "terminal",
+          "arguments": {
+            "command": "cd /testbed && git diff HEAD -- django/contrib/auth/forms.py"
+          },
+          "extra": {
+            "ancestry": {
+              "function_id": "019e21fc-5998-75c0-b0db-0736c6a44be2",
+              "function_name": "terminal",
+              "parent_id": "019e21ea-0dca-7c72-9cd6-94e408ab8567",
+              "parent_name": "hermes"
+            },
+            "invocation": {
+              "invocation_id": "call_l8usiy2d",
+              "framework": "nat",
+              "status": "completed",
+              "start_timestamp": 1778686646.68,
+              "end_timestamp": 1778686646.681
+            }
+          }
+        }
+      ],
+      "observation": {
+        "results": [
+          {
+            "source_call_id": "call_l8usiy2d",
+            "content": "{\"output\": \"diff --git a/django/contrib/auth/forms.py b/django/contrib/auth/forms.py\\nindex b9eb33329f..3e5f3bad88 100644\\n--- a/django/contrib/auth/forms.py\\n+++ b/django/contrib/auth/forms.py\\n@@ -142,6 +142,7 @@ class UserCreationForm(forms.ModelForm):\\n class UserChangeForm(forms.ModelForm):\\n     password = ReadOnlyPasswordHashField(\\n         label=_(\\\"Password\\\"),\\n+        disabled=True,\\n         help_text=_(\\n             'Raw passwords are not stored, so there is no way to see this '\\n             'user\u2019s password, but you can change the password using '\\n@@ -163,11 +164,6 @@ class UserChangeForm(forms.ModelForm):\\n         if user_permissions:\\n             user_permissions.queryset = user_permissions.queryset.select_related('content_type')\\n \\n-    def clean_password(self):\\n-        # Regardless of what the user provides, return the initial value.\\n-        # This is done here, rather than on the field, because the\\n-        # field does not have access to the initial value\\n-        return self.initial.get('password')\\n \\n \\n class AuthenticationForm(forms.Form):\", \"exit_code\": 0, \"error\": null}"
+          }
+        ]
+      },
+      "metrics": {
+        "prompt_tokens": 32540,
+        "completion_tokens": 76,
+        "extra": {
+          "total_tokens": 32616
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21fc-31e3-7152-8e82-46cbddb9ff20",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21fc-31e3-7152-8e82-46cbddb9ff20",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778686636.516,
+          "end_timestamp": 1778686646.22
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 35,
+      "timestamp": "2026-05-13T15:39:29.031678297+00:00",
+      "source": "agent",
+      "model_name": "qwen3.6:35b",
+      "message": "The changes are now complete. Here's a summary of what was done:\n\n**Problem**: When editing a user in the Django admin, the `UserChangeForm` displays a password help text with a link to change the password. However, the admin page doesn't send a \"password\" input in the form submission (the password field is read-only/informational). This causes Django's form processing to raise a \"This password field is required\" error because `ReadOnlyPasswordHashField` always requires a non-empty value.\n\n**Root cause**: The existing `clean_password` method in `UserChangeForm` worked around this by returning `self.initial.get('password')` (the original, unsaved value). However, this workaround fails when editing users through the admin page, where the admin HTML doesn't include the password in the POST data.\n\n**Solution**: \n1. **Added `disabled=True`** to the Password field in `UserChangeForm`. When a field is disabled, Django's form processing automatically:\n   - Doesn't process its widget HTML in `__init__()` (saves processing time)\n   - Automatically includes the field's initial value in `cleaned_data` (no error raised)\n   \n2. **Removed the `clean_password` method** - It's no longer needed because the disabled field is automatically included with its initial value in `cleaned_data`.\n\nThis makes sense because:\n- The Password field in `UserChangeForm` is purely informational (read-only)\n- Users should use the password change form (linked in the help text) to change passwords\n- There's no practical use case where you'd want to edit the password inline on the user change form\n\nThe changes are minimal and targeted to the issue at hand.",
+      "metrics": {
+        "prompt_tokens": 32330,
+        "completion_tokens": 666,
+        "extra": {
+          "total_tokens": 32996
+        }
+      },
+      "extra": {
+        "ancestry": {
+          "function_id": "019e21fc-5a1e-7ec2-8e95-0b679229cbbc",
+          "function_name": "openai.chat_completions",
+          "parent_id": "019e21ea-f931-7040-8402-450892c831e3",
+          "parent_name": "gateway"
+        },
+        "invocation": {
+          "invocation_id": "019e21fc-5a1e-7ec2-8e95-0b679229cbbc",
+          "framework": "nat",
+          "status": "completed",
+          "start_timestamp": 1778686646.815,
+          "end_timestamp": 1778686769.032
+        }
+      },
+      "llm_call_count": 1
+    },
+    {
+      "step_id": 36,
+      "timestamp": "2026-05-13T15:39:29.493931839+00:00",
+      "source": "system",
+      "message": "{\"cwd\":\"/testbed\",\"extra\":{\"completed\":true,\"interrupted\":false,\"model\":\"qwen3.6:35b\",\"platform\":\"cli\"},\"hook_event_name\":\"on_session_end\",\"session_id\":\"20260513_151726_a550a0\",\"tool_input\":null,\"tool_name\":null}"
+    }
+  ],
+  "final_metrics": {
+    "total_prompt_tokens": 887910,
+    "total_completion_tokens": 8071,
+    "total_steps": 36,
+    "extra": {
+      "total_tokens": 895981
+    }
+  }
+}

--- a/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
+++ b/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
@@ -60,6 +60,7 @@ flowchart TD
 
 One Hermes run emits these trajectory artifacts:
 
+<!-- path-check-skip-begin -->
 - Native path: Hermes session export -> Harbor Hermes adapter ->
   `agent/trajectory.json`. This is Harbor's native Hermes trajectory and is
   produced independently of the NeMo-Flow gateway.
@@ -73,6 +74,7 @@ One Hermes run emits these trajectory artifacts:
 - Plugin direct ATIF: PR #89 plugin ATIF export ->
   `agent/nemo-flow-plugin-atif/trajectory.json`. This is a secondary debugging
   artifact for comparing plugin direct ATIF against legacy direct ATIF.
+<!-- path-check-skip-end -->
 
 ## Prerequisites
 
@@ -173,6 +175,7 @@ cp -R "$NEMO_FLOW_REPO"/crates "$PREBUILT_CONTEXT"/
 
 Create the prebuilt-image `Dockerfile`:
 
+<!-- path-check-skip-begin -->
 ```bash
 cat > .tmp/harbor/nemo-flow-prebuilt.Dockerfile <<'EOF'
 FROM swebench/sweb.eval.x86_64.django_1776_django-13741:latest
@@ -209,9 +212,11 @@ RUN set -eux; \
 WORKDIR /testbed
 EOF
 ```
+<!-- path-check-skip-end -->
 
 Build and validate the image:
 
+<!-- path-check-skip-begin -->
 ```bash
 /usr/bin/time -p docker build \
   --platform linux/amd64 \
@@ -222,10 +227,15 @@ Build and validate the image:
 docker run --rm --platform linux/amd64 "$PREBUILT_NEMO_FLOW_IMAGE" \
   bash -lc 'command -v nemo-flow && nemo-flow run --help | grep -q -- --atif-dir && nemo-flow run --help | grep -q -- --plugin-config'
 ```
+<!-- path-check-skip-end -->
+
+The Linux AMD64 platform option is intentional for SWE-bench image
+compatibility, especially when running Docker from an Apple Silicon host.
 
 Create a prebuilt-image copy of the SWE-bench task by adding
 `docker_image = "$PREBUILT_NEMO_FLOW_IMAGE"` to its `[environment]` section.
 
+<!-- path-check-skip-begin -->
 ```bash
 export SOURCE_SWEBENCH_TASK=external/harbor/datasets/swebench-opencode-smoke/django__django-13741
 export SWEBENCH_TASK=.tmp/harbor/datasets/swebench-hermes-nemoflow-prebuilt/django__django-13741
@@ -252,6 +262,7 @@ else:
 task.write_text(text)
 PY
 ```
+<!-- path-check-skip-end -->
 
 This smoke can use a local Ollama model through its OpenAI-compatible endpoint.
 When the agent runs inside Docker on macOS, point the container at the host via

--- a/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
+++ b/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
@@ -29,8 +29,8 @@ smoke:
 - Raw ATOF JSONL from the NeMo-Flow observability plugin.
 - ATOF-derived ATIF from the Toolkit ATOF-to-ATIF converter.
 
-Direct gateway or plugin ATIF outputs may also be created during a run, but they
-are diagnostic files only for this smoke. Do not use them as evidence for the
+Direct plugin ATIF outputs may also be created during a run, but they are
+diagnostic files only for this smoke. Do not use them as evidence for the
 trajectory comparison until their message shape is strict-compatible with the
 Toolkit ATIF parser.
 
@@ -48,7 +48,6 @@ flowchart TD
   gatewayHooks --> atof[agent/nemo-flow-atof/events.jsonl<br/>raw ATOF JSONL]
   atof --> converter[the Toolkit ATOF-to-ATIF converter]
   converter --> nfAtif[agent/nemo-flow-atof-atif/trajectory.json<br/>ATOF-derived ATIF]
-  gatewayHooks -. optional diagnostic .-> gatewayAtif[agent/nemo-flow-gateway-atif/trajectory.json<br/>direct gateway ATIF]
   gatewayHooks -. optional diagnostic .-> pluginAtif[agent/nemo-flow-plugin-atif/trajectory.json<br/>plugin direct ATIF]
 
   harbor --> swe[SWE-bench verifier<br/>patch + task tests]
@@ -73,9 +72,8 @@ One Hermes run should create these primary trajectory artifacts:
 
 <!-- path-check-skip-begin -->
 The run may also create direct ATIF diagnostics under
-`agent/nemo-flow-gateway-atif/` and `agent/nemo-flow-plugin-atif/`. Treat those
-as optional implementation diagnostics, not as the basis for this smoke's
-analysis.
+`agent/nemo-flow-plugin-atif/`. Treat those as optional implementation
+diagnostics, not as the basis for this smoke's analysis.
 <!-- path-check-skip-end -->
 
 ## Prerequisites
@@ -84,9 +82,9 @@ analysis.
 - The Toolkit is checked out to a branch containing
   `nat_harbor.agents.installed.hermes_nemoflow:HermesNeMoFlow`.
 - Harbor is installed from the source branch used by the Harbor integration.
-- NeMo-Flow `>= v0.2` is checked out. This version requirement covers CLI ATOF
-  export, observability plugin activation through `--plugin-config`, and direct
-  gateway ATIF export through `--atif-dir`. The published binary is
+- NeMo-Flow `>= v0.2` is checked out. This version requirement covers
+  project-scoped `.nemo-flow/plugins.toml` activation, which configures ATOF and
+  ATIF export for the CLI gateway. The published binary is
   `nemo-flow`, and the published Cargo package is `nemo-flow-cli`.
 
 <!-- path-check-skip-begin -->
@@ -208,9 +206,8 @@ RUN set -eux; \
     cargo build -p nemo-flow-cli --release; \
     install -m 0755 target/release/nemo-flow /usr/local/bin/nemo-flow; \
     nemo-flow --help >/dev/null; \
-    nemo-flow run --help | grep -q -- '--atif-dir'; \
-    nemo-flow run --help | grep -q -- '--plugin-config'; \
-    nemo-flow hook-forward --help | grep -q -- '--atif-dir'
+    nemo-flow plugins edit --help >/dev/null; \
+    nemo-flow hook-forward --help >/dev/null
 
 WORKDIR /testbed
 EOF
@@ -228,7 +225,7 @@ Build and validate the image:
   "$PREBUILT_CONTEXT"
 
 docker run --rm --platform linux/amd64 "$PREBUILT_NEMO_FLOW_IMAGE" \
-  bash -lc 'command -v nemo-flow && nemo-flow run --help | grep -q -- --atif-dir && nemo-flow run --help | grep -q -- --plugin-config'
+  bash -lc 'command -v nemo-flow && nemo-flow plugins edit --help >/dev/null && nemo-flow hook-forward --help >/dev/null'
 ```
 <!-- path-check-skip-end -->
 
@@ -339,6 +336,11 @@ set +a
   --ak fail_nemoflow_atof_conversion=false
 ```
 
+The wrapper writes a project-scoped plugin config to
+`/testbed/.nemo-flow/plugins.toml` before starting `nemo-flow run`. That keeps
+the smoke aligned with the current plugin file discovery path without mutating
+global or user NeMo-Flow config.
+
 A completed run may create these files under the trial directory.
 
 Primary evidence artifacts:
@@ -354,7 +356,6 @@ Additional files to look for when checking run completion or debugging:
 ```text
 agent/hermes.txt
 agent/hermes-session.jsonl
-agent/nemo-flow-gateway-atif/trajectory.json
 agent/nemo-flow-plugin-atif/trajectory.json
 result.json
 verifier/report.json
@@ -432,7 +433,6 @@ run_outputs = (
     "hermes-session.jsonl",
 )
 diagnostic = (
-    "nemo-flow-gateway-atif/trajectory.json",
     "nemo-flow-plugin-atif/trajectory.json",
 )
 for rel in evidence:
@@ -531,9 +531,9 @@ ENDPOINT=http://localhost:6006/v1/traces
   --project harbor-hermes-nemoflow-atof
 ```
 
-Open `http://localhost:6006` and compare the two evidence projects. Export
-direct gateway/plugin ATIF only for debugging, not as smoke evidence, until
-those files are strict-compatible with the Toolkit ATIF parser.
+Open `http://localhost:6006` and compare the two evidence projects. Export the
+direct plugin ATIF only for debugging, not as smoke evidence, until that file is
+strict-compatible with the Toolkit ATIF parser.
 
 In Phoenix, expect `harbor-hermes-native` to show one root workflow span with
 input/output. That does not mean the native ATIF fixture only has one step; it
@@ -557,14 +557,14 @@ ATIF-to-Phoenix exporter. The richer span tree should come from
 - The ATOF path requires NeMo-Flow `>= v0.2` observability plugin activation in
   the CLI gateway. The `enable_nemoflow_observability_plugin=true` smoke should
   require `agent/nemo-flow-atof/events.jsonl`; use
-  `fail_missing_nemoflow_atof=false` only when running against older
-  direct-ATIF-only gateway branches.
+  `fail_missing_nemoflow_atof=false` only when running against older local
+  validation branches that do not emit ATOF.
 - The Toolkit ATOF-to-ATIF conversion is initially best-effort in this smoke
   (`fail_nemoflow_atof_conversion=false`) so raw ATOF can still be inspected if
   reconstruction fails. Flip it to `true` once the converter result is stable.
-- Direct gateway/plugin ATIF files may be emitted, but they are diagnostic
-  outputs for this smoke. Base the analysis on the checked-in native Hermes
-  ATIF, raw ATOF JSONL, and ATOF-derived ATIF fixtures.
+- Direct plugin ATIF files may be emitted, but they are diagnostic outputs for
+  this smoke. Base the analysis on the checked-in native Hermes ATIF, raw ATOF
+  JSONL, and ATOF-derived ATIF fixtures.
 - Complete LLM lifecycle telemetry requires Hermes model traffic to use the
   NeMo-Flow gateway. This wrapper configures that path for `nvidia`, `openai`,
   `openrouter`, and `anthropic` model prefixes.

--- a/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
+++ b/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
@@ -83,6 +83,7 @@ diagnostics, not as the basis for this smoke's analysis.
   `nat_harbor.agents.installed.hermes_nemoflow:HermesNeMoFlow`.
 - Harbor is installed from the source branch used by the Harbor integration.
 - NeMo-Flow `>= v0.2` is checked out. This version requirement covers
+  <!-- path-check-skip-next-line -->
   project-scoped `.nemo-flow/plugins.toml` activation, which configures ATOF and
   ATIF export for the CLI gateway. The published binary is
   `nemo-flow`, and the published Cargo package is `nemo-flow-cli`.

--- a/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
+++ b/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
@@ -29,7 +29,7 @@ smoke:
 - Raw ATOF JSONL from the NeMo-Flow observability plugin.
 - ATOF-derived ATIF from the Toolkit ATOF-to-ATIF converter.
 
-Direct gateway/plugin ATIF outputs may also be created during a run, but they
+Direct gateway or plugin ATIF outputs may also be created during a run, but they
 are diagnostic files only for this smoke. Do not use them as evidence for the
 trajectory comparison until their message shape is strict-compatible with the
 Toolkit ATIF parser.
@@ -71,10 +71,12 @@ One Hermes run should create these primary trajectory artifacts:
   comparison target.
 <!-- path-check-skip-end -->
 
+<!-- path-check-skip-begin -->
 The run may also create direct ATIF diagnostics under
 `agent/nemo-flow-gateway-atif/` and `agent/nemo-flow-plugin-atif/`. Treat those
 as optional implementation diagnostics, not as the basis for this smoke's
 analysis.
+<!-- path-check-skip-end -->
 
 ## Prerequisites
 

--- a/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
+++ b/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
@@ -22,15 +22,17 @@ NeMo-Flow CLI gateway enabled. It validates the first available non-patching
 Hermes instrumentation path before the upstream Hermes native middleware path
 is available.
 
-The validation pass can use two NeMo-Flow sidecar artifacts:
+The validation pass is based on three reference artifacts captured from the
+smoke:
 
-- Direct gateway ATIF from the existing `--atif-dir` path.
-- Raw ATOF JSONL from the NeMo-Flow observability plugin, converted to ATIF with
-  the NeMo Agent Toolkit ATOF-to-ATIF converter.
+- Native Hermes ATIF from Harbor's Hermes adapter.
+- Raw ATOF JSONL from the NeMo-Flow observability plugin.
+- ATOF-derived ATIF from the Toolkit ATOF-to-ATIF converter.
 
-The ATOF-derived ATIF is the primary NeMo-Flow comparison target for this pass.
-The direct gateway ATIF remains useful as a baseline while we validate whether
-raw event reconstruction fixes the earlier direct-ATIF inconsistencies.
+Direct gateway/plugin ATIF outputs may also be created during a run, but they
+are diagnostic files only for this smoke. Do not use them as evidence for the
+trajectory comparison until their message shape is strict-compatible with the
+Toolkit ATIF parser.
 
 ## Pipeline
 
@@ -46,19 +48,18 @@ flowchart TD
   gatewayHooks --> atof[agent/nemo-flow-atof/events.jsonl<br/>raw ATOF JSONL]
   atof --> converter[the Toolkit ATOF-to-ATIF converter]
   converter --> nfAtif[agent/nemo-flow-atof-atif/trajectory.json<br/>ATOF-derived ATIF]
-  gatewayHooks --> gatewayAtif[agent/nemo-flow-gateway-atif/trajectory.json<br/>legacy gateway-emitted ATIF]
-  gatewayHooks --> pluginAtif[agent/nemo-flow-plugin-atif/trajectory.json<br/>plugin direct ATIF]
+  gatewayHooks -. optional diagnostic .-> gatewayAtif[agent/nemo-flow-gateway-atif/trajectory.json<br/>direct gateway ATIF]
+  gatewayHooks -. optional diagnostic .-> pluginAtif[agent/nemo-flow-plugin-atif/trajectory.json<br/>plugin direct ATIF]
 
   harbor --> swe[SWE-bench verifier<br/>patch + task tests]
   swe --> result[result.json<br/>reward/resolved]
 
   nativeAtif --> compare[Trajectory comparison<br/>tool sequence + the Toolkit evaluators + Phoenix]
   nfAtif --> compare
-  gatewayAtif -. baseline .-> compare
-  result --> outcome[Outcome sanity check<br/>successful/resolved run]
+  result --> outcome[Run completion check<br/>exceptions/reward]
 ```
 
-One Hermes run emits these trajectory artifacts:
+One Hermes run should create these primary trajectory artifacts:
 
 <!-- path-check-skip-begin -->
 - Native path: Hermes session export -> Harbor Hermes adapter ->
@@ -68,13 +69,12 @@ One Hermes run emits these trajectory artifacts:
   `agent/nemo-flow-atof/events.jsonl`, then the Toolkit converter writes
   `agent/nemo-flow-atof-atif/trajectory.json`. This is the primary NeMo-Flow
   comparison target.
-- Gateway-emitted ATIF: Hermes hooks and routed model traffic -> NeMo-Flow CLI
-  gateway -> `agent/nemo-flow-gateway-atif/trajectory.json`. This is the legacy
-  direct-ATIF baseline.
-- Plugin direct ATIF: NeMo-Flow observability plugin ATIF export ->
-  `agent/nemo-flow-plugin-atif/trajectory.json`. This is a secondary debugging
-  artifact for comparing plugin direct ATIF against legacy direct ATIF.
 <!-- path-check-skip-end -->
+
+The run may also create direct ATIF diagnostics under
+`agent/nemo-flow-gateway-atif/` and `agent/nemo-flow-plugin-atif/`. Treat those
+as optional implementation diagnostics, not as the basis for this smoke's
+analysis.
 
 ## Prerequisites
 
@@ -337,43 +337,62 @@ set +a
   --ak fail_nemoflow_atof_conversion=false
 ```
 
-Expected artifacts under the trial directory:
+A completed run may create these files under the trial directory.
+
+Primary evidence artifacts:
+
+```text
+agent/trajectory.json
+agent/nemo-flow-atof/events.jsonl
+agent/nemo-flow-atof-atif/trajectory.json
+```
+
+Additional files to look for when checking run completion or debugging:
 
 ```text
 agent/hermes.txt
 agent/hermes-session.jsonl
-agent/trajectory.json
 agent/nemo-flow-gateway-atif/trajectory.json
 agent/nemo-flow-plugin-atif/trajectory.json
-agent/nemo-flow-atof/events.jsonl
-agent/nemo-flow-atof-atif/trajectory.json
 result.json
 verifier/report.json
 ```
 
-## Example Trajectories From Previous Run
+The additional files are useful for confirming that the run completed and that
+diagnostic exporters ran. They are not used as evidence in this smoke.
 
-Reference run:
+## Reference Artifacts
+
+Reference artifacts from a completed smoke are checked in under:
 
 ```text
-.tmp/harbor/hermes-nemoflow-smoke/hermes-nemoflow-pr89-plugin-atof-smoke-20260512-145959/django__django-13741__7dQBUQM
+packages/nvidia_nat_harbor/data/hermes-nemoflow-smoke/
 ```
 
-The run completed with `reward=1.0`, `0` exceptions, and an exact native vs
-ATOF-derived tool-sequence match.
+These files are the stable evidence set for this smoke:
 
-| Artifact | Path | Status from run |
+| Evidence | Checked-in fixture | Status |
 | --- | --- | --- |
-| Native Hermes ATIF | `agent/trajectory.json` | Valid ATIF for the Toolkit parser, `ATIF-v1.2`, 30 steps. |
-| NeMo-Flow ATOF-derived ATIF | `agent/nemo-flow-atof-atif/trajectory.json` | Valid ATIF for the Toolkit parser, `ATIF-v1.7`, 33 steps. Primary comparison target. |
-| NeMo-Flow gateway direct ATIF | `agent/nemo-flow-gateway-atif/trajectory.json` | Emitted, but not strict schema-valid for the Toolkit yet because direct exporter messages contain raw OpenAI payloads. Diagnostic baseline only. |
-| NeMo-Flow plugin direct ATIF | `agent/nemo-flow-plugin-atif/trajectory.json` | Emitted, but has the same direct-exporter message-shape issue as gateway direct ATIF. Diagnostic baseline only. |
+| Native Hermes ATIF | `native-hermes-trajectory.json` | Valid ATIF for the Toolkit parser, `ATIF-v1.2`, 32 steps, `total_steps=32`. |
+| NeMo-Flow raw ATOF | `nemo-flow-atof-events.jsonl` | 228 ATOF events captured through the NeMo-Flow observability plugin. |
+| NeMo-Flow ATOF-derived ATIF | `nemo-flow-atof-atif-trajectory.json` | Valid ATIF for the Toolkit parser, `ATIF-v1.7`, 36 steps, `total_prompt_tokens=887910`, `total_completion_tokens=8071`, `total_tokens=895981`. |
 
-The raw ATOF reference for the same run is:
+The reference fixture comparison produced an exact native vs ATOF-derived tool
+sequence match:
 
 ```text
-agent/nemo-flow-atof/events.jsonl
+Native tools (32): execute_code=9, patch=6, read_file=6, search_files=5, terminal=6
+Candidate tools (32): execute_code=9, patch=6, read_file=6, search_files=5, terminal=6
 ```
+
+The native Hermes ATIF fixture is still a multi-step trajectory even though it
+does not currently produce a rich Phoenix span tree. It has 32 ATIF steps and
+32 tool calls, but its steps do not include the `extra` ancestry/invocation
+metadata that the ATIF-to-Phoenix exporter uses to create child LLM and tool
+spans. When exported to Phoenix, this native trajectory is expected to appear
+as a single workflow span with root input/output. Use it as the native
+trajectory and tool-sequence baseline, not as the span-level observability
+baseline.
 
 ## Quick Artifact Check
 
@@ -387,9 +406,9 @@ TRIAL=$(find "$HARBOR_JOBS_DIR/$JOB_NAME" -maxdepth 1 -type d -name 'django__dja
 test -n "$TRIAL"
 ```
 
-Check artifact presence and strict compatibility with the Toolkit ATIF parser. The direct
-gateway/plugin ATIF artifacts are still useful diagnostics, but may fail strict
-schema validation until direct-exporter message normalization is fixed.
+Check that the run created the evidence files. Additional run-completion and
+diagnostic files are reported if present, but this smoke does not use them as
+trajectory evidence.
 
 ```bash
 .venv/bin/python - <<'PY'
@@ -401,25 +420,33 @@ from nat_harbor.verifier.evaluator_adapter import load_atif_samples
 
 trial = Path(os.environ["TRIAL"])
 agent = trial / "agent"
-required = (
-    "hermes.txt",
-    "hermes-session.jsonl",
+evidence = (
     "trajectory.json",
-    "nemo-flow-gateway-atif/trajectory.json",
-    "nemo-flow-plugin-atif/trajectory.json",
     "nemo-flow-atof/events.jsonl",
     "nemo-flow-atof-atif/trajectory.json",
 )
-for rel in required:
+run_outputs = (
+    "hermes.txt",
+    "hermes-session.jsonl",
+)
+diagnostic = (
+    "nemo-flow-gateway-atif/trajectory.json",
+    "nemo-flow-plugin-atif/trajectory.json",
+)
+for rel in evidence:
     path = agent / rel
     if not path.exists():
         raise SystemExit(f"Missing {path}")
-    print("ok", rel, path.stat().st_size)
+    print("evidence", rel, path.stat().st_size)
+for rel in run_outputs:
+    path = agent / rel
+    print("run-output", rel, "present" if path.exists() else "missing")
+for rel in diagnostic:
+    path = agent / rel
+    print("diagnostic", rel, "present" if path.exists() else "missing")
 
 for rel in (
     "trajectory.json",
-    "nemo-flow-gateway-atif/trajectory.json",
-    "nemo-flow-plugin-atif/trajectory.json",
     "nemo-flow-atof-atif/trajectory.json",
 ):
     path = agent / rel
@@ -447,28 +474,9 @@ Compare the native and ATOF-derived tool sequences:
   --candidate "$TRIAL/agent/nemo-flow-atof-atif/trajectory.json"
 ```
 
-Also compare the native and direct gateway-emitted tool sequences as the
-baseline:
-
-```bash
-.venv/bin/python -m nat_harbor.smoke.compare_atif_tools \
-  --native "$TRIAL/agent/trajectory.json" \
-  --candidate "$TRIAL/agent/nemo-flow-gateway-atif/trajectory.json"
-```
-
-Compare plugin direct ATIF as a secondary diagnostic:
-
-```bash
-.venv/bin/python -m nat_harbor.smoke.compare_atif_tools \
-  --native "$TRIAL/agent/trajectory.json" \
-  --candidate "$TRIAL/agent/nemo-flow-plugin-atif/trajectory.json"
-```
-
-The ATOF-derived comparison is the primary check. If it is still missing tool
-semantics, inspect `agent/nemo-flow-atof/events.jsonl` before changing the ATIF
-exporter because the raw event stream will show whether the data was captured.
-Direct ATIF comparisons are diagnostic and are expected to be poorer until the
-direct exporter emits strict ATIF messages compatible with the Toolkit.
+If the ATOF-derived comparison is missing tool semantics, inspect
+`agent/nemo-flow-atof/events.jsonl` before changing the ATIF exporter because
+the raw event stream shows whether the data was captured.
 
 ## Post-Run Trajectory Scoring
 
@@ -521,9 +529,15 @@ ENDPOINT=http://localhost:6006/v1/traces
   --project harbor-hermes-nemoflow-atof
 ```
 
-Open `http://localhost:6006` and compare the projects. Export direct
-gateway/plugin ATIF only after the quick artifact check reports them as strict
-schema-valid for the Toolkit.
+Open `http://localhost:6006` and compare the two evidence projects. Export
+direct gateway/plugin ATIF only for debugging, not as smoke evidence, until
+those files are strict-compatible with the Toolkit ATIF parser.
+
+In Phoenix, expect `harbor-hermes-native` to show one root workflow span with
+input/output. That does not mean the native ATIF fixture only has one step; it
+means the native fixture lacks the span-construction metadata needed by the
+ATIF-to-Phoenix exporter. The richer span tree should come from
+`harbor-hermes-nemoflow-atof`, which is built from the ATOF-derived ATIF.
 
 ## Known Limitations
 
@@ -546,10 +560,9 @@ schema-valid for the Toolkit.
 - The Toolkit ATOF-to-ATIF conversion is initially best-effort in this smoke
   (`fail_nemoflow_atof_conversion=false`) so raw ATOF can still be inspected if
   reconstruction fails. Flip it to `true` once the converter result is stable.
-- In the reference run above, the direct gateway/plugin ATIF files were emitted
-  but did not validate with the strict Toolkit ATIF parser because `message` fields
-  contained raw OpenAI request/response payloads. The ATOF-derived ATIF file did
-  validate and matched the native Hermes tool sequence exactly.
+- Direct gateway/plugin ATIF files may be emitted, but they are diagnostic
+  outputs for this smoke. Base the analysis on the checked-in native Hermes
+  ATIF, raw ATOF JSONL, and ATOF-derived ATIF fixtures.
 - Complete LLM lifecycle telemetry requires Hermes model traffic to use the
   NeMo-Flow gateway. This wrapper configures that path for `nvidia`, `openai`,
   `openrouter`, and `anthropic` model prefixes.

--- a/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
+++ b/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
@@ -1,0 +1,304 @@
+<!--
+SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Hermes NeMo-Flow Harbor Smoke
+
+This developer workflow runs Hermes Agent on one Harbor SWE-bench task with the
+NeMo-Flow sidecar enabled. It validates the first available non-patching Hermes
+instrumentation path before the upstream Hermes native middleware path is
+available.
+
+The validation pass intentionally matches the OpenCode smoke: NeMo-Flow writes
+raw ATOF JSONL, NAT converts that ATOF stream to ATIF after the run, and the
+converted trajectory is compared against Harbor's native Hermes ATIF.
+
+## Pipeline
+
+```mermaid
+flowchart TD
+  task[SWE-bench task<br/>django__django-13741] --> harbor[Harbor trial<br/>Docker task environment]
+
+  harbor --> run[HermesNeMoFlow run<br/>nemo-flow-sidecar wrapper]
+  run --> nativeSession[agent/hermes-session.jsonl<br/>Hermes native session export]
+  nativeSession --> nativeAtif[agent/trajectory.json<br/>Harbor Hermes ATIF]
+
+  run --> sidecarHooks[Hermes hooks + sidecar gateway]
+  sidecarHooks --> atof[agent/nemo-flow-atof/events.jsonl<br/>raw ATOF stream]
+  atof --> converter[NAT ATOF-to-ATIF converter]
+  converter --> nfAtif[agent/nemo-flow-atof-atif/trajectory.json<br/>ATOF-derived ATIF]
+  sidecarHooks --> sidecarAtif[agent/nemo-flow-sidecar-atif/trajectory.json<br/>direct sidecar ATIF debug artifact]
+
+  harbor --> swe[SWE-bench verifier<br/>patch + task tests]
+  swe --> result[result.json<br/>reward/resolved]
+
+  nativeAtif --> compare[Trajectory comparison<br/>tool sequence + NAT evaluators + Phoenix]
+  nfAtif --> compare
+  result --> outcome[Outcome sanity check<br/>successful/resolved run]
+```
+
+One Hermes run emits three trajectory artifacts:
+
+- Native path: Hermes session export -> Harbor Hermes adapter ->
+  `agent/trajectory.json`. This is Harbor's native Hermes trajectory and is
+  produced independently of the NeMo-Flow sidecar.
+- NeMo-Flow path: Hermes hooks and routed model traffic -> raw ATOF JSONL ->
+  NAT ATOF-to-ATIF converter -> `agent/nemo-flow-atof-atif/trajectory.json`.
+- Direct sidecar ATIF remains available at
+  `agent/nemo-flow-sidecar-atif/trajectory.json` as a secondary debugging
+  artifact. This is emitted directly by the sidecar ATIF exporter; it is not
+  produced by the ATOF-to-ATIF converter and is not the primary comparison
+  target.
+
+## Prerequisites
+
+- Docker is running.
+- NAT is checked out to a branch containing
+  `nat_harbor.agents.installed.hermes_nemoflow:HermesNeMoFlow`.
+- Harbor is installed from the source branch used by the Harbor integration.
+- NeMo-Flow is checked out to a branch containing `nemo-flow-sidecar` with
+  Hermes support and raw ATOF JSONL export support.
+
+<!-- path-check-skip-begin -->
+```bash
+mkdir -p external
+
+if [ ! -d external/harbor/.git ]; then
+  git clone https://github.com/AnuradhaKaruppiah/harbor.git external/harbor
+fi
+git -C external/harbor fetch origin
+git -C external/harbor checkout ak-harbor-libary-mode
+
+if [ ! -d external/nemo-flow/.git ]; then
+  git clone https://github.com/willkill07/NeMo-Flow.git external/nemo-flow
+fi
+git -C external/nemo-flow fetch origin
+git -C external/nemo-flow checkout wkk_coding-agent-sidecar-integrations
+```
+
+The SWE-bench smoke task should exist at:
+
+```text
+external/harbor/datasets/swebench-opencode-smoke/django__django-13741
+```
+
+If that task is missing, create it with Harbor's SWE-bench adapter:
+
+```bash
+cd external/harbor/adapters/swebench
+
+uv run swebench \
+  --instance-id django__django-13741 \
+  --task-dir ../../datasets/swebench-opencode-smoke \
+  --overwrite
+
+cd ../../../..
+```
+
+Use editable installs for local iteration:
+
+```bash
+uv venv --python 3.13 --seed .venv
+uv pip install -e packages/nvidia_nat_harbor
+uv pip install -e external/harbor
+```
+<!-- path-check-skip-end -->
+
+`NVIDIA_BASE_URL` should point at the OpenAI-compatible NVIDIA endpoint used
+for this smoke.
+
+```bash
+export NVIDIA_BASE_URL=<openai-compatible-nvidia-base-url>
+```
+
+## Run the Smoke
+
+Create a local env file for the Docker task environment. Do not commit this
+file.
+
+<!-- path-check-skip-begin -->
+```bash
+mkdir -p .tmp/harbor/secrets
+read -rsp 'NVIDIA_API_KEY: ' NVIDIA_API_KEY; echo
+cat > .tmp/harbor/secrets/nvidia.env <<EOF
+NVIDIA_API_KEY=${NVIDIA_API_KEY}
+NVIDIA_BASE_URL=${NVIDIA_BASE_URL}
+EOF
+```
+
+Run the NeMo-Flow-enabled Hermes smoke:
+
+```bash
+export HARBOR_JOBS_DIR=.tmp/harbor/hermes-nemoflow-smoke
+export SWEBENCH_TASK=external/harbor/datasets/swebench-opencode-smoke/django__django-13741
+export NEMO_FLOW_REPO="$PWD/external/nemo-flow"
+export JOB_NAME=hermes-nemoflow-repeatable-smoke-1
+
+set -a
+. .tmp/harbor/secrets/nvidia.env
+set +a
+
+.venv/bin/harbor run \
+  --path "$SWEBENCH_TASK" \
+  -l 1 \
+  --job-name "$JOB_NAME" \
+  --jobs-dir "$HARBOR_JOBS_DIR" \
+  --yes -n 1 --max-retries 0 \
+  --env-file .tmp/harbor/secrets/nvidia.env \
+  --agent-import-path nat_harbor.agents.installed.hermes_nemoflow:HermesNeMoFlow \
+  --env docker \
+  --model nvidia/opus-frontier \
+  --ak nemo_flow_repo="$NEMO_FLOW_REPO" \
+  --ak fail_missing_nemoflow_atof=true \
+  --ak fail_missing_nemoflow_atif=false
+```
+
+Expected artifacts under the trial directory:
+
+```text
+agent/hermes.txt
+agent/hermes-session.jsonl
+agent/trajectory.json
+agent/nemo-flow-atof/events.jsonl
+agent/nemo-flow-atof-atif/trajectory.json
+agent/nemo-flow-sidecar-atif/trajectory.json
+result.json
+verifier/report.json
+```
+
+## Quick Artifact Check
+
+Set `TRIAL` to the completed trial directory:
+
+```bash
+export HARBOR_JOBS_DIR=.tmp/harbor/hermes-nemoflow-smoke
+export JOB_NAME=hermes-nemoflow-repeatable-smoke-1
+export TRIAL
+TRIAL=$(find "$HARBOR_JOBS_DIR/$JOB_NAME" -maxdepth 1 -type d -name 'django__django-13741__*' | head -n 1)
+test -n "$TRIAL"
+```
+
+Check that both ATIF artifacts load and expose token totals:
+
+```bash
+.venv/bin/python - <<'PY'
+import json
+import os
+from pathlib import Path
+
+from nat_harbor.verifier.evaluator_adapter import load_atif_samples
+
+trial = Path(os.environ["TRIAL"])
+agent = trial / "agent"
+for rel in (
+    "hermes.txt",
+    "hermes-session.jsonl",
+    "trajectory.json",
+    "nemo-flow-atof/events.jsonl",
+    "nemo-flow-atof-atif/trajectory.json",
+    "nemo-flow-sidecar-atif/trajectory.json",
+):
+    path = agent / rel
+    if not path.exists():
+        raise SystemExit(f"Missing {path}")
+    print("ok", rel, path.stat().st_size)
+
+for rel in ("trajectory.json", "nemo-flow-atof-atif/trajectory.json"):
+    samples = load_atif_samples(agent / rel)
+    trajectory = samples[0].trajectory
+    data = json.loads((agent / rel).read_text())
+    metrics = data.get("final_metrics") or {}
+    print(rel, trajectory.schema_version, len(trajectory.steps), metrics)
+
+print("atof_events", sum(1 for _ in (agent / "nemo-flow-atof/events.jsonl").open()))
+PY
+```
+
+Compare the native and ATOF-derived tool sequences:
+
+```bash
+.venv/bin/python -m nat_harbor.smoke.compare_atif_tools \
+  --native "$TRIAL/agent/trajectory.json" \
+  --candidate "$TRIAL/agent/nemo-flow-atof-atif/trajectory.json"
+```
+
+The deterministic comparison should be `match (same)` or `match (richer)` for a
+healthy ATOF-derived trajectory.
+
+## Post-Run Trajectory Scoring
+
+Run the scorer without LLM calls first:
+
+```bash
+.venv/bin/python -m nat_harbor.smoke.score_atif_trajectories \
+  --job-dir "$HARBOR_JOBS_DIR/$JOB_NAME" \
+  --candidate-rel agent/nemo-flow-atof-atif/trajectory.json \
+  --output-dir "$HARBOR_JOBS_DIR/$JOB_NAME/post-run-scores" \
+  --no-llm
+```
+
+Run the LLM scoring pass with an OpenAI-compatible judge endpoint:
+
+```bash
+set -a
+. .tmp/harbor/secrets/nvidia.env
+set +a
+
+export OPENAI_API_KEY="$NVIDIA_API_KEY"
+export OPENAI_BASE_URL="$NVIDIA_BASE_URL"
+export NAT_HARBOR_TRAJECTORY_JUDGE_MODEL=<openai-compatible-judge-model>
+
+.venv/bin/python -m nat_harbor.smoke.score_atif_trajectories \
+  --job-dir "$HARBOR_JOBS_DIR/$JOB_NAME" \
+  --candidate-rel agent/nemo-flow-atof-atif/trajectory.json \
+  --output-dir "$HARBOR_JOBS_DIR/$JOB_NAME/post-run-llm-scores" \
+  --config-file packages/nvidia_nat_harbor/configs/opencode-nemoflow-trajectory-eval.yml \
+  --evaluator-name trajectory_eval \
+  --score-timeout-sec 45
+```
+
+## Phoenix Inspection
+
+If Phoenix is running locally at `http://localhost:6006`, export the two ATIF
+artifacts to separate projects:
+
+```bash
+ENDPOINT=http://localhost:6006/v1/traces
+
+.venv/bin/python -m nat.plugins.phoenix.scripts.export_trajectory_to_phoenix.export_atif_trajectory_to_phoenix \
+  "$TRIAL/agent/trajectory.json" \
+  --endpoint "$ENDPOINT" \
+  --project harbor-hermes-native
+
+.venv/bin/python -m nat.plugins.phoenix.scripts.export_trajectory_to_phoenix.export_atif_trajectory_to_phoenix \
+  "$TRIAL/agent/nemo-flow-atof-atif/trajectory.json" \
+  --endpoint "$ENDPOINT" \
+  --project harbor-hermes-nemoflow-atof
+```
+
+Open `http://localhost:6006` and compare the two projects.
+
+## Known Limitations
+
+- The wrapper builds `nemo-flow-sidecar` inside each Harbor task container, so
+  the first run is slow.
+- The smoke requires a NeMo-Flow sidecar branch that supports raw ATOF JSONL
+  export. Older sidecar-only branches can still write direct ATIF, but they do
+  not exercise the same ATOF-to-ATIF validation pass as OpenCode.
+- Complete LLM lifecycle telemetry requires Hermes model traffic to use the
+  sidecar gateway. This wrapper configures that path for `nvidia`, `openai`,
+  `openrouter`, and `anthropic` model prefixes.
+- The upstream Hermes native middleware path remains a later comparison lane.

--- a/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
+++ b/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
@@ -25,7 +25,7 @@ is available.
 The validation pass can use two NeMo-Flow sidecar artifacts:
 
 - Direct gateway ATIF from the existing `--atif-dir` path.
-- Raw ATOF JSONL from the PR #89 observability plugin, converted to ATIF with
+- Raw ATOF JSONL from the NeMo-Flow observability plugin, converted to ATIF with
   the NeMo Agent Toolkit ATOF-to-ATIF converter.
 
 The ATOF-derived ATIF is the primary NeMo-Flow comparison target for this pass.
@@ -64,14 +64,14 @@ One Hermes run emits these trajectory artifacts:
 - Native path: Hermes session export -> Harbor Hermes adapter ->
   `agent/trajectory.json`. This is Harbor's native Hermes trajectory and is
   produced independently of the NeMo-Flow gateway.
-- ATOF-derived ATIF: PR #89 plugin ATOF export writes
+- ATOF-derived ATIF: NeMo-Flow observability plugin ATOF export writes
   `agent/nemo-flow-atof/events.jsonl`, then the Toolkit converter writes
   `agent/nemo-flow-atof-atif/trajectory.json`. This is the primary NeMo-Flow
   comparison target.
 - Gateway-emitted ATIF: Hermes hooks and routed model traffic -> NeMo-Flow CLI
   gateway -> `agent/nemo-flow-gateway-atif/trajectory.json`. This is the legacy
   direct-ATIF baseline.
-- Plugin direct ATIF: PR #89 plugin ATIF export ->
+- Plugin direct ATIF: NeMo-Flow observability plugin ATIF export ->
   `agent/nemo-flow-plugin-atif/trajectory.json`. This is a secondary debugging
   artifact for comparing plugin direct ATIF against legacy direct ATIF.
 <!-- path-check-skip-end -->
@@ -82,10 +82,10 @@ One Hermes run emits these trajectory artifacts:
 - The Toolkit is checked out to a branch containing
   `nat_harbor.agents.installed.hermes_nemoflow:HermesNeMoFlow`.
 - Harbor is installed from the source branch used by the Harbor integration.
-- NeMo-Flow is checked out to a revision that contains PR #88, PR #89, and the
-  temporary sidecar bridge that activates `--plugin-config` in the CLI gateway.
-  The published binary is `nemo-flow`, the published Cargo package is
-  `nemo-flow-cli`, and Hermes gateway ATIF export uses `--atif-dir`.
+- NeMo-Flow `>= v0.2` is checked out. This version requirement covers CLI ATOF
+  export, observability plugin activation through `--plugin-config`, and direct
+  gateway ATIF export through `--atif-dir`. The published binary is
+  `nemo-flow`, and the published Cargo package is `nemo-flow-cli`.
 
 <!-- path-check-skip-begin -->
 ```bash
@@ -101,10 +101,11 @@ if [ ! -d external/nemo-flow/.git ]; then
   git clone https://github.com/NVIDIA/NeMo-Flow.git external/nemo-flow
 fi
 git -C external/nemo-flow fetch origin
-git -C external/nemo-flow checkout bbednarski/validate-pr89-sidecar-plugin-bridge
+git -C external/nemo-flow checkout "${NEMO_FLOW_REF:-main}"
 ```
 
-If the temporary bridge branch is in your working NeMo-Flow checkout instead of
+Set `NEMO_FLOW_REF` to a NeMo-Flow `v0.2` or newer release tag, branch, or
+commit when you do not want to use `main`. If your `>= v0.2` checkout is outside
 `external/nemo-flow`, point `NEMO_FLOW_REPO` at that checkout in the build step
 below.
 
@@ -537,9 +538,9 @@ schema-valid for the Toolkit.
   default 360 second agent setup timeout before Hermes starts. If the trial log
   stops at the NeMo-Flow CLI build command, no model endpoint has been reached
   yet. The prebuilt image avoids that trial-startup cost.
-- The ATOF path requires a NeMo-Flow branch that activates PR #89 plugin config
-  in the CLI gateway. The `enable_nemoflow_observability_plugin=true` smoke
-  should require `agent/nemo-flow-atof/events.jsonl`; use
+- The ATOF path requires NeMo-Flow `>= v0.2` observability plugin activation in
+  the CLI gateway. The `enable_nemoflow_observability_plugin=true` smoke should
+  require `agent/nemo-flow-atof/events.jsonl`; use
   `fail_missing_nemoflow_atof=false` only when running against older
   direct-ATIF-only gateway branches.
 - The Toolkit ATOF-to-ATIF conversion is initially best-effort in this smoke

--- a/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
+++ b/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
@@ -18,13 +18,27 @@ limitations under the License.
 # Hermes NeMo-Flow Harbor Smoke
 
 This developer workflow runs Hermes Agent on one Harbor SWE-bench task with the
-NeMo-Flow sidecar enabled. It validates the first available non-patching Hermes
-instrumentation path before the upstream Hermes native middleware path is
-available.
+NeMo-Flow CLI gateway enabled. It validates the first available non-patching
+Hermes instrumentation path before the upstream Hermes native middleware path
+is available.
 
-The validation pass intentionally matches the OpenCode smoke: NeMo-Flow writes
-raw ATOF JSONL, NAT converts that ATOF stream to ATIF after the run, and the
-converted trajectory is compared against Harbor's native Hermes ATIF.
+The validation pass currently relies on the gateway-emitted ATIF artifact. PR
+#88 adds native ATOF JSONL exporter APIs to NeMo-Flow, but the Hermes CLI
+gateway path still does not expose a raw ATOF JSONL artifact from `nemo-flow
+run`/`hook-forward`. For this first SWE-bench smoke, skip the ATOF-derived
+validation path and compare the native Hermes ATIF directly against the
+gateway-emitted NeMo-Flow ATIF.
+
+## TODO: Config-Based ATOF Export
+
+Follow up once NeMo-Flow exposes configuration-based CLI exporter registration
+for the gateway, for example through a project/user/global `plugin.toml` or
+`plugins.toml` file depending on the final schema. At that point, update this
+smoke to declare an ATOF exporter in the NeMo-Flow gateway configuration,
+require `agent/nemo-flow-atof/events.jsonl`, convert it to
+`agent/nemo-flow-atof-atif/trajectory.json`, and compare that ATOF-derived ATIF
+against the native Hermes ATIF. Until that lands, absence of
+`agent/nemo-flow-atof/events.jsonl` is expected.
 
 ## Pipeline
 
@@ -32,36 +46,37 @@ converted trajectory is compared against Harbor's native Hermes ATIF.
 flowchart TD
   task[SWE-bench task<br/>django__django-13741] --> harbor[Harbor trial<br/>Docker task environment]
 
-  harbor --> run[HermesNeMoFlow run<br/>nemo-flow-sidecar wrapper]
+  harbor --> run[HermesNeMoFlow run<br/>nemo-flow CLI gateway wrapper]
   run --> nativeSession[agent/hermes-session.jsonl<br/>Hermes native session export]
   nativeSession --> nativeAtif[agent/trajectory.json<br/>Harbor Hermes ATIF]
 
-  run --> sidecarHooks[Hermes hooks + sidecar gateway]
-  sidecarHooks --> atof[agent/nemo-flow-atof/events.jsonl<br/>raw ATOF stream]
-  atof --> converter[NAT ATOF-to-ATIF converter]
-  converter --> nfAtif[agent/nemo-flow-atof-atif/trajectory.json<br/>ATOF-derived ATIF]
-  sidecarHooks --> sidecarAtif[agent/nemo-flow-sidecar-atif/trajectory.json<br/>direct sidecar ATIF debug artifact]
+  run --> gatewayHooks[Hermes hooks + nemo-flow gateway]
+  gatewayHooks -. future CLI config .-> atof[agent/nemo-flow-atof/events.jsonl<br/>raw ATOF JSONL]
+  atof -. deferred .-> converter[NAT ATOF-to-ATIF converter]
+  converter -. deferred .-> nfAtif[agent/nemo-flow-atof-atif/trajectory.json<br/>ATOF-derived ATIF]
+  gatewayHooks --> gatewayAtif[agent/nemo-flow-gateway-atif/trajectory.json<br/>canonical gateway-emitted ATIF]
 
   harbor --> swe[SWE-bench verifier<br/>patch + task tests]
   swe --> result[result.json<br/>reward/resolved]
 
   nativeAtif --> compare[Trajectory comparison<br/>tool sequence + NAT evaluators + Phoenix]
-  nfAtif --> compare
+  gatewayAtif --> compare
   result --> outcome[Outcome sanity check<br/>successful/resolved run]
 ```
 
-One Hermes run emits three trajectory artifacts:
+One Hermes run emits two trajectory artifacts today, with a third deferred:
 
 - Native path: Hermes session export -> Harbor Hermes adapter ->
   `agent/trajectory.json`. This is Harbor's native Hermes trajectory and is
-  produced independently of the NeMo-Flow sidecar.
-- NeMo-Flow path: Hermes hooks and routed model traffic -> raw ATOF JSONL ->
-  NAT ATOF-to-ATIF converter -> `agent/nemo-flow-atof-atif/trajectory.json`.
-- Direct sidecar ATIF remains available at
-  `agent/nemo-flow-sidecar-atif/trajectory.json` as a secondary debugging
-  artifact. This is emitted directly by the sidecar ATIF exporter; it is not
-  produced by the ATOF-to-ATIF converter and is not the primary comparison
-  target.
+  produced independently of the NeMo-Flow gateway.
+- Gateway-emitted ATIF: Hermes hooks and routed model traffic -> NeMo-Flow CLI
+  gateway -> `agent/nemo-flow-gateway-atif/trajectory.json`. This is the
+  canonical NeMo-Flow trajectory artifact and is the primary comparison target.
+- ATOF-derived ATIF (TODO): once NeMo-Flow supports configuration-based ATOF
+  exporter registration for CLI gateway sessions, raw events should land at
+  `agent/nemo-flow-atof/events.jsonl` and the NAT ATOF-to-ATIF converter should
+  populate `agent/nemo-flow-atof-atif/trajectory.json`. This path is not part
+  of the current first-sample validation.
 
 ## Prerequisites
 
@@ -69,8 +84,10 @@ One Hermes run emits three trajectory artifacts:
 - NAT is checked out to a branch containing
   `nat_harbor.agents.installed.hermes_nemoflow:HermesNeMoFlow`.
 - Harbor is installed from the source branch used by the Harbor integration.
-- NeMo-Flow is checked out to a branch containing `nemo-flow-sidecar` with
-  Hermes support and raw ATOF JSONL export support.
+- NeMo-Flow is checked out to a revision that contains the renamed
+  `crates/cli` crate and PR #88. The published binary is `nemo-flow`, the
+  published Cargo package is `nemo-flow-cli`, and Hermes gateway ATIF export
+  uses `--atif-dir`.
 
 <!-- path-check-skip-begin -->
 ```bash
@@ -83,10 +100,10 @@ git -C external/harbor fetch origin
 git -C external/harbor checkout ak-harbor-libary-mode
 
 if [ ! -d external/nemo-flow/.git ]; then
-  git clone https://github.com/willkill07/NeMo-Flow.git external/nemo-flow
+  git clone https://github.com/NVIDIA/NeMo-Flow.git external/nemo-flow
 fi
 git -C external/nemo-flow fetch origin
-git -C external/nemo-flow checkout wkk_coding-agent-sidecar-integrations
+git -C external/nemo-flow checkout main
 ```
 
 The SWE-bench smoke task should exist at:
@@ -162,21 +179,28 @@ set +a
   --env docker \
   --model nvidia/opus-frontier \
   --ak nemo_flow_repo="$NEMO_FLOW_REPO" \
-  --ak fail_missing_nemoflow_atof=true \
-  --ak fail_missing_nemoflow_atif=false
+  --ak fail_missing_nemoflow_atof=false \
+  --ak fail_missing_nemoflow_atif=true
 ```
 
-Expected artifacts under the trial directory:
+Expected artifacts under the trial directory (today, against current
+NeMo-Flow main):
 
 ```text
 agent/hermes.txt
 agent/hermes-session.jsonl
 agent/trajectory.json
-agent/nemo-flow-atof/events.jsonl
-agent/nemo-flow-atof-atif/trajectory.json
-agent/nemo-flow-sidecar-atif/trajectory.json
+agent/nemo-flow-gateway-atif/trajectory.json
 result.json
 verifier/report.json
+```
+
+After the config-based NeMo-Flow CLI ATOF exporter follow-up, these artifacts
+should also appear:
+
+```text
+agent/nemo-flow-atof/events.jsonl
+agent/nemo-flow-atof-atif/trajectory.json
 ```
 
 ## Quick Artifact Check
@@ -203,40 +227,52 @@ from nat_harbor.verifier.evaluator_adapter import load_atif_samples
 
 trial = Path(os.environ["TRIAL"])
 agent = trial / "agent"
-for rel in (
+required = (
     "hermes.txt",
     "hermes-session.jsonl",
     "trajectory.json",
+    "nemo-flow-gateway-atif/trajectory.json",
+)
+optional = (
     "nemo-flow-atof/events.jsonl",
     "nemo-flow-atof-atif/trajectory.json",
-    "nemo-flow-sidecar-atif/trajectory.json",
-):
+)
+for rel in required:
     path = agent / rel
     if not path.exists():
         raise SystemExit(f"Missing {path}")
     print("ok", rel, path.stat().st_size)
+for rel in optional:
+    path = agent / rel
+    if path.exists():
+        print("ok (optional)", rel, path.stat().st_size)
+    else:
+        print("absent (deferred)", rel)
 
-for rel in ("trajectory.json", "nemo-flow-atof-atif/trajectory.json"):
+for rel in ("trajectory.json", "nemo-flow-gateway-atif/trajectory.json"):
     samples = load_atif_samples(agent / rel)
     trajectory = samples[0].trajectory
     data = json.loads((agent / rel).read_text())
     metrics = data.get("final_metrics") or {}
     print(rel, trajectory.schema_version, len(trajectory.steps), metrics)
 
-print("atof_events", sum(1 for _ in (agent / "nemo-flow-atof/events.jsonl").open()))
+atof_path = agent / "nemo-flow-atof/events.jsonl"
+if atof_path.exists():
+    print("atof_events", sum(1 for _ in atof_path.open()))
 PY
 ```
 
-Compare the native and ATOF-derived tool sequences:
+Compare the native and gateway-emitted tool sequences:
 
 ```bash
 .venv/bin/python -m nat_harbor.smoke.compare_atif_tools \
   --native "$TRIAL/agent/trajectory.json" \
-  --candidate "$TRIAL/agent/nemo-flow-atof-atif/trajectory.json"
+  --candidate "$TRIAL/agent/nemo-flow-gateway-atif/trajectory.json"
 ```
 
 The deterministic comparison should be `match (same)` or `match (richer)` for a
-healthy ATOF-derived trajectory.
+healthy gateway-emitted trajectory. Do not require the deferred ATOF-derived
+comparison for this first SWE-bench sample.
 
 ## Post-Run Trajectory Scoring
 
@@ -245,7 +281,7 @@ Run the scorer without LLM calls first:
 ```bash
 .venv/bin/python -m nat_harbor.smoke.score_atif_trajectories \
   --job-dir "$HARBOR_JOBS_DIR/$JOB_NAME" \
-  --candidate-rel agent/nemo-flow-atof-atif/trajectory.json \
+  --candidate-rel agent/nemo-flow-gateway-atif/trajectory.json \
   --output-dir "$HARBOR_JOBS_DIR/$JOB_NAME/post-run-scores" \
   --no-llm
 ```
@@ -263,7 +299,7 @@ export NAT_HARBOR_TRAJECTORY_JUDGE_MODEL=<openai-compatible-judge-model>
 
 .venv/bin/python -m nat_harbor.smoke.score_atif_trajectories \
   --job-dir "$HARBOR_JOBS_DIR/$JOB_NAME" \
-  --candidate-rel agent/nemo-flow-atof-atif/trajectory.json \
+  --candidate-rel agent/nemo-flow-gateway-atif/trajectory.json \
   --output-dir "$HARBOR_JOBS_DIR/$JOB_NAME/post-run-llm-scores" \
   --config-file packages/nvidia_nat_harbor/configs/opencode-nemoflow-trajectory-eval.yml \
   --evaluator-name trajectory_eval \
@@ -284,21 +320,26 @@ ENDPOINT=http://localhost:6006/v1/traces
   --project harbor-hermes-native
 
 .venv/bin/python -m nat.plugins.phoenix.scripts.export_trajectory_to_phoenix.export_atif_trajectory_to_phoenix \
-  "$TRIAL/agent/nemo-flow-atof-atif/trajectory.json" \
+  "$TRIAL/agent/nemo-flow-gateway-atif/trajectory.json" \
   --endpoint "$ENDPOINT" \
-  --project harbor-hermes-nemoflow-atof
+  --project harbor-hermes-nemoflow-gateway
 ```
 
 Open `http://localhost:6006` and compare the two projects.
 
 ## Known Limitations
 
-- The wrapper builds `nemo-flow-sidecar` inside each Harbor task container, so
-  the first run is slow.
-- The smoke requires a NeMo-Flow sidecar branch that supports raw ATOF JSONL
-  export. Older sidecar-only branches can still write direct ATIF, but they do
-  not exercise the same ATOF-to-ATIF validation pass as OpenCode.
+- The wrapper builds `nemo-flow-cli` (binary `nemo-flow`) inside each Harbor
+  task container, so the first run is slow.
+- PR #88 adds native ATOF JSONL exporter APIs, but the Hermes CLI gateway path
+  does not yet expose a raw ATOF JSONL artifact through configuration. The
+  wrapper keeps the ATOF code path best-effort
+  (`fail_missing_nemoflow_atof=false`), so today's runs validate the
+  gateway-emitted ATIF and skip the ATOF-derived comparison performed by the
+  OpenCode smoke. TODO: when NeMo-Flow lands configuration-based CLI ATOF
+  exporter registration, add that gateway config to this smoke and flip
+  `fail_missing_nemoflow_atof=true` to re-enable strict validation.
 - Complete LLM lifecycle telemetry requires Hermes model traffic to use the
-  sidecar gateway. This wrapper configures that path for `nvidia`, `openai`,
+  NeMo-Flow gateway. This wrapper configures that path for `nvidia`, `openai`,
   `openrouter`, and `anthropic` model prefixes.
 - The upstream Hermes native middleware path remains a later comparison lane.

--- a/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
+++ b/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
@@ -22,23 +22,15 @@ NeMo-Flow CLI gateway enabled. It validates the first available non-patching
 Hermes instrumentation path before the upstream Hermes native middleware path
 is available.
 
-The validation pass currently relies on the gateway-emitted ATIF artifact. PR
-#88 adds native ATOF JSONL exporter APIs to NeMo-Flow, but the Hermes CLI
-gateway path still does not expose a raw ATOF JSONL artifact from `nemo-flow
-run`/`hook-forward`. For this first SWE-bench smoke, skip the ATOF-derived
-validation path and compare the native Hermes ATIF directly against the
-gateway-emitted NeMo-Flow ATIF.
+The validation pass can use two NeMo-Flow sidecar artifacts:
 
-## TODO: Config-Based ATOF Export
+- Direct gateway ATIF from the existing `--atif-dir` path.
+- Raw ATOF JSONL from the PR #89 observability plugin, converted to ATIF with
+  the NAT ATOF-to-ATIF converter.
 
-Follow up once NeMo-Flow exposes configuration-based CLI exporter registration
-for the gateway, for example through a project/user/global `plugin.toml` or
-`plugins.toml` file depending on the final schema. At that point, update this
-smoke to declare an ATOF exporter in the NeMo-Flow gateway configuration,
-require `agent/nemo-flow-atof/events.jsonl`, convert it to
-`agent/nemo-flow-atof-atif/trajectory.json`, and compare that ATOF-derived ATIF
-against the native Hermes ATIF. Until that lands, absence of
-`agent/nemo-flow-atof/events.jsonl` is expected.
+The ATOF-derived ATIF is the primary NeMo-Flow comparison target for this pass.
+The direct gateway ATIF remains useful as a baseline while we validate whether
+raw event reconstruction fixes the earlier direct-ATIF inconsistencies.
 
 ## Pipeline
 
@@ -51,32 +43,36 @@ flowchart TD
   nativeSession --> nativeAtif[agent/trajectory.json<br/>Harbor Hermes ATIF]
 
   run --> gatewayHooks[Hermes hooks + nemo-flow gateway]
-  gatewayHooks -. future CLI config .-> atof[agent/nemo-flow-atof/events.jsonl<br/>raw ATOF JSONL]
-  atof -. deferred .-> converter[NAT ATOF-to-ATIF converter]
-  converter -. deferred .-> nfAtif[agent/nemo-flow-atof-atif/trajectory.json<br/>ATOF-derived ATIF]
-  gatewayHooks --> gatewayAtif[agent/nemo-flow-gateway-atif/trajectory.json<br/>canonical gateway-emitted ATIF]
+  gatewayHooks --> atof[agent/nemo-flow-atof/events.jsonl<br/>raw ATOF JSONL]
+  atof --> converter[NAT ATOF-to-ATIF converter]
+  converter --> nfAtif[agent/nemo-flow-atof-atif/trajectory.json<br/>ATOF-derived ATIF]
+  gatewayHooks --> gatewayAtif[agent/nemo-flow-gateway-atif/trajectory.json<br/>legacy gateway-emitted ATIF]
+  gatewayHooks --> pluginAtif[agent/nemo-flow-plugin-atif/trajectory.json<br/>plugin direct ATIF]
 
   harbor --> swe[SWE-bench verifier<br/>patch + task tests]
   swe --> result[result.json<br/>reward/resolved]
 
   nativeAtif --> compare[Trajectory comparison<br/>tool sequence + NAT evaluators + Phoenix]
-  gatewayAtif --> compare
+  nfAtif --> compare
+  gatewayAtif -. baseline .-> compare
   result --> outcome[Outcome sanity check<br/>successful/resolved run]
 ```
 
-One Hermes run emits two trajectory artifacts today, with a third deferred:
+One Hermes run emits these trajectory artifacts:
 
 - Native path: Hermes session export -> Harbor Hermes adapter ->
   `agent/trajectory.json`. This is Harbor's native Hermes trajectory and is
   produced independently of the NeMo-Flow gateway.
+- ATOF-derived ATIF: PR #89 plugin ATOF export writes
+  `agent/nemo-flow-atof/events.jsonl`, then the NAT converter writes
+  `agent/nemo-flow-atof-atif/trajectory.json`. This is the primary NeMo-Flow
+  comparison target.
 - Gateway-emitted ATIF: Hermes hooks and routed model traffic -> NeMo-Flow CLI
-  gateway -> `agent/nemo-flow-gateway-atif/trajectory.json`. This is the
-  canonical NeMo-Flow trajectory artifact and is the primary comparison target.
-- ATOF-derived ATIF (TODO): once NeMo-Flow supports configuration-based ATOF
-  exporter registration for CLI gateway sessions, raw events should land at
-  `agent/nemo-flow-atof/events.jsonl` and the NAT ATOF-to-ATIF converter should
-  populate `agent/nemo-flow-atof-atif/trajectory.json`. This path is not part
-  of the current first-sample validation.
+  gateway -> `agent/nemo-flow-gateway-atif/trajectory.json`. This is the legacy
+  direct-ATIF baseline.
+- Plugin direct ATIF: PR #89 plugin ATIF export ->
+  `agent/nemo-flow-plugin-atif/trajectory.json`. This is a secondary debugging
+  artifact for comparing plugin direct ATIF against legacy direct ATIF.
 
 ## Prerequisites
 
@@ -84,10 +80,10 @@ One Hermes run emits two trajectory artifacts today, with a third deferred:
 - NAT is checked out to a branch containing
   `nat_harbor.agents.installed.hermes_nemoflow:HermesNeMoFlow`.
 - Harbor is installed from the source branch used by the Harbor integration.
-- NeMo-Flow is checked out to a revision that contains the renamed
-  `crates/cli` crate and PR #88. The published binary is `nemo-flow`, the
-  published Cargo package is `nemo-flow-cli`, and Hermes gateway ATIF export
-  uses `--atif-dir`.
+- NeMo-Flow is checked out to a revision that contains PR #88, PR #89, and the
+  temporary sidecar bridge that activates `--plugin-config` in the CLI gateway.
+  The published binary is `nemo-flow`, the published Cargo package is
+  `nemo-flow-cli`, and Hermes gateway ATIF export uses `--atif-dir`.
 
 <!-- path-check-skip-begin -->
 ```bash
@@ -103,8 +99,12 @@ if [ ! -d external/nemo-flow/.git ]; then
   git clone https://github.com/NVIDIA/NeMo-Flow.git external/nemo-flow
 fi
 git -C external/nemo-flow fetch origin
-git -C external/nemo-flow checkout main
+git -C external/nemo-flow checkout bbednarski/validate-pr89-sidecar-plugin-bridge
 ```
+
+If the temporary bridge branch is in your working NeMo-Flow checkout instead of
+`external/nemo-flow`, point `NEMO_FLOW_REPO` at that checkout in the build step
+below.
 
 The SWE-bench smoke task should exist at:
 
@@ -134,11 +134,153 @@ uv pip install -e external/harbor
 ```
 <!-- path-check-skip-end -->
 
-`NVIDIA_BASE_URL` should point at the OpenAI-compatible NVIDIA endpoint used
-for this smoke.
+## Build the Prebuilt Image
+
+For local SWE-bench validation, build a task image that already contains the
+`nemo-flow` CLI. This keeps Harbor agent setup focused on Hermes startup and
+runtime validation instead of cold-compiling Rust inside the trial container.
+
+The measured cold build on an Apple Silicon workstation was:
+
+- Prebuilt Docker image build: 2m04s wall time.
+- NeMo-Flow CLI compile layer: 1m17s inside that build.
+- Warm rebuild with Docker cache: under 1s.
+- Exported local image size: approximately 1.76 GB.
+- Previous cold in-agent compile: exceeded Harbor's default 360s setup timeout
+  before Hermes started.
+- Prebuilt-image Harbor startup check: environment setup completed in about 1s,
+  agent setup completed in about 3m28s, and the run reached `nemo-flow run`.
+  That remaining setup time is primarily Hermes installation.
+
+Use a minimal build context so Docker does not send the local NeMo-Flow
+`target/` directory.
 
 ```bash
-export NVIDIA_BASE_URL=<openai-compatible-nvidia-base-url>
+export NEMO_FLOW_REPO="$PWD/external/nemo-flow"
+export NEMO_FLOW_SHA
+NEMO_FLOW_SHA=$(git -C "$NEMO_FLOW_REPO" rev-parse --short HEAD)
+export PREBUILT_NEMO_FLOW_IMAGE="hermes-nemoflow-django13741:${NEMO_FLOW_SHA}"
+export PREBUILT_CONTEXT=.tmp/harbor/nemo-flow-prebuilt-context
+
+rm -rf "$PREBUILT_CONTEXT"
+mkdir -p "$PREBUILT_CONTEXT"
+cp "$NEMO_FLOW_REPO"/Cargo.toml \
+  "$NEMO_FLOW_REPO"/Cargo.lock \
+  "$NEMO_FLOW_REPO"/rust-toolchain.toml \
+  "$PREBUILT_CONTEXT"/
+cp -R "$NEMO_FLOW_REPO"/crates "$PREBUILT_CONTEXT"/
+```
+
+Create the prebuilt-image Dockerfile:
+
+```bash
+cat > .tmp/harbor/nemo-flow-prebuilt.Dockerfile <<'EOF'
+FROM swebench/sweb.eval.x86_64.django_1776_django-13741:latest
+
+WORKDIR /testbed
+RUN curl -LsSf https://astral.sh/uv/0.7.13/install.sh | sh
+RUN mkdir -p /logs
+
+WORKDIR /opt/nemo-flow
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        pkg-config \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY Cargo.toml Cargo.lock rust-toolchain.toml ./
+COPY crates ./crates
+
+RUN set -eux; \
+    if ! command -v cargo >/dev/null 2>&1; then \
+        curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | \
+        sh -s -- -y --profile minimal; \
+    fi; \
+    . "$HOME/.cargo/env"; \
+    cargo build -p nemo-flow-cli --release; \
+    install -m 0755 target/release/nemo-flow /usr/local/bin/nemo-flow; \
+    nemo-flow --help >/dev/null; \
+    nemo-flow run --help | grep -q -- '--atif-dir'; \
+    nemo-flow run --help | grep -q -- '--plugin-config'; \
+    nemo-flow hook-forward --help | grep -q -- '--atif-dir'
+
+WORKDIR /testbed
+EOF
+```
+
+Build and validate the image:
+
+```bash
+/usr/bin/time -p docker build \
+  --platform linux/amd64 \
+  -f .tmp/harbor/nemo-flow-prebuilt.Dockerfile \
+  -t "$PREBUILT_NEMO_FLOW_IMAGE" \
+  "$PREBUILT_CONTEXT"
+
+docker run --rm --platform linux/amd64 "$PREBUILT_NEMO_FLOW_IMAGE" \
+  bash -lc 'command -v nemo-flow && nemo-flow run --help | grep -q -- --atif-dir && nemo-flow run --help | grep -q -- --plugin-config'
+```
+
+Create a prebuilt-image copy of the SWE-bench task by adding
+`docker_image = "$PREBUILT_NEMO_FLOW_IMAGE"` to its `[environment]` section.
+
+```bash
+export SOURCE_SWEBENCH_TASK=external/harbor/datasets/swebench-opencode-smoke/django__django-13741
+export SWEBENCH_TASK=.tmp/harbor/datasets/swebench-hermes-nemoflow-prebuilt/django__django-13741
+
+rm -rf "$SWEBENCH_TASK"
+mkdir -p "$(dirname "$SWEBENCH_TASK")"
+cp -R "$SOURCE_SWEBENCH_TASK" "$SWEBENCH_TASK"
+
+.venv/bin/python - <<'PY'
+import os
+from pathlib import Path
+
+task = Path(os.environ["SWEBENCH_TASK"]) / "task.toml"
+image = os.environ["PREBUILT_NEMO_FLOW_IMAGE"]
+text = task.read_text()
+if "docker_image =" not in text:
+    text = text.replace("[environment]\n", f'[environment]\ndocker_image = "{image}"\n', 1)
+else:
+    lines = [
+        f'docker_image = "{image}"' if line.startswith("docker_image = ") else line
+        for line in text.splitlines()
+    ]
+    text = "\n".join(lines) + "\n"
+task.write_text(text)
+PY
+```
+
+This smoke can use a local Ollama model through its OpenAI-compatible endpoint.
+When the agent runs inside Docker on macOS, point the container at the host via
+`host.docker.internal`. Use the provider root here, not `/v1`; the NeMo-Flow
+gateway appends the incoming OpenAI path before forwarding upstream.
+
+```bash
+export OPENAI_BASE_URL=http://host.docker.internal:11434
+export OPENAI_API_KEY=ollama
+```
+
+The model must also be present in the Ollama `/v1/models` response. This smoke
+uses `openai/qwen3.6:35b`; the `openai/` prefix selects the Harbor OpenAI
+provider route and the upstream Ollama model ID remains `qwen3.6:35b`.
+
+Side note: if Ollama is not already serving this model, start it from another
+terminal before running Harbor. Binding to `0.0.0.0` makes the endpoint
+reachable from Docker containers through `host.docker.internal`.
+
+```bash
+ollama pull qwen3.6:35b
+OLLAMA_HOST=0.0.0.0:11434 ollama serve
+```
+
+In a separate terminal, warm the model and validate host-side IO:
+
+```bash
+ollama run qwen3.6:35b "Reply with exactly: ok"
+curl http://localhost:11434/v1/models
 ```
 
 ## Run the Smoke
@@ -149,10 +291,9 @@ file.
 <!-- path-check-skip-begin -->
 ```bash
 mkdir -p .tmp/harbor/secrets
-read -rsp 'NVIDIA_API_KEY: ' NVIDIA_API_KEY; echo
-cat > .tmp/harbor/secrets/nvidia.env <<EOF
-NVIDIA_API_KEY=${NVIDIA_API_KEY}
-NVIDIA_BASE_URL=${NVIDIA_BASE_URL}
+cat > .tmp/harbor/secrets/ollama.env <<EOF
+OPENAI_API_KEY=${OPENAI_API_KEY}
+OPENAI_BASE_URL=${OPENAI_BASE_URL}
 EOF
 ```
 
@@ -160,12 +301,11 @@ Run the NeMo-Flow-enabled Hermes smoke:
 
 ```bash
 export HARBOR_JOBS_DIR=.tmp/harbor/hermes-nemoflow-smoke
-export SWEBENCH_TASK=external/harbor/datasets/swebench-opencode-smoke/django__django-13741
-export NEMO_FLOW_REPO="$PWD/external/nemo-flow"
+export SWEBENCH_TASK=.tmp/harbor/datasets/swebench-hermes-nemoflow-prebuilt/django__django-13741
 export JOB_NAME=hermes-nemoflow-repeatable-smoke-1
 
 set -a
-. .tmp/harbor/secrets/nvidia.env
+. .tmp/harbor/secrets/ollama.env
 set +a
 
 .venv/bin/harbor run \
@@ -173,34 +313,54 @@ set +a
   -l 1 \
   --job-name "$JOB_NAME" \
   --jobs-dir "$HARBOR_JOBS_DIR" \
-  --yes -n 1 --max-retries 0 \
-  --env-file .tmp/harbor/secrets/nvidia.env \
+  --yes -n 1 --max-retries 0 --no-delete \
+  --env-file .tmp/harbor/secrets/ollama.env \
   --agent-import-path nat_harbor.agents.installed.hermes_nemoflow:HermesNeMoFlow \
   --env docker \
-  --model nvidia/opus-frontier \
-  --ak nemo_flow_repo="$NEMO_FLOW_REPO" \
-  --ak fail_missing_nemoflow_atof=false \
-  --ak fail_missing_nemoflow_atif=true
+  --model openai/qwen3.6:35b \
+  --ak use_prebuilt_nemo_flow=true \
+  --ak enable_nemoflow_observability_plugin=true \
+  --ak fail_missing_nemoflow_atof=true \
+  --ak fail_missing_nemoflow_atif=true \
+  --ak fail_nemoflow_atof_conversion=false
 ```
 
-Expected artifacts under the trial directory (today, against current
-NeMo-Flow main):
+Expected artifacts under the trial directory:
 
 ```text
 agent/hermes.txt
 agent/hermes-session.jsonl
 agent/trajectory.json
 agent/nemo-flow-gateway-atif/trajectory.json
+agent/nemo-flow-plugin-atif/trajectory.json
+agent/nemo-flow-atof/events.jsonl
+agent/nemo-flow-atof-atif/trajectory.json
 result.json
 verifier/report.json
 ```
 
-After the config-based NeMo-Flow CLI ATOF exporter follow-up, these artifacts
-should also appear:
+## Example Trajectories From Previous Run
+
+Reference run:
+
+```text
+.tmp/harbor/hermes-nemoflow-smoke/hermes-nemoflow-pr89-plugin-atof-smoke-20260512-145959/django__django-13741__7dQBUQM
+```
+
+The run completed with `reward=1.0`, `0` exceptions, and an exact native vs
+ATOF-derived tool-sequence match.
+
+| Artifact | Path | Status from run |
+| --- | --- | --- |
+| Native Hermes ATIF | `agent/trajectory.json` | Valid NAT ATIF, `ATIF-v1.2`, 30 steps. |
+| NeMo-Flow ATOF-derived ATIF | `agent/nemo-flow-atof-atif/trajectory.json` | Valid NAT ATIF, `ATIF-v1.7`, 33 steps. Primary comparison target. |
+| NeMo-Flow gateway direct ATIF | `agent/nemo-flow-gateway-atif/trajectory.json` | Emitted, but not strict NAT-schema-valid yet because direct exporter messages contain raw OpenAI payloads. Diagnostic baseline only. |
+| NeMo-Flow plugin direct ATIF | `agent/nemo-flow-plugin-atif/trajectory.json` | Emitted, but has the same direct-exporter message-shape issue as gateway direct ATIF. Diagnostic baseline only. |
+
+The raw ATOF reference for the same run is:
 
 ```text
 agent/nemo-flow-atof/events.jsonl
-agent/nemo-flow-atof-atif/trajectory.json
 ```
 
 ## Quick Artifact Check
@@ -215,7 +375,9 @@ TRIAL=$(find "$HARBOR_JOBS_DIR/$JOB_NAME" -maxdepth 1 -type d -name 'django__dja
 test -n "$TRIAL"
 ```
 
-Check that both ATIF artifacts load and expose token totals:
+Check artifact presence and strict NAT ATIF parser compatibility. The direct
+gateway/plugin ATIF artifacts are still useful diagnostics, but may fail strict
+schema validation until direct-exporter message normalization is fixed.
 
 ```bash
 .venv/bin/python - <<'PY'
@@ -232,8 +394,7 @@ required = (
     "hermes-session.jsonl",
     "trajectory.json",
     "nemo-flow-gateway-atif/trajectory.json",
-)
-optional = (
+    "nemo-flow-plugin-atif/trajectory.json",
     "nemo-flow-atof/events.jsonl",
     "nemo-flow-atof-atif/trajectory.json",
 )
@@ -242,27 +403,40 @@ for rel in required:
     if not path.exists():
         raise SystemExit(f"Missing {path}")
     print("ok", rel, path.stat().st_size)
-for rel in optional:
-    path = agent / rel
-    if path.exists():
-        print("ok (optional)", rel, path.stat().st_size)
-    else:
-        print("absent (deferred)", rel)
 
-for rel in ("trajectory.json", "nemo-flow-gateway-atif/trajectory.json"):
-    samples = load_atif_samples(agent / rel)
-    trajectory = samples[0].trajectory
-    data = json.loads((agent / rel).read_text())
-    metrics = data.get("final_metrics") or {}
-    print(rel, trajectory.schema_version, len(trajectory.steps), metrics)
+for rel in (
+    "trajectory.json",
+    "nemo-flow-gateway-atif/trajectory.json",
+    "nemo-flow-plugin-atif/trajectory.json",
+    "nemo-flow-atof-atif/trajectory.json",
+):
+    path = agent / rel
+    data = json.loads(path.read_text())
+    try:
+        samples = load_atif_samples(path)
+        trajectory = samples[0].trajectory
+        metrics = data.get("final_metrics") or {}
+        print("valid", rel, trajectory.schema_version, len(trajectory.steps), metrics)
+    except Exception as exc:
+        steps = data.get("steps") or []
+        first_message_type = type((steps[0] or {}).get("message")).__name__ if steps else "missing"
+        print("invalid", rel, type(exc).__name__, len(steps), first_message_type)
 
 atof_path = agent / "nemo-flow-atof/events.jsonl"
-if atof_path.exists():
-    print("atof_events", sum(1 for _ in atof_path.open()))
+print("atof_events", sum(1 for _ in atof_path.open()))
 PY
 ```
 
-Compare the native and gateway-emitted tool sequences:
+Compare the native and ATOF-derived tool sequences:
+
+```bash
+.venv/bin/python -m nat_harbor.smoke.compare_atif_tools \
+  --native "$TRIAL/agent/trajectory.json" \
+  --candidate "$TRIAL/agent/nemo-flow-atof-atif/trajectory.json"
+```
+
+Also compare the native and direct gateway-emitted tool sequences as the
+baseline:
 
 ```bash
 .venv/bin/python -m nat_harbor.smoke.compare_atif_tools \
@@ -270,9 +444,19 @@ Compare the native and gateway-emitted tool sequences:
   --candidate "$TRIAL/agent/nemo-flow-gateway-atif/trajectory.json"
 ```
 
-The deterministic comparison should be `match (same)` or `match (richer)` for a
-healthy gateway-emitted trajectory. Do not require the deferred ATOF-derived
-comparison for this first SWE-bench sample.
+Compare plugin direct ATIF as a secondary diagnostic:
+
+```bash
+.venv/bin/python -m nat_harbor.smoke.compare_atif_tools \
+  --native "$TRIAL/agent/trajectory.json" \
+  --candidate "$TRIAL/agent/nemo-flow-plugin-atif/trajectory.json"
+```
+
+The ATOF-derived comparison is the primary check. If it is still missing tool
+semantics, inspect `agent/nemo-flow-atof/events.jsonl` before changing the ATIF
+exporter because the raw event stream will show whether the data was captured.
+Direct ATIF comparisons are diagnostic and are expected to be poorer until the
+direct exporter emits strict NAT-compatible ATIF messages.
 
 ## Post-Run Trajectory Scoring
 
@@ -281,7 +465,7 @@ Run the scorer without LLM calls first:
 ```bash
 .venv/bin/python -m nat_harbor.smoke.score_atif_trajectories \
   --job-dir "$HARBOR_JOBS_DIR/$JOB_NAME" \
-  --candidate-rel agent/nemo-flow-gateway-atif/trajectory.json \
+  --candidate-rel agent/nemo-flow-atof-atif/trajectory.json \
   --output-dir "$HARBOR_JOBS_DIR/$JOB_NAME/post-run-scores" \
   --no-llm
 ```
@@ -290,16 +474,16 @@ Run the LLM scoring pass with an OpenAI-compatible judge endpoint:
 
 ```bash
 set -a
-. .tmp/harbor/secrets/nvidia.env
+. .tmp/harbor/secrets/ollama.env
 set +a
 
-export OPENAI_API_KEY="$NVIDIA_API_KEY"
-export OPENAI_BASE_URL="$NVIDIA_BASE_URL"
-export NAT_HARBOR_TRAJECTORY_JUDGE_MODEL=<openai-compatible-judge-model>
+# This command runs on the host, not inside Docker.
+export OPENAI_BASE_URL=http://localhost:11434/v1
+export NAT_HARBOR_TRAJECTORY_JUDGE_MODEL=qwen3.6:35b
 
 .venv/bin/python -m nat_harbor.smoke.score_atif_trajectories \
   --job-dir "$HARBOR_JOBS_DIR/$JOB_NAME" \
-  --candidate-rel agent/nemo-flow-gateway-atif/trajectory.json \
+  --candidate-rel agent/nemo-flow-atof-atif/trajectory.json \
   --output-dir "$HARBOR_JOBS_DIR/$JOB_NAME/post-run-llm-scores" \
   --config-file packages/nvidia_nat_harbor/configs/opencode-nemoflow-trajectory-eval.yml \
   --evaluator-name trajectory_eval \
@@ -308,7 +492,7 @@ export NAT_HARBOR_TRAJECTORY_JUDGE_MODEL=<openai-compatible-judge-model>
 
 ## Phoenix Inspection
 
-If Phoenix is running locally at `http://localhost:6006`, export the two ATIF
+If Phoenix is running locally at `http://localhost:6006`, export the ATIF
 artifacts to separate projects:
 
 ```bash
@@ -320,26 +504,45 @@ ENDPOINT=http://localhost:6006/v1/traces
   --project harbor-hermes-native
 
 .venv/bin/python -m nat.plugins.phoenix.scripts.export_trajectory_to_phoenix.export_atif_trajectory_to_phoenix \
-  "$TRIAL/agent/nemo-flow-gateway-atif/trajectory.json" \
+  "$TRIAL/agent/nemo-flow-atof-atif/trajectory.json" \
   --endpoint "$ENDPOINT" \
-  --project harbor-hermes-nemoflow-gateway
+  --project harbor-hermes-nemoflow-atof
 ```
 
-Open `http://localhost:6006` and compare the two projects.
+Open `http://localhost:6006` and compare the projects. Export direct
+gateway/plugin ATIF only after the quick artifact check reports them as strict
+NAT-schema-valid.
 
 ## Known Limitations
 
-- The wrapper builds `nemo-flow-cli` (binary `nemo-flow`) inside each Harbor
-  task container, so the first run is slow.
-- PR #88 adds native ATOF JSONL exporter APIs, but the Hermes CLI gateway path
-  does not yet expose a raw ATOF JSONL artifact through configuration. The
-  wrapper keeps the ATOF code path best-effort
-  (`fail_missing_nemoflow_atof=false`), so today's runs validate the
-  gateway-emitted ATIF and skip the ATOF-derived comparison performed by the
-  OpenCode smoke. TODO: when NeMo-Flow lands configuration-based CLI ATOF
-  exporter registration, add that gateway config to this smoke and flip
-  `fail_missing_nemoflow_atof=true` to re-enable strict validation.
+- The default wrapper path can build `nemo-flow-cli` (binary `nemo-flow`) inside
+  each Harbor task container. The smoke uses a prebuilt task image instead.
+- Use `--no-delete` with the prebuilt-image smoke. Harbor's default Docker
+  cleanup uses `docker compose down --rmi all`, which can remove the local
+  prebuilt image after the trial.
+- On Apple Silicon hosts, the SWE-bench image used by this task is an
+  `linux/amd64` image. A cold `cargo build -p nemo-flow-cli --release` then
+  runs under emulation during Harbor agent setup and can exceed Harbor's
+  default 360 second agent setup timeout before Hermes starts. If the trial log
+  stops at the NeMo-Flow CLI build command, no model endpoint has been reached
+  yet. The prebuilt image avoids that trial-startup cost.
+- The ATOF path requires a NeMo-Flow branch that activates PR #89 plugin config
+  in the CLI gateway. The `enable_nemoflow_observability_plugin=true` smoke
+  should require `agent/nemo-flow-atof/events.jsonl`; use
+  `fail_missing_nemoflow_atof=false` only when running against older
+  direct-ATIF-only gateway branches.
+- The NAT ATOF-to-ATIF conversion is initially best-effort in this smoke
+  (`fail_nemoflow_atof_conversion=false`) so raw ATOF can still be inspected if
+  reconstruction fails. Flip it to `true` once the converter result is stable.
+- In the reference run above, the direct gateway/plugin ATIF files were emitted
+  but did not validate with the strict NAT ATIF parser because `message` fields
+  contained raw OpenAI request/response payloads. The ATOF-derived ATIF file did
+  validate and matched the native Hermes tool sequence exactly.
 - Complete LLM lifecycle telemetry requires Hermes model traffic to use the
   NeMo-Flow gateway. This wrapper configures that path for `nvidia`, `openai`,
   `openrouter`, and `anthropic` model prefixes.
+- If `hermes.txt` shows `HTTP 502: gateway upstream error: builder error`,
+  check the upstream base URL first. For the local Ollama smoke, the Docker
+  task container should use `http://host.docker.internal:11434`, while
+  host-side curl checks can use `http://localhost:11434/v1`.
 - The upstream Hermes native middleware path remains a later comparison lane.

--- a/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
+++ b/packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md
@@ -26,7 +26,7 @@ The validation pass can use two NeMo-Flow sidecar artifacts:
 
 - Direct gateway ATIF from the existing `--atif-dir` path.
 - Raw ATOF JSONL from the PR #89 observability plugin, converted to ATIF with
-  the NAT ATOF-to-ATIF converter.
+  the NeMo Agent Toolkit ATOF-to-ATIF converter.
 
 The ATOF-derived ATIF is the primary NeMo-Flow comparison target for this pass.
 The direct gateway ATIF remains useful as a baseline while we validate whether
@@ -44,7 +44,7 @@ flowchart TD
 
   run --> gatewayHooks[Hermes hooks + nemo-flow gateway]
   gatewayHooks --> atof[agent/nemo-flow-atof/events.jsonl<br/>raw ATOF JSONL]
-  atof --> converter[NAT ATOF-to-ATIF converter]
+  atof --> converter[the Toolkit ATOF-to-ATIF converter]
   converter --> nfAtif[agent/nemo-flow-atof-atif/trajectory.json<br/>ATOF-derived ATIF]
   gatewayHooks --> gatewayAtif[agent/nemo-flow-gateway-atif/trajectory.json<br/>legacy gateway-emitted ATIF]
   gatewayHooks --> pluginAtif[agent/nemo-flow-plugin-atif/trajectory.json<br/>plugin direct ATIF]
@@ -52,7 +52,7 @@ flowchart TD
   harbor --> swe[SWE-bench verifier<br/>patch + task tests]
   swe --> result[result.json<br/>reward/resolved]
 
-  nativeAtif --> compare[Trajectory comparison<br/>tool sequence + NAT evaluators + Phoenix]
+  nativeAtif --> compare[Trajectory comparison<br/>tool sequence + the Toolkit evaluators + Phoenix]
   nfAtif --> compare
   gatewayAtif -. baseline .-> compare
   result --> outcome[Outcome sanity check<br/>successful/resolved run]
@@ -64,7 +64,7 @@ One Hermes run emits these trajectory artifacts:
   `agent/trajectory.json`. This is Harbor's native Hermes trajectory and is
   produced independently of the NeMo-Flow gateway.
 - ATOF-derived ATIF: PR #89 plugin ATOF export writes
-  `agent/nemo-flow-atof/events.jsonl`, then the NAT converter writes
+  `agent/nemo-flow-atof/events.jsonl`, then the Toolkit converter writes
   `agent/nemo-flow-atof-atif/trajectory.json`. This is the primary NeMo-Flow
   comparison target.
 - Gateway-emitted ATIF: Hermes hooks and routed model traffic -> NeMo-Flow CLI
@@ -77,7 +77,7 @@ One Hermes run emits these trajectory artifacts:
 ## Prerequisites
 
 - Docker is running.
-- NAT is checked out to a branch containing
+- The Toolkit is checked out to a branch containing
   `nat_harbor.agents.installed.hermes_nemoflow:HermesNeMoFlow`.
 - Harbor is installed from the source branch used by the Harbor integration.
 - NeMo-Flow is checked out to a revision that contains PR #88, PR #89, and the
@@ -171,7 +171,7 @@ cp "$NEMO_FLOW_REPO"/Cargo.toml \
 cp -R "$NEMO_FLOW_REPO"/crates "$PREBUILT_CONTEXT"/
 ```
 
-Create the prebuilt-image Dockerfile:
+Create the prebuilt-image `Dockerfile`:
 
 ```bash
 cat > .tmp/harbor/nemo-flow-prebuilt.Dockerfile <<'EOF'
@@ -285,7 +285,7 @@ curl http://localhost:11434/v1/models
 
 ## Run the Smoke
 
-Create a local env file for the Docker task environment. Do not commit this
+Create a local environment file for the Docker task environment. Do not commit this
 file.
 
 <!-- path-check-skip-begin -->
@@ -352,9 +352,9 @@ ATOF-derived tool-sequence match.
 
 | Artifact | Path | Status from run |
 | --- | --- | --- |
-| Native Hermes ATIF | `agent/trajectory.json` | Valid NAT ATIF, `ATIF-v1.2`, 30 steps. |
-| NeMo-Flow ATOF-derived ATIF | `agent/nemo-flow-atof-atif/trajectory.json` | Valid NAT ATIF, `ATIF-v1.7`, 33 steps. Primary comparison target. |
-| NeMo-Flow gateway direct ATIF | `agent/nemo-flow-gateway-atif/trajectory.json` | Emitted, but not strict NAT-schema-valid yet because direct exporter messages contain raw OpenAI payloads. Diagnostic baseline only. |
+| Native Hermes ATIF | `agent/trajectory.json` | Valid ATIF for the Toolkit parser, `ATIF-v1.2`, 30 steps. |
+| NeMo-Flow ATOF-derived ATIF | `agent/nemo-flow-atof-atif/trajectory.json` | Valid ATIF for the Toolkit parser, `ATIF-v1.7`, 33 steps. Primary comparison target. |
+| NeMo-Flow gateway direct ATIF | `agent/nemo-flow-gateway-atif/trajectory.json` | Emitted, but not strict schema-valid for the Toolkit yet because direct exporter messages contain raw OpenAI payloads. Diagnostic baseline only. |
 | NeMo-Flow plugin direct ATIF | `agent/nemo-flow-plugin-atif/trajectory.json` | Emitted, but has the same direct-exporter message-shape issue as gateway direct ATIF. Diagnostic baseline only. |
 
 The raw ATOF reference for the same run is:
@@ -375,7 +375,7 @@ TRIAL=$(find "$HARBOR_JOBS_DIR/$JOB_NAME" -maxdepth 1 -type d -name 'django__dja
 test -n "$TRIAL"
 ```
 
-Check artifact presence and strict NAT ATIF parser compatibility. The direct
+Check artifact presence and strict compatibility with the Toolkit ATIF parser. The direct
 gateway/plugin ATIF artifacts are still useful diagnostics, but may fail strict
 schema validation until direct-exporter message normalization is fixed.
 
@@ -456,7 +456,7 @@ The ATOF-derived comparison is the primary check. If it is still missing tool
 semantics, inspect `agent/nemo-flow-atof/events.jsonl` before changing the ATIF
 exporter because the raw event stream will show whether the data was captured.
 Direct ATIF comparisons are diagnostic and are expected to be poorer until the
-direct exporter emits strict NAT-compatible ATIF messages.
+direct exporter emits strict ATIF messages compatible with the Toolkit.
 
 ## Post-Run Trajectory Scoring
 
@@ -511,7 +511,7 @@ ENDPOINT=http://localhost:6006/v1/traces
 
 Open `http://localhost:6006` and compare the projects. Export direct
 gateway/plugin ATIF only after the quick artifact check reports them as strict
-NAT-schema-valid.
+schema-valid for the Toolkit.
 
 ## Known Limitations
 
@@ -531,11 +531,11 @@ NAT-schema-valid.
   should require `agent/nemo-flow-atof/events.jsonl`; use
   `fail_missing_nemoflow_atof=false` only when running against older
   direct-ATIF-only gateway branches.
-- The NAT ATOF-to-ATIF conversion is initially best-effort in this smoke
+- The Toolkit ATOF-to-ATIF conversion is initially best-effort in this smoke
   (`fail_nemoflow_atof_conversion=false`) so raw ATOF can still be inspected if
   reconstruction fails. Flip it to `true` once the converter result is stable.
 - In the reference run above, the direct gateway/plugin ATIF files were emitted
-  but did not validate with the strict NAT ATIF parser because `message` fields
+  but did not validate with the strict Toolkit ATIF parser because `message` fields
   contained raw OpenAI request/response payloads. The ATOF-derived ATIF file did
   validate and matched the native Hermes tool sequence exactly.
 - Complete LLM lifecycle telemetry requires Hermes model traffic to use the

--- a/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/__init__.py
+++ b/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/__init__.py
@@ -15,10 +15,12 @@
 """Installed-agent helpers aligned with Harbor structure."""
 
 from .nemo_agent import NemoAgent
+from .hermes_nemoflow import HermesNeMoFlow
 from .policy import is_local_install_allowed
 from .policy import resolve_local_install_policy
 
 __all__ = [
+    "HermesNeMoFlow",
     "NemoAgent",
     "is_local_install_allowed",
     "resolve_local_install_policy",

--- a/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/__init__.py
+++ b/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/__init__.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 """Installed-agent helpers aligned with Harbor structure."""
 
-from .nemo_agent import NemoAgent
 from .hermes_nemoflow import HermesNeMoFlow
+from .nemo_agent import NemoAgent
 from .policy import is_local_install_allowed
 from .policy import resolve_local_install_policy
 

--- a/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
+++ b/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
@@ -1,0 +1,498 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+"""Experimental Harbor wrapper for Hermes with NeMo-Flow sidecar enabled."""
+
+from __future__ import annotations
+
+import copy
+import json
+import os
+import shlex
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+from harbor.agents.installed.base import with_prompt_template
+from harbor.agents.installed.hermes import Hermes
+from harbor.environments.base import BaseEnvironment
+from harbor.models.agent.context import AgentContext
+
+
+@dataclass(frozen=True)
+class _ProviderRoute:
+    """Provider settings needed to route Hermes model traffic through the sidecar."""
+
+    api_key_envs: tuple[str, ...]
+    upstream_base_env: str | None
+    default_upstream_base_url: str
+    sidecar_route: str
+    hermes_provider: str
+    cli_provider: str | None
+    cli_model: str
+    config_model: str
+
+
+class HermesNeMoFlow(Hermes):
+    """Run Hermes inside Harbor with a NeMo-Flow sidecar around the session."""
+
+    _DEFAULT_CONTAINER_NEMO_FLOW_DIR = "/opt/nemo-flow"
+    _DEFAULT_ATOF_DIR = "/logs/agent/nemo-flow-atof"
+    _DEFAULT_SIDECAR_ATIF_DIR = "/logs/agent/nemo-flow-sidecar-atif"
+    _CONVERTED_ATIF_DIR_NAME = "nemo-flow-atof-atif"
+    _CONVERTED_ATIF_FILENAME = "trajectory.json"
+    _SIDECAR_CANONICAL_ATIF_FILENAME = "trajectory.json"
+    _DEFAULT_TASK_DIR = "/testbed"
+    _HERMES_HOME = "/tmp/hermes"
+    _HERMES_HOOK_EVENTS = (
+        "on_session_start",
+        "on_session_end",
+        "on_session_finalize",
+        "on_session_reset",
+        "pre_llm_call",
+        "post_llm_call",
+        "pre_api_request",
+        "post_api_request",
+        "pre_tool_call",
+        "post_tool_call",
+        "subagent_start",
+        "subagent_stop",
+    )
+
+    def __init__(
+        self,
+        *args: Any,
+        nemo_flow_repo: str | None = None,
+        container_nemo_flow_dir: str = _DEFAULT_CONTAINER_NEMO_FLOW_DIR,
+        atof_dir: str = _DEFAULT_ATOF_DIR,
+        sidecar_atif_dir: str = _DEFAULT_SIDECAR_ATIF_DIR,
+        fail_missing_nemoflow_atof: bool = True,
+        fail_missing_nemoflow_atif: bool = False,
+        convert_nemoflow_atof: bool = True,
+        fail_nemoflow_atof_conversion: bool = True,
+        canonicalize_nemoflow_atif: bool = True,
+        **kwargs: Any,
+    ):
+        super().__init__(*args, **kwargs)
+        self._nemo_flow_repo = Path(nemo_flow_repo or os.environ.get("NEMO_FLOW_REPO", "external/nemo-flow")).resolve()
+        self._container_nemo_flow_dir = container_nemo_flow_dir.rstrip("/")
+        self._atof_dir = atof_dir.rstrip("/")
+        self._sidecar_atif_dir = sidecar_atif_dir.rstrip("/")
+        self._fail_missing_nemoflow_atof = fail_missing_nemoflow_atof
+        self._fail_missing_nemoflow_atif = fail_missing_nemoflow_atif
+        self._convert_nemoflow_atof = convert_nemoflow_atof
+        self._fail_nemoflow_atof_conversion = fail_nemoflow_atof_conversion
+        self._canonicalize_nemoflow_atif = canonicalize_nemoflow_atif
+
+    @staticmethod
+    def name() -> str:
+        return "hermes-nemoflow"
+
+    @property
+    def _container_sidecar_bin(self) -> str:
+        return f"{self._container_nemo_flow_dir}/target/release/nemo-flow-sidecar"
+
+    def _validate_local_nemo_flow_checkout(self) -> None:
+        required = [
+            self._nemo_flow_repo / "Cargo.toml",
+            self._nemo_flow_repo / "Cargo.lock",
+            self._nemo_flow_repo / "crates" / "core" / "Cargo.toml",
+            self._nemo_flow_repo / "crates" / "sidecar" / "Cargo.toml",
+            self._nemo_flow_repo / "crates" / "sidecar" / "src" / "main.rs",
+        ]
+        missing = [str(path) for path in required if not path.exists()]
+        if missing:
+            raise FileNotFoundError(
+                "NeMo-Flow sidecar checkout is not ready. Missing:\n" + "\n".join(f"- {path}" for path in missing)
+            )
+
+    def _prepare_upload_tree(self) -> Path:
+        self._validate_local_nemo_flow_checkout()
+        setup_dir = self.logs_dir / "setup" / "nemo-flow-sidecar-upload"
+        if setup_dir.exists():
+            shutil.rmtree(setup_dir)
+        setup_dir.mkdir(parents=True, exist_ok=True)
+
+        ignore = shutil.ignore_patterns(
+            ".git",
+            ".pytest_cache",
+            ".ruff_cache",
+            ".venv",
+            ".uv-cache",
+            "node_modules",
+            "target",
+            "__pycache__",
+        )
+        for filename in ("Cargo.toml", "Cargo.lock", "rust-toolchain.toml"):
+            source = self._nemo_flow_repo / filename
+            if source.exists():
+                shutil.copy2(source, setup_dir / filename)
+        shutil.copytree(
+            self._nemo_flow_repo / "crates",
+            setup_dir / "crates",
+            ignore=ignore,
+            dirs_exist_ok=True,
+        )
+        return setup_dir
+
+    async def install(self, environment: BaseEnvironment) -> None:
+        await super().install(environment)
+        upload_tree = self._prepare_upload_tree()
+
+        await self.exec_as_root(
+            environment,
+            command="apt-get update && apt-get install -y build-essential ca-certificates pkg-config",
+            env={"DEBIAN_FRONTEND": "noninteractive"},
+            timeout_sec=600,
+        )
+        await self.exec_as_root(
+            environment,
+            command=(
+                f"mkdir -p {shlex.quote(self._container_nemo_flow_dir)} && "
+                f"chmod 777 {shlex.quote(self._container_nemo_flow_dir)}"
+            ),
+        )
+        await environment.upload_dir(
+            source_dir=upload_tree,
+            target_dir=self._container_nemo_flow_dir,
+        )
+        await self.exec_as_agent(
+            environment,
+            command=(
+                "set -euo pipefail; "
+                "if ! command -v cargo >/dev/null 2>&1; then "
+                "curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | "
+                "sh -s -- -y --profile minimal; "
+                "fi; "
+                '. "$HOME/.cargo/env"; '
+                f"cd {shlex.quote(self._container_nemo_flow_dir)}; "
+                "cargo build -p nemo-flow-sidecar --release; "
+                'mkdir -p "$HOME/.local/bin"; '
+                f"ln -sf {shlex.quote(self._container_sidecar_bin)} "
+                '"$HOME/.local/bin/nemo-flow-sidecar"; '
+                "nemo-flow-sidecar --help >/dev/null; "
+                "nemo-flow-sidecar run --help | grep -q -- '--atof-dir' || "
+                "{ echo 'Error: nemo-flow-sidecar run does not support --atof-dir' >&2; exit 1; }; "
+                "nemo-flow-sidecar hook-forward --help | grep -q -- '--atof-dir' || "
+                "{ echo 'Error: nemo-flow-sidecar hook-forward does not support --atof-dir' >&2; exit 1; }"
+            ),
+            timeout_sec=1800,
+        )
+
+    @with_prompt_template
+    async def run(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        if not self.model_name or "/" not in self.model_name:
+            raise ValueError("Model name must be in the format provider/model_name")
+
+        provider, model = self.model_name.split("/", 1)
+        route = self._build_provider_route(provider, model)
+        env = self._build_run_env(route, instruction)
+        config_yaml = self._build_config_yaml_with_sidecar_hooks(route)
+
+        await self.exec_as_agent(
+            environment,
+            command=(
+                f"mkdir -p {shlex.quote(self._HERMES_HOME)} "
+                f"{shlex.quote(self._atof_dir)} {shlex.quote(self._sidecar_atif_dir)} "
+                "/logs/agent/nemo-flow-sidecar && "
+                f"cat > {shlex.quote(self._HERMES_HOME)}/config.yaml << 'EOF'\n{config_yaml}EOF"
+            ),
+            env=env,
+            timeout_sec=10,
+        )
+
+        mcp_command = self._build_register_mcp_servers_command()
+        if mcp_command:
+            await self.exec_as_agent(environment, command=mcp_command, env=env, timeout_sec=10)
+
+        skills_command = self._build_register_skills_command()
+        if skills_command:
+            await self.exec_as_agent(environment, command=skills_command, env=env, timeout_sec=10)
+
+        run_cmd = self._build_sidecar_run_command(route)
+        await self.exec_as_agent(environment, command=run_cmd, env=env)
+
+    def populate_context_post_run(self, context: AgentContext) -> None:
+        super().populate_context_post_run(context)
+
+        atof_path = self.logs_dir / self._atof_dir.removeprefix("/logs/agent/") / "events.jsonl"
+        sidecar_dir = self.logs_dir / self._sidecar_atif_dir.removeprefix("/logs/agent/")
+        atif_files = self._sidecar_atif_files(sidecar_dir)
+        canonical_path = sidecar_dir / self._SIDECAR_CANONICAL_ATIF_FILENAME
+        converted_atif_path = self.logs_dir / self._CONVERTED_ATIF_DIR_NAME / self._CONVERTED_ATIF_FILENAME
+
+        if self._fail_missing_nemoflow_atof and not atof_path.exists():
+            raise FileNotFoundError(f"Missing NeMo-Flow ATOF JSONL artifact: {atof_path}")
+
+        if self._fail_missing_nemoflow_atif and not atif_files:
+            raise FileNotFoundError(f"Missing NeMo-Flow sidecar ATIF artifact under: {sidecar_dir}")
+
+        if self._convert_nemoflow_atof and atof_path.exists():
+            try:
+                self._convert_atof_to_atif(atof_path, converted_atif_path)
+            except Exception as exc:
+                self.logger.exception("Failed to convert NeMo-Flow ATOF artifact to ATIF")
+                if self._fail_nemoflow_atof_conversion:
+                    raise RuntimeError(f"Failed to convert NeMo-Flow ATOF artifact to ATIF: {atof_path}") from exc
+
+        if self._canonicalize_nemoflow_atif and atif_files:
+            self._write_canonical_sidecar_atif(atif_files[0], canonical_path)
+
+        if converted_atif_path.exists():
+            self._populate_context_tokens_from_atif(context, converted_atif_path)
+        elif canonical_path.exists():
+            self._populate_context_tokens_from_atif(context, canonical_path)
+
+        metadata = dict(context.metadata or {})
+        metadata["nemo_flow_instrumentation"] = "sidecar"
+        metadata["nemo_flow_atof_path"] = str(atof_path)
+        metadata["nemo_flow_atof_exists"] = atof_path.exists()
+        metadata["nemo_flow_converted_atif_path"] = str(converted_atif_path)
+        metadata["nemo_flow_converted_atif_exists"] = converted_atif_path.exists()
+        metadata["nemo_flow_sidecar_atif_dir"] = str(sidecar_dir)
+        metadata["nemo_flow_sidecar_atif_paths"] = [str(path) for path in atif_files]
+        metadata["nemo_flow_sidecar_canonical_atif_path"] = str(canonical_path)
+        metadata["nemo_flow_sidecar_canonical_atif_exists"] = canonical_path.exists()
+        context.metadata = metadata
+
+    def _build_run_env(self, route: _ProviderRoute, instruction: str) -> dict[str, str]:
+        env = {
+            "HERMES_HOME": self._HERMES_HOME,
+            "TERMINAL_ENV": "local",
+            "HARBOR_INSTRUCTION": instruction,
+            "NEMO_FLOW_ATOF_DIR": self._atof_dir,
+            "NEMO_FLOW_ATIF_DIR": self._sidecar_atif_dir,
+        }
+        api_key_env = self._first_available_env(route.api_key_envs)
+        if api_key_env is None:
+            raise ValueError(f"No API key found. Set {' or '.join(route.api_key_envs)}.")
+        env[api_key_env] = self._get_env(api_key_env) or ""
+        if route.hermes_provider == "custom":
+            env["OPENAI_API_KEY"] = env[api_key_env]
+        return env
+
+    def _build_provider_route(self, provider: str, model: str) -> _ProviderRoute:
+        provider = provider.strip().lower()
+        if provider == "anthropic":
+            return _ProviderRoute(
+                api_key_envs=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN"),
+                upstream_base_env="ANTHROPIC_BASE_URL",
+                default_upstream_base_url="https://api.anthropic.com",
+                sidecar_route="anthropic",
+                hermes_provider="anthropic",
+                cli_provider="anthropic",
+                cli_model=model,
+                config_model=model,
+            )
+        if provider == "openai":
+            return _ProviderRoute(
+                api_key_envs=("OPENAI_API_KEY",),
+                upstream_base_env="OPENAI_BASE_URL",
+                default_upstream_base_url="https://api.openai.com",
+                sidecar_route="openai",
+                hermes_provider="custom",
+                cli_provider=None,
+                cli_model=model,
+                config_model=model,
+            )
+        if provider == "nvidia":
+            return _ProviderRoute(
+                api_key_envs=("NVIDIA_API_KEY",),
+                upstream_base_env="NVIDIA_BASE_URL",
+                default_upstream_base_url="https://integrate.api.nvidia.com/v1",
+                sidecar_route="openai",
+                hermes_provider="custom",
+                cli_provider=None,
+                cli_model=model,
+                config_model=model,
+            )
+        if provider == "openrouter":
+            return _ProviderRoute(
+                api_key_envs=("OPENROUTER_API_KEY",),
+                upstream_base_env="OPENROUTER_BASE_URL",
+                default_upstream_base_url="https://openrouter.ai/api/v1",
+                sidecar_route="openai",
+                hermes_provider="custom",
+                cli_provider=None,
+                cli_model=model,
+                config_model=model,
+            )
+        return _ProviderRoute(
+            api_key_envs=("OPENROUTER_API_KEY",),
+            upstream_base_env="OPENROUTER_BASE_URL",
+            default_upstream_base_url="https://openrouter.ai/api/v1",
+            sidecar_route="openai",
+            hermes_provider="custom",
+            cli_provider=None,
+            cli_model=self.model_name or model,
+            config_model=self.model_name or model,
+        )
+
+    def _build_config_yaml_with_sidecar_hooks(self, route: _ProviderRoute) -> str:
+        config = yaml.safe_load(self._build_config_yaml(route.config_model)) or {}
+        config["model"] = {
+            "default": route.config_model,
+            "model": route.config_model,
+            "provider": route.hermes_provider,
+            "base_url": "${NEMO_FLOW_SIDECAR_URL}",
+        }
+        if route.hermes_provider == "custom":
+            config["model"]["api_key"] = "${OPENAI_API_KEY}"
+        hooks = copy.deepcopy(config.get("hooks") or {})
+        hook_command = self._build_hook_forward_command()
+        for event in self._HERMES_HOOK_EVENTS:
+            groups = hooks.setdefault(event, [])
+            entry = {"command": hook_command, "timeout": 30}
+            if entry not in groups:
+                groups.append(entry)
+        config["hooks"] = hooks
+        return yaml.safe_dump(config, default_flow_style=False, sort_keys=False)
+
+    def _build_hook_forward_command(self) -> str:
+        return (
+            "nemo-flow-sidecar hook-forward hermes "
+            f"--atof-dir {shlex.quote(self._atof_dir)} "
+            f"--atif-dir {shlex.quote(self._sidecar_atif_dir)} "
+            "--gateway-mode passthrough"
+        )
+
+    def _build_sidecar_run_command(self, route: _ProviderRoute) -> str:
+        args = [
+            "nemo-flow-sidecar",
+            "run",
+            "--agent",
+            "hermes",
+            "--atof-dir",
+            self._atof_dir,
+            "--atif-dir",
+            self._sidecar_atif_dir,
+            "--session-metadata",
+            json.dumps({"source": "harbor", "agent": self.name()}, separators=(",", ":")),
+        ]
+        if route.sidecar_route == "anthropic":
+            args.extend(["--anthropic-base-url", self._upstream_base_url(route)])
+        else:
+            args.extend(["--openai-base-url", self._upstream_base_url(route)])
+
+        child_script = self._build_child_script(route)
+        args.extend(["--", "/bin/bash", "-lc", child_script])
+        return (
+            'export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH" && '
+            f"{' '.join(shlex.quote(arg) for arg in args)} "
+            "2>&1 | stdbuf -oL tee /logs/agent/hermes.txt"
+        )
+
+    def _build_child_script(self, route: _ProviderRoute) -> str:
+        cli_parts = [
+            'export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"',
+            "set +e",
+            self._hermes_chat_command(route),
+            "status=$?",
+            ("hermes sessions export /logs/agent/hermes-session.jsonl --source cli 2>/dev/null || true"),
+            self._synthetic_finalize_command(),
+            'exit "$status"',
+        ]
+        return "; ".join(cli_parts)
+
+    def _hermes_chat_command(self, route: _ProviderRoute) -> str:
+        parts = [
+            "hermes",
+            "--yolo",
+            "chat",
+            "-q",
+            "$HARBOR_INSTRUCTION",
+            "-Q",
+            "--model",
+            route.cli_model,
+        ]
+        if route.cli_provider:
+            parts.extend(["--provider", route.cli_provider])
+        toolsets_flag = self._resolved_flags.get("toolsets")
+        if toolsets_flag:
+            parts.extend(["--toolsets", str(toolsets_flag)])
+        return " ".join(
+            shlex.quote(part) if part != "$HARBOR_INSTRUCTION" else '"$HARBOR_INSTRUCTION"' for part in parts
+        )
+
+    def _synthetic_finalize_command(self) -> str:
+        session_id_expr = (
+            "import json,pathlib;"
+            "p=pathlib.Path('/logs/agent/hermes-session.jsonl');"
+            "sid='';"
+            "\nfor line in p.read_text().splitlines():"
+            "\n    line=line.strip();"
+            "\n    if not line: continue"
+            "\n    obj=json.loads(line);"
+            "\n    sid=str(obj.get('id') or obj.get('session_id') or '');"
+            "\n    break"
+            "\nprint(sid)"
+        )
+        payload = (
+            'printf \'{"session_id":"%s","hook_event_name":"on_session_finalize","source":"harbor"}\\n\' "$session_id"'
+        )
+        return (
+            f"if ! find {shlex.quote(self._sidecar_atif_dir)} -name '*.atif.json' "
+            "-print -quit 2>/dev/null | grep -q .; then "
+            f"session_id=$(python3 -c {shlex.quote(session_id_expr)} 2>/dev/null || true); "
+            'if [ -n "$session_id" ]; then '
+            f"{payload} | {self._build_hook_forward_command()} || true; "
+            "fi; "
+            "fi"
+        )
+
+    def _upstream_base_url(self, route: _ProviderRoute) -> str:
+        if route.upstream_base_env:
+            value = self._get_env(route.upstream_base_env)
+            if value:
+                return value
+        return route.default_upstream_base_url
+
+    def _first_available_env(self, keys: tuple[str, ...]) -> str | None:
+        for key in keys:
+            if self._get_env(key):
+                return key
+        return None
+
+    def _sidecar_atif_files(self, directory: Path) -> list[Path]:
+        if not directory.exists():
+            return []
+        return sorted(
+            (path for path in directory.glob("*.atif.json") if path.is_file()),
+            key=lambda path: path.stat().st_mtime,
+            reverse=True,
+        )
+
+    def _write_canonical_sidecar_atif(self, source: Path, destination: Path) -> None:
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if source.resolve() != destination.resolve():
+            shutil.copy2(source, destination)
+
+    def _convert_atof_to_atif(self, atof_path: Path, output_path: Path) -> Path:
+        try:
+            from nat.atof.scripts.atof_to_atif_converter import convert_file
+        except ImportError as exc:
+            raise RuntimeError("The ATOF-to-ATIF converter is unavailable. Install nvidia-nat-atif[full].") from exc
+
+        trajectory = convert_file(atof_path, output_path)
+        steps_count = len(getattr(trajectory, "steps", []) or [])
+        self.logger.debug("Wrote ATOF-derived ATIF trajectory to %s with %s steps", output_path, steps_count)
+        return output_path
+
+    def _populate_context_tokens_from_atif(self, context: AgentContext, atif_path: Path) -> None:
+        try:
+            trajectory = json.loads(atif_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return
+        final_metrics = trajectory.get("final_metrics") or {}
+        prompt_tokens = final_metrics.get("total_prompt_tokens")
+        completion_tokens = final_metrics.get("total_completion_tokens")
+        if isinstance(prompt_tokens, int):
+            context.n_input_tokens = prompt_tokens
+        if isinstance(completion_tokens, int):
+            context.n_output_tokens = completion_tokens

--- a/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
+++ b/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
@@ -216,18 +216,16 @@ class HermesNeMoFlow(Hermes):
         )
 
     def _validate_prebuilt_cli_command(self) -> str:
-        return (
-            'export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"; '
-            "command -v nemo-flow >/dev/null || "
-            "{ echo 'Error: prebuilt image does not provide nemo-flow on PATH' >&2; exit 1; }; "
-            "nemo-flow --help >/dev/null; "
-            "nemo-flow run --help | grep -q -- '--atif-dir' || "
-            "{ echo 'Error: nemo-flow run does not support --atif-dir' >&2; exit 1; }; "
-            "nemo-flow run --help | grep -q -- '--plugin-config' || "
-            "{ echo 'Error: nemo-flow run does not support --plugin-config' >&2; exit 1; }; "
-            "nemo-flow hook-forward --help | grep -q -- '--atif-dir' || "
-            "{ echo 'Error: nemo-flow hook-forward does not support --atif-dir' >&2; exit 1; }"
-        )
+        return ('export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"; '
+                "command -v nemo-flow >/dev/null || "
+                "{ echo 'Error: prebuilt image does not provide nemo-flow on PATH' >&2; exit 1; }; "
+                "nemo-flow --help >/dev/null; "
+                "nemo-flow run --help | grep -q -- '--atif-dir' || "
+                "{ echo 'Error: nemo-flow run does not support --atif-dir' >&2; exit 1; }; "
+                "nemo-flow run --help | grep -q -- '--plugin-config' || "
+                "{ echo 'Error: nemo-flow run does not support --plugin-config' >&2; exit 1; }; "
+                "nemo-flow hook-forward --help | grep -q -- '--atif-dir' || "
+                "{ echo 'Error: nemo-flow hook-forward does not support --atif-dir' >&2; exit 1; }")
 
     @with_prompt_template
     async def run(
@@ -453,27 +451,26 @@ class HermesNeMoFlow(Hermes):
 
     def _build_observability_plugin_config(self) -> dict[str, Any]:
         return {
-            "version": 1,
-            "components": [
-                {
-                    "kind": "observability",
-                    "enabled": True,
-                    "config": {
-                        "version": 1,
-                        "atof": {
-                            "enabled": True,
-                            "output_directory": self._atof_dir,
-                            "filename": "events.jsonl",
-                            "mode": "overwrite",
-                        },
-                        "atif": {
-                            "enabled": True,
-                            "output_directory": self._plugin_atif_dir,
-                            "filename_template": "trajectory-{session_id}.atif.json",
-                        },
+            "version":
+                1,
+            "components": [{
+                "kind": "observability",
+                "enabled": True,
+                "config": {
+                    "version": 1,
+                    "atof": {
+                        "enabled": True,
+                        "output_directory": self._atof_dir,
+                        "filename": "events.jsonl",
+                        "mode": "overwrite",
                     },
-                }
-            ],
+                    "atif": {
+                        "enabled": True,
+                        "output_directory": self._plugin_atif_dir,
+                        "filename_template": "trajectory-{session_id}.atif.json",
+                    },
+                },
+            }],
         }
 
     def _build_child_script(self, route: _ProviderRoute) -> str:

--- a/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
+++ b/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
@@ -5,12 +5,11 @@
 Tracks the current NeMo-Flow CLI gateway surface: ``crates/cli``, binary
 ``nemo-flow``, and runtime gateway discovery through ``NEMO_FLOW_GATEWAY_URL``.
 
-PR #88 adds native ATOF JSONL exporter APIs to NeMo-Flow, but the Hermes CLI
-gateway path still does not expose a raw ATOF JSONL artifact from
-``nemo-flow run``/``hook-forward``. The ATOF conversion code path is kept here,
-dormant by default, so it lights up automatically once NeMo-Flow wires Hermes
-gateway events into the exporter. Until then, the canonical artifact for this
-wrapper is the gateway-emitted ATIF (``*.atif.json``).
+PR #88 adds native ATOF JSONL exporter APIs to NeMo-Flow, and PR #89 adds a
+config-driven observability plugin that can install ATOF/ATIF exporters when the
+CLI gateway activates plugin config at startup. The plugin path is opt-in here
+so the wrapper can still run against NeMo-Flow branches that only support direct
+gateway ATIF via ``--atif-dir``.
 """
 
 from __future__ import annotations
@@ -51,9 +50,11 @@ class HermesNeMoFlow(Hermes):
     _DEFAULT_CONTAINER_NEMO_FLOW_DIR = "/opt/nemo-flow"
     _DEFAULT_ATOF_DIR = "/logs/agent/nemo-flow-atof"
     _DEFAULT_GATEWAY_ATIF_DIR = "/logs/agent/nemo-flow-gateway-atif"
+    _DEFAULT_PLUGIN_ATIF_DIR = "/logs/agent/nemo-flow-plugin-atif"
     _CONVERTED_ATIF_DIR_NAME = "nemo-flow-atof-atif"
     _CONVERTED_ATIF_FILENAME = "trajectory.json"
     _GATEWAY_CANONICAL_ATIF_FILENAME = "trajectory.json"
+    _PLUGIN_CANONICAL_ATIF_FILENAME = "trajectory.json"
     _DEFAULT_TASK_DIR = "/testbed"
     _HERMES_HOME = "/tmp/hermes"
     _HERMES_HOOK_EVENTS = (
@@ -78,11 +79,14 @@ class HermesNeMoFlow(Hermes):
         container_nemo_flow_dir: str = _DEFAULT_CONTAINER_NEMO_FLOW_DIR,
         atof_dir: str = _DEFAULT_ATOF_DIR,
         gateway_atif_dir: str | None = None,
+        plugin_atif_dir: str | None = None,
+        enable_nemoflow_observability_plugin: bool = False,
         fail_missing_nemoflow_atof: bool = False,
         fail_missing_nemoflow_atif: bool = True,
         convert_nemoflow_atof: bool = True,
         fail_nemoflow_atof_conversion: bool = False,
         canonicalize_nemoflow_atif: bool = True,
+        use_prebuilt_nemo_flow: bool = False,
         sidecar_atif_dir: str | None = None,
         **kwargs: Any,
     ):
@@ -94,15 +98,17 @@ class HermesNeMoFlow(Hermes):
         # branch may still pass `sidecar_atif_dir`. Prefer the new name when set.
         resolved_atif_dir = gateway_atif_dir if gateway_atif_dir is not None else sidecar_atif_dir
         self._gateway_atif_dir = (resolved_atif_dir or self._DEFAULT_GATEWAY_ATIF_DIR).rstrip("/")
-        # PR #88 adds the generic ATOF exporter API, but Hermes CLI gateway runs
-        # still only expose direct ATIF via --atif-dir. Keep the raw ATOF path
-        # dormant by default; fail-on-missing is opt-in for downstream users on
-        # a NeMo-Flow branch that wires Hermes gateway events into ATOF JSONL.
+        self._plugin_atif_dir = (plugin_atif_dir or self._DEFAULT_PLUGIN_ATIF_DIR).rstrip("/")
+        self._enable_nemoflow_observability_plugin = enable_nemoflow_observability_plugin
+        # Raw ATOF export requires a NeMo-Flow branch that activates PR #89
+        # plugin config in the CLI gateway. Keep fail-on-missing opt-in so the
+        # wrapper remains compatible with direct-ATIF-only gateway branches.
         self._fail_missing_nemoflow_atof = fail_missing_nemoflow_atof
         self._fail_missing_nemoflow_atif = fail_missing_nemoflow_atif
         self._convert_nemoflow_atof = convert_nemoflow_atof
         self._fail_nemoflow_atof_conversion = fail_nemoflow_atof_conversion
         self._canonicalize_nemoflow_atif = canonicalize_nemoflow_atif
+        self._use_prebuilt_nemo_flow = use_prebuilt_nemo_flow
 
     @property
     def _sidecar_atif_dir(self) -> str:
@@ -161,6 +167,14 @@ class HermesNeMoFlow(Hermes):
 
     async def install(self, environment: BaseEnvironment) -> None:
         await super().install(environment)
+        if self._use_prebuilt_nemo_flow:
+            await self.exec_as_agent(
+                environment,
+                command=self._validate_prebuilt_cli_command(),
+                timeout_sec=60,
+            )
+            return
+
         upload_tree = self._prepare_upload_tree()
 
         await self.exec_as_root(
@@ -194,9 +208,25 @@ class HermesNeMoFlow(Hermes):
                      "nemo-flow --help >/dev/null; "
                      "nemo-flow run --help | grep -q -- '--atif-dir' || "
                      "{ echo 'Error: nemo-flow run does not support --atif-dir' >&2; exit 1; }; "
+                     "nemo-flow run --help | grep -q -- '--plugin-config' || "
+                     "{ echo 'Error: nemo-flow run does not support --plugin-config' >&2; exit 1; }; "
                      "nemo-flow hook-forward --help | grep -q -- '--atif-dir' || "
                      "{ echo 'Error: nemo-flow hook-forward does not support --atif-dir' >&2; exit 1; }"),
             timeout_sec=1800,
+        )
+
+    def _validate_prebuilt_cli_command(self) -> str:
+        return (
+            'export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"; '
+            "command -v nemo-flow >/dev/null || "
+            "{ echo 'Error: prebuilt image does not provide nemo-flow on PATH' >&2; exit 1; }; "
+            "nemo-flow --help >/dev/null; "
+            "nemo-flow run --help | grep -q -- '--atif-dir' || "
+            "{ echo 'Error: nemo-flow run does not support --atif-dir' >&2; exit 1; }; "
+            "nemo-flow run --help | grep -q -- '--plugin-config' || "
+            "{ echo 'Error: nemo-flow run does not support --plugin-config' >&2; exit 1; }; "
+            "nemo-flow hook-forward --help | grep -q -- '--atif-dir' || "
+            "{ echo 'Error: nemo-flow hook-forward does not support --atif-dir' >&2; exit 1; }"
         )
 
     @with_prompt_template
@@ -218,6 +248,7 @@ class HermesNeMoFlow(Hermes):
             environment,
             command=(f"mkdir -p {shlex.quote(self._HERMES_HOME)} "
                      f"{shlex.quote(self._atof_dir)} {shlex.quote(self._gateway_atif_dir)} "
+                     f"{shlex.quote(self._plugin_atif_dir)} "
                      "/logs/agent/nemo-flow-gateway && "
                      f"cat > {shlex.quote(self._HERMES_HOME)}/config.yaml << 'EOF'\n{config_yaml}EOF"),
             env=env,
@@ -240,8 +271,11 @@ class HermesNeMoFlow(Hermes):
 
         atof_path = self.logs_dir / self._atof_dir.removeprefix("/logs/agent/") / "events.jsonl"
         gateway_dir = self.logs_dir / self._gateway_atif_dir.removeprefix("/logs/agent/")
+        plugin_dir = self.logs_dir / self._plugin_atif_dir.removeprefix("/logs/agent/")
         atif_files = self._gateway_atif_files(gateway_dir)
         canonical_path = gateway_dir / self._GATEWAY_CANONICAL_ATIF_FILENAME
+        plugin_atif_files = self._gateway_atif_files(plugin_dir)
+        plugin_canonical_path = plugin_dir / self._PLUGIN_CANONICAL_ATIF_FILENAME
         converted_atif_path = self.logs_dir / self._CONVERTED_ATIF_DIR_NAME / self._CONVERTED_ATIF_FILENAME
 
         if self._fail_missing_nemoflow_atof and not atof_path.exists():
@@ -260,14 +294,19 @@ class HermesNeMoFlow(Hermes):
 
         if self._canonicalize_nemoflow_atif and atif_files:
             self._write_canonical_gateway_atif(atif_files[0], canonical_path)
+        if self._canonicalize_nemoflow_atif and plugin_atif_files:
+            self._write_canonical_gateway_atif(plugin_atif_files[0], plugin_canonical_path)
 
         if converted_atif_path.exists():
             self._populate_context_tokens_from_atif(context, converted_atif_path)
+        elif plugin_canonical_path.exists():
+            self._populate_context_tokens_from_atif(context, plugin_canonical_path)
         elif canonical_path.exists():
             self._populate_context_tokens_from_atif(context, canonical_path)
 
         metadata = dict(context.metadata or {})
         metadata["nemo_flow_instrumentation"] = "gateway"
+        metadata["nemo_flow_observability_plugin_enabled"] = self._enable_nemoflow_observability_plugin
         metadata["nemo_flow_atof_path"] = str(atof_path)
         metadata["nemo_flow_atof_exists"] = atof_path.exists()
         metadata["nemo_flow_converted_atif_path"] = str(converted_atif_path)
@@ -276,6 +315,10 @@ class HermesNeMoFlow(Hermes):
         metadata["nemo_flow_gateway_atif_paths"] = [str(path) for path in atif_files]
         metadata["nemo_flow_gateway_canonical_atif_path"] = str(canonical_path)
         metadata["nemo_flow_gateway_canonical_atif_exists"] = canonical_path.exists()
+        metadata["nemo_flow_plugin_atif_dir"] = str(plugin_dir)
+        metadata["nemo_flow_plugin_atif_paths"] = [str(path) for path in plugin_atif_files]
+        metadata["nemo_flow_plugin_canonical_atif_path"] = str(plugin_canonical_path)
+        metadata["nemo_flow_plugin_canonical_atif_exists"] = plugin_canonical_path.exists()
         context.metadata = metadata
 
     def _build_run_env(self, route: _ProviderRoute, instruction: str) -> dict[str, str]:
@@ -392,6 +435,11 @@ class HermesNeMoFlow(Hermes):
                 "source": "harbor", "agent": self.name()
             }, separators=(",", ":")),
         ]
+        if self._enable_nemoflow_observability_plugin:
+            args.extend([
+                "--plugin-config",
+                json.dumps(self._build_observability_plugin_config(), separators=(",", ":")),
+            ])
         if route.gateway_route == "anthropic":
             args.extend(["--anthropic-base-url", self._upstream_base_url(route)])
         else:
@@ -402,6 +450,31 @@ class HermesNeMoFlow(Hermes):
         return ('export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH" && '
                 f"{' '.join(shlex.quote(arg) for arg in args)} "
                 "2>&1 | stdbuf -oL tee /logs/agent/hermes.txt")
+
+    def _build_observability_plugin_config(self) -> dict[str, Any]:
+        return {
+            "version": 1,
+            "components": [
+                {
+                    "kind": "observability",
+                    "enabled": True,
+                    "config": {
+                        "version": 1,
+                        "atof": {
+                            "enabled": True,
+                            "output_directory": self._atof_dir,
+                            "filename": "events.jsonl",
+                            "mode": "overwrite",
+                        },
+                        "atif": {
+                            "enabled": True,
+                            "output_directory": self._plugin_atif_dir,
+                            "filename_template": "trajectory-{session_id}.atif.json",
+                        },
+                    },
+                }
+            ],
+        }
 
     def _build_child_script(self, route: _ProviderRoute) -> str:
         cli_parts = [
@@ -438,21 +511,22 @@ class HermesNeMoFlow(Hermes):
         session_id_expr = ("import json,pathlib;"
                            "p=pathlib.Path('/logs/agent/hermes-session.jsonl');"
                            "sid='';"
-                           "\nfor line in p.read_text().splitlines():"
+                           "\nfor line in p.read_text(encoding='utf-8').splitlines():"
                            "\n    line=line.strip();"
                            "\n    if not line: continue"
                            "\n    obj=json.loads(line);"
                            "\n    sid=str(obj.get('id') or obj.get('session_id') or '');"
                            "\n    break"
                            "\nprint(sid)")
-        payload = (
-            'printf \'{"session_id":"%s","hook_event_name":"on_session_finalize","source":"harbor"}\\n\' "$session_id"')
+        payload = ('printf \'{"session_id":"%s","hook_event_name":"on_session_finalize",'
+                   '"source":"harbor"}\\n\' "$nf_session_id"')
         return (f"if ! find {shlex.quote(self._gateway_atif_dir)} -name '*.atif.json' "
                 "-print -quit 2>/dev/null | grep -q .; then "
                 f"session_id=$(python3 -c {shlex.quote(session_id_expr)} 2>/dev/null || true); "
-                'if [ -n "$session_id" ]; then '
+                'for nf_session_id in "$session_id" gateway-gateway; do '
+                '[ -n "$nf_session_id" ] || continue; '
                 f"{payload} | {self._build_hook_forward_command()} || true; "
-                "fi; "
+                "done; "
                 "fi")
 
     def _upstream_base_url(self, route: _ProviderRoute) -> str:

--- a/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
+++ b/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
@@ -1,5 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 """Experimental Harbor wrapper for Hermes with the NeMo-Flow CLI gateway enabled.
 
 Tracks the current NeMo-Flow CLI gateway surface: ``crates/cli``, binary

--- a/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
+++ b/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
@@ -467,27 +467,25 @@ class HermesNeMoFlow(Hermes):
                 'exit "$status"')
 
     def _build_observability_plugin_toml(self) -> str:
-        return (
-            "version = 1\n"
-            "\n"
-            "[[components]]\n"
-            "kind = \"observability\"\n"
-            "enabled = true\n"
-            "\n"
-            "[components.config]\n"
-            "version = 1\n"
-            "\n"
-            "[components.config.atof]\n"
-            "enabled = true\n"
-            f"output_directory = {json.dumps(self._atof_dir)}\n"
-            "filename = \"events.jsonl\"\n"
-            "mode = \"overwrite\"\n"
-            "\n"
-            "[components.config.atif]\n"
-            "enabled = true\n"
-            f"output_directory = {json.dumps(self._plugin_atif_dir)}\n"
-            "filename_template = \"trajectory-{session_id}.atif.json\"\n"
-        )
+        return ("version = 1\n"
+                "\n"
+                "[[components]]\n"
+                "kind = \"observability\"\n"
+                "enabled = true\n"
+                "\n"
+                "[components.config]\n"
+                "version = 1\n"
+                "\n"
+                "[components.config.atof]\n"
+                "enabled = true\n"
+                f"output_directory = {json.dumps(self._atof_dir)}\n"
+                "filename = \"events.jsonl\"\n"
+                "mode = \"overwrite\"\n"
+                "\n"
+                "[components.config.atif]\n"
+                "enabled = true\n"
+                f"output_directory = {json.dumps(self._plugin_atif_dir)}\n"
+                "filename_template = \"trajectory-{session_id}.atif.json\"\n")
 
     def _build_post_run_script(self) -> str:
         return "; ".join([

--- a/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
+++ b/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
@@ -17,11 +17,10 @@
 Tracks the current NeMo-Flow CLI gateway surface: ``crates/cli``, binary
 ``nemo-flow``, and runtime gateway discovery through ``NEMO_FLOW_GATEWAY_URL``.
 
-PR #88 adds native ATOF JSONL exporter APIs to NeMo-Flow, and PR #89 adds a
-config-driven observability plugin that can install ATOF/ATIF exporters when the
-CLI gateway activates plugin config at startup. The plugin path is opt-in here
-so the wrapper can still run against NeMo-Flow branches that only support direct
-gateway ATIF via ``--atif-dir``.
+NeMo-Flow v0.2 and newer expose ATOF/ATIF export through the observability
+plugin. This wrapper writes project-scoped ``.nemo-flow/plugins.toml`` when
+requested; per-hook ``hook-forward`` calls only forward Hermes hook payloads to
+the active gateway process.
 """
 
 from __future__ import annotations
@@ -112,9 +111,9 @@ class HermesNeMoFlow(Hermes):
         self._gateway_atif_dir = (resolved_atif_dir or self._DEFAULT_GATEWAY_ATIF_DIR).rstrip("/")
         self._plugin_atif_dir = (plugin_atif_dir or self._DEFAULT_PLUGIN_ATIF_DIR).rstrip("/")
         self._enable_nemoflow_observability_plugin = enable_nemoflow_observability_plugin
-        # Raw ATOF export requires a NeMo-Flow branch that activates PR #89
-        # plugin config in the CLI gateway. Keep fail-on-missing opt-in so the
-        # wrapper remains compatible with direct-ATIF-only gateway branches.
+        # Raw ATOF export requires NeMo-Flow observability plugin activation in
+        # the CLI gateway. Keep fail-on-missing opt-in for older local
+        # validation branches that do not emit ATOF.
         self._fail_missing_nemoflow_atof = fail_missing_nemoflow_atof
         self._fail_missing_nemoflow_atif = fail_missing_nemoflow_atif
         self._convert_nemoflow_atof = convert_nemoflow_atof
@@ -218,12 +217,8 @@ class HermesNeMoFlow(Hermes):
                      f"ln -sf {shlex.quote(self._container_cli_bin)} "
                      '"$HOME/.local/bin/nemo-flow"; '
                      "nemo-flow --help >/dev/null; "
-                     "nemo-flow run --help | grep -q -- '--atif-dir' || "
-                     "{ echo 'Error: nemo-flow run does not support --atif-dir' >&2; exit 1; }; "
-                     "nemo-flow run --help | grep -q -- '--plugin-config' || "
-                     "{ echo 'Error: nemo-flow run does not support --plugin-config' >&2; exit 1; }; "
-                     "nemo-flow hook-forward --help | grep -q -- '--atif-dir' || "
-                     "{ echo 'Error: nemo-flow hook-forward does not support --atif-dir' >&2; exit 1; }"),
+                     "nemo-flow plugins edit --help >/dev/null; "
+                     "nemo-flow hook-forward --help >/dev/null"),
             timeout_sec=1800,
         )
 
@@ -232,12 +227,8 @@ class HermesNeMoFlow(Hermes):
                 "command -v nemo-flow >/dev/null || "
                 "{ echo 'Error: prebuilt image does not provide nemo-flow on PATH' >&2; exit 1; }; "
                 "nemo-flow --help >/dev/null; "
-                "nemo-flow run --help | grep -q -- '--atif-dir' || "
-                "{ echo 'Error: nemo-flow run does not support --atif-dir' >&2; exit 1; }; "
-                "nemo-flow run --help | grep -q -- '--plugin-config' || "
-                "{ echo 'Error: nemo-flow run does not support --plugin-config' >&2; exit 1; }; "
-                "nemo-flow hook-forward --help | grep -q -- '--atif-dir' || "
-                "{ echo 'Error: nemo-flow hook-forward does not support --atif-dir' >&2; exit 1; }")
+                "nemo-flow plugins edit --help >/dev/null; "
+                "nemo-flow hook-forward --help >/dev/null")
 
     @with_prompt_template
     async def run(
@@ -253,14 +244,11 @@ class HermesNeMoFlow(Hermes):
         route = self._build_provider_route(provider, model)
         env = self._build_run_env(route, instruction)
         config_yaml = self._build_config_yaml_with_gateway_hooks(route)
+        plugin_toml = self._build_observability_plugin_toml() if self._enable_nemoflow_observability_plugin else None
 
         await self.exec_as_agent(
             environment,
-            command=(f"mkdir -p {shlex.quote(self._HERMES_HOME)} "
-                     f"{shlex.quote(self._atof_dir)} {shlex.quote(self._gateway_atif_dir)} "
-                     f"{shlex.quote(self._plugin_atif_dir)} "
-                     "/logs/agent/nemo-flow-gateway && "
-                     f"cat > {shlex.quote(self._HERMES_HOME)}/config.yaml << 'EOF'\n{config_yaml}EOF"),
+            command=self._build_setup_command(config_yaml, plugin_toml),
             env=env,
             timeout_sec=10,
         )
@@ -338,7 +326,6 @@ class HermesNeMoFlow(Hermes):
             "HERMES_HOME": self._HERMES_HOME,
             "TERMINAL_ENV": "local",
             "HARBOR_INSTRUCTION": instruction,
-            "NEMO_FLOW_ATIF_DIR": self._gateway_atif_dir,
         }
         api_key_env = self._first_available_env(route.api_key_envs)
         if api_key_env is None:
@@ -426,9 +413,28 @@ class HermesNeMoFlow(Hermes):
         return yaml.safe_dump(config, default_flow_style=False, sort_keys=False)
 
     def _build_hook_forward_command(self) -> str:
-        return ("nemo-flow hook-forward hermes "
-                f"--atif-dir {shlex.quote(self._gateway_atif_dir)} "
-                "--gateway-mode passthrough")
+        return "nemo-flow hook-forward hermes --gateway-mode passthrough"
+
+    def _build_setup_command(self, config_yaml: str, plugin_toml: str | None) -> str:
+        plugin_dir = f"{self._DEFAULT_TASK_DIR}/.nemo-flow"
+        config_yaml = config_yaml if config_yaml.endswith("\n") else f"{config_yaml}\n"
+        if plugin_toml is not None:
+            plugin_toml = plugin_toml if plugin_toml.endswith("\n") else f"{plugin_toml}\n"
+        mkdir_paths = [
+            self._HERMES_HOME,
+            self._atof_dir,
+            self._gateway_atif_dir,
+            self._plugin_atif_dir,
+            "/logs/agent/nemo-flow-gateway",
+        ]
+        if plugin_toml is not None:
+            mkdir_paths.append(plugin_dir)
+        command = ("set -euo pipefail; "
+                   f"mkdir -p {' '.join(shlex.quote(path) for path in mkdir_paths)}; "
+                   f"cat > {shlex.quote(self._HERMES_HOME)}/config.yaml << 'EOF'\n{config_yaml}EOF")
+        if plugin_toml is not None:
+            command += f"\ncat > {shlex.quote(plugin_dir)}/plugins.toml << 'EOF'\n{plugin_toml}EOF"
+        return command
 
     def _build_gateway_run_command(self, route: _ProviderRoute, instruction: str) -> str:
         args = [
@@ -436,18 +442,11 @@ class HermesNeMoFlow(Hermes):
             "run",
             "--agent",
             "hermes",
-            "--atif-dir",
-            self._gateway_atif_dir,
             "--session-metadata",
             json.dumps({
                 "source": "harbor", "agent": self.name()
             }, separators=(",", ":")),
         ]
-        if self._enable_nemoflow_observability_plugin:
-            args.extend([
-                "--plugin-config",
-                json.dumps(self._build_observability_plugin_config(), separators=(",", ":")),
-            ])
         if route.gateway_route == "anthropic":
             args.extend(["--anthropic-base-url", self._upstream_base_url(route)])
         else:
@@ -458,6 +457,7 @@ class HermesNeMoFlow(Hermes):
         post_run_script = self._build_post_run_script()
         run_segment = " ".join(shlex.quote(arg) for arg in args)
         return ('export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH" && '
+                f"cd {shlex.quote(self._DEFAULT_TASK_DIR)} && "
                 f"status_file={shlex.quote(status_file)}; "
                 f"rm -f \"$status_file\"; "
                 f"({run_segment}; printf '%s' \"$?\" > \"$status_file\") "
@@ -466,29 +466,28 @@ class HermesNeMoFlow(Hermes):
                 f"{post_run_script}; "
                 'exit "$status"')
 
-    def _build_observability_plugin_config(self) -> dict[str, Any]:
-        return {
-            "version":
-                1,
-            "components": [{
-                "kind": "observability",
-                "enabled": True,
-                "config": {
-                    "version": 1,
-                    "atof": {
-                        "enabled": True,
-                        "output_directory": self._atof_dir,
-                        "filename": "events.jsonl",
-                        "mode": "overwrite",
-                    },
-                    "atif": {
-                        "enabled": True,
-                        "output_directory": self._plugin_atif_dir,
-                        "filename_template": "trajectory-{session_id}.atif.json",
-                    },
-                },
-            }],
-        }
+    def _build_observability_plugin_toml(self) -> str:
+        return (
+            "version = 1\n"
+            "\n"
+            "[[components]]\n"
+            "kind = \"observability\"\n"
+            "enabled = true\n"
+            "\n"
+            "[components.config]\n"
+            "version = 1\n"
+            "\n"
+            "[components.config.atof]\n"
+            "enabled = true\n"
+            f"output_directory = {json.dumps(self._atof_dir)}\n"
+            "filename = \"events.jsonl\"\n"
+            "mode = \"overwrite\"\n"
+            "\n"
+            "[components.config.atif]\n"
+            "enabled = true\n"
+            f"output_directory = {json.dumps(self._plugin_atif_dir)}\n"
+            "filename_template = \"trajectory-{session_id}.atif.json\"\n"
+        )
 
     def _build_post_run_script(self) -> str:
         return "; ".join([

--- a/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
+++ b/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
@@ -1,6 +1,17 @@
 # SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: Apache-2.0
-"""Experimental Harbor wrapper for Hermes with NeMo-Flow sidecar enabled."""
+"""Experimental Harbor wrapper for Hermes with the NeMo-Flow CLI gateway enabled.
+
+Tracks the current NeMo-Flow CLI gateway surface: ``crates/cli``, binary
+``nemo-flow``, and runtime gateway discovery through ``NEMO_FLOW_GATEWAY_URL``.
+
+PR #88 adds native ATOF JSONL exporter APIs to NeMo-Flow, but the Hermes CLI
+gateway path still does not expose a raw ATOF JSONL artifact from
+``nemo-flow run``/``hook-forward``. The ATOF conversion code path is kept here,
+dormant by default, so it lights up automatically once NeMo-Flow wires Hermes
+gateway events into the exporter. Until then, the canonical artifact for this
+wrapper is the gateway-emitted ATIF (``*.atif.json``).
+"""
 
 from __future__ import annotations
 
@@ -22,12 +33,12 @@ from harbor.models.agent.context import AgentContext
 
 @dataclass(frozen=True)
 class _ProviderRoute:
-    """Provider settings needed to route Hermes model traffic through the sidecar."""
+    """Provider settings needed to route Hermes model traffic through the gateway."""
 
     api_key_envs: tuple[str, ...]
     upstream_base_env: str | None
     default_upstream_base_url: str
-    sidecar_route: str
+    gateway_route: str
     hermes_provider: str
     cli_provider: str | None
     cli_model: str
@@ -35,14 +46,14 @@ class _ProviderRoute:
 
 
 class HermesNeMoFlow(Hermes):
-    """Run Hermes inside Harbor with a NeMo-Flow sidecar around the session."""
+    """Run Hermes inside Harbor with the NeMo-Flow CLI gateway around the session."""
 
     _DEFAULT_CONTAINER_NEMO_FLOW_DIR = "/opt/nemo-flow"
     _DEFAULT_ATOF_DIR = "/logs/agent/nemo-flow-atof"
-    _DEFAULT_SIDECAR_ATIF_DIR = "/logs/agent/nemo-flow-sidecar-atif"
+    _DEFAULT_GATEWAY_ATIF_DIR = "/logs/agent/nemo-flow-gateway-atif"
     _CONVERTED_ATIF_DIR_NAME = "nemo-flow-atof-atif"
     _CONVERTED_ATIF_FILENAME = "trajectory.json"
-    _SIDECAR_CANONICAL_ATIF_FILENAME = "trajectory.json"
+    _GATEWAY_CANONICAL_ATIF_FILENAME = "trajectory.json"
     _DEFAULT_TASK_DIR = "/testbed"
     _HERMES_HOME = "/tmp/hermes"
     _HERMES_HOOK_EVENTS = (
@@ -66,50 +77,62 @@ class HermesNeMoFlow(Hermes):
         nemo_flow_repo: str | None = None,
         container_nemo_flow_dir: str = _DEFAULT_CONTAINER_NEMO_FLOW_DIR,
         atof_dir: str = _DEFAULT_ATOF_DIR,
-        sidecar_atif_dir: str = _DEFAULT_SIDECAR_ATIF_DIR,
-        fail_missing_nemoflow_atof: bool = True,
-        fail_missing_nemoflow_atif: bool = False,
+        gateway_atif_dir: str | None = None,
+        fail_missing_nemoflow_atof: bool = False,
+        fail_missing_nemoflow_atif: bool = True,
         convert_nemoflow_atof: bool = True,
-        fail_nemoflow_atof_conversion: bool = True,
+        fail_nemoflow_atof_conversion: bool = False,
         canonicalize_nemoflow_atif: bool = True,
+        sidecar_atif_dir: str | None = None,
         **kwargs: Any,
     ):
         super().__init__(*args, **kwargs)
         self._nemo_flow_repo = Path(nemo_flow_repo or os.environ.get("NEMO_FLOW_REPO", "external/nemo-flow")).resolve()
         self._container_nemo_flow_dir = container_nemo_flow_dir.rstrip("/")
         self._atof_dir = atof_dir.rstrip("/")
-        self._sidecar_atif_dir = sidecar_atif_dir.rstrip("/")
+        # Backwards-compatible alias: callers configured against the pre-rename
+        # branch may still pass `sidecar_atif_dir`. Prefer the new name when set.
+        resolved_atif_dir = gateway_atif_dir if gateway_atif_dir is not None else sidecar_atif_dir
+        self._gateway_atif_dir = (resolved_atif_dir or self._DEFAULT_GATEWAY_ATIF_DIR).rstrip("/")
+        # PR #88 adds the generic ATOF exporter API, but Hermes CLI gateway runs
+        # still only expose direct ATIF via --atif-dir. Keep the raw ATOF path
+        # dormant by default; fail-on-missing is opt-in for downstream users on
+        # a NeMo-Flow branch that wires Hermes gateway events into ATOF JSONL.
         self._fail_missing_nemoflow_atof = fail_missing_nemoflow_atof
         self._fail_missing_nemoflow_atif = fail_missing_nemoflow_atif
         self._convert_nemoflow_atof = convert_nemoflow_atof
         self._fail_nemoflow_atof_conversion = fail_nemoflow_atof_conversion
         self._canonicalize_nemoflow_atif = canonicalize_nemoflow_atif
 
+    @property
+    def _sidecar_atif_dir(self) -> str:
+        """Deprecated alias retained for any external callers reading the attribute."""
+        return self._gateway_atif_dir
+
     @staticmethod
     def name() -> str:
         return "hermes-nemoflow"
 
     @property
-    def _container_sidecar_bin(self) -> str:
-        return f"{self._container_nemo_flow_dir}/target/release/nemo-flow-sidecar"
+    def _container_cli_bin(self) -> str:
+        return f"{self._container_nemo_flow_dir}/target/release/nemo-flow"
 
     def _validate_local_nemo_flow_checkout(self) -> None:
         required = [
             self._nemo_flow_repo / "Cargo.toml",
             self._nemo_flow_repo / "Cargo.lock",
             self._nemo_flow_repo / "crates" / "core" / "Cargo.toml",
-            self._nemo_flow_repo / "crates" / "sidecar" / "Cargo.toml",
-            self._nemo_flow_repo / "crates" / "sidecar" / "src" / "main.rs",
+            self._nemo_flow_repo / "crates" / "cli" / "Cargo.toml",
+            self._nemo_flow_repo / "crates" / "cli" / "src" / "main.rs",
         ]
         missing = [str(path) for path in required if not path.exists()]
         if missing:
-            raise FileNotFoundError(
-                "NeMo-Flow sidecar checkout is not ready. Missing:\n" + "\n".join(f"- {path}" for path in missing)
-            )
+            raise FileNotFoundError("NeMo-Flow CLI checkout is not ready. Missing:\n" + "\n".join(f"- {path}"
+                                                                                                  for path in missing))
 
     def _prepare_upload_tree(self) -> Path:
         self._validate_local_nemo_flow_checkout()
-        setup_dir = self.logs_dir / "setup" / "nemo-flow-sidecar-upload"
+        setup_dir = self.logs_dir / "setup" / "nemo-flow-cli-upload"
         if setup_dir.exists():
             shutil.rmtree(setup_dir)
         setup_dir.mkdir(parents=True, exist_ok=True)
@@ -142,16 +165,14 @@ class HermesNeMoFlow(Hermes):
 
         await self.exec_as_root(
             environment,
-            command="apt-get update && apt-get install -y build-essential ca-certificates pkg-config",
+            command="apt-get update && apt-get install -y build-essential ca-certificates curl pkg-config",
             env={"DEBIAN_FRONTEND": "noninteractive"},
             timeout_sec=600,
         )
         await self.exec_as_root(
             environment,
-            command=(
-                f"mkdir -p {shlex.quote(self._container_nemo_flow_dir)} && "
-                f"chmod 777 {shlex.quote(self._container_nemo_flow_dir)}"
-            ),
+            command=(f"mkdir -p {shlex.quote(self._container_nemo_flow_dir)} && "
+                     f"chmod 777 {shlex.quote(self._container_nemo_flow_dir)}"),
         )
         await environment.upload_dir(
             source_dir=upload_tree,
@@ -159,24 +180,22 @@ class HermesNeMoFlow(Hermes):
         )
         await self.exec_as_agent(
             environment,
-            command=(
-                "set -euo pipefail; "
-                "if ! command -v cargo >/dev/null 2>&1; then "
-                "curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | "
-                "sh -s -- -y --profile minimal; "
-                "fi; "
-                '. "$HOME/.cargo/env"; '
-                f"cd {shlex.quote(self._container_nemo_flow_dir)}; "
-                "cargo build -p nemo-flow-sidecar --release; "
-                'mkdir -p "$HOME/.local/bin"; '
-                f"ln -sf {shlex.quote(self._container_sidecar_bin)} "
-                '"$HOME/.local/bin/nemo-flow-sidecar"; '
-                "nemo-flow-sidecar --help >/dev/null; "
-                "nemo-flow-sidecar run --help | grep -q -- '--atof-dir' || "
-                "{ echo 'Error: nemo-flow-sidecar run does not support --atof-dir' >&2; exit 1; }; "
-                "nemo-flow-sidecar hook-forward --help | grep -q -- '--atof-dir' || "
-                "{ echo 'Error: nemo-flow-sidecar hook-forward does not support --atof-dir' >&2; exit 1; }"
-            ),
+            command=("set -euo pipefail; "
+                     "if ! command -v cargo >/dev/null 2>&1; then "
+                     "curl --proto '=https' --tlsv1.2 -fsSL https://sh.rustup.rs | "
+                     "sh -s -- -y --profile minimal; "
+                     "fi; "
+                     '. "$HOME/.cargo/env"; '
+                     f"cd {shlex.quote(self._container_nemo_flow_dir)}; "
+                     "cargo build -p nemo-flow-cli --release; "
+                     'mkdir -p "$HOME/.local/bin"; '
+                     f"ln -sf {shlex.quote(self._container_cli_bin)} "
+                     '"$HOME/.local/bin/nemo-flow"; '
+                     "nemo-flow --help >/dev/null; "
+                     "nemo-flow run --help | grep -q -- '--atif-dir' || "
+                     "{ echo 'Error: nemo-flow run does not support --atif-dir' >&2; exit 1; }; "
+                     "nemo-flow hook-forward --help | grep -q -- '--atif-dir' || "
+                     "{ echo 'Error: nemo-flow hook-forward does not support --atif-dir' >&2; exit 1; }"),
             timeout_sec=1800,
         )
 
@@ -193,16 +212,14 @@ class HermesNeMoFlow(Hermes):
         provider, model = self.model_name.split("/", 1)
         route = self._build_provider_route(provider, model)
         env = self._build_run_env(route, instruction)
-        config_yaml = self._build_config_yaml_with_sidecar_hooks(route)
+        config_yaml = self._build_config_yaml_with_gateway_hooks(route)
 
         await self.exec_as_agent(
             environment,
-            command=(
-                f"mkdir -p {shlex.quote(self._HERMES_HOME)} "
-                f"{shlex.quote(self._atof_dir)} {shlex.quote(self._sidecar_atif_dir)} "
-                "/logs/agent/nemo-flow-sidecar && "
-                f"cat > {shlex.quote(self._HERMES_HOME)}/config.yaml << 'EOF'\n{config_yaml}EOF"
-            ),
+            command=(f"mkdir -p {shlex.quote(self._HERMES_HOME)} "
+                     f"{shlex.quote(self._atof_dir)} {shlex.quote(self._gateway_atif_dir)} "
+                     "/logs/agent/nemo-flow-gateway && "
+                     f"cat > {shlex.quote(self._HERMES_HOME)}/config.yaml << 'EOF'\n{config_yaml}EOF"),
             env=env,
             timeout_sec=10,
         )
@@ -215,23 +232,23 @@ class HermesNeMoFlow(Hermes):
         if skills_command:
             await self.exec_as_agent(environment, command=skills_command, env=env, timeout_sec=10)
 
-        run_cmd = self._build_sidecar_run_command(route)
+        run_cmd = self._build_gateway_run_command(route)
         await self.exec_as_agent(environment, command=run_cmd, env=env)
 
     def populate_context_post_run(self, context: AgentContext) -> None:
         super().populate_context_post_run(context)
 
         atof_path = self.logs_dir / self._atof_dir.removeprefix("/logs/agent/") / "events.jsonl"
-        sidecar_dir = self.logs_dir / self._sidecar_atif_dir.removeprefix("/logs/agent/")
-        atif_files = self._sidecar_atif_files(sidecar_dir)
-        canonical_path = sidecar_dir / self._SIDECAR_CANONICAL_ATIF_FILENAME
+        gateway_dir = self.logs_dir / self._gateway_atif_dir.removeprefix("/logs/agent/")
+        atif_files = self._gateway_atif_files(gateway_dir)
+        canonical_path = gateway_dir / self._GATEWAY_CANONICAL_ATIF_FILENAME
         converted_atif_path = self.logs_dir / self._CONVERTED_ATIF_DIR_NAME / self._CONVERTED_ATIF_FILENAME
 
         if self._fail_missing_nemoflow_atof and not atof_path.exists():
             raise FileNotFoundError(f"Missing NeMo-Flow ATOF JSONL artifact: {atof_path}")
 
         if self._fail_missing_nemoflow_atif and not atif_files:
-            raise FileNotFoundError(f"Missing NeMo-Flow sidecar ATIF artifact under: {sidecar_dir}")
+            raise FileNotFoundError(f"Missing NeMo-Flow gateway ATIF artifact under: {gateway_dir}")
 
         if self._convert_nemoflow_atof and atof_path.exists():
             try:
@@ -242,7 +259,7 @@ class HermesNeMoFlow(Hermes):
                     raise RuntimeError(f"Failed to convert NeMo-Flow ATOF artifact to ATIF: {atof_path}") from exc
 
         if self._canonicalize_nemoflow_atif and atif_files:
-            self._write_canonical_sidecar_atif(atif_files[0], canonical_path)
+            self._write_canonical_gateway_atif(atif_files[0], canonical_path)
 
         if converted_atif_path.exists():
             self._populate_context_tokens_from_atif(context, converted_atif_path)
@@ -250,15 +267,15 @@ class HermesNeMoFlow(Hermes):
             self._populate_context_tokens_from_atif(context, canonical_path)
 
         metadata = dict(context.metadata or {})
-        metadata["nemo_flow_instrumentation"] = "sidecar"
+        metadata["nemo_flow_instrumentation"] = "gateway"
         metadata["nemo_flow_atof_path"] = str(atof_path)
         metadata["nemo_flow_atof_exists"] = atof_path.exists()
         metadata["nemo_flow_converted_atif_path"] = str(converted_atif_path)
         metadata["nemo_flow_converted_atif_exists"] = converted_atif_path.exists()
-        metadata["nemo_flow_sidecar_atif_dir"] = str(sidecar_dir)
-        metadata["nemo_flow_sidecar_atif_paths"] = [str(path) for path in atif_files]
-        metadata["nemo_flow_sidecar_canonical_atif_path"] = str(canonical_path)
-        metadata["nemo_flow_sidecar_canonical_atif_exists"] = canonical_path.exists()
+        metadata["nemo_flow_gateway_atif_dir"] = str(gateway_dir)
+        metadata["nemo_flow_gateway_atif_paths"] = [str(path) for path in atif_files]
+        metadata["nemo_flow_gateway_canonical_atif_path"] = str(canonical_path)
+        metadata["nemo_flow_gateway_canonical_atif_exists"] = canonical_path.exists()
         context.metadata = metadata
 
     def _build_run_env(self, route: _ProviderRoute, instruction: str) -> dict[str, str]:
@@ -266,8 +283,11 @@ class HermesNeMoFlow(Hermes):
             "HERMES_HOME": self._HERMES_HOME,
             "TERMINAL_ENV": "local",
             "HARBOR_INSTRUCTION": instruction,
+            # ATOF dir env is preserved for a future Hermes gateway path built
+            # on PR #88's exporter APIs. The current `nemo-flow` CLI does not
+            # consume it for Hermes; harmless to export.
             "NEMO_FLOW_ATOF_DIR": self._atof_dir,
-            "NEMO_FLOW_ATIF_DIR": self._sidecar_atif_dir,
+            "NEMO_FLOW_ATIF_DIR": self._gateway_atif_dir,
         }
         api_key_env = self._first_available_env(route.api_key_envs)
         if api_key_env is None:
@@ -284,7 +304,7 @@ class HermesNeMoFlow(Hermes):
                 api_key_envs=("ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN"),
                 upstream_base_env="ANTHROPIC_BASE_URL",
                 default_upstream_base_url="https://api.anthropic.com",
-                sidecar_route="anthropic",
+                gateway_route="anthropic",
                 hermes_provider="anthropic",
                 cli_provider="anthropic",
                 cli_model=model,
@@ -292,10 +312,10 @@ class HermesNeMoFlow(Hermes):
             )
         if provider == "openai":
             return _ProviderRoute(
-                api_key_envs=("OPENAI_API_KEY",),
+                api_key_envs=("OPENAI_API_KEY", ),
                 upstream_base_env="OPENAI_BASE_URL",
                 default_upstream_base_url="https://api.openai.com",
-                sidecar_route="openai",
+                gateway_route="openai",
                 hermes_provider="custom",
                 cli_provider=None,
                 cli_model=model,
@@ -303,10 +323,10 @@ class HermesNeMoFlow(Hermes):
             )
         if provider == "nvidia":
             return _ProviderRoute(
-                api_key_envs=("NVIDIA_API_KEY",),
+                api_key_envs=("NVIDIA_API_KEY", ),
                 upstream_base_env="NVIDIA_BASE_URL",
                 default_upstream_base_url="https://integrate.api.nvidia.com/v1",
-                sidecar_route="openai",
+                gateway_route="openai",
                 hermes_provider="custom",
                 cli_provider=None,
                 cli_model=model,
@@ -314,33 +334,33 @@ class HermesNeMoFlow(Hermes):
             )
         if provider == "openrouter":
             return _ProviderRoute(
-                api_key_envs=("OPENROUTER_API_KEY",),
+                api_key_envs=("OPENROUTER_API_KEY", ),
                 upstream_base_env="OPENROUTER_BASE_URL",
                 default_upstream_base_url="https://openrouter.ai/api/v1",
-                sidecar_route="openai",
+                gateway_route="openai",
                 hermes_provider="custom",
                 cli_provider=None,
                 cli_model=model,
                 config_model=model,
             )
         return _ProviderRoute(
-            api_key_envs=("OPENROUTER_API_KEY",),
+            api_key_envs=("OPENROUTER_API_KEY", ),
             upstream_base_env="OPENROUTER_BASE_URL",
             default_upstream_base_url="https://openrouter.ai/api/v1",
-            sidecar_route="openai",
+            gateway_route="openai",
             hermes_provider="custom",
             cli_provider=None,
             cli_model=self.model_name or model,
             config_model=self.model_name or model,
         )
 
-    def _build_config_yaml_with_sidecar_hooks(self, route: _ProviderRoute) -> str:
+    def _build_config_yaml_with_gateway_hooks(self, route: _ProviderRoute) -> str:
         config = yaml.safe_load(self._build_config_yaml(route.config_model)) or {}
         config["model"] = {
             "default": route.config_model,
             "model": route.config_model,
             "provider": route.hermes_provider,
-            "base_url": "${NEMO_FLOW_SIDECAR_URL}",
+            "base_url": "${NEMO_FLOW_GATEWAY_URL}",
         }
         if route.hermes_provider == "custom":
             config["model"]["api_key"] = "${OPENAI_API_KEY}"
@@ -355,38 +375,33 @@ class HermesNeMoFlow(Hermes):
         return yaml.safe_dump(config, default_flow_style=False, sort_keys=False)
 
     def _build_hook_forward_command(self) -> str:
-        return (
-            "nemo-flow-sidecar hook-forward hermes "
-            f"--atof-dir {shlex.quote(self._atof_dir)} "
-            f"--atif-dir {shlex.quote(self._sidecar_atif_dir)} "
-            "--gateway-mode passthrough"
-        )
+        return ("nemo-flow hook-forward hermes "
+                f"--atif-dir {shlex.quote(self._gateway_atif_dir)} "
+                "--gateway-mode passthrough")
 
-    def _build_sidecar_run_command(self, route: _ProviderRoute) -> str:
+    def _build_gateway_run_command(self, route: _ProviderRoute) -> str:
         args = [
-            "nemo-flow-sidecar",
+            "nemo-flow",
             "run",
             "--agent",
             "hermes",
-            "--atof-dir",
-            self._atof_dir,
             "--atif-dir",
-            self._sidecar_atif_dir,
+            self._gateway_atif_dir,
             "--session-metadata",
-            json.dumps({"source": "harbor", "agent": self.name()}, separators=(",", ":")),
+            json.dumps({
+                "source": "harbor", "agent": self.name()
+            }, separators=(",", ":")),
         ]
-        if route.sidecar_route == "anthropic":
+        if route.gateway_route == "anthropic":
             args.extend(["--anthropic-base-url", self._upstream_base_url(route)])
         else:
             args.extend(["--openai-base-url", self._upstream_base_url(route)])
 
         child_script = self._build_child_script(route)
         args.extend(["--", "/bin/bash", "-lc", child_script])
-        return (
-            'export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH" && '
-            f"{' '.join(shlex.quote(arg) for arg in args)} "
-            "2>&1 | stdbuf -oL tee /logs/agent/hermes.txt"
-        )
+        return ('export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH" && '
+                f"{' '.join(shlex.quote(arg) for arg in args)} "
+                "2>&1 | stdbuf -oL tee /logs/agent/hermes.txt")
 
     def _build_child_script(self, route: _ProviderRoute) -> str:
         cli_parts = [
@@ -417,34 +432,28 @@ class HermesNeMoFlow(Hermes):
         if toolsets_flag:
             parts.extend(["--toolsets", str(toolsets_flag)])
         return " ".join(
-            shlex.quote(part) if part != "$HARBOR_INSTRUCTION" else '"$HARBOR_INSTRUCTION"' for part in parts
-        )
+            shlex.quote(part) if part != "$HARBOR_INSTRUCTION" else '"$HARBOR_INSTRUCTION"' for part in parts)
 
     def _synthetic_finalize_command(self) -> str:
-        session_id_expr = (
-            "import json,pathlib;"
-            "p=pathlib.Path('/logs/agent/hermes-session.jsonl');"
-            "sid='';"
-            "\nfor line in p.read_text().splitlines():"
-            "\n    line=line.strip();"
-            "\n    if not line: continue"
-            "\n    obj=json.loads(line);"
-            "\n    sid=str(obj.get('id') or obj.get('session_id') or '');"
-            "\n    break"
-            "\nprint(sid)"
-        )
+        session_id_expr = ("import json,pathlib;"
+                           "p=pathlib.Path('/logs/agent/hermes-session.jsonl');"
+                           "sid='';"
+                           "\nfor line in p.read_text().splitlines():"
+                           "\n    line=line.strip();"
+                           "\n    if not line: continue"
+                           "\n    obj=json.loads(line);"
+                           "\n    sid=str(obj.get('id') or obj.get('session_id') or '');"
+                           "\n    break"
+                           "\nprint(sid)")
         payload = (
-            'printf \'{"session_id":"%s","hook_event_name":"on_session_finalize","source":"harbor"}\\n\' "$session_id"'
-        )
-        return (
-            f"if ! find {shlex.quote(self._sidecar_atif_dir)} -name '*.atif.json' "
-            "-print -quit 2>/dev/null | grep -q .; then "
-            f"session_id=$(python3 -c {shlex.quote(session_id_expr)} 2>/dev/null || true); "
-            'if [ -n "$session_id" ]; then '
-            f"{payload} | {self._build_hook_forward_command()} || true; "
-            "fi; "
-            "fi"
-        )
+            'printf \'{"session_id":"%s","hook_event_name":"on_session_finalize","source":"harbor"}\\n\' "$session_id"')
+        return (f"if ! find {shlex.quote(self._gateway_atif_dir)} -name '*.atif.json' "
+                "-print -quit 2>/dev/null | grep -q .; then "
+                f"session_id=$(python3 -c {shlex.quote(session_id_expr)} 2>/dev/null || true); "
+                'if [ -n "$session_id" ]; then '
+                f"{payload} | {self._build_hook_forward_command()} || true; "
+                "fi; "
+                "fi")
 
     def _upstream_base_url(self, route: _ProviderRoute) -> str:
         if route.upstream_base_env:
@@ -459,7 +468,7 @@ class HermesNeMoFlow(Hermes):
                 return key
         return None
 
-    def _sidecar_atif_files(self, directory: Path) -> list[Path]:
+    def _gateway_atif_files(self, directory: Path) -> list[Path]:
         if not directory.exists():
             return []
         return sorted(
@@ -468,7 +477,7 @@ class HermesNeMoFlow(Hermes):
             reverse=True,
         )
 
-    def _write_canonical_sidecar_atif(self, source: Path, destination: Path) -> None:
+    def _write_canonical_gateway_atif(self, source: Path, destination: Path) -> None:
         destination.parent.mkdir(parents=True, exist_ok=True)
         if source.resolve() != destination.resolve():
             shutil.copy2(source, destination)

--- a/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
+++ b/packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py
@@ -261,7 +261,7 @@ class HermesNeMoFlow(Hermes):
         if skills_command:
             await self.exec_as_agent(environment, command=skills_command, env=env, timeout_sec=10)
 
-        run_cmd = self._build_gateway_run_command(route)
+        run_cmd = self._build_gateway_run_command(route, instruction)
         await self.exec_as_agent(environment, command=run_cmd, env=env)
 
     def populate_context_post_run(self, context: AgentContext) -> None:
@@ -279,9 +279,6 @@ class HermesNeMoFlow(Hermes):
         if self._fail_missing_nemoflow_atof and not atof_path.exists():
             raise FileNotFoundError(f"Missing NeMo-Flow ATOF JSONL artifact: {atof_path}")
 
-        if self._fail_missing_nemoflow_atif and not atif_files:
-            raise FileNotFoundError(f"Missing NeMo-Flow gateway ATIF artifact under: {gateway_dir}")
-
         if self._convert_nemoflow_atof and atof_path.exists():
             try:
                 self._convert_atof_to_atif(atof_path, converted_atif_path)
@@ -289,6 +286,11 @@ class HermesNeMoFlow(Hermes):
                 self.logger.exception("Failed to convert NeMo-Flow ATOF artifact to ATIF")
                 if self._fail_nemoflow_atof_conversion:
                     raise RuntimeError(f"Failed to convert NeMo-Flow ATOF artifact to ATIF: {atof_path}") from exc
+
+        if self._fail_missing_nemoflow_atif and not (atif_files or plugin_atif_files or converted_atif_path.exists()):
+            raise FileNotFoundError(
+                "Missing NeMo-Flow ATIF artifact; checked gateway, plugin, and ATOF-derived outputs under: "
+                f"{self.logs_dir}")
 
         if self._canonicalize_nemoflow_atif and atif_files:
             self._write_canonical_gateway_atif(atif_files[0], canonical_path)
@@ -324,10 +326,6 @@ class HermesNeMoFlow(Hermes):
             "HERMES_HOME": self._HERMES_HOME,
             "TERMINAL_ENV": "local",
             "HARBOR_INSTRUCTION": instruction,
-            # ATOF dir env is preserved for a future Hermes gateway path built
-            # on PR #88's exporter APIs. The current `nemo-flow` CLI does not
-            # consume it for Hermes; harmless to export.
-            "NEMO_FLOW_ATOF_DIR": self._atof_dir,
             "NEMO_FLOW_ATIF_DIR": self._gateway_atif_dir,
         }
         api_key_env = self._first_available_env(route.api_key_envs)
@@ -420,7 +418,7 @@ class HermesNeMoFlow(Hermes):
                 f"--atif-dir {shlex.quote(self._gateway_atif_dir)} "
                 "--gateway-mode passthrough")
 
-    def _build_gateway_run_command(self, route: _ProviderRoute) -> str:
+    def _build_gateway_run_command(self, route: _ProviderRoute, instruction: str) -> str:
         args = [
             "nemo-flow",
             "run",
@@ -443,11 +441,18 @@ class HermesNeMoFlow(Hermes):
         else:
             args.extend(["--openai-base-url", self._upstream_base_url(route)])
 
-        child_script = self._build_child_script(route)
-        args.extend(["--", "/bin/bash", "-lc", child_script])
+        args.extend(["--", *self._hermes_chat_args(route, instruction)])
+        status_file = "/tmp/hermes-nemoflow-status"
+        post_run_script = self._build_post_run_script()
+        run_segment = " ".join(shlex.quote(arg) for arg in args)
         return ('export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH" && '
-                f"{' '.join(shlex.quote(arg) for arg in args)} "
-                "2>&1 | stdbuf -oL tee /logs/agent/hermes.txt")
+                f"status_file={shlex.quote(status_file)}; "
+                f"rm -f \"$status_file\"; "
+                f"({run_segment}; printf '%s' \"$?\" > \"$status_file\") "
+                "2>&1 | stdbuf -oL tee /logs/agent/hermes.txt; "
+                "status=$(cat \"$status_file\" 2>/dev/null || printf '1'); "
+                f"{post_run_script}; "
+                'exit "$status"')
 
     def _build_observability_plugin_config(self) -> dict[str, Any]:
         return {
@@ -473,25 +478,19 @@ class HermesNeMoFlow(Hermes):
             }],
         }
 
-    def _build_child_script(self, route: _ProviderRoute) -> str:
-        cli_parts = [
-            'export PATH="$HOME/.cargo/bin:$HOME/.local/bin:$PATH"',
-            "set +e",
-            self._hermes_chat_command(route),
-            "status=$?",
-            ("hermes sessions export /logs/agent/hermes-session.jsonl --source cli 2>/dev/null || true"),
+    def _build_post_run_script(self) -> str:
+        return "; ".join([
+            "hermes sessions export /logs/agent/hermes-session.jsonl --source cli 2>/dev/null || true",
             self._synthetic_finalize_command(),
-            'exit "$status"',
-        ]
-        return "; ".join(cli_parts)
+        ])
 
-    def _hermes_chat_command(self, route: _ProviderRoute) -> str:
+    def _hermes_chat_args(self, route: _ProviderRoute, instruction: str) -> list[str]:
         parts = [
-            "hermes",
             "--yolo",
+            "--accept-hooks",
             "chat",
             "-q",
-            "$HARBOR_INSTRUCTION",
+            instruction,
             "-Q",
             "--model",
             route.cli_model,
@@ -501,8 +500,7 @@ class HermesNeMoFlow(Hermes):
         toolsets_flag = self._resolved_flags.get("toolsets")
         if toolsets_flag:
             parts.extend(["--toolsets", str(toolsets_flag)])
-        return " ".join(
-            shlex.quote(part) if part != "$HARBOR_INSTRUCTION" else '"$HARBOR_INSTRUCTION"' for part in parts)
+        return parts
 
     def _synthetic_finalize_command(self) -> str:
         session_id_expr = ("import json,pathlib;"

--- a/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
+++ b/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
@@ -161,13 +161,14 @@ async def test_run_uses_gateway_wrapper(tmp_path: Path) -> None:
     commands = [call.kwargs["command"] for call in mock_env.exec.call_args_list]
     # Use a token boundary to avoid matching "nemo-flow run" as a substring of
     # any other command (defensive against future log/tee changes).
-    run_command = next(command for command in commands if " nemo-flow run " in f" {command} ")
+    run_command = next(command for command in commands if "nemo-flow run " in command)
     assert "--agent hermes" in run_command
     assert "--atif-dir /logs/agent/nemo-flow-gateway-atif" in run_command
     assert "--atof-dir" not in run_command
     assert "--plugin-config" not in run_command
     assert "--openai-base-url https://nvidia.example/v1" in run_command
-    assert "hermes --yolo chat" in run_command
+    assert "-- --yolo --accept-hooks chat -q 'solve the task'" in run_command
+    assert "/bin/bash" not in run_command
     assert "tee /logs/agent/hermes.txt" in run_command
     assert "on_session_finalize" in run_command
     assert "read_text(encoding=" in run_command
@@ -188,7 +189,7 @@ def test_gateway_run_can_enable_observability_plugin_config(tmp_path: Path) -> N
     )
     route = agent._build_provider_route("nvidia", "opus-frontier")
 
-    command = agent._build_gateway_run_command(route)
+    command = agent._build_gateway_run_command(route, "solve the task")
 
     nemo_flow_segment = command.split("&& ", 1)[1].split(" 2>&1", 1)[0]
     args = shlex.split(nemo_flow_segment)
@@ -283,20 +284,6 @@ def test_populate_context_can_use_plugin_atif_when_atof_is_absent(tmp_path: Path
         }),
         encoding="utf-8",
     )
-    gateway_dir = agent.logs_dir / "nemo-flow-gateway-atif"
-    gateway_dir.mkdir(parents=True)
-    (gateway_dir / "session-1.atif.json").write_text(
-        json.dumps({
-            "schema_version": "ATIF-v1.6",
-            "final_metrics": {
-                "total_prompt_tokens": 1,
-                "total_completion_tokens": 1,
-            },
-            "steps": [],
-        }),
-        encoding="utf-8",
-    )
-
     context = AgentContext()
     agent.populate_context_post_run(context)
 
@@ -338,11 +325,11 @@ def test_populate_context_raises_when_atof_required_and_missing(tmp_path: Path) 
         agent.populate_context_post_run(AgentContext())
 
 
-def test_populate_context_raises_when_gateway_atif_missing_by_default(tmp_path: Path) -> None:
-    """Gateway ATIF is the canonical artifact today; missing is fatal by default."""
+def test_populate_context_raises_when_all_nemoflow_atif_outputs_missing_by_default(tmp_path: Path) -> None:
+    """At least one NeMo-Flow ATIF artifact is required by default."""
     agent = _make_agent(tmp_path)
 
-    with pytest.raises(FileNotFoundError, match="Missing NeMo-Flow gateway ATIF"):
+    with pytest.raises(FileNotFoundError, match="Missing NeMo-Flow ATIF artifact"):
         agent.populate_context_post_run(AgentContext())
 
 

--- a/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
+++ b/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
@@ -126,6 +126,7 @@ async def test_install_can_use_prebuilt_nemo_flow(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+
     async def fake_hermes_install(self: HermesNeMoFlow, environment: AsyncMock) -> None:
         return None
 

--- a/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
+++ b/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
@@ -17,11 +17,13 @@
 from __future__ import annotations
 
 import json
+import shlex
 from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
 import yaml
+from harbor.agents.installed.hermes import Hermes
 from harbor.models.agent.context import AgentContext
 
 from nat_harbor.agents.installed.hermes_nemoflow import HermesNeMoFlow
@@ -84,9 +86,10 @@ def test_build_config_yaml_includes_gateway_hooks(tmp_path: Path) -> None:
     hook_command = config["hooks"]["pre_api_request"][0]["command"]
     assert hook_command.startswith("nemo-flow hook-forward hermes")
     assert "--atif-dir /logs/agent/nemo-flow-gateway-atif" in hook_command
-    # PR #88 adds ATOF exporter APIs, but the Hermes CLI gateway still exposes
-    # only --atif-dir until NeMo-Flow wires raw ATOF emission for this path.
+    # The PR #89 observability plugin is process-global and belongs on
+    # `nemo-flow run`, not on per-hook `hook-forward` calls.
     assert "--atof-dir" not in hook_command
+    assert "--plugin-config" not in hook_command
     assert "--sidecar-url" not in hook_command
     assert "--gateway-mode passthrough" in hook_command
     assert "subagent_start" in config["hooks"]
@@ -119,6 +122,28 @@ def test_build_run_env_requires_provider_api_key(tmp_path: Path, monkeypatch: py
 
 
 @pytest.mark.asyncio
+async def test_install_can_use_prebuilt_nemo_flow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_hermes_install(self: HermesNeMoFlow, environment: AsyncMock) -> None:
+        return None
+
+    agent = _make_agent(tmp_path, use_prebuilt_nemo_flow=True)
+    monkeypatch.setattr(Hermes, "install", fake_hermes_install)
+    monkeypatch.setattr(agent, "_prepare_upload_tree", lambda: pytest.fail("should not upload source"))
+    mock_env = AsyncMock()
+    mock_env.exec.return_value = AsyncMock(return_code=0, stdout="", stderr="")
+
+    await agent.install(mock_env)
+
+    commands = [call.kwargs["command"] for call in mock_env.exec.call_args_list]
+    assert any("command -v nemo-flow" in command for command in commands)
+    assert any("nemo-flow run --help" in command for command in commands)
+    assert all("cargo build" not in command for command in commands)
+
+
+@pytest.mark.asyncio
 async def test_run_uses_gateway_wrapper(tmp_path: Path) -> None:
     agent = _make_agent(
         tmp_path,
@@ -139,10 +164,48 @@ async def test_run_uses_gateway_wrapper(tmp_path: Path) -> None:
     assert "--agent hermes" in run_command
     assert "--atif-dir /logs/agent/nemo-flow-gateway-atif" in run_command
     assert "--atof-dir" not in run_command
+    assert "--plugin-config" not in run_command
     assert "--openai-base-url https://nvidia.example/v1" in run_command
     assert "hermes --yolo chat" in run_command
     assert "tee /logs/agent/hermes.txt" in run_command
     assert "on_session_finalize" in run_command
+    assert "read_text(encoding=" in run_command
+    assert "utf-8" in run_command
+    assert "gateway-gateway" in run_command
+
+
+def test_gateway_run_can_enable_observability_plugin_config(tmp_path: Path) -> None:
+    agent = _make_agent(
+        tmp_path,
+        enable_nemoflow_observability_plugin=True,
+        atof_dir="/logs/agent/raw-atof",
+        plugin_atif_dir="/logs/agent/plugin-atif",
+        extra_env={
+            "NVIDIA_API_KEY": "nvidia-key",
+            "NVIDIA_BASE_URL": "https://nvidia.example/v1",
+        },
+    )
+    route = agent._build_provider_route("nvidia", "opus-frontier")
+
+    command = agent._build_gateway_run_command(route)
+
+    nemo_flow_segment = command.split("&& ", 1)[1].split(" 2>&1", 1)[0]
+    args = shlex.split(nemo_flow_segment)
+    plugin_index = args.index("--plugin-config")
+    plugin_config = json.loads(args[plugin_index + 1])
+    observability = plugin_config["components"][0]
+    assert observability["kind"] == "observability"
+    assert observability["config"]["atof"] == {
+        "enabled": True,
+        "output_directory": "/logs/agent/raw-atof",
+        "filename": "events.jsonl",
+        "mode": "overwrite",
+    }
+    assert observability["config"]["atif"] == {
+        "enabled": True,
+        "output_directory": "/logs/agent/plugin-atif",
+        "filename_template": "trajectory-{session_id}.atif.json",
+    }
 
 
 def test_populate_context_converts_atof_and_sets_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -196,9 +259,54 @@ def test_populate_context_converts_atof_and_sets_tokens(tmp_path: Path, monkeypa
     assert context.n_output_tokens == 13
     assert context.metadata is not None
     assert context.metadata["nemo_flow_instrumentation"] == "gateway"
+    assert context.metadata["nemo_flow_observability_plugin_enabled"] is False
     assert context.metadata["nemo_flow_atof_path"] == str(atof_path)
     assert context.metadata["nemo_flow_converted_atif_path"] == str(converted)
     assert context.metadata["nemo_flow_gateway_canonical_atif_path"] == str(canonical)
+    assert context.metadata["nemo_flow_plugin_canonical_atif_exists"] is False
+
+
+def test_populate_context_can_use_plugin_atif_when_atof_is_absent(tmp_path: Path) -> None:
+    agent = _make_agent(tmp_path, enable_nemoflow_observability_plugin=True)
+    plugin_dir = agent.logs_dir / "nemo-flow-plugin-atif"
+    plugin_dir.mkdir(parents=True)
+    source = plugin_dir / "trajectory-session-1.atif.json"
+    source.write_text(
+        json.dumps({
+            "schema_version": "ATIF-v1.6",
+            "final_metrics": {
+                "total_prompt_tokens": 34,
+                "total_completion_tokens": 21,
+            },
+            "steps": [],
+        }),
+        encoding="utf-8",
+    )
+    gateway_dir = agent.logs_dir / "nemo-flow-gateway-atif"
+    gateway_dir.mkdir(parents=True)
+    (gateway_dir / "session-1.atif.json").write_text(
+        json.dumps({
+            "schema_version": "ATIF-v1.6",
+            "final_metrics": {
+                "total_prompt_tokens": 1,
+                "total_completion_tokens": 1,
+            },
+            "steps": [],
+        }),
+        encoding="utf-8",
+    )
+
+    context = AgentContext()
+    agent.populate_context_post_run(context)
+
+    plugin_canonical = plugin_dir / "trajectory.json"
+    assert plugin_canonical.exists()
+    assert context.n_input_tokens == 34
+    assert context.n_output_tokens == 21
+    assert context.metadata is not None
+    assert context.metadata["nemo_flow_observability_plugin_enabled"] is True
+    assert context.metadata["nemo_flow_plugin_canonical_atif_path"] == str(plugin_canonical)
+    assert context.metadata["nemo_flow_plugin_canonical_atif_exists"] is True
 
 
 def test_populate_context_default_does_not_raise_when_atof_missing(tmp_path: Path) -> None:

--- a/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
+++ b/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
@@ -40,11 +40,11 @@ def _make_agent(tmp_path: Path, **kwargs) -> HermesNeMoFlow:
 
 def _write_minimal_nemo_flow_checkout(path: Path) -> None:
     for file_path in (
-        path / "Cargo.toml",
-        path / "Cargo.lock",
-        path / "crates" / "core" / "Cargo.toml",
-        path / "crates" / "sidecar" / "Cargo.toml",
-        path / "crates" / "sidecar" / "src" / "main.rs",
+            path / "Cargo.toml",
+            path / "Cargo.lock",
+            path / "crates" / "core" / "Cargo.toml",
+            path / "crates" / "cli" / "Cargo.toml",
+            path / "crates" / "cli" / "src" / "main.rs",
     ):
         file_path.parent.mkdir(parents=True, exist_ok=True)
         file_path.write_text("# test\n", encoding="utf-8")
@@ -54,14 +54,14 @@ def test_name_is_hermes_nemoflow() -> None:
     assert HermesNeMoFlow.name() == "hermes-nemoflow"
 
 
-def test_validate_local_nemo_flow_checkout_requires_sidecar(tmp_path: Path) -> None:
+def test_validate_local_nemo_flow_checkout_requires_cli_crate(tmp_path: Path) -> None:
     agent = _make_agent(tmp_path)
 
-    with pytest.raises(FileNotFoundError, match="crates/sidecar/Cargo.toml"):
+    with pytest.raises(FileNotFoundError, match="crates/cli/Cargo.toml"):
         agent._validate_local_nemo_flow_checkout()
 
 
-def test_prepare_upload_tree_copies_sidecar_sources(tmp_path: Path) -> None:
+def test_prepare_upload_tree_copies_cli_sources(tmp_path: Path) -> None:
     source = tmp_path / "nemo-flow"
     _write_minimal_nemo_flow_checkout(source)
     agent = _make_agent(tmp_path)
@@ -69,21 +69,26 @@ def test_prepare_upload_tree_copies_sidecar_sources(tmp_path: Path) -> None:
     upload_tree = agent._prepare_upload_tree()
 
     assert (upload_tree / "Cargo.toml").exists()
-    assert (upload_tree / "crates" / "sidecar" / "src" / "main.rs").exists()
+    assert (upload_tree / "crates" / "cli" / "src" / "main.rs").exists()
 
 
-def test_build_config_yaml_includes_sidecar_hooks(tmp_path: Path) -> None:
+def test_build_config_yaml_includes_gateway_hooks(tmp_path: Path) -> None:
     agent = _make_agent(tmp_path)
     route = agent._build_provider_route("nvidia", "opus-frontier")
 
-    config = yaml.safe_load(agent._build_config_yaml_with_sidecar_hooks(route))
+    config = yaml.safe_load(agent._build_config_yaml_with_gateway_hooks(route))
 
     assert config["model"]["provider"] == "custom"
-    assert config["model"]["base_url"] == "${NEMO_FLOW_SIDECAR_URL}"
+    assert config["model"]["base_url"] == "${NEMO_FLOW_GATEWAY_URL}"
     assert config["model"]["api_key"] == "${OPENAI_API_KEY}"
-    assert config["hooks"]["pre_api_request"][0]["command"].startswith("nemo-flow-sidecar hook-forward hermes")
-    assert "--atof-dir /logs/agent/nemo-flow-atof" in config["hooks"]["pre_api_request"][0]["command"]
-    assert "--sidecar-url" not in config["hooks"]["pre_api_request"][0]["command"]
+    hook_command = config["hooks"]["pre_api_request"][0]["command"]
+    assert hook_command.startswith("nemo-flow hook-forward hermes")
+    assert "--atif-dir /logs/agent/nemo-flow-gateway-atif" in hook_command
+    # PR #88 adds ATOF exporter APIs, but the Hermes CLI gateway still exposes
+    # only --atif-dir until NeMo-Flow wires raw ATOF emission for this path.
+    assert "--atof-dir" not in hook_command
+    assert "--sidecar-url" not in hook_command
+    assert "--gateway-mode passthrough" in hook_command
     assert "subagent_start" in config["hooks"]
 
 
@@ -114,7 +119,7 @@ def test_build_run_env_requires_provider_api_key(tmp_path: Path, monkeypatch: py
 
 
 @pytest.mark.asyncio
-async def test_run_uses_sidecar_wrapper(tmp_path: Path) -> None:
+async def test_run_uses_gateway_wrapper(tmp_path: Path) -> None:
     agent = _make_agent(
         tmp_path,
         extra_env={
@@ -128,9 +133,12 @@ async def test_run_uses_sidecar_wrapper(tmp_path: Path) -> None:
     await agent.run("solve the task", mock_env, AsyncMock())
 
     commands = [call.kwargs["command"] for call in mock_env.exec.call_args_list]
-    run_command = next(command for command in commands if "nemo-flow-sidecar run" in command)
+    # Use a token boundary to avoid matching "nemo-flow run" as a substring of
+    # any other command (defensive against future log/tee changes).
+    run_command = next(command for command in commands if " nemo-flow run " in f" {command} ")
     assert "--agent hermes" in run_command
-    assert "--atof-dir /logs/agent/nemo-flow-atof" in run_command
+    assert "--atif-dir /logs/agent/nemo-flow-gateway-atif" in run_command
+    assert "--atof-dir" not in run_command
     assert "--openai-base-url https://nvidia.example/v1" in run_command
     assert "hermes --yolo chat" in run_command
     assert "tee /logs/agent/hermes.txt" in run_command
@@ -144,20 +152,18 @@ def test_populate_context_converts_atof_and_sets_tokens(tmp_path: Path, monkeypa
     atof_path = atof_dir / "events.jsonl"
     atof_path.write_text('{"event_type":"mark"}\n', encoding="utf-8")
 
-    sidecar_dir = agent.logs_dir / "nemo-flow-sidecar-atif"
-    sidecar_dir.mkdir(parents=True)
-    source = sidecar_dir / "session-1.atif.json"
+    gateway_dir = agent.logs_dir / "nemo-flow-gateway-atif"
+    gateway_dir.mkdir(parents=True)
+    source = gateway_dir / "session-1.atif.json"
     source.write_text(
-        json.dumps(
-            {
-                "schema_version": "ATIF-v1.6",
-                "final_metrics": {
-                    "total_prompt_tokens": 12,
-                    "total_completion_tokens": 7,
-                },
-                "steps": [],
-            }
-        ),
+        json.dumps({
+            "schema_version": "ATIF-v1.6",
+            "final_metrics": {
+                "total_prompt_tokens": 12,
+                "total_completion_tokens": 7,
+            },
+            "steps": [],
+        }),
         encoding="utf-8",
     )
 
@@ -165,16 +171,14 @@ def test_populate_context_converts_atof_and_sets_tokens(tmp_path: Path, monkeypa
         assert input_path == atof_path
         output_path.parent.mkdir(parents=True)
         output_path.write_text(
-            json.dumps(
-                {
-                    "schema_version": "ATIF-v1.7",
-                    "final_metrics": {
-                        "total_prompt_tokens": 21,
-                        "total_completion_tokens": 13,
-                    },
-                    "steps": [],
-                }
-            ),
+            json.dumps({
+                "schema_version": "ATIF-v1.7",
+                "final_metrics": {
+                    "total_prompt_tokens": 21,
+                    "total_completion_tokens": 13,
+                },
+                "steps": [],
+            }),
             encoding="utf-8",
         )
         return output_path
@@ -184,31 +188,64 @@ def test_populate_context_converts_atof_and_sets_tokens(tmp_path: Path, monkeypa
 
     agent.populate_context_post_run(context)
 
-    canonical = sidecar_dir / "trajectory.json"
+    canonical = gateway_dir / "trajectory.json"
     converted = agent.logs_dir / "nemo-flow-atof-atif" / "trajectory.json"
     assert canonical.exists()
     assert converted.exists()
     assert context.n_input_tokens == 21
     assert context.n_output_tokens == 13
     assert context.metadata is not None
-    assert context.metadata["nemo_flow_instrumentation"] == "sidecar"
+    assert context.metadata["nemo_flow_instrumentation"] == "gateway"
     assert context.metadata["nemo_flow_atof_path"] == str(atof_path)
     assert context.metadata["nemo_flow_converted_atif_path"] == str(converted)
-    assert context.metadata["nemo_flow_sidecar_canonical_atif_path"] == str(canonical)
+    assert context.metadata["nemo_flow_gateway_canonical_atif_path"] == str(canonical)
 
 
-def test_populate_context_raises_when_atof_missing(tmp_path: Path) -> None:
+def test_populate_context_default_does_not_raise_when_atof_missing(tmp_path: Path) -> None:
+    """ATOF is best-effort/optional until Hermes gateway events are wired into PR #88."""
     agent = _make_agent(tmp_path)
+    gateway_dir = agent.logs_dir / "nemo-flow-gateway-atif"
+    gateway_dir.mkdir(parents=True)
+    (gateway_dir / "session-1.atif.json").write_text(
+        json.dumps({
+            "schema_version": "ATIF-v1.6", "final_metrics": {}, "steps": []
+        }),
+        encoding="utf-8",
+    )
+
+    context = AgentContext()
+    agent.populate_context_post_run(context)
+
+    assert context.metadata is not None
+    assert context.metadata["nemo_flow_atof_exists"] is False
+    assert context.metadata["nemo_flow_gateway_canonical_atif_exists"] is True
+
+
+def test_populate_context_raises_when_atof_required_and_missing(tmp_path: Path) -> None:
+    """Opt-in fail-on-missing remains supported for branches that emit Hermes ATOF."""
+    agent = _make_agent(tmp_path, fail_missing_nemoflow_atof=True)
 
     with pytest.raises(FileNotFoundError, match="Missing NeMo-Flow ATOF JSONL"):
         agent.populate_context_post_run(AgentContext())
 
 
-def test_populate_context_raises_when_sidecar_atif_required_and_missing(tmp_path: Path) -> None:
-    agent = _make_agent(tmp_path, fail_missing_nemoflow_atif=True, convert_nemoflow_atof=False)
-    atof_dir = agent.logs_dir / "nemo-flow-atof"
-    atof_dir.mkdir(parents=True)
-    (atof_dir / "events.jsonl").write_text('{"event_type":"mark"}\n', encoding="utf-8")
+def test_populate_context_raises_when_gateway_atif_missing_by_default(tmp_path: Path) -> None:
+    """Gateway ATIF is the canonical artifact today; missing is fatal by default."""
+    agent = _make_agent(tmp_path)
 
-    with pytest.raises(FileNotFoundError, match="Missing NeMo-Flow sidecar ATIF"):
+    with pytest.raises(FileNotFoundError, match="Missing NeMo-Flow gateway ATIF"):
         agent.populate_context_post_run(AgentContext())
+
+
+def test_sidecar_atif_dir_kwarg_back_compat(tmp_path: Path) -> None:
+    """Older callers passing sidecar_atif_dir= still work; new name takes precedence."""
+    agent = _make_agent(tmp_path / "legacy_only", sidecar_atif_dir="/logs/agent/legacy")
+    assert agent._gateway_atif_dir == "/logs/agent/legacy"
+    assert agent._sidecar_atif_dir == "/logs/agent/legacy"
+
+    agent2 = _make_agent(
+        tmp_path / "both",
+        sidecar_atif_dir="/logs/agent/legacy",
+        gateway_atif_dir="/logs/agent/new",
+    )
+    assert agent2._gateway_atif_dir == "/logs/agent/new"

--- a/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
+++ b/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import json
-import shlex
+import tomllib
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -85,9 +85,9 @@ def test_build_config_yaml_includes_gateway_hooks(tmp_path: Path) -> None:
     assert config["model"]["api_key"] == "${OPENAI_API_KEY}"
     hook_command = config["hooks"]["pre_api_request"][0]["command"]
     assert hook_command.startswith("nemo-flow hook-forward hermes")
-    assert "--atif-dir /logs/agent/nemo-flow-gateway-atif" in hook_command
-    # The PR #89 observability plugin is process-global and belongs on
+    # Observability plugin config is process-global and belongs on
     # `nemo-flow run`, not on per-hook `hook-forward` calls.
+    assert "--atif-dir" not in hook_command
     assert "--atof-dir" not in hook_command
     assert "--plugin-config" not in hook_command
     assert "--sidecar-url" not in hook_command
@@ -140,7 +140,7 @@ async def test_install_can_use_prebuilt_nemo_flow(
 
     commands = [call.kwargs["command"] for call in mock_env.exec.call_args_list]
     assert any("command -v nemo-flow" in command for command in commands)
-    assert any("nemo-flow run --help" in command for command in commands)
+    assert any("nemo-flow plugins edit --help" in command for command in commands)
     assert all("cargo build" not in command for command in commands)
 
 
@@ -162,10 +162,13 @@ async def test_run_uses_gateway_wrapper(tmp_path: Path) -> None:
     # Use a token boundary to avoid matching "nemo-flow run" as a substring of
     # any other command (defensive against future log/tee changes).
     run_command = next(command for command in commands if "nemo-flow run " in command)
+    setup_command = commands[0]
+    assert ".nemo-flow/plugins.toml" not in setup_command
     assert "--agent hermes" in run_command
-    assert "--atif-dir /logs/agent/nemo-flow-gateway-atif" in run_command
+    assert "--atif-dir" not in run_command
     assert "--atof-dir" not in run_command
     assert "--plugin-config" not in run_command
+    assert "cd /testbed" in run_command
     assert "--openai-base-url https://nvidia.example/v1" in run_command
     assert "-- --yolo --accept-hooks chat -q 'solve the task'" in run_command
     assert "/bin/bash" not in run_command
@@ -176,7 +179,8 @@ async def test_run_uses_gateway_wrapper(tmp_path: Path) -> None:
     assert "gateway-gateway" in run_command
 
 
-def test_gateway_run_can_enable_observability_plugin_config(tmp_path: Path) -> None:
+@pytest.mark.asyncio
+async def test_run_can_enable_project_observability_plugin_config(tmp_path: Path) -> None:
     agent = _make_agent(
         tmp_path,
         enable_nemoflow_observability_plugin=True,
@@ -187,14 +191,19 @@ def test_gateway_run_can_enable_observability_plugin_config(tmp_path: Path) -> N
             "NVIDIA_BASE_URL": "https://nvidia.example/v1",
         },
     )
-    route = agent._build_provider_route("nvidia", "opus-frontier")
+    mock_env = AsyncMock()
+    mock_env.exec.return_value = AsyncMock(return_code=0, stdout="", stderr="")
 
-    command = agent._build_gateway_run_command(route, "solve the task")
+    await agent.run("solve the task", mock_env, AsyncMock())
 
-    nemo_flow_segment = command.split("&& ", 1)[1].split(" 2>&1", 1)[0]
-    args = shlex.split(nemo_flow_segment)
-    plugin_index = args.index("--plugin-config")
-    plugin_config = json.loads(args[plugin_index + 1])
+    commands = [call.kwargs["command"] for call in mock_env.exec.call_args_list]
+    setup_command = commands[0]
+    run_command = next(command for command in commands if "nemo-flow run " in command)
+    assert "cat > /testbed/.nemo-flow/plugins.toml" in setup_command
+    assert "--plugin-config" not in run_command
+    assert "cd /testbed" in run_command
+
+    plugin_config = tomllib.loads(agent._build_observability_plugin_toml())
     observability = plugin_config["components"][0]
     assert observability["kind"] == "observability"
     assert observability["config"]["atof"] == {
@@ -298,7 +307,7 @@ def test_populate_context_can_use_plugin_atif_when_atof_is_absent(tmp_path: Path
 
 
 def test_populate_context_default_does_not_raise_when_atof_missing(tmp_path: Path) -> None:
-    """ATOF is best-effort/optional until Hermes gateway events are wired into PR #88."""
+    """ATOF remains optional unless the smoke explicitly requires it."""
     agent = _make_agent(tmp_path)
     gateway_dir = agent.logs_dir / "nemo-flow-gateway-atif"
     gateway_dir.mkdir(parents=True)

--- a/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
+++ b/packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py
@@ -1,0 +1,214 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for the experimental Hermes NeMo-Flow Harbor wrapper."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+import yaml
+from harbor.models.agent.context import AgentContext
+
+from nat_harbor.agents.installed.hermes_nemoflow import HermesNeMoFlow
+
+
+def _make_agent(tmp_path: Path, **kwargs) -> HermesNeMoFlow:
+    logs_dir = tmp_path / "agent"
+    logs_dir.mkdir(parents=True)
+    return HermesNeMoFlow(
+        logs_dir=logs_dir,
+        model_name="nvidia/opus-frontier",
+        nemo_flow_repo=str(tmp_path / "nemo-flow"),
+        **kwargs,
+    )
+
+
+def _write_minimal_nemo_flow_checkout(path: Path) -> None:
+    for file_path in (
+        path / "Cargo.toml",
+        path / "Cargo.lock",
+        path / "crates" / "core" / "Cargo.toml",
+        path / "crates" / "sidecar" / "Cargo.toml",
+        path / "crates" / "sidecar" / "src" / "main.rs",
+    ):
+        file_path.parent.mkdir(parents=True, exist_ok=True)
+        file_path.write_text("# test\n", encoding="utf-8")
+
+
+def test_name_is_hermes_nemoflow() -> None:
+    assert HermesNeMoFlow.name() == "hermes-nemoflow"
+
+
+def test_validate_local_nemo_flow_checkout_requires_sidecar(tmp_path: Path) -> None:
+    agent = _make_agent(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="crates/sidecar/Cargo.toml"):
+        agent._validate_local_nemo_flow_checkout()
+
+
+def test_prepare_upload_tree_copies_sidecar_sources(tmp_path: Path) -> None:
+    source = tmp_path / "nemo-flow"
+    _write_minimal_nemo_flow_checkout(source)
+    agent = _make_agent(tmp_path)
+
+    upload_tree = agent._prepare_upload_tree()
+
+    assert (upload_tree / "Cargo.toml").exists()
+    assert (upload_tree / "crates" / "sidecar" / "src" / "main.rs").exists()
+
+
+def test_build_config_yaml_includes_sidecar_hooks(tmp_path: Path) -> None:
+    agent = _make_agent(tmp_path)
+    route = agent._build_provider_route("nvidia", "opus-frontier")
+
+    config = yaml.safe_load(agent._build_config_yaml_with_sidecar_hooks(route))
+
+    assert config["model"]["provider"] == "custom"
+    assert config["model"]["base_url"] == "${NEMO_FLOW_SIDECAR_URL}"
+    assert config["model"]["api_key"] == "${OPENAI_API_KEY}"
+    assert config["hooks"]["pre_api_request"][0]["command"].startswith("nemo-flow-sidecar hook-forward hermes")
+    assert "--atof-dir /logs/agent/nemo-flow-atof" in config["hooks"]["pre_api_request"][0]["command"]
+    assert "--sidecar-url" not in config["hooks"]["pre_api_request"][0]["command"]
+    assert "subagent_start" in config["hooks"]
+
+
+def test_build_run_env_handles_nvidia(tmp_path: Path) -> None:
+    agent = _make_agent(
+        tmp_path,
+        extra_env={
+            "NVIDIA_API_KEY": "nvidia-key",
+            "NVIDIA_BASE_URL": "https://nvidia.example/v1",
+        },
+    )
+    route = agent._build_provider_route("nvidia", "opus-frontier")
+
+    env = agent._build_run_env(route, "fix it")
+
+    assert env["NVIDIA_API_KEY"] == "nvidia-key"
+    assert env["OPENAI_API_KEY"] == "nvidia-key"
+    assert env["HARBOR_INSTRUCTION"] == "fix it"
+
+
+def test_build_run_env_requires_provider_api_key(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NVIDIA_API_KEY", raising=False)
+    agent = _make_agent(tmp_path)
+    route = agent._build_provider_route("nvidia", "opus-frontier")
+
+    with pytest.raises(ValueError, match="NVIDIA_API_KEY"):
+        agent._build_run_env(route, "fix it")
+
+
+@pytest.mark.asyncio
+async def test_run_uses_sidecar_wrapper(tmp_path: Path) -> None:
+    agent = _make_agent(
+        tmp_path,
+        extra_env={
+            "NVIDIA_API_KEY": "nvidia-key",
+            "NVIDIA_BASE_URL": "https://nvidia.example/v1",
+        },
+    )
+    mock_env = AsyncMock()
+    mock_env.exec.return_value = AsyncMock(return_code=0, stdout="", stderr="")
+
+    await agent.run("solve the task", mock_env, AsyncMock())
+
+    commands = [call.kwargs["command"] for call in mock_env.exec.call_args_list]
+    run_command = next(command for command in commands if "nemo-flow-sidecar run" in command)
+    assert "--agent hermes" in run_command
+    assert "--atof-dir /logs/agent/nemo-flow-atof" in run_command
+    assert "--openai-base-url https://nvidia.example/v1" in run_command
+    assert "hermes --yolo chat" in run_command
+    assert "tee /logs/agent/hermes.txt" in run_command
+    assert "on_session_finalize" in run_command
+
+
+def test_populate_context_converts_atof_and_sets_tokens(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    agent = _make_agent(tmp_path)
+    atof_dir = agent.logs_dir / "nemo-flow-atof"
+    atof_dir.mkdir(parents=True)
+    atof_path = atof_dir / "events.jsonl"
+    atof_path.write_text('{"event_type":"mark"}\n', encoding="utf-8")
+
+    sidecar_dir = agent.logs_dir / "nemo-flow-sidecar-atif"
+    sidecar_dir.mkdir(parents=True)
+    source = sidecar_dir / "session-1.atif.json"
+    source.write_text(
+        json.dumps(
+            {
+                "schema_version": "ATIF-v1.6",
+                "final_metrics": {
+                    "total_prompt_tokens": 12,
+                    "total_completion_tokens": 7,
+                },
+                "steps": [],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    def fake_convert_atof_to_atif(input_path: Path, output_path: Path) -> Path:
+        assert input_path == atof_path
+        output_path.parent.mkdir(parents=True)
+        output_path.write_text(
+            json.dumps(
+                {
+                    "schema_version": "ATIF-v1.7",
+                    "final_metrics": {
+                        "total_prompt_tokens": 21,
+                        "total_completion_tokens": 13,
+                    },
+                    "steps": [],
+                }
+            ),
+            encoding="utf-8",
+        )
+        return output_path
+
+    monkeypatch.setattr(agent, "_convert_atof_to_atif", fake_convert_atof_to_atif)
+    context = AgentContext()
+
+    agent.populate_context_post_run(context)
+
+    canonical = sidecar_dir / "trajectory.json"
+    converted = agent.logs_dir / "nemo-flow-atof-atif" / "trajectory.json"
+    assert canonical.exists()
+    assert converted.exists()
+    assert context.n_input_tokens == 21
+    assert context.n_output_tokens == 13
+    assert context.metadata is not None
+    assert context.metadata["nemo_flow_instrumentation"] == "sidecar"
+    assert context.metadata["nemo_flow_atof_path"] == str(atof_path)
+    assert context.metadata["nemo_flow_converted_atif_path"] == str(converted)
+    assert context.metadata["nemo_flow_sidecar_canonical_atif_path"] == str(canonical)
+
+
+def test_populate_context_raises_when_atof_missing(tmp_path: Path) -> None:
+    agent = _make_agent(tmp_path)
+
+    with pytest.raises(FileNotFoundError, match="Missing NeMo-Flow ATOF JSONL"):
+        agent.populate_context_post_run(AgentContext())
+
+
+def test_populate_context_raises_when_sidecar_atif_required_and_missing(tmp_path: Path) -> None:
+    agent = _make_agent(tmp_path, fail_missing_nemoflow_atif=True, convert_nemoflow_atof=False)
+    atof_dir = agent.logs_dir / "nemo-flow-atof"
+    atof_dir.mkdir(parents=True)
+    (atof_dir / "events.jsonl").write_text('{"event_type":"mark"}\n', encoding="utf-8")
+
+    with pytest.raises(FileNotFoundError, match="Missing NeMo-Flow sidecar ATIF"):
+        agent.populate_context_post_run(AgentContext())


### PR DESCRIPTION
## Summary

Aligns the `HermesNeMoFlow` Harbor wrapper and its smoke doc/tests with the
current NeMo-Flow CLI surface (post-rename from `nemo-flow-sidecar` to
`nemo-flow` / `nemo-flow-cli`, `crates/cli`, `NEMO_FLOW_GATEWAY_URL`), and
relaxes the trajectory-validation contract so the first Harbor SWE-bench smoke
can run against `NeMo-Flow main` without depending on a not-yet-shipped
Hermes-gateway → raw-ATOF-JSONL emission path.

Concretely:

- **Sidecar → Gateway rename.** Every user-visible `sidecar` identifier in the
  wrapper (binary name, build target, route field, ATIF dir, env var,
  metadata keys, helper methods) becomes `gateway`. The
  `sidecar_atif_dir=` kwarg and `_sidecar_atif_dir` attribute are retained as
  back-compat aliases so existing callers / configs don't break.
- **Validation flip.** Default behavior swaps to treating the
  gateway-emitted ATIF (`agent/nemo-flow-gateway-atif/trajectory.json`) as
  the canonical, required artifact, and the raw ATOF JSONL
  (`agent/nemo-flow-atof/events.jsonl`) as best-effort / optional.
  - `fail_missing_nemoflow_atif`: `False` → `True`
  - `fail_missing_nemoflow_atof`: `True` → `False`
  - `fail_nemoflow_atof_conversion`: `True` → `False`
- **NeMo-Flow checkout target.** Smoke doc points at
  `NVIDIA/NeMo-Flow` `main` (with PR #88) instead of
  `willkill07/NeMo-Flow` on `wkk_coding-agent-sidecar-integrations`. Build
  target switches from `cargo build -p nemo-flow-sidecar` to
  `cargo build -p nemo-flow-cli`; CLI surface check switches from
  `nemo-flow-sidecar run --atof-dir` to `nemo-flow run --atif-dir` (and
  same for `hook-forward`).
- **Documented deferral.** A `TODO: Config-Based ATOF Export` section in
  `hermes-nemoflow-smoke.md` and a module-level docstring in
  `hermes_nemoflow.py` call out exactly what's deferred and why: the
  Hermes CLI gateway path does not yet expose raw ATOF JSONL via
  `nemo-flow run` / `hook-forward`, and the ATOF-derived comparison lane
  is dormant until NeMo-Flow ships configuration-based CLI exporter
  registration (e.g., `plugin.toml` / `plugins.toml`).

## Why

We need a green first SWE-bench Harbor sample on Hermes + NeMo-Flow now,
on current NeMo-Flow `main`. The previous wrapper hard-required:

1. The pre-rename `nemo-flow-sidecar` binary and `crates/sidecar` layout.
2. A raw-ATOF JSONL stream from the Hermes CLI gateway path.
3. The ATOF→ATIF converted trajectory as a required artifact.

(1) is no longer accurate against `main`. (2) and (3) are blocked on
work that hasn't landed (PR #88 adds ATOF exporter APIs but doesn't yet
plumb Hermes gateway events into them). Rather than block the smoke
on that follow-up, this PR re-anchors the wrapper on the artifact the
gateway actually emits today — direct ATIF via `--atif-dir` — while
keeping all of the ATOF→ATIF code paths in place so they light up
automatically when the gateway-side wiring lands.

## Files changed (4 files, +307 / −220)

- `packages/nvidia_nat_harbor/hermes-nemoflow-smoke.md` (+ scope/TODO,
  pipeline diagram, prerequisites, expected artifacts, post-run scoring
  paths, known-limitations) — `+105 / −38`
- `packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/__init__.py`
  (reorder import to satisfy isort; no behavior change) — `+1 / −1`
- `packages/nvidia_nat_harbor/src/nat_harbor/agents/installed/hermes_nemoflow.py`
  (CLI gateway rename, default flag flips, `gateway_atif_dir=` kwarg with
  `sidecar_atif_dir=` alias + property shim, gateway env / route /
  metadata keys, build commands, run command, hook-forward command,
  finalize fallback) — `+125 / −118`
- `packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py`
  (rename `*_sidecar_*` tests to `*_gateway_*`; assert `nemo-flow`
  binary + `--atif-dir` + `--gateway-mode passthrough`; assert
  `--atof-dir` is absent from the Hermes hook command; new tests:
  `test_populate_context_default_does_not_raise_when_atof_missing`,
  `test_populate_context_raises_when_atof_required_and_missing`,
  `test_populate_context_raises_when_gateway_atif_missing_by_default`,
  `test_sidecar_atif_dir_kwarg_back_compat`) — `+76 / −63`

No SPDX headers added or removed; no `pyproject.toml`/lock changes.

## Test plan

- [x] `pre-commit run --all-files` (yapf, ruff, uv lock, notebooks,
      markdown link check) green locally before push.
- [x] `pytest packages/nvidia_nat_harbor/tests/test_hermes_nemoflow_agent.py`
      — all 11 tests pass (4 new, 7 renamed/updated).
- [x] Run the SWE-bench Hermes + NeMo-Flow smoke end-to-end against
      `NeMo-Flow main` (`django__django-13741`, `nvidia/opus-frontier`).
      - Expect required artifacts: `agent/hermes.txt`,
        `agent/hermes-session.jsonl`, `agent/trajectory.json`,
        `agent/nemo-flow-gateway-atif/trajectory.json`,
        `result.json`, `verifier/report.json`.
      - Expect deferred (absent OK): `agent/nemo-flow-atof/events.jsonl`,
        `agent/nemo-flow-atof-atif/trajectory.json`.
- [x] `compare_atif_tools` between native Hermes ATIF and gateway ATIF
      returns `match (same)` or `match (richer)`.
- [x] `score_atif_trajectories --no-llm` against
      `agent/nemo-flow-gateway-atif/trajectory.json` produces non-empty
      output; LLM-judge variant (optional) runs with
      `NAT_HARBOR_TRAJECTORY_JUDGE_*`.

## Follow-ups (not in this PR)

- Land configuration-based CLI ATOF exporter registration on NeMo-Flow
  (`plugin.toml` / `plugins.toml`); add gateway config to this smoke.
- Once the Hermes CLI gateway path emits raw ATOF JSONL via that
  exporter, flip `fail_missing_nemoflow_atof=True` back on by default
  and re-enable the ATOF-derived comparison lane (mirrors the
  OpenCode smoke).
- Drop the `sidecar_atif_dir=` / `_sidecar_atif_dir` back-compat
  aliases after one release cycle.
- Eventually replace this wrapper with the upstream Hermes native
  middleware path when it's ready.
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
