### PR TITLE
fix(front-end): Fix `HTTPInteractiveRunner` streaming cleanup on client disconnect

### DIFF
--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/http_interactive_runner.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/http_interactive_runner.py
@@ -78,6 +78,30 @@ class HTTPInteractiveRunner:
         self._store = execution_store
         self._session_manager = session_manager
         self._http_flow_handler = http_flow_handler
+        self._stream_cleanup_tasks: set[asyncio.Task[None]] = set()
+
+    async def _await_stream_task_cleanup(self, task: asyncio.Task[None], error_log_message: str) -> None:
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("%s during cancellation cleanup", error_log_message)
+
+    def _cleanup_stream_task(self, task: asyncio.Task[None], error_log_message: str) -> None:
+        task.cancel()
+        if task.done():
+            try:
+                task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                logger.exception("%s during cancellation cleanup", error_log_message)
+            return
+
+        cleanup_task = asyncio.create_task(self._await_stream_task_cleanup(task, error_log_message))
+        self._stream_cleanup_tasks.add(cleanup_task)
+        cleanup_task.add_done_callback(self._stream_cleanup_tasks.discard)
 
     # ------------------------------------------------------------------
     # HITL callback (used as ``user_input_callback``)
@@ -285,11 +309,7 @@ class HTTPInteractiveRunner:
                 else:
                     yield f"data: {item}\n\n"
         finally:
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+            self._cleanup_stream_task(task, error_log_message)
 
     async def streaming_generator(
         self,

--- a/packages/nvidia_nat_core/tests/nat/front_ends/test_http_interactive_runner_cancellation.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/test_http_interactive_runner_cancellation.py
@@ -1,0 +1,89 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+from contextlib import asynccontextmanager
+
+import pytest
+
+from nat.front_ends.fastapi.execution_store import ExecutionStore
+from nat.front_ends.fastapi.http_interactive_runner import HTTPInteractiveRunner
+
+
+class _FakeHTTPFlowHandler:
+
+    def set_execution_context(self, **kwargs):
+        pass
+
+
+class _SlowCleanupSessionManager:
+
+    def __init__(self):
+        self.cleanup_started = asyncio.Event()
+        self.cleanup_finished = asyncio.Event()
+        self.allow_cleanup = asyncio.Event()
+
+    @asynccontextmanager
+    async def session(self, **kwargs):
+        try:
+            yield object()
+        finally:
+            # Model slow session/workflow teardown that can happen after a streaming client disconnects.
+            self.cleanup_started.set()
+            await self.allow_cleanup.wait()
+            self.cleanup_finished.set()
+
+
+async def _workflow_that_never_finishes(_session):
+    yield "first"
+    await asyncio.Event().wait()
+
+
+@pytest.mark.asyncio
+async def test_streaming_generator_close_does_not_wait_for_slow_producer_cleanup():
+    session_manager = _SlowCleanupSessionManager()
+    runner = HTTPInteractiveRunner(
+        ExecutionStore(),
+        session_manager,
+        _FakeHTTPFlowHandler(),
+    )
+    generator = runner._streaming_generator_impl(
+        None,
+        workflow_gen_factory=_workflow_that_never_finishes,
+        error_log_message="test streaming failure",
+    )
+
+    assert await generator.__anext__() == "data: first\n\n"
+
+    # Simulate Starlette closing the response generator on client disconnect.
+    # The close path should return promptly even while producer cleanup is still blocked.
+    close_task = asyncio.create_task(generator.aclose())
+    await asyncio.wait_for(session_manager.cleanup_started.wait(), timeout=1)
+
+    close_blocked_on_session_cleanup = False
+    try:
+        await asyncio.wait_for(asyncio.shield(close_task), timeout=0.25)
+    except TimeoutError:
+        close_blocked_on_session_cleanup = True
+    finally:
+        session_manager.allow_cleanup.set()
+        await close_task
+        await asyncio.wait_for(session_manager.cleanup_finished.wait(), timeout=1)
+        await asyncio.sleep(0)
+
+    assert not close_blocked_on_session_cleanup, (
+        "Closing the streaming response generator must not wait for slow producer/session cleanup. "
+        "On client disconnect, Starlette closes the generator under GeneratorExit; if this path waits "
+        "for session/workflow teardown, uvicorn workers can be left with partially-cancelled task state.")


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

Fixes `HTTPInteractiveRunner` streaming cancellation cleanup so closing the response generator does not wait on slow producer/session teardown.

Previously, `_streaming_generator_impl()` cancelled the producer task and then awaited it directly inside the async generator `finally` block. On client disconnect, Starlette closes the streaming response generator via `aclose()`. If producer cleanup is still unwinding session/workflow state, that close path can block during generator finalization and trigger `RuntimeError: async generator ignored GeneratorExit`.

This change cancels the producer task immediately, then delegates slow cleanup to a retained background cleanup task. That lets the response generator close promptly while still awaiting the producer elsewhere so cancellation/errors are retrieved.

## Changes

- Add `_cleanup_stream_task()` helper for producer task cancellation.
- Retain background cleanup tasks on the runner until they complete.
- Replace direct `await task` in streaming generator finalization.
- Add a regression test that simulates slow session cleanup during `generator.aclose()`.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced streaming response handling to close promptly when clients disconnect, eliminating delays from background cleanup tasks.

* **Tests**
  * Added test to verify streaming responses close immediately on client disconnect.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1916)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->