### PR TITLE
fix: improve Dynamo latency demo startup reliability

### DIFF
--- a/examples/dynamo_integration/latency_sensitivity_demo/README.md
+++ b/examples/dynamo_integration/latency_sensitivity_demo/README.md
@@ -251,8 +251,9 @@ source .venv/bin/activate
 bash dynamo_stack_sensitivity.sh
 ```
 
-The sensitivity stack uses the same overrideable GPU, tensor-parallel, and NCCL startup defaults as the
-baseline stack.
+The sensitivity stack uses the same GPU, tensor-parallel, and NCCL startup defaults as the baseline
+stack. Set the same environment variables before running the script if your environment requires
+different values.
 
 Verify the endpoint is responding:
 

--- a/examples/dynamo_integration/latency_sensitivity_demo/README.md
+++ b/examples/dynamo_integration/latency_sensitivity_demo/README.md
@@ -137,20 +137,34 @@ source .venv/bin/activate
 bash dynamo_stack.sh
 ```
 
+The stack script defaults to a local two-GPU setup with `CUDA_VISIBLE_DEVICES=0,1` and `TP_SIZE=2`.
+It also uses single-node NCCL startup defaults (`NCCL_NET_PLUGIN=none`, `NCCL_IB_DISABLE=1`) so local
+validation does not load host-specific network plugins or use RDMA/InfiniBand by default. Override these
+values before running the script if your machine requires a different GPU list, tensor-parallel size, or
+RDMA/InfiniBand configuration.
+The script waits for the model to appear in `/v1/models` and exits with a pointer to
+`/tmp/dynamo-stack/all.log` if the worker dies or startup times out.
+
 #### D. Verify
 
-From this terminal, verify you can reach the Dynamo endpoint assuming your port for inference is 8099 and available
-on localhost:
+From another terminal, verify the Dynamo endpoint has registered the served model:
+
+```bash
+curl -s http://localhost:8099/v1/models | python3 -m json.tool
+```
+
+Then send a test request:
 
 ```bash
 curl http://localhost:8099/v1/chat/completions \
   -H "Content-Type: application/json" \
   -d '{
-    "model": "YOUR_MODEL_NAME",
+    "model": "nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16",
     "messages": [{"role": "user", "content": "Hello!"}],
     "max_tokens": 64
   }'
 ```
+
 ### Step 1b: Run the Profiler to Build the Prediction Trie
 
 ```bash
@@ -236,6 +250,9 @@ cd "$DYNAMO_SOURCE_DIR"
 source .venv/bin/activate
 bash dynamo_stack_sensitivity.sh
 ```
+
+The sensitivity stack uses the same overrideable GPU, tensor-parallel, and NCCL startup defaults as the
+baseline stack.
 
 Verify the endpoint is responding:
 

--- a/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/scripts/dynamo_stack.sh
+++ b/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/scripts/dynamo_stack.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Nemotron 3 Nano on 2 GPUs with Dynamo frontend, HiCache, and PIN.
+# Nemotron 3 Nano on 2 GPUs with a Dynamo frontend and SGLang worker.
 # Edit the config below, then: bash dynamo_stack.sh
 # Ctrl+C to stop. Logs in /tmp/dynamo-stack/
 #
@@ -28,17 +28,25 @@ set -euo pipefail
 
 # ── Config ───────────────────────────────────────────────────────────────────
 MODEL="nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
-PAGE_SIZE=64
-HICACHE_RATIO=1.0
-HICACHE_POLICY=write_through
 CONTEXT_LENGTH=262144
 MEM_FRACTION=0.7
+HTTP_PORT="${HTTP_PORT:-8099}"
+TP_SIZE="${TP_SIZE:-2}"
+CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1}"
+STARTUP_TIMEOUT_SECONDS="${STARTUP_TIMEOUT_SECONDS:-1800}"
+
+# This demo runs a local two-GPU stack. Avoid loading host-specific NCCL network
+# plugins unless the user explicitly opts into them for their environment.
+NCCL_NET_PLUGIN="${NCCL_NET_PLUGIN:-none}"
+NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-1}"
+NCCL_DEBUG="${NCCL_DEBUG:-WARN}"
 
 LOG_DIR="/tmp/dynamo-stack"
 
 # ── Cleanup ──────────────────────────────────────────────────────────────────
 PIDS=()
 
