### PR TITLE
fix(atof->atif): Recover NeMo-Flow CLI Chat Observability Details

### DIFF
--- a/packages/nvidia_nat_atif/src/nat/atof/scripts/atof_to_atif_converter.py
+++ b/packages/nvidia_nat_atif/src/nat/atof/scripts/atof_to_atif_converter.py
@@ -60,6 +60,7 @@ except ImportError as _jsonschema_import_err:  # pragma: no cover
                       "    uv pip install nvidia-nat-atif[full]") from _jsonschema_import_err
 
 from nat.atif.agent import Agent
+from nat.atif.final_metrics import FinalMetrics
 from nat.atif.step import Step
 from nat.atif.tool_call import ToolCall
 from nat.atif.trajectory import Trajectory
@@ -231,6 +232,151 @@ def _build_invocation_info(start_micros: int | None, end_micros: int | None, inv
     return info
 
 
+def _event_metadata(event: Event) -> dict[str, Any]:
+    """Return event metadata when it is object-shaped."""
+    return event.metadata if isinstance(event.metadata, dict) else {}
+
+
+def _agent_name_from_event(event: Event) -> str:
+    """Prefer producer-provided agent identity over generic gateway scope names."""
+    metadata = _event_metadata(event)
+    agent_name = metadata.get("agent")
+    if isinstance(agent_name, str) and agent_name:
+        return agent_name
+    return event.name or "unknown"
+
+
+def _cached_tokens_from_usage(usage: dict[str, Any]) -> int | None:
+    """Extract cached-token counts from OpenAI-compatible usage payloads."""
+    direct = usage.get("cached_tokens")
+    if isinstance(direct, int):
+        return direct
+
+    prompt_details = usage.get("prompt_tokens_details")
+    if isinstance(prompt_details, dict):
+        cached = prompt_details.get("cached_tokens")
+        if isinstance(cached, int):
+            return cached
+
+    return None
+
+
+def _metrics_from_usage(usage: Any) -> dict[str, Any] | None:
+    """Map OpenAI-compatible ``usage`` payloads to ATIF step metrics."""
+    if not isinstance(usage, dict) or not usage:
+        return None
+
+    metrics: dict[str, Any] = {}
+    prompt_tokens = usage.get("prompt_tokens")
+    completion_tokens = usage.get("completion_tokens")
+    cached_tokens = _cached_tokens_from_usage(usage)
+
+    if isinstance(prompt_tokens, int):
+        metrics["prompt_tokens"] = prompt_tokens
+    if isinstance(completion_tokens, int):
+        metrics["completion_tokens"] = completion_tokens
+    if cached_tokens is not None:
+        metrics["cached_tokens"] = cached_tokens
+
+    extra = {k: v for k, v in usage.items() if k not in {"prompt_tokens", "completion_tokens", "cached_tokens"}}
+    if extra:
+        metrics["extra"] = extra
+
+    return metrics or None
+
+
+def _build_final_metrics(steps: list[Step]) -> FinalMetrics | None:
+    """Aggregate ATIF final metrics from per-step metrics."""
+    total_prompt_tokens = 0
+    total_completion_tokens = 0
+    total_cached_tokens = 0
+    total_tokens = 0
+    has_prompt_tokens = False
+    has_completion_tokens = False
+    has_cached_tokens = False
+    has_total_tokens = False
+
+    for step in steps:
+        metrics = step.metrics
+        if metrics is None:
+            continue
+        if metrics.prompt_tokens is not None:
+            has_prompt_tokens = True
+            total_prompt_tokens += metrics.prompt_tokens
+        if metrics.completion_tokens is not None:
+            has_completion_tokens = True
+            total_completion_tokens += metrics.completion_tokens
+        if metrics.cached_tokens is not None:
+            has_cached_tokens = True
+            total_cached_tokens += metrics.cached_tokens
+        extra_total = (metrics.extra or {}).get("total_tokens")
+        if isinstance(extra_total, int):
+            has_total_tokens = True
+            total_tokens += extra_total
+
+    extra: dict[str, Any] = {}
+    if has_total_tokens:
+        extra["total_tokens"] = total_tokens
+
+    if not any((has_prompt_tokens, has_completion_tokens, has_cached_tokens, has_total_tokens)):
+        return None
+
+    return FinalMetrics(
+        total_prompt_tokens=total_prompt_tokens if has_prompt_tokens else None,
+        total_completion_tokens=total_completion_tokens if has_completion_tokens else None,
+        total_cached_tokens=total_cached_tokens if has_cached_tokens else None,
+        total_steps=len(steps),
+        extra=extra or None,
+    )
+
+
+def _tool_observation_key(message: dict[str, Any]) -> tuple[str | None, str]:
+    """Stable de-duplication key for cumulative OpenAI chat histories."""
+    content = message.get("content")
+    if isinstance(content, str):
+        serialized = content
+    else:
+        serialized = json.dumps(content, sort_keys=True, separators=(",", ":"))
+    tool_call_id = message.get("tool_call_id")
+    return (tool_call_id if isinstance(tool_call_id, str) else None, serialized)
+
+
+def _extract_tool_observations_from_messages(
+    messages: list[dict[str, Any]],
+    seen_tool_observations: set[tuple[str | None, str]],
+    explicit_tool_call_ids: set[str],
+) -> list[dict]:
+    """Recover tool results from OpenAI-compatible cumulative chat history.
+
+    Sidecar gateway ATOF currently captures model traffic, not first-class
+    tool spans. OpenAI-compatible request histories still carry completed tool
+    results as ``{"role": "tool", "tool_call_id": ..., "content": ...}``.
+    Treat newly observed tool messages as observations for the preceding
+    assistant step.
+    """
+    observations: list[dict] = []
+    for message in messages:
+        if message.get("role") != "tool":
+            continue
+        tool_call_id = message.get("tool_call_id")
+        if isinstance(tool_call_id, str) and tool_call_id in explicit_tool_call_ids:
+            continue
+        key = _tool_observation_key(message)
+        if key in seen_tool_observations:
+            continue
+        seen_tool_observations.add(key)
+
+        content = message.get("content")
+        if not isinstance(content, str):
+            content = json.dumps(content, separators=(",", ":"))
+
+        obs_entry: dict = {"content": content}
+        if isinstance(tool_call_id, str) and tool_call_id:
+            obs_entry["source_call_id"] = tool_call_id
+        observations.append(obs_entry)
+    return observations
+
+
 def _serialize_root_data(data: Any) -> str | None:
     """Tier-1 boundary-step message serializer.
 
@@ -390,6 +536,18 @@ def _events_to_step_dicts(
     # each NEW role=user / role=system message in an LLM's input seed a
     # new step, which naturally models multi-turn conversations.
     seen_input_messages: dict[tuple[str | None, str], set[str]] = {}
+    seen_tool_observations: set[tuple[str | None, str]] = set()
+    completed_llm_uuids = {
+        event.uuid
+        for event in sorted_events if _is_scope_end(event) and isinstance(event, ScopeEvent) and event.category == "llm"
+    }
+    explicit_tool_call_ids = {
+        tool_call_id
+        for event in sorted_events
+        if _is_scope_end(event) and isinstance(event, ScopeEvent) and event.category == "tool"
+        for tool_call_id in [(event.category_profile or {}).get("tool_call_id")]
+        if isinstance(tool_call_id, str) and tool_call_id
+    }
 
     def flush_observations() -> None:
         """Attach buffered observations to the preceding agent step (R4 drain).
@@ -456,14 +614,16 @@ def _events_to_step_dicts(
     # Main event loop
     for event in sorted_events:
         if _is_scope_start(event) and event.category == "llm":
-            flush_observations()
-
             # R2/R3 (multi-turn aware): emit user/system steps for every NEW
             # role=user or role=system message in the LLM's input. A
             # continuation LLM call under the same agent where the user has
             # said nothing new emits no step; a follow-up user turn (new
             # content) emits one. System prompts surface as source=system
             # steps the first time they appear.
+            if event.uuid not in completed_llm_uuids:
+                logger.debug("Skipping incomplete LLM start event without matching end: %s", event.uuid)
+                continue
+
             data = event.data if isinstance(event.data, dict) else {}
             llm_extractor = resolve_llm_extractor(event.data_schema)
             messages = llm_extractor.extract_input_messages(data)
@@ -474,6 +634,19 @@ def _events_to_step_dicts(
                     data_schema=event.data_schema,
                     data_keys=sorted(data.keys()),
                 )
+
+            recovered_observations = _extract_tool_observations_from_messages(
+                messages,
+                seen_tool_observations,
+                explicit_tool_call_ids,
+            )
+            if recovered_observations:
+                pending_observations.extend(recovered_observations)
+                if pending_obs_timestamp is None:
+                    pending_obs_timestamp = event.timestamp
+
+            flush_observations()
+
             for m in messages:
                 role = m.get("role")
                 content = m.get("content")
@@ -577,10 +750,12 @@ def _events_to_step_dicts(
             # orchestrator steps (R13, llm_call_count=0) — model_name on a
             # deterministic dispatch step is meaningless per spec.
             step_model_name = (event.category_profile or {}).get("model_name") or event.name
+            has_explicit_tool_scopes = any(
+                call.get("tool_call_id") in explicit_tool_call_ids for call in tool_call_dicts)
 
             step_dict: dict = {
                 "source": "agent",
-                "message": agent_msg,
+                "message": agent_msg or ("[tool call]" if tool_call_dicts and not has_explicit_tool_scopes else ""),
                 "timestamp": event.timestamp,
                 "model_name": step_model_name,
                 "llm_call_count": 1,
@@ -588,6 +763,9 @@ def _events_to_step_dicts(
             }
             if tool_call_dicts:
                 step_dict["tool_calls"] = tool_call_dicts
+            metrics = _metrics_from_usage(raw_data.get("usage"))
+            if metrics:
+                step_dict["metrics"] = metrics
 
             step_dicts.append(step_dict)
             current_agent_step_idx = len(step_dicts) - 1
@@ -923,36 +1101,37 @@ def _convert_impl(events: list[Event], explicit_root_uuid: str | None) -> Trajec
     if explicit_root_uuid is not None:
         for event in events:
             if _is_scope_start(event) and event.uuid == explicit_root_uuid:
-                agent_name = event.name
+                agent_name = _agent_name_from_event(event)
                 root_agent_uuid = event.uuid
-                if event.metadata and isinstance(event.metadata, dict):
-                    v = event.metadata.get("version")
-                    if isinstance(v, str):
-                        agent_version = v
-                    s = event.metadata.get("session_id")
-                    if isinstance(s, str):
-                        session_id = s
+                metadata = _event_metadata(event)
+                v = metadata.get("version")
+                if isinstance(v, str):
+                    agent_version = v
+                s = metadata.get("session_id")
+                if isinstance(s, str):
+                    session_id = s
                 break
     else:
         # R1: outermost agent scope with parent_uuid None
         for event in main_events:
-            if _is_scope_start(event) and event.category == "agent" and event.parent_uuid is None:
-                agent_name = event.name
+            if (_is_scope_start(event) and event.category == "agent"
+                    and (event.parent_uuid is None or event.parent_uuid not in parent_map)):
+                agent_name = _agent_name_from_event(event)
                 root_agent_uuid = event.uuid
-                if event.metadata and isinstance(event.metadata, dict):
-                    v = event.metadata.get("version")
-                    if isinstance(v, str):
-                        agent_version = v
-                    s = event.metadata.get("session_id")
-                    if isinstance(s, str):
-                        session_id = s
+                metadata = _event_metadata(event)
+                v = metadata.get("version")
+                if isinstance(v, str):
+                    agent_version = v
+                s = metadata.get("session_id")
+                if isinstance(s, str):
+                    session_id = s
                 break
 
         # Tier-1 fallback
         if agent_name is None:
             for event in main_events:
                 if _is_scope_start(event) and event.parent_uuid is None:
-                    agent_name = event.name
+                    agent_name = _agent_name_from_event(event)
                     root_agent_uuid = event.uuid
                     break
 
@@ -992,6 +1171,7 @@ def _convert_impl(events: list[Event], explicit_root_uuid: str | None) -> Trajec
         trajectory_id=trajectory_id,
         agent=Agent(name=agent_name, version=agent_version, model_name=model_name),
         steps=steps,
+        final_metrics=_build_final_metrics(steps),
         subagent_trajectories=subagent_trajectories or None,
     )
 

--- a/packages/nvidia_nat_atif/tests/test_sidecar_openai_conversion.py
+++ b/packages/nvidia_nat_atif/tests/test_sidecar_openai_conversion.py
@@ -36,7 +36,9 @@ def _llm_start(uuid: str, timestamp: str, messages: list[dict[str, Any]]) -> Sco
         name="openai.chat_completions",
         category="llm",
         category_profile={"model_name": "qwen3.6:35b"},
-        data={"content": {"messages": messages, "model": "qwen3.6:35b"}},
+        data={"content": {
+            "messages": messages, "model": "qwen3.6:35b"
+        }},
     )
 
 
@@ -75,12 +77,16 @@ def _sidecar_stream_without_tool_scopes() -> list[ScopeEvent]:
     system = {"role": "system", "content": "You are Hermes Agent."}
     user = {"role": "user", "content": "Find the answer."}
     assistant_tool = {
-        "role": "assistant",
-        "content": "",
+        "role":
+            "assistant",
+        "content":
+            "",
         "tool_calls": [{
             "id": "call_1",
             "type": "function",
-            "function": {"name": "search_files", "arguments": '{"pattern":"needle"}'},
+            "function": {
+                "name": "search_files", "arguments": '{"pattern":"needle"}'
+            },
         }],
     }
     tool_result = {
@@ -99,7 +105,9 @@ def _sidecar_stream_without_tool_scopes() -> list[ScopeEvent]:
             timestamp="2026-05-12T22:00:00Z",
             name="gateway",
             category="agent",
-            metadata={"agent": "hermes-nemoflow", "session_id": "gateway-gateway", "source": "harbor"},
+            metadata={
+                "agent": "hermes-nemoflow", "session_id": "gateway-gateway", "source": "harbor"
+            },
         ),
         _llm_start("llm-001", "2026-05-12T22:00:01Z", [system, user]),
         _llm_end(
@@ -107,14 +115,18 @@ def _sidecar_stream_without_tool_scopes() -> list[ScopeEvent]:
             "2026-05-12T22:00:02Z",
             content="",
             tool_calls=assistant_tool["tool_calls"],
-            usage={"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+            usage={
+                "prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12
+            },
         ),
         _llm_start("llm-002", "2026-05-12T22:00:03Z", [system, user, assistant_tool, tool_result]),
         _llm_end(
             "llm-002",
             "2026-05-12T22:00:04Z",
             content="Done.",
-            usage={"prompt_tokens": 20, "completion_tokens": 3, "total_tokens": 23},
+            usage={
+                "prompt_tokens": 20, "completion_tokens": 3, "total_tokens": 23
+            },
         ),
         _llm_start("llm-orphan", "2026-05-12T22:00:05Z", [system, user, assistant_tool, tool_result, orphan_user]),
         ScopeEvent(
@@ -124,7 +136,9 @@ def _sidecar_stream_without_tool_scopes() -> list[ScopeEvent]:
             timestamp="2026-05-12T22:00:06Z",
             name="gateway",
             category="agent",
-            metadata={"agent": "hermes-nemoflow", "session_id": "gateway-gateway", "source": "harbor"},
+            metadata={
+                "agent": "hermes-nemoflow", "session_id": "gateway-gateway", "source": "harbor"
+            },
         ),
     ]
 

--- a/packages/nvidia_nat_atif/tests/test_sidecar_openai_conversion.py
+++ b/packages/nvidia_nat_atif/tests/test_sidecar_openai_conversion.py
@@ -1,0 +1,170 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for OpenAI-compatible sidecar ATOF streams.
+
+The NeMo-Flow gateway sidecar captures LLM request/response traffic but does
+not yet emit first-class tool scope events. Tool results are still recoverable
+from the next OpenAI request history as ``role=tool`` messages.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nat.atof import ScopeEvent
+from nat.atof.scripts.atof_to_atif_converter import convert
+
+
+def _llm_start(uuid: str, timestamp: str, messages: list[dict[str, Any]]) -> ScopeEvent:
+    return ScopeEvent(
+        scope_category="start",
+        uuid=uuid,
+        parent_uuid="gateway-001",
+        timestamp=timestamp,
+        name="openai.chat_completions",
+        category="llm",
+        category_profile={"model_name": "qwen3.6:35b"},
+        data={"content": {"messages": messages, "model": "qwen3.6:35b"}},
+    )
+
+
+def _llm_end(
+    uuid: str,
+    timestamp: str,
+    *,
+    content: str,
+    usage: dict[str, int],
+    tool_calls: list[dict[str, Any]] | None = None,
+) -> ScopeEvent:
+    message: dict[str, Any] = {"role": "assistant", "content": content}
+    if tool_calls:
+        message["tool_calls"] = tool_calls
+    return ScopeEvent(
+        scope_category="end",
+        uuid=uuid,
+        parent_uuid="gateway-001",
+        timestamp=timestamp,
+        name="openai.chat_completions",
+        category="llm",
+        category_profile={"model_name": "qwen3.6:35b"},
+        data={
+            "choices": [{
+                "index": 0,
+                "finish_reason": "tool_calls" if tool_calls else "stop",
+                "message": message,
+            }],
+            "model": "qwen3.6:35b",
+            "usage": usage,
+        },
+    )
+
+
+def _sidecar_stream_without_tool_scopes() -> list[ScopeEvent]:
+    system = {"role": "system", "content": "You are Hermes Agent."}
+    user = {"role": "user", "content": "Find the answer."}
+    assistant_tool = {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [{
+            "id": "call_1",
+            "type": "function",
+            "function": {"name": "search_files", "arguments": '{"pattern":"needle"}'},
+        }],
+    }
+    tool_result = {
+        "role": "tool",
+        "tool_call_id": "call_1",
+        "name": "search_files",
+        "content": '{"total_count":1,"files":["needle.py"]}',
+    }
+    orphan_user = {"role": "user", "content": "Review the conversation and update memory."}
+
+    return [
+        ScopeEvent(
+            scope_category="start",
+            uuid="gateway-001",
+            parent_uuid="external-parent-not-in-stream",
+            timestamp="2026-05-12T22:00:00Z",
+            name="gateway",
+            category="agent",
+            metadata={"agent": "hermes-nemoflow", "session_id": "gateway-gateway", "source": "harbor"},
+        ),
+        _llm_start("llm-001", "2026-05-12T22:00:01Z", [system, user]),
+        _llm_end(
+            "llm-001",
+            "2026-05-12T22:00:02Z",
+            content="",
+            tool_calls=assistant_tool["tool_calls"],
+            usage={"prompt_tokens": 10, "completion_tokens": 2, "total_tokens": 12},
+        ),
+        _llm_start("llm-002", "2026-05-12T22:00:03Z", [system, user, assistant_tool, tool_result]),
+        _llm_end(
+            "llm-002",
+            "2026-05-12T22:00:04Z",
+            content="Done.",
+            usage={"prompt_tokens": 20, "completion_tokens": 3, "total_tokens": 23},
+        ),
+        _llm_start("llm-orphan", "2026-05-12T22:00:05Z", [system, user, assistant_tool, tool_result, orphan_user]),
+        ScopeEvent(
+            scope_category="end",
+            uuid="gateway-001",
+            parent_uuid="external-parent-not-in-stream",
+            timestamp="2026-05-12T22:00:06Z",
+            name="gateway",
+            category="agent",
+            metadata={"agent": "hermes-nemoflow", "session_id": "gateway-gateway", "source": "harbor"},
+        ),
+    ]
+
+
+def test_sidecar_openai_history_recovers_observations_metrics_and_metadata() -> None:
+    trajectory = convert(_sidecar_stream_without_tool_scopes())
+
+    assert trajectory.session_id == "gateway-gateway"
+    assert trajectory.agent.name == "hermes-nemoflow"
+    assert trajectory.agent.model_name == "qwen3.6:35b"
+
+    assert [step.source for step in trajectory.steps] == ["system", "user", "agent", "agent"]
+    assert [step.message for step in trajectory.steps] == [
+        "You are Hermes Agent.",
+        "Find the answer.",
+        "[tool call]",
+        "Done.",
+    ]
+
+    tool_step = trajectory.steps[2]
+    assert tool_step.tool_calls is not None
+    assert tool_step.tool_calls[0].tool_call_id == "call_1"
+    assert tool_step.tool_calls[0].function_name == "search_files"
+    assert tool_step.tool_calls[0].arguments == {"pattern": "needle"}
+    assert tool_step.observation is not None
+    assert tool_step.observation.results[0].source_call_id == "call_1"
+    assert tool_step.observation.results[0].content == '{"total_count":1,"files":["needle.py"]}'
+
+    assert tool_step.metrics is not None
+    assert tool_step.metrics.prompt_tokens == 10
+    assert tool_step.metrics.completion_tokens == 2
+    assert tool_step.metrics.extra == {"total_tokens": 12}
+
+    final_step = trajectory.steps[3]
+    assert final_step.metrics is not None
+    assert final_step.metrics.prompt_tokens == 20
+    assert final_step.metrics.completion_tokens == 3
+
+    assert trajectory.final_metrics is not None
+    assert trajectory.final_metrics.total_steps == 4
+    assert trajectory.final_metrics.total_prompt_tokens == 30
+    assert trajectory.final_metrics.total_completion_tokens == 5
+    assert trajectory.final_metrics.extra == {"total_tokens": 35}


### PR DESCRIPTION
## Summary

This PR improves the ATOF-to-ATIF converter for NeMo-Flow sidecar traces whose LLM events are emitted in an OpenAI Chat Completions-compatible payload shape. The sidecar architecture itself is provider-agnostic; this is the shape used by the Hermes smoke path because Hermes is routed through an OpenAI-compatible chat endpoint in the smoke test.

The converter now reconstructs a richer ATIF trajectory from those sidecar ATOF events by recovering tool observations from cumulative chat history, mapping token usage into ATIF metrics, skipping orphan request-only LLM events, and using gateway metadata for trajectory identity. Other provider payloads remain covered by the converter's schema-driven extractor registry when producers declare `data_schema`; a follow-up can make NeMo-Flow sidecar conversion more provider-neutral by consuming normalized `category_profile.annotated_response` metadata when present.

## Changes

- Recover tool observations from OpenAI-compatible `role="tool"` messages when explicit ATOF tool scope events are absent.
- Avoid double-counting observations when explicit tool scope events are already present.
- Map OpenAI-compatible `usage` payloads into per-step ATIF `metrics`.
- Aggregate token totals into trajectory-level `final_metrics`.
- Skip incomplete LLM start events that do not have a matching LLM end event.
- Prefer producer metadata such as `metadata.agent` and `metadata.session_id` when deriving ATIF agent/session identity from gateway sidecar traces.
- Normalize tool-call-only assistant messages to `[tool call]` only for sidecar-style streams without explicit tool scopes.
- Add a regression test that models the Hermes/NeMo-Flow sidecar ATOF shape observed when Hermes uses an OpenAI-compatible chat endpoint.

## Validation

- `152 passed, 1 warning`

```bash
.tmp/hermes-nemoflow-venv/bin/python -m pytest packages/nvidia_nat_atif/tests
```

- Re-ran the original checked-in ATOF example regression for `exmp01` through `exmp06`.
- Regenerated outputs matched the existing expected `exmpNN_atif.json` files byte-for-byte.
- Reconverted the Hermes sidecar smoke ATOF and confirmed:
  - `31` converted ATIF steps
  - `28` observation-bearing tool steps
  - `29` metric-bearing LLM steps
  - `final_metrics.total_prompt_tokens=811556`
  - `final_metrics.total_completion_tokens=4801`
  - `final_metrics.extra.total_tokens=816357`
  - Native Hermes ATIF vs ATOF-derived ATIF tool sequence: `match (same)`

## Notes

This keeps existing explicit-tool-span behavior stable while adding a fallback path for sidecar traces that only capture chat-model traffic without first-class tool spans. The fallback relies on cumulative OpenAI Chat-compatible histories containing prior `role="tool"` messages with `tool_call_id`, so exact tool timing/duration is still unavailable unless producers emit explicit tool scope events.

Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
