### PR TITLE
fix: support function workflows in FastMCP front end

### DIFF
--- a/packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/front_end_plugin_worker.py
+++ b/packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/front_end_plugin_worker.py
@@ -172,10 +172,12 @@ class FastMCPFrontEndPluginWorkerBase(ABC):
         for function_group in workflow.function_groups.values():
             functions.update(await function_group.get_accessible_functions())
 
-        if workflow.config.workflow.workflow_alias:
-            functions[workflow.config.workflow.workflow_alias] = workflow
+        workflow_config = workflow.config.workflow
+        workflow_alias = getattr(workflow_config, "workflow_alias", None)
+        if workflow_alias:
+            functions[workflow_alias] = workflow
         else:
-            functions[workflow.config.workflow.type] = workflow
+            functions[workflow_config.type] = workflow
 
         return functions
 

--- a/packages/nvidia_nat_fastmcp/tests/test_fastmcp.py
+++ b/packages/nvidia_nat_fastmcp/tests/test_fastmcp.py
@@ -15,6 +15,7 @@
 """Tests for FastMCP CLI and server wiring."""
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
@@ -226,6 +227,18 @@ async def test_fastmcp_nat_token_verifier_rejects_inactive_result(monkeypatch: p
     monkeypatch.setattr(verifier._bearer_token_validator, "verify", verify)
 
     assert await verifier.verify_token("token-value") is None
+
+
+async def test_fastmcp_function_workflow_config_without_alias_uses_type():
+    config = Config(general=GeneralConfig(front_end=FastMCPFrontEndConfig()))
+    worker = FastMCPFrontEndPluginWorker(config)
+    workflow = SimpleNamespace(functions={},
+                               function_groups={},
+                               config=SimpleNamespace(workflow=SimpleNamespace(type="langgraph_wrapper")))
+
+    functions = await worker._get_all_functions(workflow)
+
+    assert functions == {"langgraph_wrapper": workflow}
 
 
 def test_fastmcp_debug_route_lists_tools():


### PR DESCRIPTION
## Summary
- avoid reading `workflow_alias` directly on FastMCP function-style workflow configs
- fall back to the workflow type when a FastMCP workflow config does not define an alias
- add a regression for `langgraph_wrapper`-style configs without `workflow_alias`

Complements #2097 by covering the FastMCP worker side of #1991.

## Testing
- `python3 -m py_compile packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/front_end_plugin_worker.py packages/nvidia_nat_fastmcp/tests/test_fastmcp.py`
- `git diff --check upstream/develop...HEAD`