+# shellcheck disable=SC2329 # Invoked by EXIT/INT/TERM traps.
 cleanup() {
     echo ""
     echo "Shutting down..."
@@ -54,35 +62,130 @@ trap cleanup EXIT INT TERM
 
 mkdir -p "$LOG_DIR"
 
+require_positive_integer() {
+    local name="$1"
+    local value="$2"
+
+    if ! [[ "$value" =~ ^[0-9]+$ ]] || ((10#$value < 1)); then
+        echo "$name must be a positive integer. Current value: $value"
+        exit 1
+    fi
+}
+
+validate_config() {
+    require_positive_integer "TP_SIZE" "$TP_SIZE"
+    require_positive_integer "HTTP_PORT" "$HTTP_PORT"
+    require_positive_integer "STARTUP_TIMEOUT_SECONDS" "$STARTUP_TIMEOUT_SECONDS"
+
+    local visible_devices="${CUDA_VISIBLE_DEVICES//[[:space:]]/}"
+    if [[ -z "$visible_devices" ]]; then
+        echo "CUDA_VISIBLE_DEVICES must list at least $TP_SIZE device(s)."
+        exit 1
+    fi
+    if [[ "$visible_devices" == ,* || "$visible_devices" == *, || "$visible_devices" == *,,* ]]; then
+        echo "CUDA_VISIBLE_DEVICES contains an empty device entry: $visible_devices"
+        exit 1
+    fi
+    CUDA_VISIBLE_DEVICES="$visible_devices"
+
+    local devices
+    IFS=',' read -r -a devices <<<"$visible_devices"
+    if ((${#devices[@]} < TP_SIZE)); then
+        echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES exposes ${#devices[@]} device(s), but TP_SIZE=$TP_SIZE requires at least $TP_SIZE."
+        exit 1
+    fi
+}
+
+wait_for_model() {
+    local frontend_pid="$1"
+    local worker_pid="$2"
+    local endpoint="http://localhost:${HTTP_PORT}/v1/models"
+    local deadline=$((SECONDS + STARTUP_TIMEOUT_SECONDS))
+    local response
+
+    echo "Waiting up to ${STARTUP_TIMEOUT_SECONDS}s for $MODEL to register at $endpoint..."
+    while true; do
+        if response=$(curl -sf "$endpoint" 2>/dev/null) && grep -F "\"$MODEL\"" <<<"$response" >/dev/null; then
+            echo "Model registered. Dynamo endpoint is ready."
+            return 0
+        fi
+
+        if ! kill -0 "$frontend_pid" 2>/dev/null; then
+            echo "Dynamo frontend exited before model registration. See $LOGFILE."
+            exit 1
+        fi
+
+        if ! kill -0 "$worker_pid" 2>/dev/null; then
+            echo "Dynamo worker exited before model registration. See $LOGFILE."
+            exit 1
+        fi
+
+        if ((SECONDS >= deadline)); then
+            echo "Timed out waiting for model registration at $endpoint."
+            echo "Last /v1/models response:"
+            curl -s "$endpoint" || true
+            echo ""
+            echo "See $LOGFILE."
+            exit 1
+        fi
+
+        sleep 5
+    done
+}
+
+monitor_processes() {
+    while true; do
+        for pid in "${PIDS[@]}"; do
+            if ! kill -0 "$pid" 2>/dev/null; then
+                echo "A Dynamo process exited. See $LOGFILE."
+                exit 1
+            fi
+        done
+
+        sleep 5
+    done
+}
+
 # ── Preflight ────────────────────────────────────────────────────────────────
+validate_config
 curl -sf http://localhost:2379/health >/dev/null 2>&1 || { echo "etcd not running. See header comment."; exit 1; }
 curl -sf http://localhost:8222/healthz >/dev/null 2>&1 || { echo "NATS not running. See header comment."; exit 1; }
 
 LOGFILE="$LOG_DIR/all.log"
-> "$LOGFILE"
+: > "$LOGFILE"
+
+echo "Launching Dynamo stack with CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES, TP_SIZE=$TP_SIZE"
+echo "NCCL startup defaults: NCCL_NET_PLUGIN=$NCCL_NET_PLUGIN, NCCL_IB_DISABLE=$NCCL_IB_DISABLE"
 
 # ── Frontend ─────────────────────────────────────────────────────────────────
 OTEL_SERVICE_NAME=dynamo-frontend \
 python3 -m dynamo.frontend \
-    --http-port 8099 \
-    2>&1 | tee -a "$LOGFILE" &
-PIDS+=($!)
+    --http-port "$HTTP_PORT" \
+    > >(tee -a "$LOGFILE") 2>&1 &
+FRONTEND_PID=$!
+PIDS+=("$FRONTEND_PID")
 
 # ── Workers ──────────────────────────────────────────────────────────────────
-CUDA_VISIBLE_DEVICES=0,1 \
+CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
 OTEL_SERVICE_NAME=dynamo-worker-0 \
 DYN_SYSTEM_PORT=8081 \
+NCCL_NET_PLUGIN="$NCCL_NET_PLUGIN" \
+NCCL_IB_DISABLE="$NCCL_IB_DISABLE" \
+NCCL_DEBUG="$NCCL_DEBUG" \
 python3 -m dynamo.sglang \
     --model-path "$MODEL" \
     --served-model-name "$MODEL" \
-    --tp 2 \
+    --tp "$TP_SIZE" \
     --mem-fraction-static $MEM_FRACTION \
     --context-length $CONTEXT_LENGTH \
     --trust-remote-code \
     --enable-metrics \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' \
-    2>&1 | tee -a "$LOGFILE" &
-PIDS+=($!)
+    > >(tee -a "$LOGFILE") 2>&1 &
+WORKER_PID=$!
+PIDS+=("$WORKER_PID")
+
+wait_for_model "$FRONTEND_PID" "$WORKER_PID"
 
 echo "Ctrl+C to stop. Log: $LOGFILE"
-wait
+monitor_processes

--- a/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/scripts/dynamo_stack_sensitivity.sh
+++ b/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/scripts/dynamo_stack_sensitivity.sh
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Nemotron 3 Nano on 2 GPUs with Dynamo frontend, HiCache, and PIN.
+# Nemotron 3 Nano on 2 GPUs with a Dynamo frontend and priority-aware SGLang worker.
 # Edit the config below, then: bash dynamo_stack_sensitivity.sh
 # Ctrl+C to stop. Logs in /tmp/dynamo-stack/
 #
@@ -28,17 +28,25 @@ set -euo pipefail
 
 # ── Config ───────────────────────────────────────────────────────────────────
 MODEL="nvidia/NVIDIA-Nemotron-3-Nano-30B-A3B-BF16"
-PAGE_SIZE=64
-HICACHE_RATIO=1.0
-HICACHE_POLICY=write_through
 CONTEXT_LENGTH=262144
 MEM_FRACTION=0.7
+HTTP_PORT="${HTTP_PORT:-8099}"
+TP_SIZE="${TP_SIZE:-2}"
+CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1}"
+STARTUP_TIMEOUT_SECONDS="${STARTUP_TIMEOUT_SECONDS:-1800}"
+
+# This demo runs a local two-GPU stack. Avoid loading host-specific NCCL network
+# plugins unless the user explicitly opts into them for their environment.
+NCCL_NET_PLUGIN="${NCCL_NET_PLUGIN:-none}"
+NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-1}"
+NCCL_DEBUG="${NCCL_DEBUG:-WARN}"
 
 LOG_DIR="/tmp/dynamo-stack"
 
 # ── Cleanup ──────────────────────────────────────────────────────────────────
 PIDS=()
 
+# shellcheck disable=SC2329 # Invoked by EXIT/INT/TERM traps.
 cleanup() {
     echo ""
     echo "Shutting down..."
@@ -54,28 +62,120 @@ trap cleanup EXIT INT TERM
 
 mkdir -p "$LOG_DIR"
 
+require_positive_integer() {
+    local name="$1"
+    local value="$2"
+
+    if ! [[ "$value" =~ ^[0-9]+$ ]] || ((10#$value < 1)); then
+        echo "$name must be a positive integer. Current value: $value"
+        exit 1
+    fi
+}
+
+validate_config() {
+    require_positive_integer "TP_SIZE" "$TP_SIZE"
+    require_positive_integer "HTTP_PORT" "$HTTP_PORT"
+    require_positive_integer "STARTUP_TIMEOUT_SECONDS" "$STARTUP_TIMEOUT_SECONDS"
+
+    local visible_devices="${CUDA_VISIBLE_DEVICES//[[:space:]]/}"
+    if [[ -z "$visible_devices" ]]; then
+        echo "CUDA_VISIBLE_DEVICES must list at least $TP_SIZE device(s)."
+        exit 1
+    fi
+    if [[ "$visible_devices" == ,* || "$visible_devices" == *, || "$visible_devices" == *,,* ]]; then
+        echo "CUDA_VISIBLE_DEVICES contains an empty device entry: $visible_devices"
+        exit 1
+    fi
+    CUDA_VISIBLE_DEVICES="$visible_devices"
+
+    local devices
+    IFS=',' read -r -a devices <<<"$visible_devices"
+    if ((${#devices[@]} < TP_SIZE)); then
+        echo "CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES exposes ${#devices[@]} device(s), but TP_SIZE=$TP_SIZE requires at least $TP_SIZE."
+        exit 1
+    fi
+}
+
+wait_for_model() {
+    local frontend_pid="$1"
+    local worker_pid="$2"
+    local endpoint="http://localhost:${HTTP_PORT}/v1/models"
+    local deadline=$((SECONDS + STARTUP_TIMEOUT_SECONDS))
+    local response
+
+    echo "Waiting up to ${STARTUP_TIMEOUT_SECONDS}s for $MODEL to register at $endpoint..."
+    while true; do
+        if response=$(curl -sf "$endpoint" 2>/dev/null) && grep -F "\"$MODEL\"" <<<"$response" >/dev/null; then
+            echo "Model registered. Dynamo endpoint is ready."
+            return 0
+        fi
+
+        if ! kill -0 "$frontend_pid" 2>/dev/null; then
+            echo "Dynamo frontend exited before model registration. See $LOGFILE."
+            exit 1
+        fi
+
+        if ! kill -0 "$worker_pid" 2>/dev/null; then
+            echo "Dynamo worker exited before model registration. See $LOGFILE."
+            exit 1
+        fi
+
+        if ((SECONDS >= deadline)); then
+            echo "Timed out waiting for model registration at $endpoint."
+            echo "Last /v1/models response:"
+            curl -s "$endpoint" || true
+            echo ""
+            echo "See $LOGFILE."
+            exit 1
+        fi
+
+        sleep 5
+    done
+}
+
+monitor_processes() {
+    while true; do
+        for pid in "${PIDS[@]}"; do
+            if ! kill -0 "$pid" 2>/dev/null; then
+                echo "A Dynamo process exited. See $LOGFILE."
+                exit 1
+            fi
+        done
+
+        sleep 5
+    done
+}
+
 # ── Preflight ────────────────────────────────────────────────────────────────
+validate_config
 curl -sf http://localhost:2379/health >/dev/null 2>&1 || { echo "etcd not running. See header comment."; exit 1; }
 curl -sf http://localhost:8222/healthz >/dev/null 2>&1 || { echo "NATS not running. See header comment."; exit 1; }
 
 LOGFILE="$LOG_DIR/all.log"
-> "$LOGFILE"
+: > "$LOGFILE"
+
+echo "Launching Dynamo stack with CUDA_VISIBLE_DEVICES=$CUDA_VISIBLE_DEVICES, TP_SIZE=$TP_SIZE"
+echo "NCCL startup defaults: NCCL_NET_PLUGIN=$NCCL_NET_PLUGIN, NCCL_IB_DISABLE=$NCCL_IB_DISABLE"
 
 # ── Frontend ─────────────────────────────────────────────────────────────────
 OTEL_SERVICE_NAME=dynamo-frontend \
 python3 -m dynamo.frontend \
-    --http-port 8099 \
-    2>&1 | tee -a "$LOGFILE" &
-PIDS+=($!)
+    --http-port "$HTTP_PORT" \
+    > >(tee -a "$LOGFILE") 2>&1 &
+FRONTEND_PID=$!
+PIDS+=("$FRONTEND_PID")
 
 # ── Workers ──────────────────────────────────────────────────────────────────
-CUDA_VISIBLE_DEVICES=0,1 \
+CUDA_VISIBLE_DEVICES="$CUDA_VISIBLE_DEVICES" \
 OTEL_SERVICE_NAME=dynamo-worker-0 \
 DYN_SYSTEM_PORT=8081 \
+NCCL_NET_PLUGIN="$NCCL_NET_PLUGIN" \
+NCCL_IB_DISABLE="$NCCL_IB_DISABLE" \
+NCCL_DEBUG="$NCCL_DEBUG" \
 python3 -m dynamo.sglang \
     --model-path "$MODEL" \
     --served-model-name "$MODEL" \
-    --tp 2 \
+    --tp "$TP_SIZE" \
     --mem-fraction-static $MEM_FRACTION \
     --context-length $CONTEXT_LENGTH \
     --trust-remote-code \
@@ -83,8 +183,11 @@ python3 -m dynamo.sglang \
     --schedule-low-priority-values-first \
     --enable-priority-scheduling \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' \
-    2>&1 | tee -a "$LOGFILE" &
-PIDS+=($!)
+    > >(tee -a "$LOGFILE") 2>&1 &
+WORKER_PID=$!
+PIDS+=("$WORKER_PID")
+
+wait_for_model "$FRONTEND_PID" "$WORKER_PID"
 
 echo "Ctrl+C to stop. Log: $LOGFILE"
-wait
+monitor_processes

--- a/examples/dynamo_integration/latency_sensitivity_demo/tests/test_workflow.py
+++ b/examples/dynamo_integration/latency_sensitivity_demo/tests/test_workflow.py
@@ -14,11 +14,15 @@
 # limitations under the License.
 """Tests for the latency sensitivity demo workflow."""
 
+import os
+import subprocess
 from pathlib import Path
 
 import yaml
 
 CONFIGS_DIR = Path(__file__).parent.parent / "src" / "latency_sensitivity_demo" / "configs"
+SCRIPTS_DIR = Path(__file__).parent.parent / "src" / "latency_sensitivity_demo" / "scripts"
+STACK_SCRIPT_PATHS = [SCRIPTS_DIR / "dynamo_stack.sh", SCRIPTS_DIR / "dynamo_stack_sensitivity.sh"]
 
 
 class TestConfigFiles:
@@ -98,6 +102,42 @@ class TestDataset:
         for entry in data:
             assert "id" in entry
             assert "question" in entry
+
+
+class TestDynamoStackScripts:
+    """Verify the checked-in Dynamo launch helpers stay safe for local validation."""
+
+    def test_stack_scripts_have_valid_bash_syntax(self):
+        for script_path in STACK_SCRIPT_PATHS:
+            subprocess.run(["bash", "-n", str(script_path)], check=True)
+
+    def test_stack_scripts_have_overrideable_single_node_nccl_defaults(self):
+        for script_path in STACK_SCRIPT_PATHS:
+            script = script_path.read_text()
+            assert 'CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1}"' in script
+            assert 'TP_SIZE="${TP_SIZE:-2}"' in script
+            assert 'NCCL_NET_PLUGIN="${NCCL_NET_PLUGIN:-none}"' in script
+            assert 'NCCL_IB_DISABLE="${NCCL_IB_DISABLE:-1}"' in script
+            assert 'NCCL_DEBUG="${NCCL_DEBUG:-WARN}"' in script
+            assert '--tp "$TP_SIZE"' in script
+
+    def test_stack_scripts_fail_fast_when_tp_exceeds_visible_gpu_count(self):
+        env = os.environ.copy()
+        env["CUDA_VISIBLE_DEVICES"] = "0"
+        env["TP_SIZE"] = "2"
+
+        for script_path in STACK_SCRIPT_PATHS:
+            result = subprocess.run(["bash", str(script_path)], check=False, env=env, capture_output=True, text=True)
+            assert result.returncode == 1
+            assert "requires at least 2" in result.stdout
+
+    def test_stack_scripts_wait_for_model_registration(self):
+        for script_path in STACK_SCRIPT_PATHS:
+            script = script_path.read_text()
+            assert "validate_config" in script
+            assert "wait_for_model \"$FRONTEND_PID\" \"$WORKER_PID\"" in script
+            assert "monitor_processes" in script
+            assert "/v1/models" in script
 
 
 class TestWorkflowRegistration:

--- a/examples/dynamo_integration/latency_sensitivity_demo/tests/test_workflow.py
+++ b/examples/dynamo_integration/latency_sensitivity_demo/tests/test_workflow.py
@@ -111,7 +111,7 @@ class TestDynamoStackScripts:
         for script_path in STACK_SCRIPT_PATHS:
             subprocess.run(["bash", "-n", str(script_path)], check=True)
 
-    def test_stack_scripts_have_overrideable_single_node_nccl_defaults(self):
+    def test_stack_scripts_have_configurable_single_node_nccl_defaults(self):
         for script_path in STACK_SCRIPT_PATHS:
             script = script_path.read_text()
             assert 'CUDA_VISIBLE_DEVICES="${CUDA_VISIBLE_DEVICES:-0,1}"' in script


### PR DESCRIPTION
## Description
Improves the NVIDIA NeMo Agent Toolkit Dynamo latency sensitivity demo startup flow for local two-GPU validation.

This PR updates the baseline and sensitivity Dynamo stack scripts to:
- use overrideable `CUDA_VISIBLE_DEVICES`, `TP_SIZE`, `HTTP_PORT`, and startup timeout values
- default to single-node NCCL startup settings for local validation
- fail fast on invalid GPU/tensor-parallel configuration
- wait for the served model to appear in `/v1/models`
- exit with a clear log pointer if the frontend or SGLang worker exits before or after startup

The README verification steps now check `/v1/models` first and use the actual served Nemotron model name in the sample request.

## Validation:
- `uv run --python 3.11 --group dev pre-commit run --all-files`
- `PYTHONPATH=examples/dynamo_integration/latency_sensitivity_demo/src uv run --extra test pytest -q examples/dynamo_integration/latency_sensitivity_demo/tests/test_workflow.py`
- `uvx --from shellcheck-py shellcheck examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/scripts/dynamo_stack.sh`
- `uvx --from shellcheck-py shellcheck examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/scripts/dynamo_stack_sensitivity.sh`
- `bash -n examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/scripts/dynamo_stack.sh`
- `bash -n examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/scripts/dynamo_stack_sensitivity.sh`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded startup verification with default runtime/environment values, expected model-registration behavior, and failure-log location.

* **Improvements**
  * Added environment-overridable defaults (GPU visibility, tensor-parallel size, NCCL/startup settings) and validation checks.
  * Switched to model-registration wait logic, robust process monitoring, and consolidated/truncated logging for clearer startup diagnostics.

* **Tests**
  * New automated checks validating script syntax, configurable defaults, and failure behavior when TP size exceeds available GPUs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->