### PR TITLE
fix(auth): Fix protected `FastMCP` OAuth token validation

### DIFF
--- a/docs/source/run-workflows/fastmcp-server.md
+++ b/docs/source/run-workflows/fastmcp-server.md
@@ -221,7 +221,7 @@ nat run --config_file examples/MCP/simple_calculator_fastmcp/configs/config-mcp-
 
 ## Authentication
 
-MCP servers started with the FastMCP server runtime can validate OAuth2 bearer tokens using JWKS/discovery for JWT access tokens and token introspection for opaque access tokens. Configure `server_auth` in your front-end config with the issuer, required scopes, and the validation endpoints required by your authorization server.
+MCP servers started with the FastMCP server runtime can validate OAuth2 bearer tokens using JWKS or discovery for JWT access tokens and token introspection for opaque access tokens. Configure `server_auth` in your front-end config with the issuer, required scopes, and the validation endpoints required by your authorization server.
 
 When using Keycloak, configure the token audience so the resource-server client is present in the access token `aud` claim. The protected FastMCP example sets `audience: nat-mcp-resource-server`; the matching Keycloak client scope must add `nat-mcp-resource-server` to access tokens.
 

--- a/docs/source/run-workflows/fastmcp-server.md
+++ b/docs/source/run-workflows/fastmcp-server.md
@@ -221,7 +221,9 @@ nat run --config_file examples/MCP/simple_calculator_fastmcp/configs/config-mcp-
 
 ## Authentication
 
-MCP servers started with the FastMCP server runtime can validate bearer tokens using OAuth2 token introspection. Configure `server_auth` in your front end config with the introspection endpoint and client credentials.
+MCP servers started with the FastMCP server runtime can validate OAuth2 bearer tokens using JWKS/discovery for JWT access tokens and token introspection for opaque access tokens. Configure `server_auth` in your front end config with the issuer, required scopes, and the validation endpoints required by your authorization server.
+
+When using Keycloak, configure the token audience so the resource-server client is present in the access token `aud` claim. The protected FastMCP example sets `audience: nat-mcp-resource-server`; the matching Keycloak client scope must add `nat-mcp-resource-server` to access tokens.
 
 See the protected example for a full setup:
 

--- a/docs/source/run-workflows/fastmcp-server.md
+++ b/docs/source/run-workflows/fastmcp-server.md
@@ -221,7 +221,7 @@ nat run --config_file examples/MCP/simple_calculator_fastmcp/configs/config-mcp-
 
 ## Authentication
 
-MCP servers started with the FastMCP server runtime can validate OAuth2 bearer tokens using JWKS/discovery for JWT access tokens and token introspection for opaque access tokens. Configure `server_auth` in your front end config with the issuer, required scopes, and the validation endpoints required by your authorization server.
+MCP servers started with the FastMCP server runtime can validate OAuth2 bearer tokens using JWKS/discovery for JWT access tokens and token introspection for opaque access tokens. Configure `server_auth` in your front-end config with the issuer, required scopes, and the validation endpoints required by your authorization server.
 
 When using Keycloak, configure the token audience so the resource-server client is present in the access token `aud` claim. The protected FastMCP example sets `audience: nat-mcp-resource-server`; the matching Keycloak client scope must add `nat-mcp-resource-server` to access tokens.
 

--- a/examples/MCP/simple_calculator_fastmcp_protected/README.md
+++ b/examples/MCP/simple_calculator_fastmcp_protected/README.md
@@ -156,7 +156,7 @@ You can register the client manually or use the dynamic client registration feat
 
 ### Step 4: Register Resource Server for Introspection
 
-The FastMCP server runtime uses OAuth2 token introspection for this example. Register a resource server client so the MCP server can authenticate to Keycloak when introspecting tokens.
+The FastMCP server runtime validates OAuth2 bearer tokens for this example. Register a resource server client so the MCP server can authenticate to Keycloak when introspecting opaque tokens, and so JWT access tokens can be audience-bound to the same resource server.
 
 1. In Keycloak Admin Console, go to **Clients**
 2. Click **Create client**
@@ -177,6 +177,23 @@ The FastMCP server runtime uses OAuth2 token introspection for this example. Reg
    - Go to **Credentials** tab
    - Copy the **Client secret**
    - Note the **Client ID**: `nat-mcp-resource-server`
+
+6. **Add the resource server audience to calculator tokens:**
+   - Go back to **Client scopes** (left sidebar)
+   - Open the `calculator_mcp_execute` scope
+   - Go to the **Mappers** tab
+   - Click **Configure a new mapper**
+   - Select **Audience**
+   - Configure the mapper:
+     - **Name**: `mcp-resource-server-audience`
+     - **Included Client Audience**: `nat-mcp-resource-server`
+     - **Included Custom Audience**: Leave blank
+     - **Add to ID token**: `Off`
+     - **Add to access token**: `On`
+     - **Add to token introspection**: `On` (if available in your Keycloak version)
+   - Click **Save**
+
+   The server config expects `nat-mcp-resource-server` in the access token's `aud` claim. Without this mapper, browser consent can succeed but the protected FastMCP server still rejects MCP initialization.
 
 ### Step 5: Start the Protected FastMCP Server
 
@@ -240,7 +257,9 @@ general:
     host: localhost
     server_auth:
       issuer_url: http://localhost:8080/realms/master
+      discovery_url: http://localhost:8080/realms/master/.well-known/openid-configuration
       introspection_endpoint: http://localhost:8080/realms/master/protocol/openid-connect/token/introspect
+      audience: nat-mcp-resource-server
       client_id: ${NAT_CALCULATOR_RESOURCE_CLIENT_ID:-"nat-mcp-resource-server"}
       client_secret: ${NAT_CALCULATOR_RESOURCE_CLIENT_SECRET}
       scopes: [calculator_mcp_execute]
