### PR TITLE
fix(skills): Fix skill-evolution routing for skill update decisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,6 +66,8 @@ Use the routing table before opening detailed references inside the skill.
 
 ## Skill Evolution
 
+Before creating, editing, or deciding whether to update any file under `skills/`, read `skills/skill-evolution/SKILL.md` first. Then read the target skill and make the smallest warranted change.
+
 When a user corrects your approach, a command fails and you recover, or you discover a generalizable gotcha, finish the task first and then read `skills/skill-evolution/SKILL.md` to decide whether the skills should be updated.
 
 ## Quick Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Use the routing table before opening detailed references inside the skill.
 
 ## Skill Evolution
 
-Before creating, editing, or deciding whether to update any file under `skills/`, read `skills/skill-evolution/SKILL.md` first. For skill-routing/skill-maintenance tasks, treat skill-evolution as an explicit pre-edit gate (i.e., don't jump directly to editing a named target skill without consulting skill-evolution). Then read the target skill and make the smallest warranted change.
+Before creating, editing, or deciding whether to update any file under `skills/`, read `skills/skill-evolution/SKILL.md` first. For skill routing and skill maintenance tasks, treat skill-evolution as an explicit pre-edit gate (i.e., don't jump directly to editing a named target skill without consulting skill-evolution). Then read the target skill and make the smallest warranted change.
 
 When a user corrects your approach, a command fails and you recover, or you discover a generalizable gotcha, finish the task first and then read `skills/skill-evolution/SKILL.md` to decide whether the skills should be updated.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,7 +66,7 @@ Use the routing table before opening detailed references inside the skill.
 
 ## Skill Evolution
 
-Before creating, editing, or deciding whether to update any file under `skills/`, read `skills/skill-evolution/SKILL.md` first. Then read the target skill and make the smallest warranted change.
+Before creating, editing, or deciding whether to update any file under `skills/`, read `skills/skill-evolution/SKILL.md` first. For skill-routing/skill-maintenance tasks, treat skill-evolution as an explicit pre-edit gate (i.e., don't jump directly to editing a named target skill without consulting skill-evolution). Then read the target skill and make the smallest warranted change.
 
 When a user corrects your approach, a command fails and you recover, or you discover a generalizable gotcha, finish the task first and then read `skills/skill-evolution/SKILL.md` to decide whether the skills should be updated.
 

--- a/skills/skill-evolution/SKILL.md
+++ b/skills/skill-evolution/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: skill-evolution
-description: Use when creating, refining, or maintaining AI coding agent skills in this repository, especially after user corrections, repeated failures, stale references, routing gaps, or reusable lessons learned.
+description: Use before creating, editing, or deciding whether to update any AI coding agent skill in this repository, including corrections to existing skill behavior, references, or routing.
 author: NVIDIA Corporation and Affiliates
 license: Apache-2.0
 ---
 
 # Skill Evolution
 
-Use this skill when a workflow, command, reference, or user correction reveals a reusable improvement for the repository's AI coding agent skills.
+Use this skill before creating, editing, or deciding whether to update any AI coding agent skill in this repository.
 
 ## When to Update Skills
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
- Require agents to read `skills/skill-evolution/SKILL.md` before creating, editing, or deciding whether to update files under `skills/`
- Strengthen the `skill-evolution` trigger wording so skill maintenance tasks route there before editing the target skill

## Motivation

Tests showed that agents could jump directly to editing a named target skill, such as `nat-telemetry`, without first consulting `skill-evolution`. This change makes `skill-evolution` an explicit pre-edit gate for skill maintenance tasks.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a “Skill Evolution” prerequisite: contributors must read the Skill Evolution guidance before creating, editing, or deciding on skill updates.
  * Revised the Skill Evolution guidance to frame using the resource prior to any skill changes and to streamline the workflow with recommendations for minimal, targeted edits.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1970?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->