### PR TITLE
fix(server): emit canonical {"value": ...} envelope from /generate/full

### DIFF
--- a/packages/nvidia_nat_core/src/nat/data_models/api_server.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/api_server.py
@@ -15,6 +15,7 @@
 
 import abc
 import datetime
+import json
 import typing
 import uuid
 from abc import abstractmethod
@@ -520,15 +521,61 @@ class ResponseObservabilityTrace(BaseModel, ResponseSerializable):
 
 
 class ResponsePayloadOutput(BaseModel, ResponseSerializable):
+    """SSE wrapper for the workflow's output on the ``/generate/full`` endpoint.
+
+    The wire contract for ``/generate/full`` is::
+
+        data: {"value": "<answer string>"}
+
+    paired with ``intermediate_data: ...`` lines for step events. Consumers
+    (notably ``nat.plugins.eval.runtime.remote_workflow``) rely on the
+    ``value`` key to extract the workflow's final answer; see the test
+    fixture in ``packages/nvidia_nat_eval/tests/eval/test_remote_evaluate.py``
+    which simulates the server emitting exactly this shape.
+
+    ``payload`` accepts whatever the workflow yields from its single-output
+    function or stream chunks: a primitive (``str``, ``int``, ...), a
+    Pydantic ``BaseModel`` (e.g. ``ChatResponseChunk`` for ReAct-style
+    workflows that opt into token streaming), or any JSON-serializable
+    object. ``get_stream_data`` normalizes that to a string answer and
+    emits the canonical ``{"value": ...}`` envelope so the wire shape stays
+    stable across workflow types.
+    """
 
     payload: typing.Any
 
+    def _payload_as_value(self) -> str:
+        """Coerce ``payload`` into the string answer that goes in ``value``.
+
+        - ``ChatResponseChunk`` (used by streaming agent workflows like
+          ``react_agent``): take the first choice's ``delta.content``,
+          falling back to an empty string for keep-alive chunks that carry
+          only a role or finish_reason.
+        - ``ChatResponse`` (single-shot chat completions): take the first
+          choice's ``message.content``.
+        - Other ``BaseModel`` payloads: serialize to JSON. Consumers that
+          want structured output can json-decode the ``value`` string.
+        - Primitives / non-Pydantic objects: ``str()``.
+        """
+        payload = self.payload
+
+        if isinstance(payload, ChatResponseChunk):
+            if payload.choices:
+                return payload.choices[0].delta.content or ""
+            return ""
+
+        if isinstance(payload, ChatResponse):
+            if payload.choices:
+                return payload.choices[0].message.content or ""
+            return ""
+
+        if isinstance(payload, BaseModel):
+            return payload.model_dump_json()
+
+        return str(payload)
+
     def get_stream_data(self) -> str:
-
-        if (isinstance(self.payload, BaseModel)):
-            return f"data: {self.payload.model_dump_json()}\n\n"
-
-        return f"data: {self.payload}\n\n"
+        return f"data: {json.dumps({'value': self._payload_as_value()})}\n\n"
 
 
 class ResponseATIFStep(BaseModel, ResponseSerializable):

--- a/packages/nvidia_nat_core/tests/nat/server/test_unified_api_server.py
+++ b/packages/nvidia_nat_core/tests/nat/server/test_unified_api_server.py
@@ -787,6 +787,65 @@ async def test_chat_response_chunk_to_websocket_message():
     assert isinstance(nat_chat_repsonse_chunk_to_system_response, WebSocketSystemResponseTokenMessage)
 
 
