### PR TITLE
fix(hitl): improve por_to_jiratickets example

### DIFF
--- a/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/configs/config.yml
+++ b/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/configs/config.yml
@@ -53,13 +53,13 @@ llms:
     model_name: meta/llama-3.3-70b-instruct
     temperature: 0.0
     seed: 33
-    max_tokens: 2000
+    max_tokens: 4096
   agent_llm:
     _type: nim
     model_name: meta/llama-3.3-70b-instruct
     temperature: 0.0
     seed: 33
-    max_tokens: 2000
+    max_tokens: 4096
 
 workflow:
   _type: react_agent

--- a/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/extract_por_tool.py
+++ b/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/extract_por_tool.py
@@ -148,7 +148,10 @@ async def extract_from_por_tool(config: ExtractPORToolConfig, builder: Builder):
         # Remove any stale extraction output so a failed run can't pollute the next tool calls
         stale_file: str = os.path.join(config.root_path, "epics_tasks.json")
         if os.path.isfile(stale_file):
-            os.remove(stale_file)
+            try:
+                os.remove(stale_file)
+            except OSError as e:
+                logger.warning("Could not remove stale file %s: %s", stale_file, e)
 
         input_file = os.path.join(config.root_path, input_text)
         if os.path.isfile(input_file):
@@ -195,7 +198,7 @@ async def show_tickets_tool(config: ShowTicketsToolConfig, builder: Builder):
     """
     Return a string listing the epics from the last extraction.
     """
-    filename = config.root_path + "epics_tasks.json"
+    filename = os.path.join(config.root_path, "epics_tasks.json")
 
     async def _arun(input_text: str) -> str:
         # input_text = process_input_text(input_text)

--- a/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/extract_por_tool.py
+++ b/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/extract_por_tool.py
@@ -18,6 +18,8 @@ import logging
 import os
 import re
 
+from pydantic import Field
+
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
@@ -119,8 +121,8 @@ def process_input_text(input_text):
 
 
 class ExtractPORToolConfig(FunctionBaseConfig, name="extract_por_tool"):
-    root_path: str
-    llm: LLMRef
+    root_path: str = Field(..., min_length=1, description="Directory containing POR input files and extraction output")
+    llm: LLMRef = Field(..., description="LLM used to extract epics, tasks, bugs, and features from the POR")
 
 
 @register_function(config_type=ExtractPORToolConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
@@ -142,6 +144,11 @@ async def extract_from_por_tool(config: ExtractPORToolConfig, builder: Builder):
     chain = prompt | llm | StrOutputParser()
 
     async def _arun(input_text: str) -> str:
+
+        # Remove any stale extraction output so a failed run can't pollute the next tool calls
+        stale_file: str = os.path.join(config.root_path, "epics_tasks.json")
+        if os.path.isfile(stale_file):
+            os.remove(stale_file)
 
         input_file = os.path.join(config.root_path, input_text)
         if os.path.isfile(input_file):
@@ -180,7 +187,7 @@ async def extract_from_por_tool(config: ExtractPORToolConfig, builder: Builder):
 
 
 class ShowTicketsToolConfig(FunctionBaseConfig, name="show_jira_tickets"):
-    root_path: str
+    root_path: str = Field(..., min_length=1, description="Directory containing the epics_tasks.json extraction output")
 
 
 @register_function(config_type=ShowTicketsToolConfig)
@@ -196,6 +203,8 @@ async def show_tickets_tool(config: ShowTicketsToolConfig, builder: Builder):
             with open(filename, encoding='utf-8') as json_file:
                 data = json.load(json_file)
                 logger.debug("Data successfully loaded from %s", filename)
+        except FileNotFoundError:
+            return "No extraction data found. Please run extract_por_tool first."
         except Exception as e:
             logger.error("An error occurred while loading the file: %s", e)
             raise

--- a/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/hitl_approval_tool.py
+++ b/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/hitl_approval_tool.py
@@ -62,7 +62,7 @@ async def hitl_approval_function(config: HITLApprovalFnConfig, builder: Builder)
                                             error="Approval window has expired.")
         response: InteractionResponse = await user_input_manager.prompt_user_input(human_prompt_text)
         response_str = response.content.text.lower()  # type: ignore
-        selected_option = re.search(r'\b(yes)\b', response_str)
+        selected_option = re.search(r'\b(yes|y)\b', response_str)
 
         if selected_option:
             return True

--- a/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/jira_tickets_tool.py
+++ b/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/jira_tickets_tool.py
@@ -20,7 +20,6 @@ import os
 import re
 
 import httpx
-import requests
 from pydantic import Field
 from pydantic import model_validator
 
@@ -254,14 +253,18 @@ def process_input_text(input_text):
     return input_text
 
 
-def _validate_jira_credentials() -> str | None:
+def _validate_jira_credentials(require_userid: bool = True) -> str | None:
     """Return an error message if required Jira environment variables are missing, else None.
+
+    Args:
+        require_userid: When True, also checks for JIRA_USERID (needed for Basic auth).
+            Set to False for Bearer-auth-only paths that only need JIRA_TOKEN.
 
     Returns:
         A human-readable error string listing missing env vars, or None if all present.
     """
     missing: list[str] = []
