### PR TITLE
fix(agent): flatten list-style message content for Bedrock/Anthropic

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/base.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/base.py
@@ -45,6 +45,31 @@ def _extract_reasoning_content(message: BaseMessage) -> str:
     return reasoning if isinstance(reasoning, str) else str(reasoning)
 
 
+def _extract_message_text(content: Any) -> str:
+    """Flatten LangChain message content to plain text.
+
+    Chat models return ``content`` either as a string or, for providers such as
+    Anthropic (including via AWS Bedrock ``ChatBedrockConverse``), as a list of
+    typed content blocks (for example ``{"type": "text", "text": "..."}``). The
+    agents consume message content as text, so this concatenates the text of any
+    text blocks and ignores non-text blocks such as tool-use or reasoning. A
+    plain string is returned unchanged and any other type yields an empty string.
+    """
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for block in content:
+            if isinstance(block, str):
+                parts.append(block)
+            elif isinstance(block, dict) and block.get("type", "text") == "text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "".join(parts)
+    return ""
+
+
 def _format_agent_thoughts_for_log(message: BaseMessage) -> str:
     """Return concise text for detailed agent thought logs."""
     content = message.content

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/agent.py
@@ -43,6 +43,7 @@ from nat.plugins.langchain.agent.base import INPUT_SCHEMA_MESSAGE
 from nat.plugins.langchain.agent.base import NO_INPUT_ERROR_MESSAGE
 from nat.plugins.langchain.agent.base import TOOL_NOT_FOUND_ERROR_MESSAGE
 from nat.plugins.langchain.agent.base import AgentDecision
+from nat.plugins.langchain.agent.base import _extract_message_text
 from nat.plugins.langchain.agent.base import _format_agent_thoughts_for_log
 from nat.plugins.langchain.agent.dual_node import DualNodeAgent
 from nat.plugins.langchain.agent.react_agent.output_parser import ReActAgentParsingFailedError
@@ -221,8 +222,9 @@ class ReActAgentGraph(DualNodeAgent):
                     chat_history = self._get_chat_history(state.messages)
                     inputs = {"question": question, "chat_history": chat_history}
                     output_message = await self._stream_llm(self.agent, inputs, config=config)  # type: ignore
-                    if isinstance(output_message.content, str):
-                        output_message.content = remove_r1_think_tags(output_message.content)
+                    # Normalize content to text up front: providers such as Anthropic / AWS Bedrock
+                    # return list-style content blocks that the parsing and retry logic below cannot handle.
+                    output_message.content = remove_r1_think_tags(_extract_message_text(output_message.content))
                     agent_thoughts = _format_agent_thoughts_for_log(output_message)
 
                     if self.detailed_logs:
@@ -245,8 +247,9 @@ class ReActAgentGraph(DualNodeAgent):
 
                     inputs = {"question": question, "agent_scratchpad": agent_scratchpad, "chat_history": chat_history}
                     output_message = await self._stream_llm(self.agent, inputs, config=config)  # type: ignore
