### PR TITLE
fix(tool_wrapper): Fix `LangChain` tool input normalization for chat agent branches

### DIFF
--- a/docs/source/get-started/tutorials/create-a-new-workflow.md
+++ b/docs/source/get-started/tutorials/create-a-new-workflow.md
@@ -108,7 +108,7 @@ async def text_file_ingest_function(config: TextFileIngestFunctionConfig, builde
 ```
 
 
-Examining the `webquery_tool` function (`examples/getting_started/simple_web_query/src/nat_simple_web_query/register.py`), you can observe that at the heart of the tool is the [`langchain_community.document_loaders.WebBaseLoader`](https://python.langchain.com/docs/integrations/document_loaders/web_base) class.
+Examining the `webquery_tool` function (`examples/getting_started/simple_web_query/src/nat_simple_web_query/register.py`), you can observe that at the heart of the tool is the `langchain_community.document_loaders.WebBaseLoader` class.
 
 ```python
     loader = WebBaseLoader(config.webpage_url)

--- a/docs/source/get-started/tutorials/create-a-new-workflow.md
+++ b/docs/source/get-started/tutorials/create-a-new-workflow.md
@@ -108,7 +108,7 @@ async def text_file_ingest_function(config: TextFileIngestFunctionConfig, builde
 ```
 
 
-Examining the `webquery_tool` function (`examples/getting_started/simple_web_query/src/nat_simple_web_query/register.py`), you can observe that at the heart of the tool is the `langchain_community.document_loaders.WebBaseLoader` class.
+Examining the `webquery_tool` function (`examples/getting_started/simple_web_query/src/nat_simple_web_query/register.py`), you can observe that at the heart of the tool is the [`langchain_community.document_loaders.WebBaseLoader`](https://reference.langchain.com/python/langchain-community/document_loaders/web_base/WebBaseLoader) class.
 
 ```python
     loader = WebBaseLoader(config.webpage_url)

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tool_wrapper.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tool_wrapper.py
@@ -39,8 +39,10 @@ def langchain_tool_wrapper(name: str, fn: Function, builder: Builder):
     def _normalize_messages(messages: list) -> list:
         normalized_messages = []
         for message in messages:
-            if isinstance(message, dict) and isinstance(message.get("content"), dict):
-                message = {**message, "content": [message["content"]]}
+            if isinstance(message, dict):
+                content = message.get("content")
+                if isinstance(content, dict):
+                    message = {**message, "content": [content]}
             normalized_messages.append(message)
         return normalized_messages
 

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tool_wrapper.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tool_wrapper.py
@@ -27,11 +27,22 @@ logger = logging.getLogger(__name__)
 def langchain_tool_wrapper(name: str, fn: Function, builder: Builder):
 
     import asyncio
+    import json
     import typing
 
     from langchain_core.tools.structured import StructuredTool
 
+    from nat.data_models.api_server import ChatRequest
+
     assert fn.input_schema is not None, "Tool must have input schema"
+
+    def _normalize_messages(messages: list) -> list:
+        normalized_messages = []
+        for message in messages:
+            if isinstance(message, dict) and isinstance(message.get("content"), dict):
+                message = {**message, "content": [message["content"]]}
+            normalized_messages.append(message)
+        return normalized_messages
 
     class NATStructuredTool(StructuredTool):
 
@@ -40,6 +51,22 @@ def langchain_tool_wrapper(name: str, fn: Function, builder: Builder):
                 schema = self.args_schema
                 if schema is not None and "input_message" in getattr(schema, "model_fields", {}):
                     tool_input = {"input_message": tool_input}
+                elif isinstance(schema, type) and issubclass(schema, ChatRequest):
+                    tool_input = ChatRequest.from_string(tool_input).model_dump(exclude_none=True)
+            elif isinstance(tool_input, dict):
+                schema = self.args_schema
+                if schema is not None and "messages" in getattr(schema, "model_fields", {}):
+                    messages = tool_input.get("messages")
+                    if isinstance(messages, str):
+                        try:
+                            parsed_messages = json.loads(messages)
+                        except json.JSONDecodeError:
+                            pass
+                        else:
+                            if isinstance(parsed_messages, list):
+                                tool_input = {**tool_input, "messages": _normalize_messages(parsed_messages)}
+                    elif isinstance(messages, list):
+                        tool_input = {**tool_input, "messages": _normalize_messages(messages)}
 
             return typing.cast(str | dict, super()._parse_input(tool_input, tool_call_id))
 

--- a/packages/nvidia_nat_langchain/tests/test_tool_wrapper.py
+++ b/packages/nvidia_nat_langchain/tests/test_tool_wrapper.py
@@ -20,9 +20,19 @@ import pytest
 from nat.builder.builder import Builder
 from nat.builder.function import LambdaFunction
 from nat.builder.function_info import FunctionInfo
+from nat.data_models.api_server import ChatRequest
 from nat.data_models.api_server import ChatRequestOrMessage
 from nat.data_models.function import EmptyFunctionConfig
 from nat.plugins.langchain.tool_wrapper import langchain_tool_wrapper
+
+
+def _content_text(content: object) -> str:
+    if isinstance(content, list):
+        first_content = content[0]
+        if isinstance(first_content, dict):
+            return first_content["text"]
+        return str(first_content.text)
+    return str(content)
 
 
 @pytest.mark.asyncio
@@ -31,7 +41,7 @@ async def test_langchain_tool_wrapper_maps_string_to_input_message() -> None:
     async def _echo(chat_request_or_message: ChatRequestOrMessage) -> str:
         if chat_request_or_message.input_message is not None:
             return chat_request_or_message.input_message
-        return chat_request_or_message.messages[-1].content  # type: ignore[index, union-attr]
+        return _content_text(chat_request_or_message.messages[-1].content)  # type: ignore[index, union-attr]
 
     info = FunctionInfo.from_fn(_echo, description="Echo input")
     fn = LambdaFunction.from_info(config=EmptyFunctionConfig(), info=info, instance_name="echo")
@@ -39,3 +49,23 @@ async def test_langchain_tool_wrapper_maps_string_to_input_message() -> None:
 
     assert await tool.ainvoke("hello") == "hello"
     assert await tool.ainvoke({"messages": [{"role": "user", "content": "hi"}]}) == "hi"
+    assert await tool.ainvoke({"messages": '[{"role": "user", "content": "json hi"}]'}) == "json hi"
+    assert await tool.ainvoke({"messages": '[{"role": "user", "content": {"type": "text", "text": "json object hi"}}]'}
+                              ) == "json object hi"
+
+
+@pytest.mark.asyncio
+async def test_langchain_tool_wrapper_maps_string_to_chat_request() -> None:
+
+    async def _echo(chat_request: ChatRequest) -> str:
+        return _content_text(chat_request.messages[-1].content)
+
+    info = FunctionInfo.from_fn(_echo, description="Echo input")
+    fn = LambdaFunction.from_info(config=EmptyFunctionConfig(), info=info, instance_name="echo")
+    tool = langchain_tool_wrapper("echo", fn, MagicMock(spec=Builder))
+
+    assert await tool.ainvoke("hello") == "hello"
+    assert await tool.ainvoke({"messages": [{"role": "user", "content": "hi"}]}) == "hi"
+    assert await tool.ainvoke({"messages": '[{"role": "user", "content": "json hi"}]'}) == "json hi"
+    assert await tool.ainvoke({"messages": '[{"role": "user", "content": {"type": "text", "text": "json object hi"}}]'}
+                              ) == "json object hi"


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
`router_agent` and `tool_calling_agent` can pass raw or poorly shaped chat inputs into agent branches such as react_agent. This updates the `LangChain` tool wrapper to normalize those inputs before Pydantic validation:

- Map raw string input to `ChatRequest` when the wrapped tool expects chat messages.
- Preserve existing raw string to `ChatRequestOrMessage.input_message` handling.
- Parse messages when an LLM emits it as a JSON string.
- Normalize single structured content objects into content lists for chat message schemas.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced tool input parsing: accepts plain strings, JSON payloads, and chat-request–style messages; normalizes message lists for consistent handling

* **Tests**
  * Added tests covering string→input mappings, JSON "typed text" payloads, and chat-request message handling

* **Documentation**
  * Minor tutorial wording update to reference a loader class inline instead of as an external link

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1990?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->