### PR TITLE
docs: Fix vLLM serve command for Nemotron model in local LLMs guide

### DIFF
--- a/docs/source/build-workflows/llms/using-local-llms.md
+++ b/docs/source/build-workflows/llms/using-local-llms.md
@@ -172,7 +172,7 @@ The `CUDA_VISIBLE_DEVICES` environment variable is used to specify the GPUs to u
 
 In a terminal from within the vLLM environment, run the following command to serve the LLM:
 ```bash
-CUDA_VISIBLE_DEVICES=0 vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16
+CUDA_VISIBLE_DEVICES=0 vllm serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16 --trust-remote-code --max-num-seqs 256
 ```
 
 In a second terminal also from within the vLLM environment, run the following command to serve the embedding model:

--- a/examples/experimental/claude_code_agent_adapter/uv.lock
+++ b/examples/experimental/claude_code_agent_adapter/uv.lock
@@ -1930,7 +1930,7 @@ requires-dist = [
     { name = "langchain-huggingface", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain-litellm", specifier = ">=0.6.5,<1.0.0" },
     { name = "langchain-milvus", specifier = ">=0.3.3,<1.0.0" },
-    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.3.0,<2.0.0" },
+    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.4.1,<2.0.0" },
     { name = "langchain-oci", specifier = ">=0.2.4,<1.0.0" },
     { name = "langchain-openai", specifier = ">=1.1.6,<2.0.0" },
     { name = "langchain-tavily", specifier = ">=0.2.18,<1.0.0" },

--- a/examples/experimental/codex_agent_adapter/uv.lock
+++ b/examples/experimental/codex_agent_adapter/uv.lock
@@ -1930,7 +1930,7 @@ requires-dist = [
     { name = "langchain-huggingface", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain-litellm", specifier = ">=0.6.5,<1.0.0" },
     { name = "langchain-milvus", specifier = ">=0.3.3,<1.0.0" },
-    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.3.0,<2.0.0" },
+    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.4.1,<2.0.0" },
     { name = "langchain-oci", specifier = ">=0.2.4,<1.0.0" },
     { name = "langchain-openai", specifier = ">=1.1.6,<2.0.0" },
     { name = "langchain-tavily", specifier = ">=0.2.18,<1.0.0" },

--- a/examples/experimental/cursor_agent_adapter/uv.lock
+++ b/examples/experimental/cursor_agent_adapter/uv.lock
@@ -1930,7 +1930,7 @@ requires-dist = [
     { name = "langchain-huggingface", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain-litellm", specifier = ">=0.6.5,<1.0.0" },
     { name = "langchain-milvus", specifier = ">=0.3.3,<1.0.0" },
-    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.3.0,<2.0.0" },
+    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.4.1,<2.0.0" },
     { name = "langchain-oci", specifier = ">=0.2.4,<1.0.0" },
     { name = "langchain-openai", specifier = ">=1.1.6,<2.0.0" },
     { name = "langchain-tavily", specifier = ">=0.2.18,<1.0.0" },

--- a/examples/experimental/hermes_agent_adapter/uv.lock
+++ b/examples/experimental/hermes_agent_adapter/uv.lock
@@ -1930,7 +1930,7 @@ requires-dist = [
     { name = "langchain-huggingface", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain-litellm", specifier = ">=0.6.5,<1.0.0" },
     { name = "langchain-milvus", specifier = ">=0.3.3,<1.0.0" },
-    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.3.0,<2.0.0" },
+    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.4.1,<2.0.0" },
     { name = "langchain-oci", specifier = ">=0.2.4,<1.0.0" },
     { name = "langchain-openai", specifier = ">=1.1.6,<2.0.0" },
     { name = "langchain-tavily", specifier = ">=0.2.18,<1.0.0" },

--- a/examples/experimental/openclaw_agent_adapter/uv.lock
+++ b/examples/experimental/openclaw_agent_adapter/uv.lock
@@ -1930,7 +1930,7 @@ requires-dist = [
     { name = "langchain-huggingface", specifier = ">=1.2.2,<2.0.0" },
     { name = "langchain-litellm", specifier = ">=0.6.5,<1.0.0" },
     { name = "langchain-milvus", specifier = ">=0.3.3,<1.0.0" },
-    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.3.0,<2.0.0" },
+    { name = "langchain-nvidia-ai-endpoints", specifier = ">=1.4.1,<2.0.0" },
     { name = "langchain-oci", specifier = ">=0.2.4,<1.0.0" },
     { name = "langchain-openai", specifier = ">=1.1.6,<2.0.0" },
     { name = "langchain-tavily", specifier = ">=0.2.18,<1.0.0" },


### PR DESCRIPTION
The locally-hosted vLLM guide instructs users to serve nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16, but the documented command fails out of the box for two reasons:

1. The model ships custom modeling code in its repository, so vLLM exits with a ModelConfig validation error requesting trust_remote_code=True. Fixed by adding --trust-remote-code (the companion Dynamo launch scripts already pass this flag).

2. vLLM's default max_num_seqs in this case is 1024. A user hit an OOM error because 1024 is too large for their device. Adding --max-num-seqs 256 keeps the documented command working across a wider range of GPUs.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes NAT-314

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vLLM model serving instructions with enhanced configuration parameters for improved server reliability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->