### PR TITLE
fix(example): Fix `typing.Any` runtime checks in function conversion

### DIFF
--- a/packages/nvidia_nat_core/src/nat/builder/function.py
+++ b/packages/nvidia_nat_core/src/nat/builder/function.py
@@ -37,6 +37,7 @@ from nat.data_models.function import FunctionGroupBaseConfig
 from nat.middleware.function_middleware import FunctionMiddlewareChain
 from nat.middleware.middleware import FunctionMiddlewareContext
 from nat.middleware.middleware import Middleware
+from nat.utils.type_utils import DecomposedType
 
 _InvokeFnT = Callable[[InputT], Awaitable[SingleOutputT]]
 _StreamFnT = Callable[[InputT], AsyncGenerator[StreamingOutputT]]
@@ -44,6 +45,13 @@ _StreamFnT = Callable[[InputT], AsyncGenerator[StreamingOutputT]]
 _T = typing.TypeVar("_T")
 
 logger = logging.getLogger(__name__)
+
+
+def _needs_conversion(value: typing.Any, to_type: type | None) -> bool:
+    if to_type is None:
+        return False
+
+    return not DecomposedType(to_type).is_instance(value)
 
 
 class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
@@ -192,7 +200,7 @@ class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
 
                 result = await invoke_callable(converted_input)
 
-                if to_type is not None and not isinstance(result, to_type):
+                if _needs_conversion(result, to_type):
                     result = self.convert(result, to_type)
 
                 manager.set_output(result)
@@ -286,7 +294,7 @@ class Function(FunctionBase[InputT, StreamingOutputT, SingleOutputT], ABC):
                 stream_callable = self._middlewared_stream or self._astream
 
                 async for data in stream_callable(converted_input):
-                    if to_type is not None and not isinstance(data, to_type):
+                    if _needs_conversion(data, to_type):
                         converted_data = self.convert(data, to_type=to_type)
                         final_output.append(converted_data)
                         yield converted_data

--- a/packages/nvidia_nat_core/src/nat/builder/function_base.py
+++ b/packages/nvidia_nat_core/src/nat/builder/function_base.py
@@ -136,6 +136,9 @@ class FunctionBase(typing.Generic[InputT, StreamingOutputT, SingleOutputT], ABC)
             The python type of the input type
         """
 
+        if (self.input_type is typing.Any):
+            return object
+
         input_origin = typing.get_origin(self.input_type)
 
         if (input_origin is None):
@@ -221,6 +224,9 @@ class FunctionBase(typing.Generic[InputT, StreamingOutputT, SingleOutputT], ABC)
             The python type of the output type
         """
 
+        if (self.streaming_output_type is typing.Any):
+            return object
+
         output_origin = typing.get_origin(self.streaming_output_type)
 
         if (output_origin is None):
@@ -294,6 +300,9 @@ class FunctionBase(typing.Generic[InputT, StreamingOutputT, SingleOutputT], ABC)
             The python type of the output type
         """
 
+        if (self.single_output_type is typing.Any):
+            return object
+
         output_origin = typing.get_origin(self.single_output_type)
 
         if (output_origin is None):
@@ -351,7 +360,7 @@ class FunctionBase(typing.Generic[InputT, StreamingOutputT, SingleOutputT], ABC)
         return True
 
     def _convert_input(self, value: typing.Any) -> InputT:
-        if (isinstance(value, self.input_class)):
+        if (DecomposedType(self.input_type).is_instance(value)):
             return value
 
         # No converter, try to convert to the input schema

--- a/packages/nvidia_nat_core/tests/nat/builder/test_function.py
+++ b/packages/nvidia_nat_core/tests/nat/builder/test_function.py
@@ -606,6 +606,28 @@ async def test_ainvoke_output_type_conversion_failure():
             await fn_obj.ainvoke("test", to_type=IncompatibleType)
 
 
+async def test_ainvoke_accepts_any_input_and_output_type():
+    """Test that Any input/output annotations do not get passed to isinstance."""
+
+    @register_function(config_type=DummyConfig)
+    async def _register(config: DummyConfig, b: Builder):
+
+        async def _inner(message: typing.Any) -> typing.Any:
+            return {"message": message}
+
+        yield _inner
+
+    async with WorkflowBuilder() as builder:
+
+        fn_obj = await builder.add_function(name="test_function", config=DummyConfig())
+
+        assert fn_obj.input_type is typing.Any
+        assert fn_obj.input_class is object
+        assert fn_obj.single_output_type is typing.Any
+        assert fn_obj.single_output_class is object
+        assert await fn_obj.ainvoke("test", to_type=typing.Any) == {"message": "test"}
+
+
 async def test_astream_output_type_conversion_failure():
     """Test that astream raises an exception when output cannot be converted to the specified to_type."""
 
@@ -637,6 +659,31 @@ async def test_astream_output_type_conversion_failure():
         with pytest.raises(ValueError, match="Cannot convert type .* to .* No match found"):
             async for output in fn_obj.astream("test", to_type=IncompatibleType):
                 pass  # The exception should be raised during the first iteration
+
+
+async def test_astream_accepts_any_output_type():
+    """Test that Any stream output annotations do not get passed to isinstance."""
+
+    @register_function(config_type=DummyConfig)
+    async def _register(config: DummyConfig, b: Builder):
+
+        async def _stream_inner(message: str) -> AsyncGenerator[typing.Any]:
+            yield {"message": message}
+
+        yield _stream_inner
+
+    async with WorkflowBuilder() as builder:
+
+        fn_obj = await builder.add_function(name="test_function", config=DummyConfig())
+
+        assert fn_obj.streaming_output_type is typing.Any
+        assert fn_obj.streaming_output_class is object
+
+        result = None
+        async for output in fn_obj.astream("test", to_type=typing.Any):
+            result = output
+
+        assert result == {"message": "test"}
 
 
 async def test_ainvoke_primitive_type_conversion_failure():


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Fixes a `typing.Any cannot be used with isinstance()` crash when workflows fall back to `Any` annotations after a non-fatal sequential executor type compatibility warning.

The parallel executor example can produce this path because `parallel_analysis` returns `str`, while the downstream chat completion function accepts `ChatRequestOrMessage`. With `raise_type_incompatibility: false`, the sequential executor warns and annotates the generated workflow with `typing.Any`; core function conversion then needs to treat `Any` as accept-all instead of passing it to `isinstance`.

## Changes

- Use `DecomposedType.is_instance()` for function output conversion checks.
- Treat `typing.Any` class helpers as `object` for runtime class usage.
- Use `DecomposedType.is_instance()` for input conversion checks.
- Add regression coverage for `typing.Any` input/output handling in `ainvoke` and `astream`.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type conversion logic for more accurate handling of `typing.Any` type annotations in inputs and outputs.
  * Enhanced input type validation to use semantic type-instance checking instead of basic instance checks.

* **Tests**
  * Added comprehensive test coverage for `typing.Any` type support in both synchronous and streaming function invocations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1949?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->