### PR TITLE
Fix MCP schema model reuse for Kaggle tools

### DIFF
--- a/examples/MCP/simple_calculator_mcp/configs/config-mcp-client.yml
+++ b/examples/MCP/simple_calculator_mcp/configs/config-mcp-client.yml
@@ -58,9 +58,11 @@ function_groups:
 llms:
   nim_llm:
     _type: nim
-    model_name: meta/llama-3.1-70b-instruct
+    model_name: nvidia/nemotron-3-nano-30b-a3b
     temperature: 0.0
     max_tokens: 1024
+    chat_template_kwargs:
+      enable_thinking: false
 
 workflow:
   _type: react_agent

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/utils.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/utils.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from enum import Enum
 from functools import cache
 from typing import Any
@@ -20,6 +21,8 @@ from typing import Any
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import create_model
+
+_ORDER_INSENSITIVE_SCHEMA_ARRAY_KEYS = frozenset({"enum", "required"})
 
 
 @cache
@@ -43,6 +46,23 @@ def _get_or_create_enum(name: str, values: frozenset[str]) -> type[Enum]:
     return Enum(name, {item: item for item in values})
 
 
+def _schema_cache_sort_key(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _normalize_schema_for_cache(value: Any, key: str | None = None) -> Any:
+    if isinstance(value, dict):
+        return {item_key: _normalize_schema_for_cache(item_value, item_key) for item_key, item_value in value.items()}
+
+    if isinstance(value, list):
+        normalized_values = [_normalize_schema_for_cache(item) for item in value]
+        if key in _ORDER_INSENSITIVE_SCHEMA_ARRAY_KEYS:
+            return sorted(normalized_values, key=_schema_cache_sort_key)
+        return normalized_values
+
+    return value
+
+
 def truncate_session_id(session_id: str, max_length: int = 10) -> str:
     """
     Truncate a session ID for logging purposes.
@@ -63,6 +83,17 @@ def model_from_mcp_schema(name: str, mcp_input_schema: dict) -> type[BaseModel]:
     """
     Create a pydantic model from the input schema of the MCP tool
     """
+    normalized_schema = _normalize_schema_for_cache(mcp_input_schema)
+    schema_json = json.dumps(normalized_schema, sort_keys=True, separators=(",", ":"))
+    return _model_from_mcp_schema(name, schema_json)
+
+
+@cache
+def _model_from_mcp_schema(name: str, mcp_input_schema_json: str) -> type[BaseModel]:
+    """
+    Create or retrieve a cached pydantic model from a normalized MCP input schema.
+    """
+    mcp_input_schema = json.loads(mcp_input_schema_json)
     _type_map = {
         "string": str,
         "number": float,

--- a/packages/nvidia_nat_mcp/tests/client/test_mcp_schema.py
+++ b/packages/nvidia_nat_mcp/tests/client/test_mcp_schema.py
@@ -473,6 +473,93 @@ def test_nested_anyof_in_object_properties():
     assert m2.user.age_or_name == "John"
 
 
+def test_schema_generation_reuses_equivalent_nested_model_classes():
+    """Equivalent MCP schemas should accept nested model instances generated earlier."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "request": {
+                "type": "object",
+                "properties": {
+                    "search": {
+                        "type": "string"
+                    },
+                    "page": {
+                        "type": "integer"
+                    },
+                },
+                "required": [],
+            }
+        },
+        "required": ["request"],
+    }
+
+    first_model = model_from_mcp_schema("search_datasets", schema)
+    second_model = model_from_mcp_schema("search_datasets", schema)
+
+    assert second_model is first_model
+    assert second_model.model_fields["request"].annotation is first_model.model_fields["request"].annotation
+
+    first_payload = first_model.model_validate({"request": {"search": "IMDB"}})
+    second_payload = second_model.model_validate({"request": first_payload.request})
+
+    assert second_payload.model_dump(exclude_none=True, mode="json") == {"request": {"search": "IMDB"}}
+
+
+def test_schema_generation_normalizes_order_insensitive_arrays():
+    """Required and enum ordering should not affect generated model identity."""
+    first_schema = {
+        "type": "object",
+        "properties": {
+            "request": {
+                "type": "object",
+                "properties": {
+                    "search": {
+                        "type": "string"
+                    },
+                    "sort_by": {
+                        "type": "string",
+                        "enum": ["updated", "hottest"],
+                    },
+                },
+                "required": ["search", "sort_by"],
+            },
+            "include_votes": {
+                "type": "boolean"
+            },
+        },
+        "required": ["request", "include_votes"],
+    }
+    second_schema = {
+        "type": "object",
+        "properties": {
+            "request": {
+                "type": "object",
+                "properties": {
+                    "search": {
+                        "type": "string"
+                    },
+                    "sort_by": {
+                        "type": "string",
+                        "enum": ["hottest", "updated"],
+                    },
+                },
+                "required": ["sort_by", "search"],
+            },
+            "include_votes": {
+                "type": "boolean"
+            },
+        },
+        "required": ["include_votes", "request"],
+    }
+
+    first_model = model_from_mcp_schema("search_datasets_with_sort", first_schema)
+    second_model = model_from_mcp_schema("search_datasets_with_sort", second_schema)
+
+    assert second_model is first_model
+    assert second_model.model_fields["request"].annotation is first_model.model_fields["request"].annotation
+
+
 def test_anyof_array_with_anyof_items():
     """Test anyOf containing an array whose items also have anyOf"""
     schema = {


### PR DESCRIPTION
## Summary
- Cache generated MCP input models by normalized schema so repeated MCP tool discovery reuses the same Pydantic classes.
- Add a regression test for revalidating nested request values generated from equivalent MCP schemas.

## Root Cause
Repeated MCP schema conversion created structurally equivalent but distinct dynamic Pydantic model classes. When the workflow path revalidated a nested `request` model from an earlier generated schema against a later generated schema, Pydantic rejected it by class identity.

Example failure shape:
1. Initial tool registration creates `SearchDatasetsInputSchema` with a nested `RequestInputSchema`.
2. The agent input is converted into a Pydantic object using that first generated nested class.
3. The session tool lookup regenerates the same MCP schema as a new Python class with the same display name.
4. Revalidation then sees `request=<RequestInputSchema from first generation>` but expects `<RequestInputSchema from second generation>`, so Pydantic rejects it even though both classes print as `RequestInputSchema`.

The cache makes repeated generation of the same `(tool name, input schema)` return the same class object.

closes NAT-224


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration Updates**
  * Switched the default model used by the MCP client and disabled "thinking" mode.

* **Performance**
  * Improved schema normalization and caching so equivalent schemas reliably reuse generated models and avoid redundant work.

* **Testing**
  * Added tests that verify consistent model reuse and stable JSON output for nested requests and order-insensitive arrays.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1954?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->