### PR TITLE
fix(example): Fix auto-memory wrapper user ID lookup

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/auto_memory_wrapper/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/auto_memory_wrapper/agent.py
@@ -72,15 +72,25 @@ class AutoMemoryWrapperGraph:
         Extract user_id from runtime context.
 
         Priority order:
-        1. user_manager.get_id() - For authenticated sessions (set via SessionManager.session())
-        2. X-User-ID HTTP header - For testing/simple auth without middleware
-        3. "default_user" - Fallback for development/testing without authentication
+        1. Context.user_id - For authenticated sessions (set via SessionManager.session())
+        2. user_manager.get_id() - Legacy/custom context compatibility
+        3. X-User-ID HTTP header - For testing/simple auth without middleware
+        4. "default_user" - Fallback for development/testing without authentication
 
         Returns:
             str: The user ID for memory operations
         """
-        # Priority 1: Get user_id from user_manager (for authenticated sessions)
-        user_manager = self._context.user_manager
+        # Priority 1: Get user_id from the runtime context.
+        try:
+            user_id = self._context.user_id
+            if user_id:
+                logger.debug(f"Using user_id from context: {user_id}")
+                return user_id
+        except Exception as e:
+            logger.debug(f"Failed to get user_id from context: {e}")
+
+        # Priority 2: Get user_id from user_manager (legacy/custom context compatibility)
+        user_manager = getattr(self._context, "user_manager", None)
         if user_manager and hasattr(user_manager, 'get_id'):
             try:
                 user_id = user_manager.get_id()
@@ -90,9 +100,11 @@ class AutoMemoryWrapperGraph:
             except Exception as e:
                 logger.debug(f"Failed to get user_id from user_manager: {e}")
 
-        # Priority 2: Extract from X-User-ID HTTP header (temporary workaround for testing)
-        if self._context.metadata and self._context.metadata.headers:
-            user_id = self._context.metadata.headers.get("x-user-id")
+        # Priority 3: Extract from X-User-ID HTTP header (temporary workaround for testing)
+        metadata = getattr(self._context, "metadata", None)
+        headers = getattr(metadata, "headers", None) if metadata else None
+        if headers:
+            user_id = headers.get("x-user-id") or headers.get("X-User-ID")
             if user_id:
                 logger.debug(f"Using user_id from X-User-ID header: {user_id}")
                 return user_id

--- a/packages/nvidia_nat_langchain/tests/agent/test_auto_memory_wrapper.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_auto_memory_wrapper.py
@@ -69,7 +69,7 @@ def fixture_mock_inner_agent() -> Mock:
 def fixture_mock_context() -> Mock:
     """Create a mock Context for testing."""
     context = Mock(spec=Context)
-    context.user_manager = None
+    context.user_id = None
     context.metadata = None
     return context
 
@@ -144,6 +144,14 @@ class TestAutoMemoryWrapperGraph:
         """Test user ID extraction defaults to 'default_user'."""
         user_id = wrapper_graph._get_user_id_from_context()
         assert user_id == "default_user"
+
+    def test_get_user_id_from_context(self, wrapper_graph, mock_context):
+        """Test user ID extraction from Context.user_id."""
+        mock_context.user_id = "user-from-context"
+        with patch('nat.plugins.langchain.agent.auto_memory_wrapper.agent.Context.get', return_value=mock_context):
+            wrapper_graph._context = mock_context
+            user_id = wrapper_graph._get_user_id_from_context()
+        assert user_id == "user-from-context"
 
     def test_get_user_id_from_header(self, wrapper_graph, mock_context):
         """Test user ID extraction from X-User-ID header."""


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Updating the auto-memory wrapper to resolve the runtime user ID from `Context.user_id` before falling back to legacy/custom `user_manager`, `X-User-ID`, and `default_user`.

The previous implementation directly dereferenced `Context.user_manager`, which is not present in the current `nat run` context and caused the auto-memory wrapper examples to fail with:

`AttributeError: 'Context' object has no attribute 'user_manager'`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced user identification handling with more robust fallback mechanisms when retrieving user IDs from multiple sources, including context, user manager, and request headers.
  * Updated tests to verify user ID extraction behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1948?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->