### PR TITLE
fix: Delay deleting of environment directories when generating coverage files

### DIFF
--- a/ci/scripts/run_tests.py
+++ b/ci/scripts/run_tests.py
@@ -116,6 +116,16 @@ def make_env(project_dir: Path) -> dict[str, str]:
     return env
 
 
+def remove_env(project_dir: Path) -> None:
+    cmd = ["rm", "-rf", str(project_dir / ".venv")]
+    sh(cmd)
+
+
+def remove_project_envs(projects: list[Path]) -> None:
+    for project in projects:
+        remove_env(project)
+
+
 def run_one(
     project_dir: Path,
     *,
@@ -204,8 +214,8 @@ def run_one(
             logger.info(f"{display_project_dir} (tested)")
         return 0
     finally:
-        cmd = ["rm", "-rf", str(project_dir / ".venv")]
-        sh(cmd, env=env)
+        if not enable_coverage:
+            remove_env(project_dir)
 
 
 def main(junit_xml: str | None,
@@ -296,14 +306,15 @@ def main(junit_xml: str | None,
         finally:
             ex = None
             _restore_handler()
-            for p in projects:
-                sh(["rm", "-rf", str(p / ".venv")])
+            if cov_xml is None:
+                remove_project_envs(projects)
 
     if cov_xml is not None:
         sh(["uv", "tool", "install", "coverage[toml]"])
         sh(["coverage", "combine", "--keep", str(COV_DIR)])
         sh(["coverage", "xml", "-o", str(cov_xml)])
         sh(["coverage", "report"])
+        remove_project_envs(projects)
 
     if junit_xml is not None:
         sh(["uv", "tool", "install", "junitparser"])


### PR DESCRIPTION
## Description
* Fixes an issue when attempting to combine coverage reports for the `nat` namespace, when some of the `nat.plugin.<plugin>` code is now in a third-party-repo and the `.venv` directory has already been removed causing a failure.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI test infrastructure to selectively manage virtual environment cleanup, improving support for coverage reporting workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->