### PR TITLE
Fix auto memory recall scoping

### DIFF
--- a/ci/scripts/path_checks.py
+++ b/ci/scripts/path_checks.py
@@ -170,6 +170,7 @@ ALLOWLISTED_WORDS: set[str] = {
     "read/write",
     "run/host",
     "run/serve",
+    "runtime/front-end",
     "start/stop",
     "search/edit/score/select",
     "size/time",

--- a/docs/source/build-workflows/memory.md
+++ b/docs/source/build-workflows/memory.md
@@ -92,9 +92,12 @@ The automatic memory wrapper agent supports several configuration parameters:
 ### Multi-Tenant Memory Isolation
 
 User ID is automatically extracted at runtime for memory isolation via:
-1. `user_manager.get_id()` - For production with custom auth middleware (recommended)
+1. `SessionManager.session(user_id=...)` - For production with custom auth middleware (recommended)
 2. `X-User-ID` HTTP header - For testing without middleware
-3. `"default_user"` - Fallback for local development
+3. Console front end `user_id` - Defaults to `"nat_run_user_id"` for `nat run`
+
+Conversation-aware memory backends can also use `conversation_id` to isolate separate conversations for the same user.
+For `nat run`, pass `--conversation_id` when testing independent memory conversations from the CLI.
 
 For detailed configuration and usage examples, refer to the `examples/agents/auto_memory_wrapper/README.md` guide.
 

--- a/docs/source/components/agents/auto-memory-wrapper/auto-memory-wrapper.md
+++ b/docs/source/components/agents/auto-memory-wrapper/auto-memory-wrapper.md
@@ -160,13 +160,17 @@ The wrapper automatically:
 
 ## Multi-Tenant Memory Isolation
 
-The automatic memory wrapper agent provides multi-tenant support through automatic user ID extraction. User ID is **NOT** configured in YAML but extracted at runtime.
+The automatic memory wrapper agent provides multi-tenant support through runtime user ID extraction. Configure user IDs
+through the front end or session runtime, not the `auto_memory_agent` workflow block.
 
 ### User ID Extraction Priority
 
-1. **`user_manager.get_id()`** - For production with custom auth middleware (recommended)
+1. **`SessionManager.session(user_id=...)`** - For production with custom auth middleware (recommended)
 2. **`X-User-ID` HTTP header** - For testing without middleware
-3. **`"default_user"`** - Fallback for local development
+3. **Console front end `user_id`** - Defaults to `"nat_run_user_id"` for `nat run`
+
+Conversation-aware memory backends can also use `conversation_id` to isolate separate conversations for the same user.
+For Zep Cloud, if no conversation ID is supplied, the integration uses a deterministic per-user default thread.
 
 ### Production: Custom Middleware
 
@@ -187,10 +191,7 @@ async def handle_request(request):
     # Extract from JWT, OAuth, API key, etc.
     user_id = extract_user_from_jwt(request.headers["authorization"])
 
-    async with session_manager.session(
-        user_manager=AuthenticatedUserManager(user_id=user_id),
-        http_connection=request,
-    ) as session:
+    async with session_manager.session(user_id=user_id, http_connection=request) as session:
         result = await session.run(user_input)
     return result
 ```
@@ -207,12 +208,14 @@ curl -X POST http://localhost:8000/chat \
   -d '{"messages": [{"role": "user", "content": "Hello!"}]}'
 ```
 
-### Local Development: No Authentication
+### Local Development: Console User and Conversation IDs
 
-Omit both `user_manager` and `X-User-ID` header to use `"default_user"`:
+For `nat run`, set `--user_id` to control memory isolation and `--conversation_id` to isolate a specific conversation:
 
 ```bash
-nat run --config examples/agents/auto_memory_wrapper/configs/config_zep.yml
+nat run --config_file examples/agents/auto_memory_wrapper/configs/config_zep.yml \
+  --user_id test_user_123 \
+  --conversation_id test_conv_001
 ```
 
 ---
@@ -324,7 +327,7 @@ workflow:
 
 ## Important Notes
 
-1. **User ID is runtime-only** - Set via `user_manager` or `X-User-ID` header, not in configuration
+1. **User ID is runtime/front-end scoped** - Set via `SessionManager.session(user_id=...)`, `X-User-ID`, or `nat run --user_id`
 2. **Memory backends are interchangeable** - Works with any implementation of `MemoryEditor` interface
 3. **No memory tools needed** - The wrapped agent does not need explicit memory tools configured
 4. **Transparent to inner agent** - The wrapped agent is unaware of memory operations

--- a/docs/source/reference/cli.md
+++ b/docs/source/reference/cli.md
@@ -235,8 +235,15 @@ Options:
   --override <TEXT TEXT>...  Override config values using dot notation (e.g.,
                              --override llms.nim_llm.temperature 0.7)
   --input TEXT               A single input to submit the the workflow.
-  --input_file FILE          Path to a json file of inputs to submit to the
-                             workflow.
+  --input_file FILE          Path to a plain text file containing a single
+                             input to submit to the workflow. For batch
+                             evaluation of multiple inputs, use 'nat eval'
+                             instead.
+  --user_id TEXT             User ID to use for the workflow session. Defaults
+                             to 'nat_run_user_id' for single-user CLI
+                             execution.
+  --conversation_id TEXT     Conversation ID to use for the workflow session.
+                             Set this to isolate memory-backed CLI runs.
   --help                     Show this message and exit.
 ```
 

--- a/examples/agents/auto_memory_wrapper/README.md
+++ b/examples/agents/auto_memory_wrapper/README.md
@@ -127,13 +127,17 @@ See `config_zep.yml` for comprehensive parameter examples.
 
 ## Multi-Tenant Memory Isolation
 
-User ID is automatically extracted at runtime for memory isolation. It is **NOT** configured in YAML.
+User ID is extracted at runtime for memory isolation. Configure it through the front end or session runtime, not the
+`auto_memory_agent` workflow block.
 
 ### User ID Extraction Priority
 
-1. **`user_manager.get_id()`** - For production with custom auth middleware (recommended)
+1. **`SessionManager.session(user_id=...)`** - For production with custom auth middleware (recommended)
 2. **`X-User-ID` HTTP header** - For testing without middleware
-3. **`"default_user"`** - Fallback for local development
+3. **Console front end `user_id`** - Defaults to `"nat_run_user_id"` for `nat run`
+
+Conversation-aware memory backends can also use `conversation_id` to isolate separate conversations for the same user.
+For Zep Cloud, if no conversation ID is supplied, the integration uses a deterministic per-user default thread.
 
 ### Production: Custom Middleware
 
@@ -154,10 +158,7 @@ async def handle_request(request):
     # Extract from JWT, OAuth, API key, etc.
     user_id = extract_user_from_jwt(request.headers["authorization"])
 
-    async with session_manager.session(
-        user_manager=AuthenticatedUserManager(user_id=user_id),
-        http_connection=request,
-    ) as session:
+    async with session_manager.session(user_id=user_id, http_connection=request) as session:
         result = await session.run(user_input)
     return result
 ```
@@ -174,12 +175,14 @@ curl -X POST http://localhost:8000/chat \
   -d '{"messages": [{"role": "user", "content": "Hello!"}]}'
 ```
 
-### Local Development: No Authentication
+### Local Development: Console User and Conversation IDs
 
-Omit both `user_manager` and `X-User-ID` header to use `"default_user"`:
+For `nat run`, set `--user_id` to control memory isolation and `--conversation_id` to isolate a specific conversation:
 
 ```bash
-nat run --config_file examples/agents/auto_memory_wrapper/configs/config_zep.yml
+nat run --config_file examples/agents/auto_memory_wrapper/configs/config_zep.yml \
+  --user_id test_user_123 \
+  --conversation_id test_conv_001
 ```
 
 ## Advanced Example
@@ -210,7 +213,7 @@ workflow:
 
 ## Important Notes
 
-1. **User ID is runtime-only** - Set via `user_manager` or `X-User-ID` header, not in config
+1. **User ID is runtime/front-end scoped** - Set via `SessionManager.session(user_id=...)`, `X-User-ID`, or `nat run --user_id`
 2. **Memory backends are interchangeable** - Works with any implementation of `MemoryEditor` interface
 
 ## Examples

--- a/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_config.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_config.py
@@ -35,3 +35,6 @@ class ConsoleFrontEndConfig(FrontEndBaseConfig, name="console"):
     user_id: str = Field(default="nat_run_user_id",
                          description="User ID to use for the workflow session. "
                          "Defaults to 'nat_run_user_id' for single-user CLI execution.")
+    conversation_id: str | None = Field(
+        default=None,
+        description="Conversation ID to use for the workflow session. Set this to isolate memory-backed CLI runs.")

--- a/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
@@ -22,14 +22,11 @@ import unicodedata
 
 import click
 from colorama import Fore
-from pydantic import SecretStr
 
 from nat.data_models.interactive import HumanPromptModelType
 from nat.data_models.interactive import HumanResponse
 from nat.data_models.interactive import HumanResponseText
 from nat.data_models.interactive import InteractionPrompt
-from nat.data_models.user_info import BasicUserInfo
-from nat.data_models.user_info import UserInfo
 from nat.front_ends.console.authentication_flow_handler import ConsoleAuthenticationFlowHandler
 from nat.front_ends.console.console_front_end_config import ConsoleFrontEndConfig
 from nat.front_ends.simple_base.simple_front_end_plugin_base import SimpleFrontEndPluginBase
@@ -118,8 +115,8 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         assert session_manager is not None, "Session manager must be provided"
         runner_outputs = None
 
-        run_user_id: str = UserInfo(
-            basic_user=BasicUserInfo(username="nat_run_user", password=SecretStr("nat_run_user"))).get_user_id()
+        run_user_id = self.front_end_config.user_id
+        conversation_id = self.front_end_config.conversation_id
 
         if (self.front_end_config.input_query):
 
@@ -127,6 +124,7 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
 
                 async with session_manager.session(
                         user_id=run_user_id,
+                        conversation_id=conversation_id,
                         user_input_callback=prompt_for_input_cli,
                         user_authentication_callback=self.auth_flow_handler.authenticate) as session:
                     async with session.run(query) as runner:
@@ -147,7 +145,7 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
             # Run the workflow
             with open(self.front_end_config.input_file, encoding="utf-8") as f:
                 input_content = f.read()
-            async with session_manager.session(user_id=run_user_id) as session:
+            async with session_manager.session(user_id=run_user_id, conversation_id=conversation_id) as session:
                 async with session.run(input_content) as runner:
                     runner_outputs = await runner.result(to_type=str)
         else:

--- a/packages/nvidia_nat_core/src/nat/runtime/session.py
+++ b/packages/nvidia_nat_core/src/nat/runtime/session.py
@@ -465,6 +465,8 @@ class SessionManager:
         token_user_authentication = None
         token_workflow_parent_id = None
         token_workflow_parent_name = None
+        token_conversation_id = None
+        token_user_message_id = None
         token_user_id = None
 
         builder_info: PerUserBuilderInfo | None = None
@@ -477,6 +479,12 @@ class SessionManager:
 
             if user_authentication_callback is not None:
                 token_user_authentication = self._context_state.user_auth_callback.set(user_authentication_callback)
+
+            if conversation_id is not None or http_connection is not None:
+                token_conversation_id = self._context_state.conversation_id.set(conversation_id)
+
+            if user_message_id is not None or http_connection is not None:
+                token_user_message_id = self._context_state.user_message_id.set(user_message_id)
 
             if isinstance(http_connection, WebSocket):
                 if user_id is None:
@@ -539,6 +547,10 @@ class SessionManager:
                 self._context_state.workflow_parent_id.reset(token_workflow_parent_id)
             if token_user_id is not None:
                 self._context_state.user_id.reset(token_user_id)
+            if token_user_message_id is not None:
+                self._context_state.user_message_id.reset(token_user_message_id)
+            if token_conversation_id is not None:
+                self._context_state.conversation_id.reset(token_conversation_id)
             if token_user_input is not None:
                 self._context_state.user_input_callback.reset(token_user_input)
             if token_user_authentication is not None:

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
@@ -462,6 +462,32 @@ class TestSessionManagerSession:
         # After exit, should be reset
         assert ctx_state.user_input_callback.get() == original_callback
 
+    @patch('nat.cli.type_registry.GlobalTypeRegistry')
+    @pytest.mark.asyncio
+    async def test_session_sets_direct_conversation_and_message_ids(self, mock_registry):
+        """Test direct session metadata is available in context and reset on exit."""
+        mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(is_per_user=False)
+
+        sm = SessionManager(config=create_mock_config(),
+                            shared_builder=MockWorkflowBuilder(),
+                            entry_function=None,
+                            shared_workflow=MockWorkflow())
+
+        ctx_state = ContextState.get()
+        token_conversation_id = ctx_state.conversation_id.set(None)
+        token_user_message_id = ctx_state.user_message_id.set(None)
+
+        try:
+            async with sm.session(conversation_id="conversation-123", user_message_id="message-456"):
+                assert ctx_state.conversation_id.get() == "conversation-123"
+                assert ctx_state.user_message_id.get() == "message-456"
+
+            assert ctx_state.conversation_id.get() is None
+            assert ctx_state.user_message_id.get() is None
+        finally:
+            ctx_state.user_message_id.reset(token_user_message_id)
+            ctx_state.conversation_id.reset(token_conversation_id)
+
 
 class TestSessionManagerCleanup:
     """Tests for SessionManager per-user builder cleanup."""

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
@@ -463,7 +463,6 @@ class TestSessionManagerSession:
         assert ctx_state.user_input_callback.get() == original_callback
 
     @patch('nat.cli.type_registry.GlobalTypeRegistry')
-     async def test_session_sets_direct_conversation_and_message_ids(self, mock_registry):
     async def test_session_sets_direct_conversation_and_message_ids(self, mock_registry):
         """Test direct session metadata is available in context and reset on exit."""
         mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(is_per_user=False)

--- a/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
+++ b/packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py
@@ -463,7 +463,7 @@ class TestSessionManagerSession:
         assert ctx_state.user_input_callback.get() == original_callback
 
     @patch('nat.cli.type_registry.GlobalTypeRegistry')
-    @pytest.mark.asyncio
+     async def test_session_sets_direct_conversation_and_message_ids(self, mock_registry):
     async def test_session_sets_direct_conversation_and_message_ids(self, mock_registry):
         """Test direct session metadata is available in context and reset on exit."""
         mock_registry.get.return_value.get_function.return_value = create_mock_function_registration(is_per_user=False)

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/auto_memory_wrapper/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/auto_memory_wrapper/agent.py
@@ -269,17 +269,17 @@ class AutoMemoryWrapperGraph:
         if self.save_ai_responses:
             workflow.add_node("capture_ai_response", self.capture_ai_response_node)
 
-        # Connect nodes based on enabled features
-        workflow.set_entry_point("capture_user_message" if self.save_user_messages else "memory_retrieve" if self.
-                                 retrieve_memory else "inner_agent")
+        # Retrieve before storing the current user message so recall queries are not added to memory before search.
+        workflow.set_entry_point("memory_retrieve" if self.retrieve_memory else "capture_user_message" if self.
+                                 save_user_messages else "inner_agent")
 
-        if self.save_user_messages and self.retrieve_memory:
-            workflow.add_edge("capture_user_message", "memory_retrieve")
-            workflow.add_edge("memory_retrieve", "inner_agent")
-        elif self.save_user_messages:
+        if self.retrieve_memory and self.save_user_messages:
+            workflow.add_edge("memory_retrieve", "capture_user_message")
             workflow.add_edge("capture_user_message", "inner_agent")
         elif self.retrieve_memory:
             workflow.add_edge("memory_retrieve", "inner_agent")
+        elif self.save_user_messages:
+            workflow.add_edge("capture_user_message", "inner_agent")
 
         if self.save_ai_responses:
             workflow.add_edge("inner_agent", "capture_ai_response")

--- a/packages/nvidia_nat_langchain/tests/agent/test_auto_memory_wrapper.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_auto_memory_wrapper.py
@@ -336,6 +336,38 @@ class TestAutoMemoryWrapperGraph:
         graph = wrapper_graph.build_graph()
         assert graph is not None
 
+    async def test_build_graph_retrieves_before_capturing_current_user_message(self,
+                                                                               mock_inner_agent,
+                                                                               mock_memory_editor,
+                                                                               mock_context):
+        """Test graph retrieves existing memory before storing the current user query."""
+        calls = []
+
+        async def _search(**kwargs):
+            calls.append(("search", kwargs["query"]))
+            return [MemoryItem(conversation=[], memory="Stored fact", user_id="default_user")]
+
+        async def _add_items(items, **kwargs):
+            calls.append(("add", items[0].conversation[0]["content"]))
+
+        mock_memory_editor.search.side_effect = _search
+        mock_memory_editor.add_items.side_effect = _add_items
+
+        with patch('nat.plugins.langchain.agent.auto_memory_wrapper.agent.Context.get', return_value=mock_context):
+            wrapper = AutoMemoryWrapperGraph(inner_agent_fn=mock_inner_agent,
+                                             memory_editor=mock_memory_editor,
+                                             save_user_messages=True,
+                                             retrieve_memory=True,
+                                             save_ai_responses=True)
+
+        graph = wrapper.build_graph()
+        await graph.ainvoke(AutoMemoryWrapperState(messages=[HumanMessage(content="What do you remember?")]))
+
+        assert calls[:2] == [("search", "What do you remember?"), ("add", "What do you remember?")]
+        chat_request = mock_inner_agent.ainvoke.call_args[0][0]
+        assert "Stored fact" in chat_request.messages[0].content
+        assert chat_request.messages[1].content == "What do you remember?"
+
     def test_build_graph_minimal_features(self, mock_inner_agent, mock_memory_editor, mock_context):
         """Test build_graph with minimal features."""
         with patch('nat.plugins.langchain.agent.auto_memory_wrapper.agent.Context.get', return_value=mock_context):

--- a/packages/nvidia_nat_zep_cloud/src/nat/plugins/zep_cloud/zep_editor.py
+++ b/packages/nvidia_nat_zep_cloud/src/nat/plugins/zep_cloud/zep_editor.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import logging
 
 from zep_cloud import NotFoundError
@@ -44,6 +45,14 @@ class ZepEditor(MemoryEditor):
             zep_client (AsyncZep): Async client instance.
         """
         self._client = zep_client
+
+    @staticmethod
+    def _default_thread_id(user_id: str) -> str:
+        user_hash = hashlib.sha256(user_id.encode("utf-8")).hexdigest()[:32]
+        return f"default_zep_thread_{user_hash}"
+
+    def _get_thread_id(self, user_id: str) -> str:
+        return Context.get().conversation_id or self._default_thread_id(user_id)
 
     async def _ensure_user_exists(self, user_id: str) -> None:
         """
@@ -113,12 +122,8 @@ class ZepEditor(MemoryEditor):
             conversation = memory_item.conversation
             user_id = memory_item.user_id or "default_user"  # Validate user_id
 
-            # Get thread_id from NAT context (unique per UI conversation)
-            thread_id = Context.get().conversation_id
-
-            # Fallback to default thread ID if no conversation_id available
-            if not thread_id:
-                thread_id = "default_zep_thread"
+            # Get thread_id from NAT context (unique per UI conversation), with a per-user fallback.
+            thread_id = self._get_thread_id(user_id)
 
             messages = []
 
@@ -172,17 +177,17 @@ class ZepEditor(MemoryEditor):
 
         await asyncio.gather(*coroutines)
 
-    async def search(self, query: str, top_k: int = 5, **kwargs) -> list[MemoryItem]:  # noqa: ARG002
+    async def search(self, query: str, top_k: int = 5, **kwargs) -> list[MemoryItem]:
         """
-        Retrieve memory from Zep v3 using the high-level get_user_context API.
+        Retrieve memory from Zep v3 using graph search, falling back to the high-level get_user_context API.
         Uses conversation_id from NAT context as thread_id for multi-thread support.
 
-        Zep returns pre-formatted memory optimized for LLM consumption, including
-        relevant facts, timestamps, and structured information from its knowledge graph.
+        Zep graph search returns query-matched facts from the user's graph. If there are no direct graph-search
+        results, this falls back to Zep's pre-formatted context optimized for LLM consumption.
 
         Args:
-            query (str): The query string (not used by Zep's high-level API, included for interface compatibility).
-            top_k (int): Maximum number of items to return (not used by Zep's context API).
+            query (str): The query string to search for.
+            top_k (int): Maximum number of facts to retrieve.
             kwargs: Zep-specific keyword arguments.
 
                 - user_id (str, required for response construction): Used only to construct the
@@ -200,14 +205,31 @@ class ZepEditor(MemoryEditor):
         user_id = kwargs.pop("user_id")
         mode = kwargs.pop("mode", "basic")  # Get mode, default to "basic" for fast retrieval
 
-        # Get thread_id from NAT context
-        thread_id = Context.get().conversation_id
-
-        # Fallback to default thread ID if no conversation_id available
-        if not thread_id:
-            thread_id = "default_zep_thread"
+        # Get thread_id from NAT context, with a per-user fallback.
+        thread_id = self._get_thread_id(user_id)
 
         try:
+            graph_response = await self._client.graph.search(query=query, user_id=user_id, limit=top_k, **kwargs)
+            graph_facts = []
+
+            for edge in graph_response.edges or []:
+                if edge.fact:
+                    graph_facts.append(edge.fact)
+
+            for episode in graph_response.episodes or []:
+                if episode.content:
+                    graph_facts.append(episode.content)
+
+            if graph_facts:
+                return [
+                    MemoryItem(conversation=[],
+                               user_id=user_id,
+                               memory="\n".join(graph_facts),
+                               metadata={
+                                   "source": "graph_search", "thread_id": thread_id
+                               })
+                ]
+
             # Use Zep v3 thread.get_user_context - returns pre-formatted context
             memory_response = await self._client.thread.get_user_context(thread_id=thread_id, mode=mode)
             context_string = memory_response.context or ""

--- a/packages/nvidia_nat_zep_cloud/tests/test_zep_editor.py
+++ b/packages/nvidia_nat_zep_cloud/tests/test_zep_editor.py
@@ -1,0 +1,83 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
+
+from nat.plugins.zep_cloud.zep_editor import ZepEditor
+
+
+def test_get_thread_id_uses_context_conversation_id():
+    """Explicit conversation IDs should map directly to Zep threads."""
+    editor = ZepEditor(zep_client=Mock())
+    context = Mock()
+    context.conversation_id = "conversation-123"
+
+    with patch("nat.plugins.zep_cloud.zep_editor.Context.get", return_value=context):
+        assert editor._get_thread_id("user-123") == "conversation-123"
+
+
+def test_get_thread_id_defaults_to_isolated_user_thread():
+    """Missing conversation IDs should not collapse every user into one Zep thread."""
+    editor = ZepEditor(zep_client=Mock())
+    context = Mock()
+    context.conversation_id = None
+
+    with patch("nat.plugins.zep_cloud.zep_editor.Context.get", return_value=context):
+        thread_a = editor._get_thread_id("user-a")
+        thread_b = editor._get_thread_id("user-b")
+
+    assert thread_a.startswith("default_zep_thread_")
+    assert thread_b.startswith("default_zep_thread_")
+    assert thread_a != thread_b
+    assert "user-a" not in thread_a
+
+
+async def test_search_uses_graph_search_with_query():
+    """Search should use the query against the user's graph before falling back to thread context."""
+    zep_client = Mock()
+    zep_client.graph.search = AsyncMock(
+        return_value=Mock(edges=[Mock(fact="User name is Sam.")], episodes=[Mock(content="User enjoys cooking.")]))
+    zep_client.thread.get_user_context = AsyncMock()
+    editor = ZepEditor(zep_client=zep_client)
+    context = Mock()
+    context.conversation_id = "conversation-123"
+
+    with patch("nat.plugins.zep_cloud.zep_editor.Context.get", return_value=context):
+        results = await editor.search(query="What is my name and hobby?", user_id="user-123", top_k=3)
+
+    zep_client.graph.search.assert_awaited_once_with(query="What is my name and hobby?", user_id="user-123", limit=3)
+    zep_client.thread.get_user_context.assert_not_awaited()
+    assert len(results) == 1
+    assert "User name is Sam." in results[0].memory
+    assert "User enjoys cooking." in results[0].memory
+
+
+async def test_search_falls_back_to_thread_context_without_graph_results():
+    """Empty graph search results should still use Zep's formatted thread context."""
+    zep_client = Mock()
+    zep_client.graph.search = AsyncMock(return_value=Mock(edges=[], episodes=[]))
+    zep_client.thread.get_user_context = AsyncMock(return_value=Mock(context="Formatted Zep context"))
+    editor = ZepEditor(zep_client=zep_client)
+    context = Mock()
+    context.conversation_id = "conversation-123"
+
+    with patch("nat.plugins.zep_cloud.zep_editor.Context.get", return_value=context):
+        results = await editor.search(query="What do you know?", user_id="user-123", mode="summary")
+
+    zep_client.thread.get_user_context.assert_awaited_once_with(thread_id="conversation-123", mode="summary")
+    assert len(results) == 1
+    assert results[0].memory == "Formatted Zep context"


### PR DESCRIPTION
## Description

Closes NAT-270

Fix automatic memory recall for memory-backed agent workflows run across CLI invocations.

This updates the auto-memory wrapper to retrieve existing memory before storing the current user message, so recall questions do not pollute memory search before lookup. It also passes the console front end `user_id` and `conversation_id` into the runtime session, ensures direct session conversation metadata is scoped and reset correctly, and updates the Zep Cloud adapter to use query-based graph search before falling back to thread context. When no conversation ID is supplied, Zep now uses a deterministic per-user default thread instead of a single global fallback thread.

The root cause was a combination of memory operation ordering and runtime scoping gaps: 
- recall prompts were stored before retrieval
- `nat run` did not propagate the configured console user or conversation ID
- Zep adapter collapsed CLI runs without conversation IDs into `default_zep_thread` while retrieval depended on thread context.

Docs were updated to describe `nat run --user_id`, `nat run --conversation_id`, and the runtime scoping model for memory-backed workflows.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.

## Validation

Automated checks run locally:

```bash
uv run pytest packages/nvidia_nat_langchain/tests/agent/test_auto_memory_wrapper.py packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py packages/nvidia_nat_zep_cloud/tests/test_zep_editor.py
uv run ruff check packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/auto_memory_wrapper/agent.py packages/nvidia_nat_langchain/tests/agent/test_auto_memory_wrapper.py packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_config.py packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py packages/nvidia_nat_core/src/nat/runtime/session.py packages/nvidia_nat_core/tests/nat/runtime/test_session_manager.py packages/nvidia_nat_zep_cloud/src/nat/plugins/zep_cloud/zep_editor.py packages/nvidia_nat_zep_cloud/tests/test_zep_editor.py
git diff --check
```

Provided manual validation:

*Seeding*
```bash
$ nat run --config_file ./workflow.yml --input "My name is Will, and I live in Pennsylvania" --input "I wanted to let you know that I am a software engineer."
```

*Retrieval*
```bash
$ nat run --config_file ./workflow.yml --input "what is my name?" --input "what is my job?" --input "where do i live?"
...
2026-05-19 16:09:25 - INFO     - nat.runtime.session:329 - Shared workflow built (entry_function=None)
2026-05-19 16:09:52 - INFO     - nat.front_ends.console.console_front_end_plugin:160 - --------------------------------------------------
Workflow Result:
Will
You are a software engineer.
You live in Pennsylvania.
--------------------------------------------------
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CLI options --user_id and --conversation_id and a console default user_id ("nat_run_user_id") to isolate sessions and memory-backed runs.
  * Zep Cloud now uses deterministic per-user thread IDs when conversation_id is absent.

* **Bug Fixes**
  * Memory retrieval now runs before capturing the current user message so prior context is injected first.

* **Documentation**
  * Updated multi-tenant memory isolation and CLI docs for runtime user ID extraction and new options.

* **Tests**
  * Added tests for session context cleanup and memory retrieval ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1968?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->