### PR TITLE
fix(Phoenix): Fix Phoenix telemetry API key support

### DIFF
--- a/docs/source/run-workflows/observe/observe-workflow-with-phoenix.md
+++ b/docs/source/run-workflows/observe/observe-workflow-with-phoenix.md
@@ -72,6 +72,9 @@ general:
         _type: phoenix
         endpoint: http://localhost:6006/v1/traces
         project: simple_calculator
+        # Optional, for Phoenix servers with authentication enabled.
+        # You can also set PHOENIX_API_KEY instead.
+        api_key: ${PHOENIX_API_KEY}
 ```
 This setup enables tracing through Phoenix at `http://localhost:6006/v1/traces`, with traces grouped into the `simple_calculator` project.
 

--- a/packages/nvidia_nat_phoenix/src/nat/plugins/phoenix/mixin/phoenix_mixin.py
+++ b/packages/nvidia_nat_phoenix/src/nat/plugins/phoenix/mixin/phoenix_mixin.py
@@ -43,15 +43,22 @@ class PhoenixMixin:
                 super().__init__(endpoint=endpoint, project=project, **kwargs)
     """
 
-    def __init__(self, *args, endpoint: str, project: str, timeout: float = 60.0, **kwargs):
+    def __init__(self,
+                 *args,
+                 endpoint: str,
+                 project: str,
+                 timeout: float = 60.0,
+                 headers: dict[str, str] | None = None,
+                 **kwargs):
         """Initialize the Phoenix exporter.
 
         Args:
             endpoint: Phoenix service endpoint URL.
             project: Phoenix project name for trace grouping.
             timeout: Timeout in seconds for HTTP requests to Phoenix server.