-                    if isinstance(output_message.content, str):
-                        output_message.content = remove_r1_think_tags(output_message.content)
+                    # Normalize content to text up front: providers such as Anthropic / AWS Bedrock
+                    # return list-style content blocks that the parsing and retry logic below cannot handle.
+                    output_message.content = remove_r1_think_tags(_extract_message_text(output_message.content))
                     agent_thoughts = _format_agent_thoughts_for_log(output_message)
 
                     if self.detailed_logs:

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/register.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/react_agent/register.py
@@ -103,6 +103,7 @@ async def react_agent_workflow(config: ReActAgentWorkflowConfig, builder: Builde
     from langgraph.graph.state import CompiledStateGraph
 
     from nat.plugins.langchain.agent.base import AGENT_LOG_PREFIX
+    from nat.plugins.langchain.agent.base import _extract_message_text
     from nat.plugins.langchain.agent.react_agent.agent import ReActAgentGraph
     from nat.plugins.langchain.agent.react_agent.agent import ReActGraphState
     from nat.plugins.langchain.agent.react_agent.agent import create_react_agent_prompt
@@ -168,7 +169,7 @@ async def react_agent_workflow(config: ReActAgentWorkflowConfig, builder: Builde
             # get and return the output from the state
             state = ReActGraphState(**state)
             output_message = state.messages[-1]
-            content = str(output_message.content)
+            content = _extract_message_text(output_message.content)
 
             # Create usage statistics for the response
             prompt_tokens = sum(len(str(msg.content).split()) for msg in message.messages)
@@ -219,11 +220,12 @@ async def react_agent_workflow(config: ReActAgentWorkflowConfig, builder: Builde
                     continue
                 if not isinstance(metadata, dict) or metadata.get("langgraph_node") != "agent":
                     continue
-                if isinstance(msg.content, str) and msg.content and not msg.tool_call_chunks:
+                chunk_text = _extract_message_text(msg.content)
+                if chunk_text and not msg.tool_call_chunks:
                     if found_final_answer:
-                        yield ChatResponseChunk.create_streaming_chunk(msg.content, id_=chunk_id)
+                        yield ChatResponseChunk.create_streaming_chunk(chunk_text, id_=chunk_id)
                     else:
-                        buffer += msg.content
+                        buffer += chunk_text
                         cleaned_buffer = remove_r1_think_tags(buffer)
                         match = FINAL_ANSWER_PATTERN.search(cleaned_buffer)
                         if match:

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/register.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/agent/tool_calling_agent/register.py
@@ -108,6 +108,7 @@ async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, build
     from langgraph.graph.state import CompiledStateGraph
 
     from nat.plugins.langchain.agent.base import AGENT_LOG_PREFIX
+    from nat.plugins.langchain.agent.base import _extract_message_text
     from nat.plugins.langchain.agent.tool_calling_agent.agent import ToolCallAgentGraph
     from nat.plugins.langchain.agent.tool_calling_agent.agent import ToolCallAgentGraphState
     from nat.plugins.langchain.agent.tool_calling_agent.agent import create_tool_calling_agent_prompt
@@ -172,7 +173,7 @@ async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, build
             # get and return the output from the state
             state = ToolCallAgentGraphState(**state)
             output_message = state.messages[-1]
-            return str(output_message.content)
+            return _extract_message_text(output_message.content)
 
         except GraphRecursionError:
             logger.warning(
@@ -223,8 +224,9 @@ async def tool_calling_agent_workflow(config: ToolCallAgentWorkflowConfig, build
                 if metadata.get("langgraph_node") != "agent":
                     continue
 
-                if isinstance(msg.content, str) and msg.content:
-                    yield ChatResponseChunk.create_streaming_chunk(msg.content, id_=chunk_id)
+                chunk_text = _extract_message_text(msg.content)
+                if chunk_text:
+                    yield ChatResponseChunk.create_streaming_chunk(chunk_text, id_=chunk_id)
 
                 tool_calls = getattr(msg, "tool_call_chunks", None) or getattr(msg, "tool_calls", None)
                 if tool_calls:

--- a/packages/nvidia_nat_langchain/tests/agent/test_base.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_base.py
@@ -27,6 +27,7 @@ from langchain_core.runnables import RunnableConfig
 from langgraph.graph.state import CompiledStateGraph
 
 from nat.plugins.langchain.agent.base import BaseAgent
+from nat.plugins.langchain.agent.base import _extract_message_text
 from nat.plugins.langchain.agent.base import _format_agent_thoughts_for_log
 
 
@@ -196,6 +197,62 @@ def test_format_agent_thoughts_for_log_uses_reasoning_when_content_empty():
     message = AIMessage(content="\n", additional_kwargs={"reasoning_content": "thinking through the tool choice"})
 
     assert _format_agent_thoughts_for_log(message) == "thinking through the tool choice"
+
+
+@pytest.mark.parametrize(
+    "content, expected",
+    [
+        # Plain string content (OpenAI, NIM, Gemini, etc.) is returned unchanged.
+        ("hello world", "hello world"),
+        ("", ""),
+        # Anthropic / AWS Bedrock (ChatBedrockConverse) return a list of typed blocks.
+        ([{
+            "type": "text", "text": "hello world"
+        }], "hello world"),
+        ([{
+            "type": "text", "text": "There are "
+        }, {
+            "type": "text", "text": "9 datasources"
+        }], "There are 9 datasources"),
+        # Streaming deltas include empty lists before the first token.
+        ([], ""),
+        # Non-text blocks (tool use, reasoning/thinking) are ignored.
+        ([{
+            "type": "tool_use", "name": "search", "input": {}
+        }], ""),
+        ([{
+            "type": "text", "text": "answer"
+        }, {
+            "type": "tool_use", "name": "x", "input": {}
+        }], "answer"),
+        ([{
+            "type": "thinking", "thinking": "deliberating"
+        }], ""),
+        # Blocks without an explicit type but carrying text are treated as text.
+        ([{
+            "text": "untyped"
+        }], "untyped"),
+        # Bare strings inside the list are concatenated.
+        (["a", "b"], "ab"),
+        # Unsupported shapes flatten to an empty string rather than a stringified repr.
+        (None, ""),
+        (42, ""),
+    ],
+)
+def test_extract_message_text(content, expected):
+    """Flatten string and Anthropic/Bedrock list-style content to plain text."""
+    assert _extract_message_text(content) == expected
+
+
+def test_extract_message_text_streamed_blocks_reconstruct_answer():
+    """Regression: streamed Bedrock chunks (list content) must reconstruct to the full answer.
+
+    ChatBedrockConverse yields AIMessageChunk objects whose ``content`` is a list of
+    text blocks. Concatenating ``_extract_message_text`` over the chunks must rebuild
+    the answer; the previous ``isinstance(content, str)`` guard dropped them entirely.
+    """
+    streamed_chunks = [[], [{"type": "text", "text": "NEMO-"}], [{"type": "text", "text": "OK"}], ""]
+    assert "".join(_extract_message_text(c) for c in streamed_chunks) == "NEMO-OK"
 
 
 class TestCallLLM:

--- a/packages/nvidia_nat_langchain/tests/agent/test_react.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_react.py
@@ -16,9 +16,12 @@
 import pytest
 from langchain_core.agents import AgentAction
 from langchain_core.agents import AgentFinish
+from langchain_core.language_models import BaseChatModel
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
 from langchain_core.messages.tool import ToolMessage
+from langchain_core.outputs import ChatGeneration
+from langchain_core.outputs import ChatResult
 from langgraph.graph.state import CompiledStateGraph
 
 from nat.plugins.langchain.agent.base import AgentDecision
@@ -34,6 +37,33 @@ from nat.plugins.langchain.agent.react_agent.output_parser import ReActAgentPars
 from nat.plugins.langchain.agent.react_agent.output_parser import ReActOutputParser
 from nat.plugins.langchain.agent.react_agent.output_parser import ReActOutputParserException
 from nat.plugins.langchain.agent.react_agent.register import ReActAgentWorkflowConfig
+
+
+class _ListContentChatModel(BaseChatModel):
+    """Fake chat model that returns list-style content blocks.
+
+    Anthropic models, including via AWS Bedrock (``ChatBedrockConverse``), return
+    message content as a list of typed blocks (for example
+    ``[{"type": "text", "text": "..."}]``) instead of a plain string. This fake
+    reproduces that shape so the ReAct graph can be exercised against it.
+    """
+
+    blocks: list
+
+    async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs):  # noqa: ARG002
+        message = AIMessage(content=list(self.blocks), response_metadata={"mock_llm_response": True})
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def _generate(self, messages, stop=None, run_manager=None, **kwargs):  # noqa: ARG002
+        message = AIMessage(content=list(self.blocks), response_metadata={"mock_llm_response": True})
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+    def bind_tools(self, tools, **kwargs):  # noqa: ARG002
+        return self
+
+    @property
+    def _llm_type(self) -> str:
+        return "list-content-mock-llm"
 
 
 async def test_state_schema():
@@ -241,6 +271,51 @@ async def test_agent_node_parse_agent_finish_with_action_and_input_after_max_ret
     final_answer = final_answer.messages[-1]
     assert isinstance(final_answer, AIMessage)
     assert FINAL_ANSWER_AND_PARSABLE_ACTION_ERROR_MESSAGE in final_answer.content
+
+
+async def test_agent_node_flattens_list_style_final_answer(mock_config_react_agent, mock_tool):
+    """Regression: Anthropic/Bedrock list-style content must be flattened, not crash the parser.
+
+    ``ChatBedrockConverse`` returns message content as a list of typed blocks. Previously
+    ``agent_node`` passed that list straight into ``remove_r1_think_tags`` and
+    ``ReActOutputParser`` raising "TypeError: expected string or bytes-like object, got
+    'list'". The agent must flatten the content to text and return the parsed final answer.
+    """
+    blocks = [{"type": "text", "text": "Thought: I know it.\nFinal Answer: block answer"}]
+    llm = _ListContentChatModel(blocks=blocks)
+    tools = [mock_tool('Tool A')]
+    prompt = create_react_agent_prompt(mock_config_react_agent)
+    agent = ReActAgentGraph(llm=llm, prompt=prompt, tools=tools, detailed_logs=True, raise_on_parsing_failure=True)
+
+    state = await agent.agent_node(ReActGraphState(messages=[HumanMessage(content="what is the answer?")]))
+
+    assert state.final_answer == "block answer"
+    assert isinstance(state.messages[-1], AIMessage)
+    assert state.messages[-1].content == "block answer"
+
+
+async def test_agent_node_flattens_list_style_tool_call(mock_config_react_agent, mock_tool):
+    """Regression: list-style content on a tool-calling step must yield a string scratchpad log.
+
+    The agent's thoughts are stored on ``AgentAction.log`` for the next cycle. With list
+    content this previously became a stringified list; it must be flattened to text so the
+    scratchpad replayed to the LLM is clean.
+    """
+    blocks = [{"type": "text", "text": "Thought: use the tool\nAction: Tool A\nAction Input: hello, world!\n"}]
+    llm = _ListContentChatModel(blocks=blocks)
+    tools = [mock_tool('Tool A')]
+    prompt = create_react_agent_prompt(mock_config_react_agent)
+    agent = ReActAgentGraph(llm=llm, prompt=prompt, tools=tools, detailed_logs=True, raise_on_parsing_failure=True)
+
+    state = await agent.agent_node(ReActGraphState(messages=[HumanMessage(content="please use a tool")]))
+
+    assert len(state.agent_scratchpad) == 1
+    action = state.agent_scratchpad[-1]
+    assert isinstance(action, AgentAction)
+    assert action.tool == "Tool A"
+    assert action.tool_input == "hello, world!"
+    assert isinstance(action.log, str)
+    assert "Action: Tool A" in action.log
 
 
 async def test_agent_node_parse_agent_finish_with_action_and_input_after_retry(mock_react_agent_no_raise):


### PR DESCRIPTION
 ## Description
 Closes #2063
 
 The tool calling and ReAct agents consumed message content as a string: the streaming paths gated on `isinstance(msg.content, str)` and the single-shot paths called `str(output_message.content)`. Anthropic models, including via AWS Bedrock (`ChatBedrockConverse`), return content as a list of typed blocks (for example `[{"type": "text", "text": "..."}]`). As a result the agents streamed an empty reply over `/chat/stream` and the websocket, and returned a stringified list over `/chat`.
 
Adds a shared `_extract_message_text` helper in the agent base module that flattens string or list-of-blocks content to plain text, and uses it in the tool calling and ReAct agents' streaming and single-shot paths. Non-text blocks (such as tool use and reasoning) are ignored.
 
 ### Testing
 - New unit tests cover string, list, mixed, empty, and non-text content shapes.
 - Existing `test_base`, `test_tool_calling`, and `test_react` suites pass.
 - Manually verified against `anthropic.claude` models on AWS Bedrock: `/chat`, `/chat/stream`, and the websocket all return text (previously empty/garbled).
 
 ## By Submitting this PR I confirm:
 - I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
 - We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
   - Any contribution which contains commits that are not Signed-Off will not be accepted.
 - When the PR is ready for review, new or existing tests cover these changes.
 - When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved normalization of agent message content so plain-text output is produced consistently across both standard and streaming workflows, including provider-specific list-style formats.

* **Tests**
  * Added unit and regression tests to verify message content extraction, correct streaming chunk reconstruction, and proper parsing of ReAct tool-call steps with list-style content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->