@@ -272,6 +291,14 @@ workflow:
   _type: per_user_react_agent
   tool_names: [mcp_calculator_protected]
 ```
+
+## Troubleshooting
+
+If the server logs `JWT audience ['master-realm', 'account'] does not contain required audience 'nat-mcp-resource-server'`, the access token does not include the resource server audience. Re-check the `calculator_mcp_execute` client-scope mapper from Step 4.6:
+
+- **Included Client Audience** must be `nat-mcp-resource-server`
+- **Add to access token** must be `On`
+- The `calculator_mcp_execute` scope must be assigned to the `nat-mcp-client` client and requested by the client workflow
 
 ## Related Examples
 - `examples/MCP/simple_calculator_fastmcp/`: FastMCP calculator example without authentication

--- a/examples/MCP/simple_calculator_fastmcp_protected/README.md
+++ b/examples/MCP/simple_calculator_fastmcp_protected/README.md
@@ -207,6 +207,12 @@ nat fastmcp server run --config_file examples/MCP/simple_calculator_fastmcp_prot
 
 ### Step 6: Run the MCP Calculator Client
 
+The client workflow also starts the `mcp_time` function group with `python -m mcp_server_time`. If you installed this example package, the dependency is included automatically. To verify it is available before running the workflow:
+
+```bash
+uv run --project examples/MCP/simple_calculator_fastmcp_protected --locked python -m mcp_server_time --help
+```
+
 Set the client ID and client secret from Step 3 in the environment variables:
 ```bash
 # Terminal 2

--- a/examples/MCP/simple_calculator_fastmcp_protected/configs/config-server.yml
+++ b/examples/MCP/simple_calculator_fastmcp_protected/configs/config-server.yml
@@ -33,10 +33,17 @@ general:
       # Keycloak issuer URL (required by the resource server config)
       issuer_url: http://localhost:8080/realms/master
 
+      # Keycloak discovery endpoint used to resolve JWKS for JWT access-token validation
+      discovery_url: http://localhost:8080/realms/master/.well-known/openid-configuration
+
       # Keycloak introspection endpoint
       introspection_endpoint: http://localhost:8080/realms/master/protocol/openid-connect/token/introspect
 
+      # Expected token audience for this resource server
+      audience: nat-mcp-resource-server
+
       # Client credentials used by the FastMCP server when calling the introspection endpoint
+      # For Keycloak, this client must also be present in the token audience. See the example README.
       client_id: ${NAT_CALCULATOR_RESOURCE_CLIENT_ID:-"nat-mcp-resource-server"}
       client_secret: ${NAT_CALCULATOR_RESOURCE_CLIENT_SECRET}
 

--- a/examples/MCP/simple_calculator_fastmcp_protected/pyproject.toml
+++ b/examples/MCP/simple_calculator_fastmcp_protected/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
   "nvidia-nat[langchain,mcp,test] == {version}",
   "nvidia-nat-fastmcp == {version}",
   "nat_simple_calculator",
+  "mcp-server-time~=2025.8",
 ]
 
 [tool.uv.sources]

--- a/examples/MCP/simple_calculator_fastmcp_protected/uv.lock
+++ b/examples/MCP/simple_calculator_fastmcp_protected/uv.lock
@@ -1795,6 +1795,21 @@ wheels = [
 ]
 
 [[package]]
+name = "mcp-server-time"
+version = "2025.9.25"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mcp" },
+    { name = "pydantic" },
+    { name = "tzdata" },
+    { name = "tzlocal" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/30/e2/08fa9615be0c91b86d0e972638169ae0769f217950c2ea4c5f3df1a144ff/mcp_server_time-2025.9.25.tar.gz", hash = "sha256:41427e33cafba09ef0e0f197a9dc33f2bc7238947fa319e0ec7d6500e2f97421", size = 30188, upload-time = "2025-09-25T21:25:57.066Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/81/9004bc19be15d6d5aae50f18500d865d21b0634064e78deffd8178e6a494/mcp_server_time-2025.9.25-py3-none-any.whl", hash = "sha256:5cc559709887db33bf77546c2efb0a9352c13870cc2bfaeffab1a6bd6390419b", size = 6567, upload-time = "2025-09-25T21:25:55.292Z" },
+]
+
+[[package]]
 name = "mdurl"
 version = "0.1.2"
 source = { registry = "https://pypi.org/simple" }