-    if not os.getenv("JIRA_USERID"):
+    if require_userid and not os.getenv("JIRA_USERID"):
         missing.append("JIRA_USERID")
     if not os.getenv("JIRA_TOKEN"):
         missing.append("JIRA_TOKEN")
@@ -380,11 +383,12 @@ async def get_jira_tickets_tool(config: GetJiraToolConfig, builder: Builder):
     }
 
     async def _arun(input_text: str) -> str:
-        cred_error: str | None = _validate_jira_credentials()
+        cred_error: str | None = _validate_jira_credentials(require_userid=False)
         if cred_error:
             return cred_error
 
-        response = requests.get(api_endpoint, headers=headers, params=query_params, timeout=30)
+        async with httpx.AsyncClient() as client:
+            response = await client.get(api_endpoint, headers=headers, params=query_params, timeout=30)
 
         if response.status_code != 200:
             return f"Failed to fetch Jira tickets: HTTP {response.status_code} — {response.text[:200]}"

--- a/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/jira_tickets_tool.py
+++ b/examples/HITL/por_to_jiratickets/src/nat_por_to_jiratickets/jira_tickets_tool.py
@@ -21,6 +21,8 @@ import re
 
 import httpx
 import requests
+from pydantic import Field
+from pydantic import model_validator
 
 from nat.builder.builder import Builder
 from nat.builder.function_info import FunctionInfo
@@ -252,13 +254,37 @@ def process_input_text(input_text):
     return input_text
 
 
+def _validate_jira_credentials() -> str | None:
+    """Return an error message if required Jira environment variables are missing, else None.
+
+    Returns:
+        A human-readable error string listing missing env vars, or None if all present.
+    """
+    missing: list[str] = []
+    if not os.getenv("JIRA_USERID"):
+        missing.append("JIRA_USERID")
+    if not os.getenv("JIRA_TOKEN"):
+        missing.append("JIRA_TOKEN")
+    if missing:
+        return f"Missing Jira credentials: {', '.join(missing)}. Set them in .env."
+    return None
+
+
 class CreateJiraToolConfig(FunctionBaseConfig, name="create_jira_tickets_tool"):
-    root_path: str
-    jira_domain: str
-    jira_project_key: str
-    timeout: float
-    connect: float
-    hitl_approval_fn: FunctionRef
+    root_path: str = Field(...,
+                           min_length=1,
+                           description="Directory for reading extracted JSON and writing ticket results")
+    jira_domain: str = Field(..., min_length=1, description="Jira instance base URL (e.g. https://jirasw.nvidia.com)")
+    jira_project_key: str = Field(..., min_length=1, description="Jira project key to create tickets in (e.g. NAT)")
+    timeout: float = Field(..., gt=0, description="Total HTTP request timeout in seconds")
+    connect: float = Field(..., gt=0, description="HTTP connection timeout in seconds")
+    hitl_approval_fn: FunctionRef = Field(..., description="HITL approval function to call before creating tickets")
+
+    @model_validator(mode="after")
+    def validate_connect_le_timeout(self) -> "CreateJiraToolConfig":
+        if self.connect > self.timeout:
+            raise ValueError(f"connect timeout ({self.connect}s) must not exceed total timeout ({self.timeout}s)")
+        return self
 
 
 @register_function(config_type=CreateJiraToolConfig)
