### PR TITLE
fix(observability): Emit `OpenInference` LLM cost lookup attributes for span exports

### DIFF
--- a/docs/source/get-started/tutorials/create-a-new-workflow.md
+++ b/docs/source/get-started/tutorials/create-a-new-workflow.md
@@ -108,7 +108,7 @@ async def text_file_ingest_function(config: TextFileIngestFunctionConfig, builde
 ```
 
 
-Examining the `webquery_tool` function (`examples/getting_started/simple_web_query/src/nat_simple_web_query/register.py`), you can observe that at the heart of the tool is the [`langchain_community.document_loaders.WebBaseLoader`](https://python.langchain.com/docs/integrations/document_loaders/web_base) class.
+Examining the `webquery_tool` function (`examples/getting_started/simple_web_query/src/nat_simple_web_query/register.py`), you can observe that at the heart of the tool is the `langchain_community.document_loaders.WebBaseLoader` class.
 
 ```python
     loader = WebBaseLoader(config.webpage_url)
@@ -174,7 +174,7 @@ async def text_file_ingest_function(config: TextFileIngestFunctionConfig, builde
 
 ## Creating the Workflow Configuration
 
-Starting from the `custom_config.yml` file you created in the previous section, replace the two `webpage_query` tools with the new `text_file_ingest` tool. For the data source, you can use a collection of text files located in the `examples/documentation_guides/workflows/text_file_ingest/data` directory that describes [DOCA GPUNetIO](https://docs.nvidia.com/doca/sdk/DOCA-GPUNetIO/index.html).
+Starting from the `custom_config.yml` file you created in the previous section, replace the two `webpage_query` tools with the new `text_file_ingest` tool. For the data source, you can use a collection of text files located in the `examples/documentation_guides/workflows/text_file_ingest/data` directory that describes `DOCA GPUNetIO`.
 
 :::{note}
 <!-- path-check-skip-next-line -->

--- a/packages/nvidia_nat_core/src/nat/data_models/span.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/span.py
@@ -93,6 +93,8 @@ class SpanAttributes(Enum):
     NAT_SPAN_KIND = f"{_SPAN_PREFIX}.span.kind"
     INPUT_VALUE = "input.value"
     INPUT_MIME_TYPE = "input.mime_type"
+    LLM_MODEL_NAME = "llm.model_name"
+    LLM_PROVIDER = "llm.provider"
     LLM_TOKEN_COUNT_PROMPT = "llm.token_count.prompt"
     LLM_TOKEN_COUNT_COMPLETION = "llm.token_count.completion"
     LLM_TOKEN_COUNT_TOTAL = "llm.token_count.total"

--- a/packages/nvidia_nat_core/src/nat/observability/exporter/span_exporter.py
+++ b/packages/nvidia_nat_core/src/nat/observability/exporter/span_exporter.py
@@ -28,6 +28,7 @@ from nat.data_models.span import MimeTypes
 from nat.data_models.span import Span
 from nat.data_models.span import SpanAttributes
 from nat.data_models.span import SpanContext
+from nat.data_models.span import SpanKind
 from nat.data_models.span import event_type_to_span_kind
 from nat.observability.exporter.base_exporter import IsolatedAttribute
 from nat.observability.exporter.processing_exporter import ProcessingExporter
@@ -210,6 +211,11 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
 
         span_kind = event_type_to_span_kind(event.event_type)
         sub_span.set_attribute(f"{self._span_prefix}.span.kind", span_kind.value)
+        if span_kind == SpanKind.LLM:
+            if event.payload.name:
+                sub_span.set_attribute(SpanAttributes.LLM_MODEL_NAME.value, event.payload.name)
+            if event.payload.framework:
+                sub_span.set_attribute(SpanAttributes.LLM_PROVIDER.value, event.payload.framework.value)
 
         # Enable session grouping by setting session.id from conversation_id
         try:

--- a/packages/nvidia_nat_core/tests/nat/observability/exporter/test_span_exporter.py
+++ b/packages/nvidia_nat_core/tests/nat/observability/exporter/test_span_exporter.py
@@ -268,6 +268,42 @@ class TestSpanExporterFunctionality:
             assert exported_span.attributes[SpanAttributes.OUTPUT_VALUE.value] == "Test output"
             assert "nat.metadata" in exported_span.attributes
 
+    async def test_llm_span_exports_cost_lookup_attributes(self, span_exporter):
+        """Minimal reproducer for Phoenix cost lookup attributes on LLM spans."""
+        event_id = str(uuid.uuid4())
+
+        start_event = create_intermediate_step(UUID=event_id,
+                                               event_type=IntermediateStepType.LLM_START,
+                                               framework=LLMFrameworkEnum.LANGCHAIN,
+                                               name="gemini-2.5-flash",
+                                               event_timestamp=datetime.now().timestamp(),
+                                               data=StreamEventData(input="What is the capital of France?"),
+                                               metadata={})
+
+        end_event = create_intermediate_step(UUID=event_id,
+                                             event_type=IntermediateStepType.LLM_END,
+                                             framework=LLMFrameworkEnum.LANGCHAIN,
+                                             name="gemini-2.5-flash",
+                                             event_timestamp=datetime.now().timestamp(),
+                                             span_event_timestamp=datetime.now().timestamp(),
+                                             data=StreamEventData(output="Paris"),
+                                             metadata={},
+                                             usage_info=UsageInfo(num_llm_calls=1,
+                                                                  seconds_between_calls=0,
+                                                                  token_usage=TokenUsageBaseModel(prompt_tokens=7,
+                                                                                                  completion_tokens=1,
+                                                                                                  total_tokens=8)))
+
+        async with span_exporter.start():
+            span_exporter.export(start_event)
+            span_exporter.export(end_event)
+            await span_exporter.wait_for_tasks()
+
+        exported_span = span_exporter.exported_spans[0]
+        assert exported_span.attributes[SpanAttributes.LLM_MODEL_NAME.value] == "gemini-2.5-flash"
+        assert exported_span.attributes[SpanAttributes.LLM_PROVIDER.value] == LLMFrameworkEnum.LANGCHAIN.value
+        assert exported_span.attributes[SpanAttributes.LLM_TOKEN_COUNT_TOTAL.value] == 8
+
     def test_process_end_event_missing_span(self, span_exporter, sample_end_event):
         """Test processing END event with missing span."""
         with patch('nat.observability.exporter.span_exporter.logger') as mock_logger:


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
- Add OpenInference `llm.model_name` and `llm.provider` span attributes for LLM spans
- Populate model name from `IntermediateStepPayload.name`
- Populate provider from `IntermediateStepPayload.framework`
- Add a focused reproducer for LLM cost lookup attributes
- Add an OTLP-level mocked cost verification that decodes exported protobuf spans and confirms a pricing lookup can produce a non-null cost

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated tutorial formatting for improved readability.

* **New Features**
  * Enhanced LLM operation observability with automatic tracking of model name and provider metadata.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1988?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->