--- a/examples/MCP/simple_calculator_fastmcp_protected/uv.lock
+++ b/examples/MCP/simple_calculator_fastmcp_protected/uv.lock
@@ -1916,6 +1916,7 @@ requires-dist = [{ name = "nvidia-nat", extras = ["langchain", "test"], editable
 name = "nat-simple-calculator-fastmcp-protected"
 source = { editable = "." }
 dependencies = [
+    { name = "mcp-server-time" },
     { name = "nat-simple-calculator" },
     { name = "nvidia-nat", extra = ["langchain", "mcp", "test"] },
     { name = "nvidia-nat-fastmcp" },
@@ -1923,6 +1924,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "mcp-server-time", specifier = "~=2025.8" },
     { name = "nat-simple-calculator", editable = "../../getting_started/simple_calculator" },
     { name = "nvidia-nat", extras = ["langchain", "mcp", "test"], editable = "../../../" },
     { name = "nvidia-nat-fastmcp", editable = "../../../packages/nvidia_nat_fastmcp" },

--- a/packages/nvidia_nat_core/src/nat/authentication/credential_validator/bearer_token_validator.py
+++ b/packages/nvidia_nat_core/src/nat/authentication/credential_validator/bearer_token_validator.py
@@ -132,18 +132,12 @@ class BearerTokenValidator:
         if not token:
             return TokenValidationResult(client_id="", token_type="bearer", active=False)
 
-        introspection_endpoint = None
-        if self.client_id and self.client_secret:
-            try:
-                introspection_endpoint = await self._resolve_introspection_endpoint()
-            except _TOKEN_VALIDATION_ERRORS as error:
-                logger.warning("Failed to resolve token introspection endpoint: %s", error)
-        can_introspect = bool(introspection_endpoint)
         if token.count(".") == 2:
             try:
                 return await self._verify_jwt_token(token)
             except _TOKEN_VALIDATION_ERRORS as jwt_error:
-                if can_introspect:
+                introspection_endpoint = await self._resolve_introspection_endpoint_for_validation()
+                if introspection_endpoint:
                     logger.warning("JWT token validation failed; falling back to token introspection: %s", jwt_error)
                     try:
                         return await self._verify_opaque_token(token, introspection_endpoint=introspection_endpoint)
@@ -154,8 +148,9 @@ class BearerTokenValidator:
                     logger.warning("JWT token validation failed: %s", jwt_error)
                 return TokenValidationResult(client_id="", token_type="bearer", active=False)
 
+        introspection_endpoint = await self._resolve_introspection_endpoint_for_validation()
         try:
-            if can_introspect:
+            if introspection_endpoint:
                 return await self._verify_opaque_token(token, introspection_endpoint=introspection_endpoint)
         except _TOKEN_VALIDATION_ERRORS as error:
             logger.warning("Opaque token validation failed: %s", error)
@@ -339,6 +334,17 @@ class BearerTokenValidator:
         except (ValueError, TypeError, KeyError, httpx.HTTPError) as e:
             raise ValueError(f"Introspection failed: {e}") from e
 
+    async def _resolve_introspection_endpoint_for_validation(self) -> str | None:
+        """Resolve the introspection endpoint when credentials make introspection viable."""
+        if not (self.client_id and self.client_secret):
+            return None
+
+        try:
+            return await self._resolve_introspection_endpoint()
+        except _TOKEN_VALIDATION_ERRORS as error:
+            logger.warning("Failed to resolve token introspection endpoint: %s", error)
+            return None
+
     async def _resolve_introspection_endpoint(self) -> str | None:
         """Resolve the token introspection endpoint from config or discovery metadata."""
         if self.introspection_endpoint:
@@ -346,6 +352,8 @@ class BearerTokenValidator:
 
         if self.discovery_url:
             config = await self._get_oidc_configuration(self.discovery_url)
+            if not isinstance(config, Mapping):
+                return None
             endpoint = config.get("introspection_endpoint")
             if isinstance(endpoint, str) and endpoint:
                 self._require_https(endpoint, "introspection_endpoint")

--- a/packages/nvidia_nat_core/src/nat/authentication/credential_validator/bearer_token_validator.py
+++ b/packages/nvidia_nat_core/src/nat/authentication/credential_validator/bearer_token_validator.py
@@ -25,10 +25,12 @@ from authlib.integrations.httpx_client import AsyncOAuth2Client
 from authlib.jose import JsonWebKey
 from authlib.jose import KeySet
 from authlib.jose import jwt
+from authlib.jose.errors import JoseError
 
 from nat.data_models.authentication import TokenValidationResult
 
 logger = logging.getLogger(__name__)
+_TOKEN_VALIDATION_ERRORS = (ValueError, TypeError, KeyError, httpx.HTTPError, JoseError)
 
 
 class BearerTokenValidator:
@@ -130,16 +132,22 @@ class BearerTokenValidator:
         if not token:
             return TokenValidationResult(client_id="", token_type="bearer", active=False)
 
-        can_introspect = bool(self.introspection_endpoint and self.client_id and self.client_secret)
+        introspection_endpoint = None
+        if self.client_id and self.client_secret:
+            try:
+                introspection_endpoint = await self._resolve_introspection_endpoint()
+            except _TOKEN_VALIDATION_ERRORS as error:
+                logger.warning("Failed to resolve token introspection endpoint: %s", error)
+        can_introspect = bool(introspection_endpoint)
         if token.count(".") == 2:
             try:
                 return await self._verify_jwt_token(token)
-            except Exception as jwt_error:
+            except _TOKEN_VALIDATION_ERRORS as jwt_error:
                 if can_introspect:
                     logger.warning("JWT token validation failed; falling back to token introspection: %s", jwt_error)
                     try:
-                        return await self._verify_opaque_token(token)
-                    except Exception as introspection_error:
+                        return await self._verify_opaque_token(token, introspection_endpoint=introspection_endpoint)
+                    except _TOKEN_VALIDATION_ERRORS as introspection_error:
                         logger.warning("Bearer token validation failed after introspection fallback: %s",
                                        introspection_error)
                 else:
@@ -148,8 +156,8 @@ class BearerTokenValidator:
 
         try:
             if can_introspect:
-                return await self._verify_opaque_token(token)
-        except Exception as error:
+                return await self._verify_opaque_token(token, introspection_endpoint=introspection_endpoint)
+        except _TOKEN_VALIDATION_ERRORS as error:
             logger.warning("Opaque token validation failed: %s", error)
             return TokenValidationResult(client_id="", token_type="bearer", active=False)
 
@@ -229,11 +237,12 @@ class BearerTokenValidator:
             active=True,
         )
 
-    async def _verify_opaque_token(self, token: str) -> TokenValidationResult:
+    async def _verify_opaque_token(self, token: str, *, introspection_endpoint: str) -> TokenValidationResult:
         """Verify opaque token via RFC 7662 introspection.
 
         Args:
             token: Opaque token to verify
+            introspection_endpoint: OAuth 2.0 introspection URL
 
         Returns:
             TokenValidationResult
@@ -265,7 +274,7 @@ class BearerTokenValidator:
 
             async with AsyncOAuth2Client(**oauth_client_kwargs) as oauth_client:
                 introspection_response = self._coerce_introspection_response(await oauth_client.introspect_token(
-                    self.introspection_endpoint,
+                    introspection_endpoint,
                     token,
                     token_type_hint="access_token",
                 ))
@@ -329,6 +338,20 @@ class BearerTokenValidator:
 
         except (ValueError, TypeError, KeyError, httpx.HTTPError) as e:
             raise ValueError(f"Introspection failed: {e}") from e
+
+    async def _resolve_introspection_endpoint(self) -> str | None:
+        """Resolve the token introspection endpoint from config or discovery metadata."""
+        if self.introspection_endpoint:
+            return self.introspection_endpoint
+
+        if self.discovery_url:
+            config = await self._get_oidc_configuration(self.discovery_url)
+            endpoint = config.get("introspection_endpoint")
+            if isinstance(endpoint, str) and endpoint:
+                self._require_https(endpoint, "introspection_endpoint")
+                return endpoint
+
+        return None
 
     async def _resolve_jwks_uri(self) -> str:
         """Resolve JWKS URI using configuration priority: jwks_uri → discovery → issuer.

--- a/packages/nvidia_nat_core/src/nat/authentication/credential_validator/bearer_token_validator.py
+++ b/packages/nvidia_nat_core/src/nat/authentication/credential_validator/bearer_token_validator.py
@@ -16,6 +16,7 @@
 import json
 import logging
 import time
+from collections.abc import Mapping
 from typing import Any
 from urllib.parse import urlparse
 
@@ -44,6 +45,7 @@ class BearerTokenValidator:
         jwks_uri: str | None = None,
         client_id: str | None = None,
         client_secret: str | None = None,
+        client_auth_method: str | None = None,
         scopes: list[str] | None = None,
         timeout: float = 10.0,
         leeway: int = 60,
@@ -57,6 +59,7 @@ class BearerTokenValidator:
             jwks_uri: JWKS URL with public keys to verify asymmetric JWTs; optional if using discovery.
             client_id: OAuth 2.0 client ID for authenticating to the introspection endpoint.
             client_secret: OAuth 2.0 client secret for authenticating to the introspection endpoint.
+            client_auth_method: OAuth 2.0 client authentication method for introspection.
             scopes: Optional authorization scopes to check after validation; not required for token validity.
             timeout: HTTP request timeout for discovery/JWKS/introspection (default: 10.0s).
             leeway: Clock-skew allowance for `exp`/`nbf`/`iat` checks (default: 60s).
@@ -73,6 +76,7 @@ class BearerTokenValidator:
         self.timeout = timeout
         self.leeway = leeway
         self.discovery_url = discovery_url
+        self.client_auth_method = client_auth_method
 
         # Validate configuration
         self._validate_configuration()
@@ -126,19 +130,53 @@ class BearerTokenValidator:
         if not token:
             return TokenValidationResult(client_id="", token_type="bearer", active=False)
 
-        try:
-            if token.count(".") == 2:
+        can_introspect = bool(self.introspection_endpoint and self.client_id and self.client_secret)
+        if token.count(".") == 2:
+            try:
                 return await self._verify_jwt_token(token)
-            elif (self.introspection_endpoint and self.client_id and self.client_secret):
-                return await self._verify_opaque_token(token)
-            else:
+            except Exception as jwt_error:
+                if can_introspect:
+                    logger.warning("JWT token validation failed; falling back to token introspection: %s", jwt_error)
+                    try:
+                        return await self._verify_opaque_token(token)
+                    except Exception as introspection_error:
+                        logger.warning("Bearer token validation failed after introspection fallback: %s",
+                                       introspection_error)
+                else:
+                    logger.warning("JWT token validation failed: %s", jwt_error)
                 return TokenValidationResult(client_id="", token_type="bearer", active=False)
-        except Exception:
+
+        try:
+            if can_introspect:
+                return await self._verify_opaque_token(token)
+        except Exception as error:
+            logger.warning("Opaque token validation failed: %s", error)
             return TokenValidationResult(client_id="", token_type="bearer", active=False)
+
+        logger.warning("Bearer token validation failed: no validation path available for non-JWT token")
+        return TokenValidationResult(client_id="", token_type="bearer", active=False)
 
     def _is_jwt_token(self, token: str) -> bool:
         """Check if token has JWT structure."""
         return token.count(".") == 2
+
+    @staticmethod
+    def _coerce_introspection_response(response: Any) -> dict[str, Any]:
+        """Convert Authlib/httpx introspection responses to a claim dictionary."""
+        if isinstance(response, Mapping):
+            return dict(response)
+
+        raise_for_status = getattr(response, "raise_for_status", None)
+        if callable(raise_for_status):
+            raise_for_status()
+
+        json_fn = getattr(response, "json", None)
+        if callable(json_fn):
+            data = json_fn()
+            if isinstance(data, Mapping):
+                return dict(data)
+
+        raise ValueError(f"Invalid introspection response type: {type(response).__name__}")
 
     async def _verify_jwt_token(self, token: str) -> TokenValidationResult:
         """Verify JWT token.
@@ -217,16 +255,20 @@ class BearerTokenValidator:
                 del self._introspection_cache[cache_key]
 
         try:
-            async with AsyncOAuth2Client(
-                    client_id=self.client_id,
-                    client_secret=self.client_secret,
-                    timeout=httpx.Timeout(self.timeout),
-            ) as oauth_client:
-                introspection_response = await oauth_client.introspect_token(
+            oauth_client_kwargs = {
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "timeout": httpx.Timeout(self.timeout),
+            }
+            if self.client_auth_method:
+                oauth_client_kwargs["token_endpoint_auth_method"] = self.client_auth_method
+
+            async with AsyncOAuth2Client(**oauth_client_kwargs) as oauth_client:
+                introspection_response = self._coerce_introspection_response(await oauth_client.introspect_token(
                     self.introspection_endpoint,
                     token,
                     token_type_hint="access_token",
-                )
+                ))
 
                 # Check if token is active
                 if not introspection_response.get("active", False):

--- a/packages/nvidia_nat_core/tests/nat/authentication/test_bearer_token_validator.py
+++ b/packages/nvidia_nat_core/tests/nat/authentication/test_bearer_token_validator.py
@@ -141,10 +141,11 @@ class _MockAsyncHTTPClient:
 class _MockAsyncOAuth2Client:
 
     call_count = 0
-    response: dict[str, Any] = {}
+    response: dict[str, Any] | _MockHTTPResponse = {}
+    last_kwargs: dict[str, Any] = {}
 
     def __init__(self, *args, **kwargs):
-        pass
+        _MockAsyncOAuth2Client.last_kwargs = kwargs
 
     async def __aenter__(self):
         return self
@@ -182,6 +183,7 @@ def patch_httpx_and_oauth(monkeypatch, jwks_from_private):
 
     _MockAsyncOAuth2Client.call_count = 0
     _MockAsyncOAuth2Client.response = {}
+    _MockAsyncOAuth2Client.last_kwargs = {}
     yield
 
 
@@ -305,6 +307,54 @@ async def test_opaque_happy_path(validator_opaque):
     assert set(res.scopes or []) == set(SCOPES)
 
 
+async def test_opaque_accepts_response_object(validator_opaque):
+    now = int(time.time())
+    _MockAsyncOAuth2Client.response = _MockHTTPResponse({
+        "active": True,
+        "client_id": "client-abc",
+        "username": "alice",
+        "token_type": "access_token",
+        "exp": now + 600,
+        "aud": [AUDIENCE],
+        "iss": ISSUER,
+        "scope": "read write",
+    })
+
+    res = await validator_opaque.verify("opaque-response-object")
+
+    assert res.active is True
+    assert res.audience == [AUDIENCE]
+    assert set(res.scopes or []) == set(SCOPES)
+
+
+async def test_opaque_passes_client_auth_method():
+    validator = BearerTokenValidator(
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        scopes=SCOPES,
+        introspection_endpoint=f"{ISSUER}/introspect",
+        client_id="client-abc",
+        client_secret="secret-xyz",
+        client_auth_method="client_secret_post",
+        timeout=3.0,
+        leeway=30,
+    )
+    now = int(time.time())
+    _MockAsyncOAuth2Client.response = {
+        "active": True,
+        "client_id": "client-abc",
+        "exp": now + 600,
+        "aud": [AUDIENCE],
+        "iss": ISSUER,
+        "scope": "read write",
+    }
+
+    res = await validator.verify("opaque-secret-token")
+
+    assert res.active is True
+    assert _MockAsyncOAuth2Client.last_kwargs["token_endpoint_auth_method"] == "client_secret_post"
+
+
 async def test_opaque_missing_scope_rejected(validator_opaque):
     now = int(time.time())
     _MockAsyncOAuth2Client.response = {
@@ -343,6 +393,24 @@ async def test_routing_uses_jwt_when_three_segments(validator_both, rsa_private_
     jwt_token = _make_jwt(rsa_private_pem, exp_offset_secs=300, scopes=SCOPES)
     res = await validator_both.verify(jwt_token)
     assert res.active is True  # verified via JWKS/JWT path
+
+
+async def test_jwt_like_token_falls_back_to_introspection_when_configured(validator_both):
+    now = int(time.time())
+    _MockAsyncOAuth2Client.response = {
+        "active": True,
+        "client_id": "client-abc",
+        "token_type": "access_token",
+        "exp": now + 600,
+        "aud": [AUDIENCE],
+        "iss": ISSUER,
+        "scope": "read write",
+    }
+
+    res = await validator_both.verify("opaque.with.dots")
+
+    assert res.active is True
+    assert _MockAsyncOAuth2Client.call_count == 1
 
 
 async def test_routing_uses_opaque_when_non_jwt(validator_both):

--- a/packages/nvidia_nat_core/tests/nat/authentication/test_bearer_token_validator.py
+++ b/packages/nvidia_nat_core/tests/nat/authentication/test_bearer_token_validator.py
@@ -68,6 +68,7 @@ def jwks_from_private(rsa_private_pem: str) -> dict[str, Any]:
 ISSUER = "https://issuer.test"
 JWKS_URI = f"{ISSUER}/.well-known/jwks.json"
 DISCOVERY_URL = f"{ISSUER}/.well-known/openid-configuration"
+INTROSPECTION_ENDPOINT = f"{ISSUER}/introspect"
 AUDIENCE = "api://resource"
 SCOPES = ["read", "write"]
 
@@ -132,7 +133,7 @@ class _MockAsyncHTTPClient:
         jwks = kwargs.pop("_jwks_payload", None)
 
         if url == DISCOVERY_URL:
-            return _MockHTTPResponse({"jwks_uri": JWKS_URI})
+            return _MockHTTPResponse({"jwks_uri": JWKS_URI, "introspection_endpoint": INTROSPECTION_ENDPOINT})
         if url == JWKS_URI:
             return _MockHTTPResponse(jwks)
         return _MockHTTPResponse({"error": "not found"}, status=404)
@@ -143,6 +144,7 @@ class _MockAsyncOAuth2Client:
     call_count = 0
     response: dict[str, Any] | _MockHTTPResponse = {}
     last_kwargs: dict[str, Any] = {}
+    last_endpoint: str | None = None
 
     def __init__(self, *args, **kwargs):
         _MockAsyncOAuth2Client.last_kwargs = kwargs
@@ -155,6 +157,7 @@ class _MockAsyncOAuth2Client:
 
     async def introspect_token(self, endpoint: str, token: str, token_type_hint: str = "access_token"):
         _MockAsyncOAuth2Client.call_count += 1
+        _MockAsyncOAuth2Client.last_endpoint = endpoint
         return _MockAsyncOAuth2Client.response
 
 
@@ -184,6 +187,7 @@ def patch_httpx_and_oauth(monkeypatch, jwks_from_private):
     _MockAsyncOAuth2Client.call_count = 0
     _MockAsyncOAuth2Client.response = {}
     _MockAsyncOAuth2Client.last_kwargs = {}
+    _MockAsyncOAuth2Client.last_endpoint = None
     yield
 
 
@@ -218,7 +222,7 @@ def validator_opaque():
         issuer=ISSUER,
         audience=AUDIENCE,
         scopes=SCOPES,
-        introspection_endpoint=f"{ISSUER}/introspect",
+        introspection_endpoint=INTROSPECTION_ENDPOINT,
         client_id="client-abc",
         client_secret="secret-xyz",
         timeout=3.0,
@@ -233,7 +237,7 @@ def validator_both():
         audience=AUDIENCE,
         scopes=SCOPES,
         jwks_uri=JWKS_URI,
-        introspection_endpoint=f"{ISSUER}/introspect",
+        introspection_endpoint=INTROSPECTION_ENDPOINT,
         client_id="client-abc",
         client_secret="secret-xyz",
         timeout=3.0,
@@ -332,7 +336,7 @@ async def test_opaque_passes_client_auth_method():
         issuer=ISSUER,
         audience=AUDIENCE,
         scopes=SCOPES,
-        introspection_endpoint=f"{ISSUER}/introspect",
+        introspection_endpoint=INTROSPECTION_ENDPOINT,
         client_id="client-abc",
         client_secret="secret-xyz",
         client_auth_method="client_secret_post",
@@ -353,6 +357,33 @@ async def test_opaque_passes_client_auth_method():
 
     assert res.active is True
     assert _MockAsyncOAuth2Client.last_kwargs["token_endpoint_auth_method"] == "client_secret_post"
+
+
+async def test_opaque_uses_introspection_endpoint_from_discovery():
+    validator = BearerTokenValidator(
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        scopes=SCOPES,
+        discovery_url=DISCOVERY_URL,
+        client_id="client-abc",
+        client_secret="secret-xyz",
+        timeout=3.0,
+        leeway=30,
+    )
+    now = int(time.time())
+    _MockAsyncOAuth2Client.response = {
+        "active": True,
+        "client_id": "client-abc",
+        "exp": now + 600,
+        "aud": [AUDIENCE],
+        "iss": ISSUER,
+        "scope": "read write",
+    }
+
+    res = await validator.verify("opaque-from-discovery")
+
+    assert res.active is True
+    assert _MockAsyncOAuth2Client.last_endpoint == INTROSPECTION_ENDPOINT
 
 
 async def test_opaque_missing_scope_rejected(validator_opaque):

--- a/packages/nvidia_nat_core/tests/nat/authentication/test_bearer_token_validator.py
+++ b/packages/nvidia_nat_core/tests/nat/authentication/test_bearer_token_validator.py
@@ -119,6 +119,8 @@ class _MockHTTPResponse:
 
 class _MockAsyncHTTPClient:
 
+    discovery_response: Any = {"jwks_uri": JWKS_URI, "introspection_endpoint": INTROSPECTION_ENDPOINT}
+
     def __init__(self, *args, **kwargs):
         self._closed = False
 
@@ -133,7 +135,7 @@ class _MockAsyncHTTPClient:
         jwks = kwargs.pop("_jwks_payload", None)
 
         if url == DISCOVERY_URL:
-            return _MockHTTPResponse({"jwks_uri": JWKS_URI, "introspection_endpoint": INTROSPECTION_ENDPOINT})
+            return _MockHTTPResponse(_MockAsyncHTTPClient.discovery_response)
         if url == JWKS_URI:
             return _MockHTTPResponse(jwks)
         return _MockHTTPResponse({"error": "not found"}, status=404)
@@ -188,6 +190,7 @@ def patch_httpx_and_oauth(monkeypatch, jwks_from_private):
     _MockAsyncOAuth2Client.response = {}
     _MockAsyncOAuth2Client.last_kwargs = {}
     _MockAsyncOAuth2Client.last_endpoint = None
+    _MockAsyncHTTPClient.discovery_response = {"jwks_uri": JWKS_URI, "introspection_endpoint": INTROSPECTION_ENDPOINT}
     yield
 
 
@@ -386,6 +389,25 @@ async def test_opaque_uses_introspection_endpoint_from_discovery():
     assert _MockAsyncOAuth2Client.last_endpoint == INTROSPECTION_ENDPOINT
 
 
+async def test_opaque_with_non_mapping_discovery_metadata_returns_inactive():
+    validator = BearerTokenValidator(
+        issuer=ISSUER,
+        audience=AUDIENCE,
+        scopes=SCOPES,
+        discovery_url=DISCOVERY_URL,
+        client_id="client-abc",
+        client_secret="secret-xyz",
+        timeout=3.0,
+        leeway=30,
+    )
+    _MockAsyncHTTPClient.discovery_response = ["not", "a", "mapping"]
+
+    res = await validator.verify("opaque-from-invalid-discovery")
+
+    assert res.active is False
+    assert _MockAsyncOAuth2Client.call_count == 0
+
+
 async def test_opaque_missing_scope_rejected(validator_opaque):
     now = int(time.time())
     _MockAsyncOAuth2Client.response = {
@@ -424,6 +446,19 @@ async def test_routing_uses_jwt_when_three_segments(validator_both, rsa_private_
     jwt_token = _make_jwt(rsa_private_pem, exp_offset_secs=300, scopes=SCOPES)
     res = await validator_both.verify(jwt_token)
     assert res.active is True  # verified via JWKS/JWT path
+
+
+async def test_routing_valid_jwt_does_not_resolve_introspection(validator_both, rsa_private_pem, monkeypatch):
+
+    async def fail_if_called():
+        raise AssertionError("introspection endpoint resolution should be lazy for valid JWTs")
+
+    monkeypatch.setattr(validator_both, "_resolve_introspection_endpoint_for_validation", fail_if_called)
+
+    jwt_token = _make_jwt(rsa_private_pem, exp_offset_secs=300, scopes=SCOPES)
+    res = await validator_both.verify(jwt_token)
+
+    assert res.active is True
 
 
 async def test_jwt_like_token_falls_back_to_introspection_when_configured(validator_both):

--- a/packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/front_end_plugin_worker.py
+++ b/packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/front_end_plugin_worker.py
@@ -298,21 +298,13 @@ class FastMCPFrontEndPluginWorker(FastMCPFrontEndPluginWorkerBase):
         server_auth = self.front_end_config.server_auth
         if server_auth:
             from fastmcp.server.auth import RemoteAuthProvider
-            from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
+            from nat.plugins.fastmcp.server.token_verifier import NATFastMCPTokenVerifier
 
-            verifier_kwargs = {
-                "introspection_url": server_auth.introspection_endpoint,
-                "client_id": server_auth.client_id,
-                "client_secret": (server_auth.client_secret.get_secret_value() if server_auth.client_secret else None),
-                "required_scopes": server_auth.scopes,
-            }
-            if server_auth.client_auth_method:
-                verifier_kwargs["client_auth_method"] = server_auth.client_auth_method
-            verifier = IntrospectionTokenVerifier(**verifier_kwargs)
             host = self.front_end_config.host
             if host in {"0.0.0.0", "::"}:
                 host = "localhost"
             base_url = f"http://{host}:{self.front_end_config.port}"
+            verifier = NATFastMCPTokenVerifier(server_auth, base_url=base_url)
             auth_provider = RemoteAuthProvider(
                 token_verifier=verifier,
                 authorization_servers=[server_auth.issuer_url],

--- a/packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/token_verifier.py
+++ b/packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/token_verifier.py
@@ -1,0 +1,64 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""FastMCP token verifier backed by NAT's OAuth2 resource-server validator."""
+
+from fastmcp.server.auth import AccessToken
+from fastmcp.server.auth import TokenVerifier
+from nat.authentication.credential_validator.bearer_token_validator import BearerTokenValidator
+from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
+
+
+class NATFastMCPTokenVerifier(TokenVerifier):
+    """FastMCP token verifier that delegates validation to BearerTokenValidator."""
+
+    def __init__(self, config: OAuth2ResourceServerConfig, *, base_url: str):
+        super().__init__(base_url=base_url, required_scopes=config.scopes or [])
+        self._bearer_token_validator = BearerTokenValidator(
+            issuer=config.issuer_url,
+            audience=config.audience,
+            scopes=config.scopes,
+            jwks_uri=config.jwks_uri,
+            introspection_endpoint=config.introspection_endpoint,
+            discovery_url=config.discovery_url,
+            client_id=config.client_id,
+            client_secret=config.client_secret.get_secret_value() if config.client_secret else None,
+            client_auth_method=config.client_auth_method,
+        )
+
+    async def verify_token(self, token: str) -> AccessToken | None:
+        """Verify a bearer token and adapt the result to FastMCP's access-token model."""
+        validation_result = await self._bearer_token_validator.verify(token)
+        if not validation_result.active:
+            return None
+
+        claims = {
+            "aud": validation_result.audience,
+            "sub": validation_result.subject,
+            "iss": validation_result.issuer,
+            "jti": validation_result.jti,
+            "username": validation_result.username,
+            "token_type": validation_result.token_type,
+            "iat": validation_result.iat,
+            "nbf": validation_result.nbf,
+        }
+        claims = {key: value for key, value in claims.items() if value is not None}
+
+        return AccessToken(
+            token=token,
+            client_id=validation_result.client_id or "",
+            scopes=validation_result.scopes or [],
+            expires_at=validation_result.expires_at,
+            claims=claims,
+        )

--- a/packages/nvidia_nat_fastmcp/tests/test_fastmcp.py
+++ b/packages/nvidia_nat_fastmcp/tests/test_fastmcp.py
@@ -192,17 +192,16 @@ async def test_fastmcp_nat_token_verifier_adapts_active_result(monkeypatch: pyte
         scopes=["calculator_mcp_execute"],
     )
     verifier = NATFastMCPTokenVerifier(server_auth, base_url="http://localhost:9902")
-    verify = AsyncMock(
-        return_value=TokenValidationResult(
-            client_id="client-abc",
-            scopes=["calculator_mcp_execute"],
-            expires_at=1234567890,
-            audience=["test-client"],
-            subject="user-123",
-            issuer="http://localhost:8080/realms/master",
-            token_type="at+jwt",
-            active=True,
-        ))
+    verify = AsyncMock(return_value=TokenValidationResult(
+        client_id="client-abc",
+        scopes=["calculator_mcp_execute"],
+        expires_at=1234567890,
+        audience=["test-client"],
+        subject="user-123",
+        issuer="http://localhost:8080/realms/master",
+        token_type="at+jwt",
+        active=True,
+    ))
     monkeypatch.setattr(verifier._bearer_token_validator, "verify", verify)
 
     access_token = await verifier.verify_token("token-value")

--- a/packages/nvidia_nat_fastmcp/tests/test_fastmcp.py
+++ b/packages/nvidia_nat_fastmcp/tests/test_fastmcp.py
@@ -15,11 +15,11 @@
 """Tests for FastMCP CLI and server wiring."""
 
 from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from fastmcp import FastMCP
 from fastmcp.server.auth import RemoteAuthProvider
-from fastmcp.server.auth.providers.introspection import IntrospectionTokenVerifier
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import SecretStr
@@ -28,6 +28,7 @@ from watchfiles import Change
 
 from nat.authentication.oauth2.oauth2_resource_server_config import OAuth2ResourceServerConfig
 from nat.builder.function_base import FunctionBase
+from nat.data_models.authentication import TokenValidationResult
 from nat.data_models.config import Config
 from nat.data_models.config import GeneralConfig
 from nat.plugins.fastmcp.cli.commands import fastmcp_command  # pylint: disable=import-error,no-name-in-module
@@ -35,6 +36,7 @@ from nat.plugins.fastmcp.cli.utils import _filter_change_set
 from nat.plugins.fastmcp.cli.utils import iter_file_changes
 from nat.plugins.fastmcp.server.front_end_config import FastMCPFrontEndConfig
 from nat.plugins.fastmcp.server.front_end_plugin_worker import FastMCPFrontEndPluginWorker
+from nat.plugins.fastmcp.server.token_verifier import NATFastMCPTokenVerifier
 
 
 class _MockTestSchema(BaseModel):
@@ -175,10 +177,56 @@ async def test_fastmcp_auth_introspection_exposes_metadata():
     mcp = await worker.create_mcp_server()
 
     assert isinstance(mcp.auth, RemoteAuthProvider)
-    assert isinstance(mcp.auth.token_verifier, IntrospectionTokenVerifier)
+    assert isinstance(mcp.auth.token_verifier, NATFastMCPTokenVerifier)
 
     routes = mcp.auth.get_well_known_routes(mcp_path="/mcp")
     assert any(route.path.startswith("/.well-known/oauth-protected-resource") for route in routes)
+
+
+async def test_fastmcp_nat_token_verifier_adapts_active_result(monkeypatch: pytest.MonkeyPatch):
+    server_auth = OAuth2ResourceServerConfig(
+        issuer_url="http://localhost:8080/realms/master",
+        introspection_endpoint="http://localhost:8080/realms/master/protocol/openid-connect/token/introspect",
+        client_id="test-client",
+        client_secret=SecretStr("secret"),
+        scopes=["calculator_mcp_execute"],
+    )
+    verifier = NATFastMCPTokenVerifier(server_auth, base_url="http://localhost:9902")
+    verify = AsyncMock(
+        return_value=TokenValidationResult(
+            client_id="client-abc",
+            scopes=["calculator_mcp_execute"],
+            expires_at=1234567890,
+            audience=["test-client"],
+            subject="user-123",
+            issuer="http://localhost:8080/realms/master",
+            token_type="at+jwt",
+            active=True,
+        ))
+    monkeypatch.setattr(verifier._bearer_token_validator, "verify", verify)
+
+    access_token = await verifier.verify_token("token-value")
+
+    assert access_token is not None
+    assert access_token.client_id == "client-abc"
+    assert access_token.scopes == ["calculator_mcp_execute"]
+    assert access_token.expires_at == 1234567890
+    assert access_token.claims["aud"] == ["test-client"]
+
+
+async def test_fastmcp_nat_token_verifier_rejects_inactive_result(monkeypatch: pytest.MonkeyPatch):
+    server_auth = OAuth2ResourceServerConfig(
+        issuer_url="http://localhost:8080/realms/master",
+        introspection_endpoint="http://localhost:8080/realms/master/protocol/openid-connect/token/introspect",
+        client_id="test-client",
+        client_secret=SecretStr("secret"),
+        scopes=["calculator_mcp_execute"],
+    )
+    verifier = NATFastMCPTokenVerifier(server_auth, base_url="http://localhost:9902")
+    verify = AsyncMock(return_value=TokenValidationResult(client_id="", token_type="bearer", active=False))
+    monkeypatch.setattr(verifier._bearer_token_validator, "verify", verify)
+
+    assert await verifier.verify_token("token-value") is None
 
 
 def test_fastmcp_debug_route_lists_tools():

--- a/uv.lock
+++ b/uv.lock
@@ -6039,6 +6039,7 @@ requires-dist = [
 name = "nat-simple-calculator-fastmcp-protected"
 source = { editable = "examples/MCP/simple_calculator_fastmcp_protected" }
 dependencies = [
+    { name = "mcp-server-time" },
     { name = "nat-simple-calculator" },
     { name = "nvidia-nat", extra = ["langchain", "mcp", "test"] },
     { name = "nvidia-nat-fastmcp" },
@@ -6046,6 +6047,7 @@ dependencies = [
 
 [package.metadata]
 requires-dist = [
+    { name = "mcp-server-time", specifier = "~=2025.8" },
     { name = "nat-simple-calculator", editable = "examples/getting_started/simple_calculator" },
     { name = "nvidia-nat", extras = ["langchain", "mcp", "test"], editable = "." },
     { name = "nvidia-nat-fastmcp", editable = "packages/nvidia_nat_fastmcp" },


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Fixes the protected FastMCP server OAuth path used by `simple_calculator_fastmcp_protected`.

The FastMCP server now validates bearer tokens through the toolkit `BearerTokenValidator` instead of the FastMCP introspection-only verifier, so `server_auth` consistently honors issuer, audience, discovery/JWKS, introspection, scopes, and client auth method settings.

Also updates the protected FastMCP example so it works e2e with Keycloak:
- Adds discovery URL and expected audience to the server config.
- Documents the required Keycloak audience mapper.
- Adds the missing `mcp-server-time` dependency used by the client workflow.
- Covers JWT fallback/introspection response handling and the FastMCP adapter with focused tests.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OAuth2 bearer token handling: prefer JWT (JWKS/discovery) validation, with optional introspection fallback and explicit audience support; server-side verifier updated to use this flow.

* **Documentation**
  * Expanded FastMCP OAuth2 docs and protected example README with Keycloak audience-mapper guidance, discovery/audience config examples, and troubleshooting for audience-mismatch errors.

* **Chores**
  * Updated example dependency to include a newer mcp-server-time release.

* **Tests**
  * Added/expanded tests for JWT vs opaque-token routing, introspection behaviors, and verifier adaptations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->