### PR TITLE
fix(agent): Fix ReWOO nested evidence placeholder substitution

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/rewoo_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/rewoo_agent/agent.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import asyncio
+import copy
 import json
 import logging
 import re
@@ -208,32 +209,53 @@ class ReWOOAgentGraph(BaseAgent):
         return evidences, levels
 
     @staticmethod
-    def _replace_placeholder(placeholder: str, tool_input: str | dict, tool_output: str | dict) -> str | dict:
+    def _replace_placeholders(tool_input: Any, replacements: dict[str, Any]) -> Any:
+        """
+        Replace ReWOO evidence placeholders in a planner-provided tool input.
 
-        # Replace the placeholders in the tool input with the previous tool output
+        Exact placeholder matches preserve the evidence output type so tools with
+        structured schemas can receive lists, objects, or numeric values. Partial
+        string matches stringify the evidence, matching the original behavior.
+        """
         if isinstance(tool_input, dict):
+            replaced_tool_input = {}
             for key, value in tool_input.items():
-                if value is not None:
-                    if value == placeholder:
-                        tool_input[key] = tool_output
-                    elif isinstance(value, str) and placeholder in value:
-                        # If the placeholder is part of the value, replace it with the stringified output
-                        tool_input[key] = value.replace(placeholder, str(tool_output))
+                replaced_tool_input[key] = ReWOOAgentGraph._replace_placeholders(value, replacements)
+            return replaced_tool_input
 
-        elif isinstance(tool_input, str):
-            tool_input = tool_input.replace(placeholder, str(tool_output))
+        if isinstance(tool_input, list):
+            return [ReWOOAgentGraph._replace_placeholders(value, replacements) for value in tool_input]
 
-        else:
-            assert False, f"Unexpected type for tool_input: {type(tool_input)}"
+        if isinstance(tool_input, str):
+            if tool_input in replacements:
+                return copy.deepcopy(replacements[tool_input])
+
+            for placeholder, tool_output in replacements.items():
+                if placeholder in tool_input:
+                    tool_input = tool_input.replace(placeholder, str(tool_output))
 
         return tool_input
 
     @staticmethod
-    def _parse_tool_input(tool_input: str | dict):
+    def _replace_placeholder(placeholder: str, tool_input: Any, tool_output: Any) -> Any:
+
+        # Replace the placeholders in the tool input with the previous tool output
+        return ReWOOAgentGraph._replace_placeholders(tool_input, {placeholder: tool_output})
+
+    @staticmethod
+    def _parse_tool_input(tool_input: Any):
 
         # If the input is already a dictionary, return it as is
         if isinstance(tool_input, dict):
             logger.debug("%s Tool input is already a dictionary. Use the tool input as is.", AGENT_LOG_PREFIX)
+            return tool_input
+
+        if isinstance(tool_input, list):
+            logger.debug("%s Tool input is already structured. Use the tool input as is.", AGENT_LOG_PREFIX)
+            return tool_input
+
+        if not isinstance(tool_input, str):
+            logger.debug("%s Tool input is not a string. Use the tool input as is.", AGENT_LOG_PREFIX)
             return tool_input
 
         # If the input is a string, attempt to parse it as JSON