+            headers: HTTP headers for authentication and metadata.
         """
-        self._exporter = HTTPSpanExporter(endpoint=endpoint, timeout=timeout)
+        self._exporter = HTTPSpanExporter(endpoint=endpoint, timeout=timeout, headers=headers)
         self._project = project
 
         # Add Phoenix project name to resource attributes

--- a/packages/nvidia_nat_phoenix/src/nat/plugins/phoenix/register.py
+++ b/packages/nvidia_nat_phoenix/src/nat/plugins/phoenix/register.py
@@ -14,11 +14,14 @@
 # limitations under the License.
 
 import logging
+import os
 
 from pydantic import Field
 
 from nat.builder.builder import Builder
 from nat.cli.register_workflow import register_telemetry_exporter
+from nat.data_models.common import SerializableSecretStr
+from nat.data_models.common import get_secret_value
 from nat.data_models.telemetry_exporter import TelemetryExporterBaseConfig
 from nat.observability.mixin.batch_config_mixin import BatchConfigMixin
 from nat.observability.mixin.collector_config_mixin import CollectorConfigMixin
@@ -26,12 +29,26 @@ from nat.observability.mixin.collector_config_mixin import CollectorConfigMixin
 logger = logging.getLogger(__name__)
 
 
+def _phoenix_auth_headers(api_key: str) -> dict[str, str]:
+    """Build Phoenix OTLP auth headers."""
+    if api_key.lower().startswith("bearer "):
+        bearer_token = api_key
+    else:
+        bearer_token = f"Bearer {api_key}"
+
+    return {"authorization": bearer_token}
+
+
 class PhoenixTelemetryExporter(BatchConfigMixin, CollectorConfigMixin, TelemetryExporterBaseConfig, name="phoenix"):
     """A telemetry exporter to transmit traces to externally hosted phoenix service."""
 
     endpoint: str = Field(
-        description="Phoenix server endpoint for trace export (e.g., 'http://localhost:6006/v1/traces'")
+        description="Phoenix server endpoint for trace export (e.g., 'http://localhost:6006/v1/traces')")
     timeout: float = Field(default=30.0, description="Timeout in seconds for HTTP requests to Phoenix server")
+    api_key: SerializableSecretStr = Field(
+        description="Phoenix API key. If empty, uses the PHOENIX_API_KEY environment variable.",
+        default_factory=lambda: SerializableSecretStr(""),
+    )
 
 
 @register_telemetry_exporter(config_type=PhoenixTelemetryExporter)
@@ -41,10 +58,15 @@ async def phoenix_telemetry_exporter(config: PhoenixTelemetryExporter, builder: 
     try:
         from nat.plugins.phoenix.phoenix_exporter import PhoenixOtelExporter
 
+        api_key = get_secret_value(config.api_key) if config.api_key else None
+        api_key = (api_key or os.environ.get("PHOENIX_API_KEY") or "").strip()
+        headers = _phoenix_auth_headers(api_key) if api_key else None
+
         # Create the exporter
         yield PhoenixOtelExporter(endpoint=config.endpoint,
                                   project=config.project,
                                   timeout=config.timeout,
+                                  headers=headers,
                                   batch_size=config.batch_size,
                                   flush_interval=config.flush_interval,
                                   max_queue_size=config.max_queue_size,

--- a/packages/nvidia_nat_phoenix/tests/test_phoenix_telemetry_exporter.py
+++ b/packages/nvidia_nat_phoenix/tests/test_phoenix_telemetry_exporter.py
@@ -1,0 +1,88 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import Mock
+from unittest.mock import patch
+
+import pytest
+
+from nat.plugins.phoenix.mixin.phoenix_mixin import PhoenixMixin
+from nat.plugins.phoenix.register import PhoenixTelemetryExporter
+from nat.plugins.phoenix.register import _phoenix_auth_headers
+from nat.plugins.phoenix.register import phoenix_telemetry_exporter
+
+
+def test_phoenix_auth_headers_add_bearer_prefix():
+    assert _phoenix_auth_headers("test-key") == {"authorization": "Bearer test-key"}
+
+
+def test_phoenix_auth_headers_preserve_existing_bearer_prefix():
+    assert _phoenix_auth_headers("Bearer test-key") == {"authorization": "Bearer test-key"}
+
+
+class _BaseExporter:
+
+    def __init__(self, resource_attributes=None):
+        self.resource_attributes = resource_attributes
+
+
+class _PhoenixMixinExporter(PhoenixMixin, _BaseExporter):
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+
+
+@patch("nat.plugins.phoenix.mixin.phoenix_mixin.HTTPSpanExporter")
+def test_phoenix_mixin_passes_headers_to_http_span_exporter(mock_http_span_exporter):
+    headers = {"authorization": "Bearer test-key"}
+
+    _PhoenixMixinExporter(endpoint="http://localhost:6006/v1/traces",
+                          project="simple_calculator",
+                          timeout=5.0,
+                          headers=headers)
+
+    mock_http_span_exporter.assert_called_once_with(endpoint="http://localhost:6006/v1/traces",
+                                                    timeout=5.0,
+                                                    headers=headers)
+
+
+async def _collect_exporter(config: PhoenixTelemetryExporter):
+    async with phoenix_telemetry_exporter(config, Mock()) as exporter:
+        return exporter
+
+
+@pytest.mark.usefixtures("restore_environ")
+async def test_phoenix_telemetry_exporter_passes_api_key_header():
+    config = PhoenixTelemetryExporter(endpoint="http://localhost:6006/v1/traces",
+                                      project="simple_calculator",
+                                      api_key="test-key")
+
+    with patch("nat.plugins.phoenix.phoenix_exporter.PhoenixOtelExporter") as mock_exporter:
+        await _collect_exporter(config)
+
+    mock_exporter.assert_called_once()
+    assert mock_exporter.call_args.kwargs["headers"] == {"authorization": "Bearer test-key"}
+
+
+@pytest.mark.usefixtures("restore_environ")
+async def test_phoenix_telemetry_exporter_uses_env_api_key(monkeypatch):
+    monkeypatch.setenv("PHOENIX_API_KEY", "env-key")
+    config = PhoenixTelemetryExporter(endpoint="http://localhost:6006/v1/traces", project="simple_calculator")
+
+    with patch("nat.plugins.phoenix.phoenix_exporter.PhoenixOtelExporter") as mock_exporter:
+        await _collect_exporter(config)
+
+    mock_exporter.assert_called_once()
+    assert mock_exporter.call_args.kwargs["headers"] == {"authorization": "Bearer env-key"}


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Fixes Phoenix telemetry API key support by wiring Phoenix telemetry `api_key` configuration into the Phoenix OTLP exporter auth headers.

## Changes

- Add `api_key` support to the `phoenix` telemetry exporter config
- Fall back to `PHOENIX_API_KEY` when `api_key` is not provided in YAML
- Pass `authorization: Bearer <token>` headers into `phoenix.otel.HTTPSpanExporter`
- Document authenticated Phoenix usage
- Add focused tests for config-provided and environment-provided API keys


Closes #1914 

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Phoenix telemetry now supports authentication with configurable API keys
  * API key can be provided via configuration or the `PHOENIX_API_KEY` environment variable
  * Authorization headers are automatically formatted for authenticated Phoenix OTLP requests

* **Documentation**
  * Updated workflow telemetry examples to include optional authentication configuration guidance

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1928)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->