### PR TITLE
fix(agent): Fix thinking metadata handling in agents

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/base.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/base.py
@@ -39,6 +39,21 @@ from langgraph.runtime import DEFAULT_RUNTIME
 logger = logging.getLogger(__name__)
 
 
+def _extract_reasoning_content(message: BaseMessage) -> str:
+    """Extract provider-side reasoning text from a LangChain message."""
+    reasoning = message.additional_kwargs.get("reasoning_content", "")
+    return reasoning if isinstance(reasoning, str) else str(reasoning)
+
+
+def _format_agent_thoughts_for_log(message: BaseMessage) -> str:
+    """Return concise text for detailed agent thought logs."""
+    content = message.content
+    content_text = content if isinstance(content, str) else str(content)
+    if content_text.strip():
+        return content_text
+    return _extract_reasoning_content(message)
+
+
 def _chunk_to_message(chunk: AIMessageChunk) -> AIMessage:
     """Convert an accumulated AIMessageChunk into an AIMessage, preserving tool_calls.
 

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
@@ -223,9 +223,10 @@ class ReActAgentGraph(DualNodeAgent):
                     output_message = await self._stream_llm(self.agent, inputs, config=config)  # type: ignore
                     if isinstance(output_message.content, str):
                         output_message.content = remove_r1_think_tags(output_message.content)
+                    agent_thoughts = _format_agent_thoughts_for_log(output_message)
 
                     if self.detailed_logs:
-                        logger.info(AGENT_CALL_LOG_MESSAGE, question, _format_agent_thoughts_for_log(output_message))
+                        logger.info(AGENT_CALL_LOG_MESSAGE, question, agent_thoughts)
                 else:
                     # ReAct Agents require agentic cycles
                     # in an agentic cycle, preserve the agent's thoughts from the previous cycles,
@@ -246,9 +247,10 @@ class ReActAgentGraph(DualNodeAgent):
                     output_message = await self._stream_llm(self.agent, inputs, config=config)  # type: ignore
                     if isinstance(output_message.content, str):
                         output_message.content = remove_r1_think_tags(output_message.content)
+                    agent_thoughts = _format_agent_thoughts_for_log(output_message)
 
                     if self.detailed_logs:
-                        logger.info(AGENT_CALL_LOG_MESSAGE, question, _format_agent_thoughts_for_log(output_message))
+                        logger.info(AGENT_CALL_LOG_MESSAGE, question, agent_thoughts)
                         logger.debug("%s The agent's scratchpad (with tool result) was:\n%s",
                                      AGENT_LOG_PREFIX,
                                      agent_scratchpad)
@@ -269,8 +271,7 @@ class ReActAgentGraph(DualNodeAgent):
 
                         agent_output = AgentAction(tool=tool_name,
                                                    tool_input=tool_input_str,
-                                                   log=_format_agent_thoughts_for_log(output_message)
-                                                   or f"Calling {tool_name}")
+                                                   log=agent_thoughts or f"Calling {tool_name}")
                         logger.debug("%s Native tool call detected: %s", AGENT_LOG_PREFIX, tool_name)
                         state.agent_scratchpad += [agent_output]
                         return state

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
@@ -43,6 +43,7 @@ from nat.plugins.langchain.agent.base import INPUT_SCHEMA_MESSAGE
 from nat.plugins.langchain.agent.base import NO_INPUT_ERROR_MESSAGE
 from nat.plugins.langchain.agent.base import TOOL_NOT_FOUND_ERROR_MESSAGE
 from nat.plugins.langchain.agent.base import AgentDecision
+from nat.plugins.langchain.agent.base import _format_agent_thoughts_for_log
 from nat.plugins.langchain.agent.dual_node import DualNodeAgent
 from nat.plugins.langchain.agent.react_agent.output_parser import ReActAgentParsingFailedError
 from nat.plugins.langchain.agent.react_agent.output_parser import ReActOutputParser
@@ -221,19 +222,10 @@ class ReActAgentGraph(DualNodeAgent):
                     inputs = {"question": question, "chat_history": chat_history}
                     output_message = await self._stream_llm(self.agent, inputs, config=config)  # type: ignore
                     if isinstance(output_message.content, str):
-                        raw_content = output_message.content
-                        output_message.content = remove_r1_think_tags(raw_content)
-                        if not output_message.content.strip():
-                            think_match = re.search(r'<think>(.*?)</think>', raw_content, re.DOTALL)
-                            if think_match:
-                                output_message.content = think_match.group(1).strip()
-                        if not output_message.content.strip():
-                            reasoning = output_message.additional_kwargs.get('reasoning_content', '')
-                            if reasoning:
-                                output_message.content = reasoning
+                        output_message.content = remove_r1_think_tags(output_message.content)
 
                     if self.detailed_logs:
-                        logger.info(AGENT_CALL_LOG_MESSAGE, question, output_message.content)
+                        logger.info(AGENT_CALL_LOG_MESSAGE, question, _format_agent_thoughts_for_log(output_message))
                 else:
                     # ReAct Agents require agentic cycles
                     # in an agentic cycle, preserve the agent's thoughts from the previous cycles,
@@ -253,19 +245,10 @@ class ReActAgentGraph(DualNodeAgent):
                     inputs = {"question": question, "agent_scratchpad": agent_scratchpad, "chat_history": chat_history}
                     output_message = await self._stream_llm(self.agent, inputs, config=config)  # type: ignore
                     if isinstance(output_message.content, str):
-                        raw_content = output_message.content
-                        output_message.content = remove_r1_think_tags(raw_content)
-                        if not output_message.content.strip():
-                            think_match = re.search(r'<think>(.*?)</think>', raw_content, re.DOTALL)
-                            if think_match:
-                                output_message.content = think_match.group(1).strip()
-                        if not output_message.content.strip():
-                            reasoning = output_message.additional_kwargs.get('reasoning_content', '')
-                            if reasoning:
-                                output_message.content = reasoning
+                        output_message.content = remove_r1_think_tags(output_message.content)
 
                     if self.detailed_logs:
-                        logger.info(AGENT_CALL_LOG_MESSAGE, question, output_message.content)
+                        logger.info(AGENT_CALL_LOG_MESSAGE, question, _format_agent_thoughts_for_log(output_message))
                         logger.debug("%s The agent's scratchpad (with tool result) was:\n%s",
                                      AGENT_LOG_PREFIX,
                                      agent_scratchpad)
@@ -287,7 +270,7 @@ class ReActAgentGraph(DualNodeAgent):
                         agent_output = AgentAction(
                             tool=tool_name,
                             tool_input=tool_input_str,
-                            log=str(output_message.content) if output_message.content else f"Calling {tool_name}")
+                            log=_format_agent_thoughts_for_log(output_message) or f"Calling {tool_name}")
                         logger.debug("%s Native tool call detected: %s", AGENT_LOG_PREFIX, tool_name)
                         state.agent_scratchpad += [agent_output]
                         return state

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
@@ -267,10 +267,10 @@ class ReActAgentGraph(DualNodeAgent):
                         # Convert tool args to JSON string for consistency with text parsing
                         tool_input_str = json.dumps(tool_args) if isinstance(tool_args, dict) else str(tool_args)
 
-                        agent_output = AgentAction(
-                            tool=tool_name,
-                            tool_input=tool_input_str,
-                            log=_format_agent_thoughts_for_log(output_message) or f"Calling {tool_name}")
+                        agent_output = AgentAction(tool=tool_name,
+                                                   tool_input=tool_input_str,
+                                                   log=_format_agent_thoughts_for_log(output_message)
+                                                   or f"Calling {tool_name}")
                         logger.debug("%s Native tool call detected: %s", AGENT_LOG_PREFIX, tool_name)
                         state.agent_scratchpad += [agent_output]
                         return state

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/agent.py
@@ -38,6 +38,7 @@ from nat.plugins.langchain.agent.base import AGENT_CALL_LOG_MESSAGE
 from nat.plugins.langchain.agent.base import AGENT_LOG_PREFIX
 from nat.plugins.langchain.agent.base import AgentDecision
 from nat.plugins.langchain.agent.base import _chunk_to_message
+from nat.plugins.langchain.agent.base import _format_agent_thoughts_for_log
 from nat.plugins.langchain.agent.dual_node import DualNodeAgent
 
 if typing.TYPE_CHECKING:
@@ -148,7 +149,7 @@ class ToolCallAgentGraph(DualNodeAgent):
 
             if self.detailed_logs:
                 agent_input = "\n".join(str(message.content) for message in state.messages)
-                logger.info(AGENT_CALL_LOG_MESSAGE, agent_input, response)
+                logger.info(AGENT_CALL_LOG_MESSAGE, agent_input, _format_agent_thoughts_for_log(response))
 
             state.messages += [response]
             return state

--- a/packages/nvidia_nat_langchain/tests/agent/test_base.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_base.py
@@ -27,6 +27,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.graph.state import CompiledStateGraph
 
 from nat.plugins.langchain.agent.base import BaseAgent
+from nat.plugins.langchain.agent.base import _format_agent_thoughts_for_log
 
 
 class MockBaseAgent(BaseAgent):
@@ -188,6 +189,13 @@ class TestStreamLLM:
         assert effective is not base_agent._runnable_config, "merged config should be a new object"
         assert "internal" in effective.get("tags", [])
         assert "external" in effective.get("tags", [])
+
+
+def test_format_agent_thoughts_for_log_uses_reasoning_when_content_empty():
+    """Reasoning metadata should be logged without dumping the whole AIMessage repr."""
+    message = AIMessage(content="\n", additional_kwargs={"reasoning_content": "thinking through the tool choice"})
+
+    assert _format_agent_thoughts_for_log(message) == "thinking through the tool choice"
 
 
 class TestCallLLM:

--- a/packages/nvidia_nat_langchain/tests/agent/test_react.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_react.py
@@ -115,6 +115,23 @@ async def test_malformed_agent_output_after_max_retries(mock_react_agent_no_rais
     assert '\nQuestion: hi\n' in response.content
 
 
+async def test_reasoning_content_is_not_promoted_to_react_final_answer(mock_react_agent_no_raise):
+    from unittest.mock import AsyncMock
+    from unittest.mock import patch
+
+    mock_response = AIMessage(content="\n", additional_kwargs={"reasoning_content": "I should call a tool next."})
+    mock_state = ReActGraphState(messages=[HumanMessage(content="test question")])
+
+    with patch.object(mock_react_agent_no_raise, '_stream_llm', new_callable=AsyncMock) as mock_stream_llm:
+        mock_stream_llm.return_value = mock_response
+
+        response = await mock_react_agent_no_raise.agent_node(mock_state)
+
+    response = response.messages[-1]
+    assert MISSING_ACTION_AFTER_THOUGHT_ERROR_MESSAGE in response.content
+    assert "I should call a tool next." not in response.content
+
+
 async def test_agent_node_parse_agent_action(mock_react_agent):
     mock_react_agent_output = 'Thought:not_many\nAction:Tool A\nAction Input: hello, world!\nObservation:'
     mock_state = ReActGraphState(messages=[HumanMessage(content=mock_react_agent_output)])
@@ -1422,6 +1439,36 @@ async def test_agent_node_native_tool_calling_with_dict_args(mock_config_react_a
         assert parsed["query"] == "search term"
         assert parsed["limit"] == 10
         assert parsed["nested"]["key"] == "value"
+
+
+async def test_agent_node_native_tool_calling_uses_reasoning_for_tool_log(mock_config_react_agent, mock_llm, mock_tool):
+    """Provider reasoning metadata should be preserved as tool-call log text without becoming parser content."""
+    from unittest.mock import AsyncMock
+    from unittest.mock import patch
+
+    tools = [mock_tool('Tool A')]
+    prompt = create_react_agent_prompt(mock_config_react_agent)
+    agent = ReActAgentGraph(llm=mock_llm, prompt=prompt, tools=tools, detailed_logs=False, use_native_tool_calling=True)
+    mock_response = AIMessage(content="\n",
+                              additional_kwargs={"reasoning_content": "I should call Tool A."},
+                              tool_calls=[{
+                                  "name": "Tool A",
+                                  "args": {
+                                      "query": "test query"
+                                  },
+                                  "id": "call_123",
+                                  "type": "tool_call",
+                              }])
+    state = ReActGraphState(messages=[HumanMessage(content="test question")])
+
+    with patch.object(agent, '_stream_llm', new_callable=AsyncMock) as mock_stream_llm:
+        mock_stream_llm.return_value = mock_response
+
+        result_state = await agent.agent_node(state)
+
+    agent_action = result_state.agent_scratchpad[0]
+    assert agent_action.tool == "Tool A"
+    assert agent_action.log == "I should call Tool A."
 
 
 # =============================================================================

--- a/packages/nvidia_nat_langchain/tests/agent/test_tool_calling.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_tool_calling.py
@@ -15,6 +15,7 @@
 
 import datetime
 import json
+import logging
 import typing
 from unittest.mock import AsyncMock
 from unittest.mock import patch
@@ -239,6 +240,30 @@ async def test_agent_node(mock_tool_agent):
     response = response.messages[-1]
     assert isinstance(response, AIMessage)
     assert response.content == 'mock tool call'
+
+
+async def test_agent_node_logs_reasoning_content_without_message_repr(mock_tool_agent, caplog):
+    mock_state = ToolCallAgentGraphState(messages=[HumanMessage(content='needs a tool')])
+    mock_response = AIMessage(content="\n",
+                              additional_kwargs={"reasoning_content": "I should call Tool A."},
+                              tool_calls=[{
+                                  "name": "Tool A",
+                                  "args": {
+                                      "query": "mock query"
+                                  },
+                                  "id": "Tool A",
+                                  "type": "tool_call",
+                              }])
+
+    with patch.object(mock_tool_agent, '_invoke_llm', new_callable=AsyncMock) as mock_invoke_llm:
+        mock_invoke_llm.return_value = mock_response
+
+        with caplog.at_level(logging.INFO, logger="nat.plugins.langchain.agent.tool_calling_agent.agent"):
+            await mock_tool_agent.agent_node(mock_state)
+
+    assert "I should call Tool A." in caplog.text
+    assert "additional_kwargs" not in caplog.text
+    assert "tool_calls=[" not in caplog.text
 
 
 async def test_conditional_edge_no_input(mock_tool_agent):


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
- Fix detailed logging for `tool_calling_agent` so thinking-enabled responses log concise reasoning text instead of the full `AIMessage` repr
- Stop `react_agent` from promoting provider `reasoning_content` into parser/final-answer content
- Preserve reasoning metadata for native ReAct tool-call logs
- Add targeted regression coverage for feedback-shaped thinking/tool-call responses

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented provider reasoning from being unintentionally promoted into message content.
  * Improved logs to exclude raw/internal message representations.

* **New Features**
  * Formatted agent "thoughts" are now surfaced in logs and tool-call records for clearer decision context.
  * Native tool calls now preserve provider reasoning in agent activity logs.

* **Tests**
  * Added regressions ensuring reasoning content is logged/preserved correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/NVIDIA/NeMo-Agent-Toolkit/pull/1992?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->