@@ -396,7 +418,7 @@ class ReWOOAgentGraph(BaseAgent):
         """
         evidence_info = step_info.evidence
         tool_name = evidence_info.tool
-        tool_input = evidence_info.tool_input
+        replacements = {}
 
         # Replace placeholders in tool input with previous results
         for ph_key, tool_output in intermediate_results.items():
@@ -406,7 +428,9 @@ class ReWOOAgentGraph(BaseAgent):
                 tool_output_content = tool_output_content[0]
                 assert isinstance(tool_output_content, dict)
 
-            tool_input = self._replace_placeholder(ph_key, tool_input, tool_output_content)
+            replacements[ph_key] = tool_output_content
+
+        tool_input = self._replace_placeholders(evidence_info.tool_input, replacements)
 
         # Get the requested tool
         requested_tool = self._get_tool(tool_name)
@@ -446,8 +470,7 @@ class ReWOOAgentGraph(BaseAgent):
                 original_tool_input = evidence_info.tool_input
                 tool_name = evidence_info.tool
 
-                # Replace placeholders in tool input with actual results
-                final_tool_input = original_tool_input
+                replacements = {}
                 for ph_key, tool_output in state.intermediate_results.items():
                     tool_output_content = tool_output.content
                     # If the content is a list, get the first element which should be a dict
@@ -455,7 +478,10 @@ class ReWOOAgentGraph(BaseAgent):
                         tool_output_content = tool_output_content[0]
                         assert isinstance(tool_output_content, dict)
 
-                    final_tool_input = self._replace_placeholder(ph_key, final_tool_input, tool_output_content)
+                    replacements[ph_key] = tool_output_content
+
+                # Replace placeholders in tool input with actual results
+                final_tool_input = self._replace_placeholders(original_tool_input, replacements)
 
                 # Get the final result for this placeholder
                 final_result = ""

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/rewoo_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/rewoo_agent/agent.py
@@ -43,6 +43,7 @@ from nat.plugins.langchain.agent.base import AgentDecision
 from nat.plugins.langchain.agent.base import BaseAgent
 
 logger = logging.getLogger(__name__)
+_REWOO_PLACEHOLDER_PATTERN = re.compile(r"#E\d+")
 
 
 class ReWOOEvidence(BaseModel):
@@ -180,7 +181,7 @@ class ReWOOAgentGraph(BaseAgent):
         # Second pass: find dependencies now that we have all placeholders
         dependencies = {
             step.evidence.placeholder: [
-                var for var in re.findall(r"#E\d+", str(step.evidence.tool_input))
+                var for var in _REWOO_PLACEHOLDER_PATTERN.findall(str(step.evidence.tool_input))
                 if var in evidences and var != step.evidence.placeholder
             ]
             for step in steps if step.evidence and step.evidence.placeholder
@@ -215,7 +216,7 @@ class ReWOOAgentGraph(BaseAgent):
 
         Exact placeholder matches preserve the evidence output type so tools with
         structured schemas can receive lists, objects, or numeric values. Partial
-        string matches stringify the evidence, matching the original behavior.
+        string matches replace only complete ReWOO placeholder tokens.
         """
         if isinstance(tool_input, dict):
             replaced_tool_input = {}
@@ -230,9 +231,8 @@ class ReWOOAgentGraph(BaseAgent):
             if tool_input in replacements:
                 return copy.deepcopy(replacements[tool_input])
 
-            for placeholder, tool_output in replacements.items():
-                if placeholder in tool_input:
-                    tool_input = tool_input.replace(placeholder, str(tool_output))
+            return _REWOO_PLACEHOLDER_PATTERN.sub(lambda match: str(replacements.get(match.group(0), match.group(0))),
+                                                  tool_input)
 
         return tool_input
 

--- a/packages/nvidia_nat_langchain/tests/agent/test_rewoo.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_rewoo.py
@@ -288,6 +288,42 @@ async def test_executor_node_handle_input_types(mock_rewoo_agent):
         assert isinstance(mock_state.intermediate_results["#E2"].content, list)
 
 
