### PR TITLE
Update `model_health_check.py` to check for deprecation header

### DIFF
--- a/ci/scripts/model_health_check.py
+++ b/ci/scripts/model_health_check.py
@@ -145,8 +145,9 @@ def get_catalog_models(api_key: str) -> set[str]:
         return set()
 
 
-def _nim_post(endpoint: str, payload: bytes, api_key: str) -> tuple[int, str]:
-    """POST *payload* to NIM_API_BASE/*endpoint* and return (status, detail)."""
+def _nim_post(endpoint: str, payload: bytes, api_key: str) -> tuple[int, str, str]:
+    """POST *payload* to NIM_API_BASE/*endpoint* and return (status, detail, deprecation)."""
+
     req = urllib.request.Request(
         f"{NIM_API_BASE}/{endpoint}",
         data=payload,
@@ -158,21 +159,24 @@ def _nim_post(endpoint: str, payload: bytes, api_key: str) -> tuple[int, str]:
     ctx = ssl.create_default_context()
     try:
         with urllib.request.urlopen(req, timeout=REQUEST_TIMEOUT, context=ctx) as resp:
-            return resp.status, ""
+            print(f"    Received response: HTTP {resp.status}")
+            deprecated = resp.headers.get("Deprecation", "")
+            return resp.status, "", deprecated
     except urllib.error.HTTPError as e:
+        print(f"    Received response: HTTP {e.code}")
         detail = ""
         try:
             body = json.loads(e.read().decode())
             detail = body.get("detail", str(body))
         except (json.JSONDecodeError, UnicodeDecodeError, KeyError, TypeError):
             detail = str(e)
-        return e.code, detail
+        return e.code, detail, ""
     except (urllib.error.URLError, TimeoutError, OSError) as e:
-        return 0, f"Connection error: {e}"
+        return 0, f"Connection error: {e}", ""
 
 
-def check_model(model: str, api_key: str) -> tuple[int, str]:
-    """Make a minimal chat/completions call and return (status_code, detail)."""
+def check_model(model: str, api_key: str) -> tuple[int, str, str]:
+    """Make a minimal chat/completions call and return (status_code, detail, deprecation)."""
     payload = json.dumps({
         "model": model,
         "messages": [{
@@ -183,7 +187,7 @@ def check_model(model: str, api_key: str) -> tuple[int, str]:
     return _nim_post("chat/completions", payload, api_key)
 
 
-def check_embedder(model: str, api_key: str) -> tuple[int, str]:
+def check_embedder(model: str, api_key: str) -> tuple[int, str, str]:
     """Make a minimal embeddings call and return (status_code, detail)."""
     payload = json.dumps({
         "model": model,
@@ -285,6 +289,7 @@ def main() -> int:
     if llm_to_test or embedder_to_test:
         print("Pass 2: inference check on catalog-listed models...")
     down: list[tuple[str, int, str]] = []
+    deprecation: list[tuple[str, str]] = []
     call_count = 0
 
     for model in llm_to_test:
@@ -292,11 +297,14 @@ def main() -> int:
             time.sleep(INTER_REQUEST_DELAY)
         call_count += 1
 
-        status, detail = check_model(model, api_key)
+        status, detail, deprecation_detail = check_model(model, api_key)
         if status in (401, 403):
             print(f"\n  ERROR: API key is invalid or expired (HTTP {status}): {detail}", file=sys.stderr)
             return 1
-        if status == 200:
+        elif deprecation_detail != "":
+            print(f"  Deprecation: {deprecation_detail}")
+            deprecation.append((model, deprecation_detail))
+        elif status == 200:
             print(f"  OK      {model}")
         else:
             label = f"HTTP {status}" if status > 0 else "ERROR"
@@ -308,11 +316,14 @@ def main() -> int:
             time.sleep(INTER_REQUEST_DELAY)
         call_count += 1
 
-        status, detail = check_embedder(model, api_key)
+        status, detail, deprecation_detail = check_embedder(model, api_key)
         if status in (401, 403):
             print(f"\n  ERROR: API key is invalid or expired (HTTP {status}): {detail}", file=sys.stderr)
             return 1
-        if status == 200:
+        elif deprecation_detail != "":
+            print(f"  Deprecation: {deprecation_detail}")
+            deprecation.append((model, deprecation_detail))
+        elif status == 200:
             print(f"  OK      {model}  (embedder)")
         else:
             label = f"HTTP {status}" if status > 0 else "ERROR"
@@ -322,12 +333,20 @@ def main() -> int:
     print()
 
     # -- Summary -------------------------------------------------------------
-    has_failures = bool(removed) or bool(down)
+    has_failures = bool(removed) or bool(down) or bool(deprecation)
 
     if removed:
         print(f"{len(removed)} model(s) REMOVED from catalog (need config update):\n")
         for model in removed:
             print(f"  {model}")
+            for f in sorted(set(all_configs[model])):
+                print(f"    - {f}")
+            print()
+
+    if deprecation:
+        print(f"{len(deprecation)} model(s) DEPRECATED (in catalog but deprecated):\n")
+        for model, detail in deprecation:
+            print(f"  {model} ({detail})")
             for f in sorted(set(all_configs[model])):
                 print(f"    - {f}")
             print()
@@ -359,6 +378,12 @@ def main() -> int:
                 "detail": d,
                 "configs": sorted(set(all_configs[m])),
             } for m, s, d in down],
+            "deprecation": [{
+                "model": m,
+                "type": "embedder" if m in embedder_models else "llm",
+                "detail": d,
+                "configs": sorted(set(all_configs[m])),
+            } for m, d in deprecation],
             "ok": [{
                 "model": m,
                 "type": "embedder" if m in embedder_models else "llm",

--- a/ci/scripts/model_health_check.py
+++ b/ci/scripts/model_health_check.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 """Check that NIM model endpoints referenced in example configs are reachable.
 
-Scans config*.yml files under examples/ for LLM and embedder blocks with
+Scans YAML files under examples/ for LLM and embedder blocks with
 _type: nim, extracts model references (including optimizer search_space),
 and checks each model in two passes:
 
@@ -365,6 +365,7 @@ def main() -> int:
 
     if args.output_json:
         down_models = {m for m, _s, _d in down}
+        deprecated_models = {m for m, _d in deprecation}
         report = {
             "removed": [{
                 "model": m,
@@ -388,7 +389,7 @@ def main() -> int:
                 "model": m,
                 "type": "embedder" if m in embedder_models else "llm",
                 "configs": sorted(set(all_configs[m])),
-            } for m in sorted(all_model_names) if m not in removed and m not in down_models],
+            } for m in sorted(all_model_names) if m not in removed and m not in down_models and m not in deprecated_models],
         }
         with open(args.output_json, "w", encoding="utf-8") as jf:
             json.dump(report, jf, indent=2)

--- a/ci/scripts/model_health_check.py
+++ b/ci/scripts/model_health_check.py
@@ -389,7 +389,8 @@ def main() -> int:
                 "model": m,
                 "type": "embedder" if m in embedder_models else "llm",
                 "configs": sorted(set(all_configs[m])),
-            } for m in sorted(all_model_names) if m not in removed and m not in down_models and m not in deprecated_models],
+            } for m in sorted(all_model_names)
+                   if m not in removed and m not in down_models and m not in deprecated_models],
         }
         with open(args.output_json, "w", encoding="utf-8") as jf:
             json.dump(report, jf, indent=2)

--- a/ci/scripts/model_health_check.py
+++ b/ci/scripts/model_health_check.py
@@ -69,7 +69,11 @@ def find_nim_models(examples_dir: Path) -> tuple[dict[str, list[str]], dict[str,
     llm_models: dict[str, list[str]] = {}
     embedder_models: dict[str, list[str]] = {}
 
-    for config_path in sorted(examples_dir.rglob("config*.yml")):
+    config_paths = []
+    for pattern in ("*.yml", "*.yaml"):
+        config_paths.extend(examples_dir.rglob(pattern))
+
+    for config_path in sorted(config_paths):
         with open(config_path, encoding="utf-8") as f:
             try:
                 cfg = yaml.safe_load(f)
@@ -229,11 +233,9 @@ def main() -> int:
     llm_models, embedder_models = find_nim_models(args.examples_dir)
 
     # Merge into a single lookup for config file references
-    all_configs: dict[str, list[str]] = {}
-    for m, files in llm_models.items():
-        all_configs.setdefault(m, []).extend(files)
-    for m, files in embedder_models.items():
-        all_configs.setdefault(m, []).extend(files)
+    all_configs: dict[str, list[str]] = llm_models.copy()
+    # Assume that LLMs and embedders are distinct sets of models
+    all_configs.update(embedder_models)
 
     if not all_configs:
         print("No NIM models found in config files")
@@ -246,10 +248,12 @@ def main() -> int:
         for label, section in (("LLMs", llm_models), ("Embedders", embedder_models)):
             if not section:
                 continue
-            print(f"  {label}:")
-            for model, files in sorted(section.items()):
-                print(f"    {model}")
+            model_by_usage = sorted(((len(files), model) for model, files in section.items()), reverse=True)
+            print(f"  {label}: Usage count")
+            for count, model in model_by_usage:
+                print(f"    {model}: {count}")
                 if args.verbose:
+                    files = section[model]
                     for f in sorted(set(files)):
                         print(f"      - {f}")
         return 0

--- a/ci/scripts/model_health_check.py
+++ b/ci/scripts/model_health_check.py
@@ -188,7 +188,7 @@ def check_model(model: str, api_key: str) -> tuple[int, str, str]:
 
 
 def check_embedder(model: str, api_key: str) -> tuple[int, str, str]:
-    """Make a minimal embeddings call and return (status_code, detail)."""
+    """Make a minimal embeddings call and return (status_code, detail, deprecation)."""
     payload = json.dumps({
         "model": model,
         "input": ["hi"],

--- a/docs/source/build-workflows/llms/using-local-llms.md
+++ b/docs/source/build-workflows/llms/using-local-llms.md
@@ -21,7 +21,7 @@ NeMo Agent Toolkit has the ability to interact with locally hosted LLMs, in this
 
 ## Using NIM
 <!-- path-check-skip-next-line -->
-In the NeMo Agent Toolkit simple example the [`meta/llama-3.1-70b-instruct`](https://build.nvidia.com/meta/llama-3_1-70b-instruct) model was used. For the purposes of this guide we will be using a smaller model, the [`nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1`](https://build.nvidia.com/nvidia/llama-3_1-nemotron-nano-4b-v1_1/) which is more likely to be runnable on a local workstation.
+In the NeMo Agent Toolkit simple example the [`meta/llama-3.1-70b-instruct`](https://build.nvidia.com/meta/llama-3_1-70b-instruct) model was used. For the purposes of this guide we will be using a smaller model, the [`nvidia/nemotron-3-nano-30b-a3b`](https://build.nvidia.com/nvidia/nemotron-3-nano-30b-a3b) which is more likely to be runnable on a local workstation.
 
 Regardless of the model you choose, the process is the same for downloading the model's container from [`build.nvidia.com`](https://build.nvidia.com/). Navigate to the model you wish to run locally, if it is able to be downloaded it will be labeled with the `RUN ANYWHERE` tag, the exact commands will be specified on the `Deploy` tab for the model.
 
@@ -50,7 +50,7 @@ Password: <PASTE_API_KEY_HERE>
 
 Download the container for the LLM:
 ```bash
-docker pull nvcr.io/nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:latest
+docker pull nvcr.io/nim/nvidia/nemotron-3-nano:latest
 ```
 
 Download the container for the embedding Model:
@@ -71,14 +71,12 @@ export NGC_API_KEY=<PASTE_API_KEY_HERE>
 export LOCAL_NIM_CACHE=~/.cache/nim
 mkdir -p "$LOCAL_NIM_CACHE"
 docker run -it --rm \
-    --runtime=nvidia \
     --gpus '"device=0"' \
     --shm-size=16GB \
     -e NGC_API_KEY \
     -v "$LOCAL_NIM_CACHE:/opt/nim/.cache" \
-    -u $(id -u) \
     -p 8000:8000 \
-    nvcr.io/nim/nvidia/llama3.1-nemotron-nano-4b-v1.1:latest
+    nvcr.io/nim/nvidia/nemotron-3-nano:latest
 ```
 
 Open a new terminal and run the embedding model container, listening on port 8001:
@@ -115,7 +113,7 @@ llms:
   nim_llm:
     _type: nim
     base_url: "http://localhost:8000/v1"
-    model_name: nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1
+    model_name: nvidia/nemotron-3-nano-30b-a3b
 
 embedders:
   nv-embedqa-e5-v5:
@@ -146,7 +144,7 @@ vLLM provides an [OpenAI-Compatible Server](https://docs.vllm.ai/en/latest/getti
 If you have not already done so, install vLLM following the [Quickstart](https://docs.vllm.ai/en/latest/getting_started/quickstart.html) guide. It is recommended to use a **separate** virtual environment for vLLM due to potential conflicts with NeMo Agent Toolkit dependencies.
 
 <!-- path-check-skip-next-line -->
-Similar to the previous example we will be using the same [`nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1`](https://huggingface.co/nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1) LLM model. Along with the [`ssmits/Qwen2-7B-Instruct-embed-base`](https://huggingface.co/ssmits/Qwen2-7B-Instruct-embed-base) embedding model.
+Similar to the previous example we will be using the same model [`nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16`](https://huggingface.co/nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16) LLM model. Along with the [`ssmits/Qwen2-7B-Instruct-embed-base`](https://huggingface.co/ssmits/Qwen2-7B-Instruct-embed-base) embedding model.
 
 ### Install the Simple Web Query Example
 
@@ -168,7 +166,7 @@ The `CUDA_VISIBLE_DEVICES` environment variable is used to specify the GPUs to u
 
 In a terminal from within the vLLM environment, run the following command to serve the LLM:
 ```bash
-CUDA_VISIBLE_DEVICES=0 vllm serve nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1
+CUDA_VISIBLE_DEVICES=0 vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
 ```
 
 In a second terminal also from within the vLLM environment, run the following command to serve the embedding model:
@@ -200,7 +198,7 @@ llms:
     _type: openai
     api_key: "EMPTY"
     base_url: "http://localhost:8000/v1"
-    model_name: nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1
+    model_name: nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
 
 embedders:
   vllm_embedder:

--- a/examples/documentation_guides/locally_hosted_llms/nim_config.yml
+++ b/examples/documentation_guides/locally_hosted_llms/nim_config.yml
@@ -27,7 +27,7 @@ llms:
   nim_llm:
     _type: nim
     base_url: "http://localhost:8000/v1"
-    model_name: nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1
+    model_name: nvidia/nemotron-3-nano-30b-a3b
 
 embedders:
   nv-embedqa-e5-v5:


### PR DESCRIPTION
## Description
* model_health_check will now check for the deprecation header
* Widen the glob pattern for yaml files to parse
* When used with the `--dry-run` flag models are listed by usage count in descending order
* Replace removed `nvidia/Llama-3.1-Nemotron-Nano-4B-v1.1` with `nvidia/nemotron-3-nano-30b-a3b` model in local LLM example

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Health checks now detect and report deprecated models separately from down/unavailable models; deprecated models are listed and included in overall failure status but not treated as "down."
  * Discovery now scans both .yml and .yaml example configs.
  * CLI summary and JSON output include a deprecation section.
  * Dry-run verbose output can rank models by usage and optionally show config paths.

* **Documentation**
  * Local LLM guides updated to use the Nemotron model in both NIM and vLLM examples.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1974?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->