+# -- ResponsePayloadOutput.get_stream_data() wire-format contract -------------
+#
+# Pins the SSE shape ``/generate/full`` emits. The eval client at
+# ``nat.plugins.eval.runtime.remote_workflow`` extracts the final answer via
+# ``chunk_data.get("value")``, so every payload type wrapped in
+# ``ResponsePayloadOutput`` must serialize to ``data: {"value": <str>}\n\n``.
+# This regressed when ``react_agent`` gained a ``_stream_fn`` (PR #1851):
+# ``ChatResponseChunk`` payloads were emitted as raw OpenAI envelopes with no
+# top-level ``value`` field, so the eval client extracted ``None`` and every
+# eval run scored zero.
+
+
+@pytest.mark.parametrize(
+    "payload, expected_value",
+    [
+        pytest.param("21", "21", id="str"),
+        pytest.param(21, "21", id="int-stringified"),
+        pytest.param(ChatResponseChunk.create_streaming_chunk("21"), "21", id="chat-response-chunk"),
+        pytest.param(
+            ChatResponseChunk.create_streaming_chunk("", finish_reason="stop"), "",
+            id="chat-response-chunk-keepalive",
+        ),
+        pytest.param(
+            ChatResponse(id="x", object="chat.completion", created=datetime.datetime.now(datetime.UTC),
+                         choices=[ChatResponseChoice(index=0, message=ChoiceMessage(content="42", role="assistant"),
+                                                     finish_reason="stop")],
+                         usage=Usage(prompt_tokens=0, completion_tokens=0, total_tokens=0)),
+            "42", id="chat-response",
+        ),
+    ],
+)
+def test_response_payload_output_emits_value_envelope(payload, expected_value):
+    """Each supported payload type serializes to ``data: {"value": <str>}\\n\\n``.
+
+    Covers strings, primitives (stringified), ``ChatResponseChunk`` (the
+    streaming-agent regression case introduced by PR #1851, including
+    role-only/finish-only keepalive chunks), and ``ChatResponse``.
+    """
+    sse = ResponsePayloadOutput(payload=payload).get_stream_data()
+    assert sse.startswith("data: ") and sse.endswith("\n\n")
+    assert json.loads(sse[len("data: "):-2]) == {"value": expected_value}
+
+
+def test_response_payload_output_other_basemodel_serializes_to_json_string():
+    """Arbitrary ``BaseModel`` payloads are JSON-encoded into ``value`` so the
+    wire shape stays uniformly ``{"value": <str>}`` while preserving the full
+    payload — consumers that need the structured form ``json.loads(value)``.
+    """
+
+    class Custom(BaseModel):
+        answer: int
+        explanation: str
+
+    sse = ResponsePayloadOutput(payload=Custom(answer=21, explanation="3*7")).get_stream_data()
+    decoded = json.loads(sse[len("data: "):-2])
+    assert set(decoded.keys()) == {"value"}
+    assert json.loads(decoded["value"]) == {"answer": 21, "explanation": "3*7"}
+
+
 async def test_nat_intermediate_step_to_websocket_message():
     """Tests ResponseIntermediateStep can be converted to a WebSocketSystemIntermediateStepMessage"""
     message_validator = MessageValidator()

--- a/packages/nvidia_nat_eval/tests/eval/test_remote_evaluate.py
+++ b/packages/nvidia_nat_eval/tests/eval/test_remote_evaluate.py
@@ -22,7 +22,9 @@ from aiohttp import web
 from aiohttp.test_utils import TestClient
 from aiohttp.test_utils import TestServer
 
+from nat.data_models.api_server import ChatResponseChunk
 from nat.data_models.api_server import ResponseIntermediateStep
+from nat.data_models.api_server import ResponsePayloadOutput
 from nat.data_models.evaluate_runtime import EndpointRetryConfig
 from nat.data_models.evaluate_runtime import EvaluationRunConfig
 from nat.plugins.eval.runtime.remote_workflow import EvaluationRemoteWorkflowHandler
@@ -414,3 +416,64 @@ async def test_max_retries_lower_bound_validation(invalid_value: int) -> None:
     error = exc_info.value.errors()[0]
     assert error["type"] == "greater_than_equal"
     assert error["loc"] == ("max_retries", )
+
+
+# -- Producer/consumer wire-format compatibility ------------------------------
+#
+# The fixtures above hand-craft ``data: {"value": ...}`` lines to match the
+# eval client's contract. The test below pins the *other* end of the contract:
+# lines emitted by the production ``ResponsePayloadOutput`` wrapper used by
+# ``/generate/full`` must round-trip through the eval client. PR #1851
+# (``feat: token streaming support for ReAct Agent``) regressed exactly this
+# compatibility — ``react_agent`` started yielding ``ChatResponseChunk`` from
+# its new ``_stream_fn``, the wrapper serialized it as the chunk's full OpenAI
+# envelope, and the client's ``chunk_data.get("value")`` returned ``None``
+# because there was no top-level ``value`` field.
+
+
+@pytest.mark.parametrize("payload_factory", [
+    pytest.param(lambda answer: answer, id="str-payload"),
+    pytest.param(ChatResponseChunk.create_streaming_chunk, id="chat-response-chunk-payload"),
+])
+async def test_remote_eval_consumes_response_payload_output(rag_eval_input, payload_factory):
+    """Production ``ResponsePayloadOutput.get_stream_data()`` lines round-trip
+    through the eval client. Covers bare-string and ``ChatResponseChunk``
+    payloads (the streaming-agent regression path from PR #1851).
+    """
+    item = rag_eval_input.eval_input_items[0]
+    expected_answer = "the answer is 21"
+
+    async def stream_response(request):
+        resp = web.StreamResponse(status=200, headers={"Content-Type": "text/event-stream"})
+        await resp.prepare(request)
+        sse_line = ResponsePayloadOutput(payload=payload_factory(expected_answer)).get_stream_data()
+        await resp.write(sse_line.encode("utf-8"))
+        await resp.write_eof()
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/generate/full", stream_response)
+    server = TestServer(app)
+    await server.start_server()
+    client = TestClient(server)
+    await client.start_server()
+
+    handler = EvaluationRemoteWorkflowHandler(
+        config=EvaluationRunConfig(endpoint=str(server.make_url("")).rstrip("/"),
+                                   endpoint_timeout=5,
+                                   config_file=Path(__file__),
+                                   dataset=None,
+                                   result_json_path="",
+                                   skip_workflow=False,
+                                   skip_completed_entries=False,
+                                   reps=1),
+        max_concurrency=2,
+    )
+
+    async with client.session as session:
+        await handler.run_workflow_remote_single(session, item)
+
+    await client.close()
+    await server.close()
+
+    assert item.output_obj == expected_answer