+async def test_executor_node_replaces_nested_placeholders_before_tool_call(mock_rewoo_agent):
+    from unittest.mock import AsyncMock
+
+    steps = [
+        _create_step_info("step1", "#E1", "mock_tool_A", "1879"),
+        _create_step_info("step2", "#E2", "mock_tool_A", "1885"),
+        _create_step_info("step3",
+                          "#E3",
+                          "mock_tool_B", {
+                              "numbers": ["#E1", "#E2"], "metadata": {
+                                  "question": "Compare #E1 with #E2"
+                              }
+                          })
+    ]
+    mock_state = _create_mock_state_with_parallel_data(
+        steps,
+        intermediate_results={
+            "#E1": ToolMessage(content="1879", tool_call_id="mock_tool_A"),
+            "#E2": ToolMessage(content="1885", tool_call_id="mock_tool_A")
+        })
+    mock_state.current_level = 1
+
+    original_call_tool = mock_rewoo_agent._call_tool
+    mock_rewoo_agent._call_tool = AsyncMock(return_value=ToolMessage(content="success", tool_call_id="mock_tool_B"))
+
+    try:
+        await mock_rewoo_agent.executor_node(mock_state)
+    finally:
+        mock_call_tool = mock_rewoo_agent._call_tool
+        mock_rewoo_agent._call_tool = original_call_tool
+
+    mock_call_tool.assert_called_once()
+    tool_input = mock_call_tool.call_args.args[1]
+    assert tool_input == {"numbers": ["1879", "1885"], "metadata": {"question": "Compare 1879 with 1885"}}
+
+
 async def test_executor_node_should_not_be_invoked_after_all_steps_executed(mock_rewoo_agent):
     steps = [
         _create_step_info("step1", "#E1", "mock_tool_A", "arg1, arg2"),
@@ -644,6 +680,35 @@ def test_placeholder_replacement_functionality():
     result = ReWOOAgentGraph._replace_placeholder("#E1", tool_input, complex_output)
     expected = f"The capital of the country in {str(complex_output)}"
     assert result == expected
+
+
+def test_placeholder_replacement_handles_nested_structures_without_mutation():
+    """Test placeholder replacement in nested dict and list inputs."""
+
+    tool_input = {
+        "numbers": ["#E1", "#E2"], "question": "Compare #E1 with #E2", "metadata": {
+            "raw": ["keep", {
+                "value": "#E1"
+            }]
+        }
+    }
+
+    result = ReWOOAgentGraph._replace_placeholders(tool_input, {"#E1": 1879, "#E2": 1885})
+
+    assert result == {
+        "numbers": [1879, 1885], "question": "Compare 1879 with 1885", "metadata": {
+            "raw": ["keep", {
+                "value": 1879
+            }]
+        }
+    }
+    assert tool_input == {
+        "numbers": ["#E1", "#E2"], "question": "Compare #E1 with #E2", "metadata": {
+            "raw": ["keep", {
+                "value": "#E1"
+            }]
+        }
+    }
 
 
 def test_tool_input_parsing_edge_cases():

--- a/packages/nvidia_nat_langchain/tests/agent/test_rewoo.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_rewoo.py
@@ -711,6 +711,16 @@ def test_placeholder_replacement_handles_nested_structures_without_mutation():
     }
 
 
+def test_placeholder_replacement_is_token_aware_for_shared_prefixes():
+    """Test that #E1 does not replace the #E1 portion of #E10."""
+
+    replacements = {"#E1": "one", "#E10": "ten"}
+
+    result = ReWOOAgentGraph._replace_placeholders("Compare #E10 and #E1", replacements)
+
+    assert result == "Compare ten and one"
+
+
 def test_tool_input_parsing_edge_cases():
     """Test edge cases in tool input parsing."""
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
### Summary

- Recursively replace ReWOO evidence placeholders inside nested dict/list tool inputs before tool execution.
- Preserve evidence output types for exact placeholder matches while retaining string interpolation behavior for partial matches.
- Avoid mutating planner-provided tool inputs during placeholder substitution.

### Why
Before the fix ReWOO agent was sending raw placeholders like `#E1` and `#E2` into dependent tool calls such as `{"numbers": ["#E1", "#E2"]}`, causing schema validation failures.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced ReWOO Agent placeholder handling to support nested structures and richer tool inputs.

* **Bug Fixes**
  * Prevented unintended mutation of original input values during placeholder substitution; token-aware replacements avoid false matches.

* **Tests**
  * Added tests validating nested placeholder replacement, immutability of inputs, and correct token matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->