### PR TITLE
fix: harden Dynamo latency demo against SGlang version drift and degenerate trie predictions

### DIFF
--- a/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/scripts/dynamo_stack_sensitivity.sh
+++ b/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/scripts/dynamo_stack_sensitivity.sh
@@ -151,6 +151,44 @@ validate_config
 curl -sf http://localhost:2379/health >/dev/null 2>&1 || { echo "etcd not running. See header comment."; exit 1; }
 curl -sf http://localhost:8222/healthz >/dev/null 2>&1 || { echo "NATS not running. See header comment."; exit 1; }
 
+# ── Priority scheduling flags (SGLang version-dependent) ───────────────────────
+# dynamo.sglang passes these through to SGLang's argparse, so an unsupported flag
+# makes the worker exit during argument parsing before the model registers on
+# /v1/models. The supported set varies with the SGLang version bundled in the
+# installed Dynamo, so probe ServerArgs and include only what is available.
+PRIORITY_ARGS=()
+SGLANG_PRIORITY_PROBE="$(python3 - <<'PY' 2>/dev/null || true
+try:
+    from sglang.srt.server_args import ServerArgs
+    fields = getattr(ServerArgs, "__dataclass_fields__", {})
+    print("PROBE_OK")
+    for name in ("enable_priority_scheduling", "schedule_low_priority_values_first"):
+        if name in fields:
+            print(name)
+except Exception:
+    pass
+PY
+)"
+if ! grep -q PROBE_OK <<<"$SGLANG_PRIORITY_PROBE"; then
+    echo "WARNING: could not probe SGLang ServerArgs; starting worker without priority"
+    echo "         scheduling flags. The priority-routing benefit this demo measures"
+    echo "         will not be exercised."
+elif grep -q enable_priority_scheduling <<<"$SGLANG_PRIORITY_PROBE"; then
+    PRIORITY_ARGS+=(--enable-priority-scheduling)
+    if grep -q schedule_low_priority_values_first <<<"$SGLANG_PRIORITY_PROBE"; then
+        PRIORITY_ARGS+=(--schedule-low-priority-values-first)
+    else
+        echo "WARNING: installed SGLang lacks --schedule-low-priority-values-first."
+        echo "         Priority scheduling is enabled, but lower-priority-value-first"
+        echo "         ordering (HIGH calls jump the queue) is unavailable. Upgrade"
+        echo "         Dynamo/SGLang for full priority-routing fidelity."
+    fi
+else
+    echo "WARNING: installed SGLang does not support --enable-priority-scheduling;"
+    echo "         starting worker without priority scheduling. The priority-routing"
+    echo "         benefit this demo measures will not be exercised."
+fi
+
 LOGFILE="$LOG_DIR/all.log"
 : > "$LOGFILE"
 
@@ -180,8 +218,7 @@ python3 -m dynamo.sglang \
     --context-length $CONTEXT_LENGTH \
     --trust-remote-code \
     --enable-metrics \
-    --schedule-low-priority-values-first \
-    --enable-priority-scheduling \
+    ${PRIORITY_ARGS[@]+"${PRIORITY_ARGS[@]}"} \
     --kv-events-config '{"publisher":"zmq","topic":"kv-events","endpoint":"tcp://*:20080"}' \
     > >(tee -a "$LOGFILE") 2>&1 &
 WORKER_PID=$!

--- a/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
+++ b/packages/nvidia_nat_core/src/nat/llm/dynamo_llm.py
@@ -543,6 +543,16 @@ class _DynamoTransport(httpx.AsyncBaseTransport):
                     osl_raw = int(prediction.output_tokens.p90)
                     iat_raw = int(prediction.interarrival_ms.mean)
 
+                    # int() truncation can yield 0 (e.g. remaining_calls.mean < 1 on the
+                    # final call); fall back to the Pydantic-validated static config values
+                    # so a degenerate prediction does not fail the request downstream.
+                    if total_requests < 1:
+                        total_requests = self._total_requests
+                    if osl_raw < 1:
+                        osl_raw = self._osl
+                    if iat_raw < 1:
+                        iat_raw = self._iat
+
                     # Auto-assign latency sensitivity from profiler data
                     # Only if prediction has it AND no manual @latency_sensitive decorator is active
                     if prediction.latency_sensitivity is not None:

--- a/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
+++ b/packages/nvidia_nat_core/tests/nat/llm/test_dynamo_llm.py
@@ -1230,8 +1230,11 @@ class TestDynamoTransport:
 
         DynamoPrefixContext.clear()
 
-    async def test_transport_raises_when_total_requests_zero(self):
-        """Test that ValueError is raised when prediction trie yields total_requests < 1."""
+    async def test_transport_falls_back_when_prediction_total_requests_zero(self):
+        """Prediction total_requests < 1 (e.g. remaining_calls.mean=0 on the final call)
+        falls back to the static config value rather than failing the request."""
+        import json
+
         import httpx
 
         from nat.llm.dynamo_llm import _DynamoTransport
@@ -1262,13 +1265,20 @@ class TestDynamoTransport:
         DynamoPrefixContext.set("zero-total-requests-test")
 
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
-        with pytest.raises(ValueError, match="total_requests must be >= 1"):
-            await transport.handle_async_request(request)
+        await transport.handle_async_request(request)
+
+        modified_request = mock_transport.handle_async_request.call_args[0][0]
+        hints = json.loads(modified_request.content)["nvext"]["agent_hints"]
+        assert hints["total_requests"] == 10  # fell back to static config
+        assert hints["osl"] == 512  # prediction value preserved
+        assert hints["iat"] == 250  # prediction value preserved
 
         DynamoPrefixContext.clear()
 