### PR DESCRIPTION
## Description

Restores the wire format that `/generate/full` emits for the workflow's output, which silently regressed between 1.6 and 1.7.

**The contract** (documented by the eval client `nat.plugins.eval.runtime.remote_workflow.py:79` and pinned by `test_remote_evaluate.py`'s server fixture):

```
data: {"value": "<final answer>"}
```

**What broke.** PR #1851 (`feat: token streaming support for ReAct Agent`) added a `_stream_fn` to `react_agent` that yields `ChatResponseChunk` (OpenAI shape). Once a stream_fn is registered, `generate_streaming_response_full` takes the streaming branch and wraps each chunk in `ResponsePayloadOutput`, whose `get_stream_data()` dumps the chunk's full OpenAI envelope. There is no top-level `value` field, so the eval client's `chunk_data.get("value")` returns `None` and every eval scores 0. The producer (`react_agent`) and consumer (eval client) ship in the same NAT release and disagree on the wire shape.

`tool_calling_agent` is exposed to the same regression for the same reason — both yield `ChatResponseChunk` from their `_stream_fn`. The fix is in the shared `ResponsePayloadOutput.get_stream_data()`, so both code paths get covered.

**The fix.** `ResponsePayloadOutput.get_stream_data()` now normalizes any payload — string, primitive, `ChatResponseChunk`, `ChatResponse`, other `BaseModel` — into the canonical `data: {"value": "<str>"}\n\n` envelope. Scoped to `/generate/full`; `/v1/chat/completions` is unaffected because that path yields `ChatResponseChunk` directly through `ResponseBaseModelOutput.get_stream_data()`, never wrapped in `ResponsePayloadOutput`. WebSocket consumers do their own payload coercion in `MessageValidator.convert_data_to_message_content()` and don't call `get_stream_data()` either.

**Tests.** Parametrized unit tests pin the wire format per payload type. A new integration test in `test_remote_evaluate.py` round-trips real `ResponsePayloadOutput` lines through the real `EvaluationRemoteWorkflowHandler`, so a future change that desynchronizes producer and consumer fails CI rather than silently scoring zero on every eval.

## How to verify

The bug surface is two pure functions on NAT data models — the producer (`ResponsePayloadOutput.get_stream_data`) and the consumer (`chunk_data.get("value")` in the eval client). You can reproduce both the bug and the fix with no FastAPI server, no LLM, and no external services:

```python
import json
from nat.data_models.api_server import ResponsePayloadOutput, ChatResponseChunk

# What react_agent's _stream_fn yields after PR #1851:
chunk = ChatResponseChunk.create_streaming_chunk("21")

# What /generate/full puts on the wire:
sse_line = ResponsePayloadOutput(payload=chunk).get_stream_data()

# What nat.plugins.eval.runtime.remote_workflow extracts:
data = json.loads(sse_line[len("data: "):-2])
print("eval client extracts:", repr(data.get("value")))
```

Expected output:

| | Output |
|---|---|
| On `release/1.7` (without this PR) | `eval client extracts: None` |
| With this PR applied | `eval client extracts: '21'` |

The full `nvidia_nat_core` and `nvidia_nat_eval` test suites pass on this branch with no regressions, including the new parametrized unit tests and the producer/consumer integration test added here.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.