@@ -267,6 +293,10 @@ async def create_jira_tickets_tool(config: CreateJiraToolConfig, builder: Builde
     hitl_approval_fn = await builder.get_function(config.hitl_approval_fn)
 
     async def _arun(input_text: str) -> str:
+
+        config_error: str | None = _validate_jira_credentials()
+        if config_error:
+            return config_error
 
         # Get user confirmation first
         try:
@@ -284,6 +314,8 @@ async def create_jira_tickets_tool(config: CreateJiraToolConfig, builder: Builde
         logger.debug("Creating %s in Jira", input_text)
         # input_text = process_input_text(input_text)
         jira_issues = get_epics_tool(config.root_path)
+        if jira_issues is None:
+            return "Could not load extracted data. Please run extract_por_tool first."
         logger.debug("Creating %s in Jira", input_text)
         jira = JiraTool(domain=config.jira_domain, project_key=config.jira_project_key, ticket_type=input_text)
         timeout_config = httpx.Timeout(config.timeout, connect=config.connect)
@@ -307,7 +339,11 @@ async def create_jira_tickets_tool(config: CreateJiraToolConfig, builder: Builde
                 results = await asyncio.gather(*tickets)
 
         for _, result in enumerate(results, start=1):
-            lines.append(f"- **{result[0]}**: {config.jira_domain + '/browse/' + str(result[0])}")
+            if isinstance(result, dict) and "error" in result:
+                detail: str = result.get("details") or result.get("message", "")
+                lines.append(f"- ERROR: {result['error']} — {detail}")
+            else:
+                lines.append(f"- **{result[0]}**: {config.jira_domain + '/browse/' + str(result[0])}")
 
         output_file = config.root_path + str(input_text) + "_data.json"
         with open(output_file, "w", encoding='utf-8') as json_file:
@@ -323,9 +359,9 @@ async def create_jira_tickets_tool(config: CreateJiraToolConfig, builder: Builde
 
 
 class GetJiraToolConfig(FunctionBaseConfig, name="get_jira_tickets_tool"):
-    root_path: str
-    jira_domain: str
-    jira_project_key: str
+    root_path: str = Field(..., min_length=1, description="Directory to write the fetched Jira tickets JSON")
+    jira_domain: str = Field(..., min_length=1, description="Jira instance base URL (e.g. https://jirasw.nvidia.com)")
+    jira_project_key: str = Field(..., min_length=1, description="Jira project key to query tickets from (e.g. NAT)")
 
 
 @register_function(config_type=GetJiraToolConfig)
@@ -344,38 +380,44 @@ async def get_jira_tickets_tool(config: GetJiraToolConfig, builder: Builder):
     }
 
     async def _arun(input_text: str) -> str:
+        cred_error: str | None = _validate_jira_credentials()
+        if cred_error:
+            return cred_error
+
         response = requests.get(api_endpoint, headers=headers, params=query_params, timeout=30)
 
-        if response.status_code == 200:
-            data = response.json()["issues"]
-            result = {"tasks": [], "epics": [], "new_features": [], "bugs": []}
+        if response.status_code != 200:
+            return f"Failed to fetch Jira tickets: HTTP {response.status_code} — {response.text[:200]}"
 
-            # Map JIRA issue types to categories in the result dictionary
-            issue_type_mapping = {
-                "Task": "tasks",
-                "Epic": "epics",
-                "New Feature": "new_features",
-                "Bug": "bugs",
+        data = response.json()["issues"]
+        result = {"tasks": [], "epics": [], "new_features": [], "bugs": []}
+
+        # Map JIRA issue types to categories in the result dictionary
+        issue_type_mapping = {
+            "Task": "tasks",
+            "Epic": "epics",
+            "New Feature": "new_features",
+            "Bug": "bugs",
+        }
+
+        for issue in data:
+            issue_type = issue["fields"]["issuetype"]["name"]
+            category = issue_type_mapping.get(issue_type, "tasks")
+            formatted_issue = {
+                "title": issue["fields"]["summary"],
+                "epic": issue["fields"].get("epic", "None"),
+                "priority": issue["fields"]["priority"]["name"] if issue["fields"].get("priority") else "None",
+                "storypoints": issue["fields"].get("customfield_10016", "None"),
+                "description": issue["fields"].get("description", "None"),
             }
 
-            for issue in data:
-                issue_type = issue["fields"]["issuetype"]["name"]
-                category = issue_type_mapping.get(issue_type, "tasks")
-                formatted_issue = {
-                    "title": issue["fields"]["summary"],
-                    "epic": issue["fields"].get("epic", "None"),
-                    "priority": issue["fields"]["priority"]["name"] if issue["fields"].get("priority") else "None",
-                    "storypoints": issue["fields"].get("customfield_10016", "None"),
-                    "description": issue["fields"].get("description", "None"),
-                }
+            result[category].append(formatted_issue)
 
-                result[category].append(formatted_issue)
+        # Save the result to a JSON file
+        with open(config.root_path + "jira_tickets.json", "w", encoding='utf-8') as json_file:
+            json.dump(result, json_file, indent=4)
 
-            # Save the result to a JSON file
-            with open(config.root_path + "jira_tickets.json", "w", encoding='utf-8') as json_file:
-                json.dump(result, json_file, indent=4)
-
-            return "JIRA issues have been successfully saved to jira_tickets.json"
+        return "JIRA issues have been successfully saved to jira_tickets.json"
 
     yield FunctionInfo.from_fn(
         _arun,

--- a/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
@@ -82,7 +82,8 @@ async def prompt_for_input_cli(question: InteractionPrompt) -> HumanResponse:
             ready, _, _ = select.select([sys.stdin], [], [], 1)
             if ready:
                 user_response: str = sys.stdin.readline().strip()
-                return HumanResponseText(text=user_response)
+                if user_response:
+                    return HumanResponseText(text=user_response)
             remaining -= 1
             # Save cursor position, update countdown line, restore cursor position
             sys.stdout.write(f"\033[s\033[A\r[{remaining}s remaining]\033[K\033[u")


### PR DESCRIPTION
Updates the por_to_jiratickets HITL example to correctly block on user input, handle missing credentials and extraction state gracefully, and require users to supply their own Jira configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for missing extraction files and failed operations
  * Removed stale extraction outputs before runs
  * Added clearer Jira failure messages (including HTTP status details) and per-issue error rendering
  * Fixed input handling to require non-empty responses

* **Improvements**
  * Increased LLM token limits for larger processing
  * Expanded approval input to accept "yes" or "y"
  * Strengthened validation and constraints for tool configuration inputs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->