-    async def test_transport_raises_when_osl_zero(self):
-        """Test that ValueError is raised when prediction trie yields osl < 1."""
+    async def test_transport_falls_back_when_prediction_osl_zero(self):
+        """Prediction osl < 1 falls back to the static config value."""
+        import json
+
         import httpx
 
         from nat.llm.dynamo_llm import _DynamoTransport
@@ -1299,13 +1309,20 @@ class TestDynamoTransport:
         DynamoPrefixContext.set("zero-osl-test")
 
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
-        with pytest.raises(ValueError, match="osl must be >= 1"):
-            await transport.handle_async_request(request)
+        await transport.handle_async_request(request)
+
+        modified_request = mock_transport.handle_async_request.call_args[0][0]
+        hints = json.loads(modified_request.content)["nvext"]["agent_hints"]
+        assert hints["osl"] == 512  # fell back to static config
+        assert hints["total_requests"] == 5  # prediction value preserved
+        assert hints["iat"] == 250  # prediction value preserved
 
         DynamoPrefixContext.clear()
 
-    async def test_transport_raises_when_iat_zero(self):
-        """Test that ValueError is raised when prediction trie yields iat < 1."""
+    async def test_transport_falls_back_when_prediction_iat_zero(self):
+        """Prediction iat < 1 falls back to the static config value."""
+        import json
+
         import httpx
 
         from nat.llm.dynamo_llm import _DynamoTransport
@@ -1336,8 +1353,13 @@ class TestDynamoTransport:
         DynamoPrefixContext.set("zero-iat-test")
 
         request = httpx.Request("POST", "https://api.example.com/chat", json={"model": "test"})
-        with pytest.raises(ValueError, match="iat must be >= 1"):
-            await transport.handle_async_request(request)
+        await transport.handle_async_request(request)
+
+        modified_request = mock_transport.handle_async_request.call_args[0][0]
+        hints = json.loads(modified_request.content)["nvext"]["agent_hints"]
+        assert hints["iat"] == 250  # fell back to static config
+        assert hints["total_requests"] == 5  # prediction value preserved
+        assert hints["osl"] == 512  # prediction value preserved
 
         DynamoPrefixContext.clear()
 


### PR DESCRIPTION
## Description

Fixes two failures in `examples/dynamo_integration/latency_sensitivity_demo` (reported against NAT v1.8.0-rc5) when run on a source-built Dynamo ≥1.1.0 (observed on ai-dynamo 1.3.x). The SGLang worker exited before serving in Step 3, and Step 4 failed requests on certain prediction-trie values. Jira: NAT-391.

## Problem

**Step 3 — worker exits during argument parsing.**`dynamo_stack_sensitivity.sh` hardcoded `--schedule-low-priority-values-first`. `dynamo.sglang` forwards this straight to SGLang's argparse via `ServerArgs.add_cli_args`, so any flag the bundled SGLang doesn't define is rejected as an unrecognized argument and the worker dies
before registering on `/v1/models`. The flag's availability is SGLang-version dependent — confirmed against real installs: 0.4.9.post6 has neither priority flag, 0.5.4.post3 has both, and the source-built Dynamo in the report bundles an intermediate SGLang that has `--enable-priority-scheduling` but not  `--schedule-low-priority-values-first`.

**Step 4 — request fails on degenerate predictions.** Prediction-trie overrides in `dynamo_llm.py` truncate sub-1 means to 0 via `int()` (e.g. `remaining_calls.mean < 1`on a conversation's final call), which tripped the `>= 1` nvalidation guard and failed the request.

## Changes

- **`dynamo_stack_sensitivity.sh`**: probe the installed SGLang `ServerArgs` and pass only the priority flags it actually supports, instead of hardcoding them. Warn clearly when `--schedule-low-priority-values-first` (lower-value-first ordering, which the demo's priority semantics depend on) is unavailable rather than crashing.
- **`dynamo_llm.py`**: when a prediction override yields a value `< 1`, fall back to the Pydantic-validated static config value (`total_requests` / `osl` / `iat`) so a degenerate prediction no longer fails the request. The downstream validation guard is retained for direct/`latency_sensitivity` cases. - **`test_dynamo_llm.py`**: the three `test_transport_raises_when_*_zero` tests encoded the old raise-on-zero behavior; rewritten a ,`test_transport_falls_back_when_prediction_*_zero` to assert the fallback and that other prediction-derived fields pass through.

This supersedes the reported manual workaround (deleting the flag and patching the validation site): deleting the flag silently inverts priority scheduling on SGLang versions that *do* support it, whereas the probe preserves intended behavior where available and degrades gracefully where not.

## Testing

- `pytest packages/nvidia_nat_core/tests/nat/llm/` → 120 passed.
- `bash -n dynamo_stack_sensitivity.sh` passes; priority-flag selection verified against
  all four version cases (both flags / enable-only / neither / probe-failure).

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved prediction handling by validating derived metrics and automatically falling back to static configuration values when predictions produce invalid or below-threshold results.
  * Enhanced worker initialization with improved runtime detection of priority-scheduling capabilities, replacing hardcoded assumptions and ensuring compatibility across different deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->