### PR TITLE
feat: add OpenAI Responses API route

### DIFF
--- a/packages/nvidia_nat_core/src/nat/data_models/api_server.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/api_server.py
@@ -207,6 +207,104 @@ class ChatRequest(BaseModel):
                            top_p=top_p)
 
 
+ResponsesInput = str | list[dict[str, typing.Any]]
+
+
+class ResponsesRequest(BaseModel):
+    """Request payload for the OpenAI Responses API."""
+
+    model_config = ConfigDict(extra="allow")
+
+    model: str | None = Field(default=None, description="Name of the model to use")
+    input: ResponsesInput = Field(description="Text or structured input items to process")
+    instructions: str | None = Field(default=None, description="System instructions for the model")
+    max_output_tokens: int | None = Field(default=None, description="Maximum number of output tokens to generate")
+    stream: bool | None = Field(default=False, description="Whether to stream response events")
+    temperature: float | None = Field(default=1.0, description="Sampling temperature between 0 and 2")
+    top_p: float | None = Field(default=None, description="Nucleus sampling parameter")
+    tools: list[dict[str, typing.Any]] | None = Field(default=None, description="List of tools the model may call")
+    tool_choice: str | dict[str, typing.Any] | None = Field(default=None, description="Controls which tool is called")
+    user: str | None = Field(default=None, description="Unique identifier representing end-user")
+
+    def to_chat_request(self) -> ChatRequest:
+        messages: list[Message] = []
+        if self.instructions:
+            messages.append(Message(content=self.instructions, role=UserMessageContentRoleType.SYSTEM))
+
+        messages.extend(self._input_to_chat_messages())
+
+        return ChatRequest(messages=messages,
+                           model=self.model,
+                           max_tokens=self.max_output_tokens,
+                           stream=self.stream,
+                           temperature=self.temperature,
+                           top_p=self.top_p,
+                           tools=self._tools_to_chat_tools(),
+                           tool_choice=self.tool_choice,
+                           user=self.user)
+
+    def _input_to_chat_messages(self) -> list[Message]:
+        if isinstance(self.input, str):
+            return [Message(content=self.input, role=UserMessageContentRoleType.USER)]
+
+        messages: list[Message] = []
+        for item in self.input:
+            item_type = item.get("type")
+            if item_type == "message" or (item_type is None and "content" in item):
+                content = item.get("content", [])
+                if isinstance(content, str):
+                    text = content
+                else:
+                    text = "\n".join(self._content_parts_to_text(content))
+                messages.append(Message(content=text, role=UserMessageContentRoleType(item.get("role", "user"))))
+            elif item_type in {"input_text", "text"}:
+                text = item.get("text")
+                if text is not None:
+                    messages.append(Message(content=str(text), role=UserMessageContentRoleType.USER))
+
+        if not messages:
+            return [Message(content="", role=UserMessageContentRoleType.USER)]
+        return messages
+
+    @staticmethod
+    def _content_parts_to_text(content: typing.Any) -> list[str]:
+        if isinstance(content, str):
+            return [content]
+        if not isinstance(content, list):
+            return []
+
+        text_parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                text_parts.append(part)
+            elif isinstance(part, dict) and part.get("type") in {"input_text", "text"}:
+                text = part.get("text")
+                if text is not None:
+                    text_parts.append(str(text))
+        return text_parts
+
+    def _tools_to_chat_tools(self) -> list[dict[str, typing.Any]] | None:
+        if self.tools is None:
+            return None
+
+        chat_tools: list[dict[str, typing.Any]] = []
+        for tool in self.tools:
+            if tool.get("type") != "function":
+                continue
+            if "function" in tool:
+                chat_tools.append(tool)
+            else:
+                chat_tools.append({
+                    "type": "function",
+                    "function": {
+                        "name": tool.get("name"),
+                        "description": tool.get("description", ""),
+                        "parameters": tool.get("parameters", {}),
+                    },
+                })
+        return chat_tools
+
+
 class ChatRequestOrMessage(BaseModel):
     """
     `ChatRequestOrMessage` is a data model that represents either a conversation or a string input.
@@ -1025,3 +1123,4 @@ def _string_to_nat_chat_response_chunk(data: str) -> ChatResponseChunk:
 
 
 GlobalTypeConverter.register_converter(_string_to_nat_chat_response_chunk)
+

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/routes/chat.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/routes/chat.py
@@ -156,7 +156,8 @@ async def add_chat_routes(
                                          path=openai_v1_path,
                                          method=endpoint.method,
                                          description=endpoint.description,
-                                         session_manager=session_manager)
+                                         session_manager=session_manager,
+                                         enable_interactive=enable_interactive_extensions)
         else:
             await add_v1_chat_completions_route(worker,
                                                 app,

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/routes/chat.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/routes/chat.py
@@ -30,6 +30,7 @@ from .common_utils import get_streaming_endpoint
 from .common_utils import post_single_endpoint
 from .common_utils import post_streaming_endpoint
 from .v1_chat_completions import add_v1_chat_completions_route
+from .v1_responses import add_v1_responses_route
 
 
 class _ChatEndpointType(StrEnum):
@@ -149,10 +150,18 @@ async def add_chat_routes(
         if endpoint_method != _ChatEndpointMethod.POST:
             raise ValueError(f"Unsupported method {endpoint.method} for {openai_v1_path}")
 
-        await add_v1_chat_completions_route(worker,
-                                            app,
-                                            path=openai_v1_path,
-                                            method=endpoint.method,
-                                            description=endpoint.description,
-                                            session_manager=session_manager,
-                                            enable_interactive=enable_interactive_extensions)
+        if openai_v1_path.endswith("/responses"):
+            await add_v1_responses_route(worker,
+                                         app,
+                                         path=openai_v1_path,
+                                         method=endpoint.method,
+                                         description=endpoint.description,
+                                         session_manager=session_manager)
+        else:
+            await add_v1_chat_completions_route(worker,
+                                                app,
+                                                path=openai_v1_path,
+                                                method=endpoint.method,
+                                                description=endpoint.description,
+                                                session_manager=session_manager,
+                                                enable_interactive=enable_interactive_extensions)

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/routes/v1_responses.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/routes/v1_responses.py
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""OpenAI v1 Responses API route registration."""
+
+import datetime
+import json
+import logging
+import uuid
+from collections.abc import AsyncGenerator
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi import Request
+from fastapi import Response
+from fastapi.responses import JSONResponse
+from fastapi.responses import StreamingResponse
+
+from nat.data_models.api_server import ChatResponse
+from nat.data_models.api_server import ChatResponseChunk
+from nat.data_models.api_server import Error
+from nat.data_models.api_server import ErrorTypes
+from nat.data_models.api_server import ResponsesRequest
+from nat.data_models.api_server import Usage
+from nat.front_ends.fastapi.response_helpers import generate_single_response
+from nat.front_ends.fastapi.response_helpers import generate_streaming_response
+from nat.runtime.session import SessionManager
+
+from .common_utils import RESPONSE_500
+from .common_utils import add_context_headers_to_response
+
+logger = logging.getLogger(__name__)
+
+
+def _responses_usage(usage: Usage | None) -> dict[str, int | None]:
+    if usage is None:
+        return {"input_tokens": None, "output_tokens": None, "total_tokens": None}
+    return {
+        "input_tokens": usage.prompt_tokens,
+        "output_tokens": usage.completion_tokens,
+        "total_tokens": usage.total_tokens,
+    }
+
+
+def _output_message(text: str, response_id: str | None = None) -> dict[str, Any]:
+    return {
+        "id": response_id or f"msg_{uuid.uuid4().hex}",
+        "type": "message",
+        "status": "completed",
+        "role": "assistant",
+        "content": [{
+            "type": "output_text",
+            "text": text,
+            "annotations": [],
+        }],
+    }
+
+
+def _responses_response(response: ChatResponse, request_model: str | None) -> dict[str, Any]:
+    response_id = f"resp_{uuid.uuid4().hex}"
+    text = ""
+    if response.choices and response.choices[0].message:
+        text = response.choices[0].message.content or ""
+
+    return {
+        "id": response_id,
+        "object": "response",
+        "created_at": int(response.created.timestamp()),
+        "status": "completed",
+        "error": None,
+        "incomplete_details": None,
+        "instructions": None,
+        "max_output_tokens": None,
+        "model": request_model or response.model,
+        "output": [_output_message(text)],
+        "parallel_tool_calls": True,
+        "previous_response_id": None,
+        "reasoning": None,
+        "store": True,
+        "temperature": None,
+        "text": {"format": {"type": "text"}},
+        "tool_choice": "auto",
+        "tools": [],
+        "top_p": None,
+        "truncation": "disabled",
+        "usage": _responses_usage(response.usage),
+        "user": None,
+        "metadata": {},
+    }
+
+
+def _event(event: str, payload: dict[str, Any]) -> str:
+    return f"event: {event}\ndata: {json.dumps(payload)}\n\n"
+
+
+async def _responses_stream(payload: ResponsesRequest,
+                            request: Request,
+                            worker: Any,
+                            session_manager: SessionManager) -> AsyncGenerator[str]:
+    response_id = f"resp_{uuid.uuid4().hex}"
+    item_id = f"msg_{uuid.uuid4().hex}"
+    content_index = 0
+    output_index = 0
+    created_at = int(datetime.datetime.now(datetime.UTC).timestamp())
+    chat_request = payload.to_chat_request()
+
+    response_base: dict[str, Any] = {
+        "id": response_id,
+        "object": "response",
+        "created_at": created_at,
+        "status": "in_progress",
+        "model": payload.model or "unknown-model",
+        "output": [],
+    }
+    output_item = _output_message("", item_id)
+    content_part = {"type": "output_text", "text": "", "annotations": []}
+
+    yield _event("response.created", {"type": "response.created", "response": response_base})
+    yield _event("response.output_item.added", {
+        "type": "response.output_item.added",
+        "output_index": output_index,
+        "item": output_item,
+    })
+    yield _event("response.content_part.added", {
+        "type": "response.content_part.added",
+        "item_id": item_id,
+        "output_index": output_index,
+        "content_index": content_index,
+        "part": content_part,
+    })
+
+    text_parts: list[str] = []
+    async with session_manager.session(http_connection=request) as session:
+        async for item in generate_streaming_response(chat_request,
+                                                      session=session,
+                                                      streaming=True,
+                                                      step_adaptor=worker.get_step_adaptor(),
+                                                      result_type=ChatResponseChunk,
+                                                      output_type=ChatResponseChunk):
+            if not isinstance(item, ChatResponseChunk):
+                continue
+            if not item.choices:
+                continue
+            delta = item.choices[0].delta.content or ""
+            if not delta:
+                continue
+            text_parts.append(delta)
+            yield _event("response.output_text.delta", {
+                "type": "response.output_text.delta",
+                "item_id": item_id,
+                "output_index": output_index,
+                "content_index": content_index,
+                "delta": delta,
+            })
+
+    text = "".join(text_parts)
+    content_part["text"] = text
+    output_item["content"] = [content_part]
+    done_response = {**response_base, "status": "completed", "output": [output_item]}
+
+    yield _event("response.output_text.done", {
+        "type": "response.output_text.done",
+        "item_id": item_id,
+        "output_index": output_index,
+        "content_index": content_index,
+        "text": text,
+    })
+    yield _event("response.content_part.done", {
+        "type": "response.content_part.done",
+        "item_id": item_id,
+        "output_index": output_index,
+        "content_index": content_index,
+        "part": content_part,
+    })
+    yield _event("response.output_item.done", {
+        "type": "response.output_item.done",
+        "output_index": output_index,
+        "item": output_item,
+    })
+    yield _event("response.done", {"type": "response.done", "response": done_response})
+
+
+def post_responses_api_endpoint(*, worker: Any, session_manager: SessionManager):
+    """Build OpenAI Responses API compatible POST handler."""
+
+    async def post_responses_api(response: Response, request: Request, payload: ResponsesRequest):
+        if payload.stream:
+            return StreamingResponse(headers={"Content-Type": "text/event-stream; charset=utf-8"},
+                                     content=_responses_stream(payload, request, worker, session_manager))
+
+        response.headers["Content-Type"] = "application/json"
+        async with session_manager.session(http_connection=request) as session:
+            try:
+                result = await generate_single_response(payload.to_chat_request(), session, result_type=ChatResponse)
+                add_context_headers_to_response(response)
+                return _responses_response(result, payload.model)
+            except Exception as exc:
+                logger.exception("Unhandled Responses API workflow error")
+                add_context_headers_to_response(response)
+                return JSONResponse(
+                    content=Error(
+                        code=ErrorTypes.WORKFLOW_ERROR,
+                        message=str(exc),
+                        details=type(exc).__name__,
+                    ).model_dump(),
+                    status_code=422,
+                )
+
+    return post_responses_api
+
+
+async def add_v1_responses_route(
+    worker: Any,
+    app: FastAPI,
+    *,
+    path: str,
+    method: str,
+    description: str,
+    session_manager: SessionManager,
+):
+    """Register OpenAI v1 Responses endpoint."""
+    app.add_api_route(
+        path=path,
+        endpoint=post_responses_api_endpoint(worker=worker, session_manager=session_manager),
+        methods=[method],
+        description=f"{description} (OpenAI Responses API compatible)",
+        responses={500: RESPONSE_500},
+    )

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/routes/v1_responses.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/routes/v1_responses.py
@@ -107,7 +107,8 @@ def _event(event: str, payload: dict[str, Any]) -> str:
 async def _responses_stream(payload: ResponsesRequest,
                             request: Request,
                             worker: Any,
-                            session_manager: SessionManager) -> AsyncGenerator[str]:
+                            session_manager: SessionManager,
+                            enable_interactive: bool = False) -> AsyncGenerator[str]:
     response_id = f"resp_{uuid.uuid4().hex}"
     item_id = f"msg_{uuid.uuid4().hex}"
     content_index = 0
@@ -191,13 +192,15 @@ async def _responses_stream(payload: ResponsesRequest,
     yield _event("response.done", {"type": "response.done", "response": done_response})
 
 
-def post_responses_api_endpoint(*, worker: Any, session_manager: SessionManager):
+def post_responses_api_endpoint(*, worker: Any, session_manager: SessionManager, enable_interactive: bool = False):
     """Build OpenAI Responses API compatible POST handler."""
 
     async def post_responses_api(response: Response, request: Request, payload: ResponsesRequest):
         if payload.stream:
-            return StreamingResponse(headers={"Content-Type": "text/event-stream; charset=utf-8"},
-                                     content=_responses_stream(payload, request, worker, session_manager))
+            return StreamingResponse(
+                headers={"Content-Type": "text/event-stream; charset=utf-8"},
+                content=_responses_stream(payload, request, worker, session_manager, enable_interactive),
+            )
 
         response.headers["Content-Type"] = "application/json"
         async with session_manager.session(http_connection=request) as session:
@@ -214,7 +217,7 @@ def post_responses_api_endpoint(*, worker: Any, session_manager: SessionManager)
                         message=str(exc),
                         details=type(exc).__name__,
                     ).model_dump(),
-                    status_code=422,
+                    status_code=500,
                 )
 
     return post_responses_api
@@ -228,11 +231,14 @@ async def add_v1_responses_route(
     method: str,
     description: str,
     session_manager: SessionManager,
+    enable_interactive: bool = False,
 ):
     """Register OpenAI v1 Responses endpoint."""
     app.add_api_route(
         path=path,
-        endpoint=post_responses_api_endpoint(worker=worker, session_manager=session_manager),
+        endpoint=post_responses_api_endpoint(
+            worker=worker, session_manager=session_manager, enable_interactive=enable_interactive
+        ),
         methods=[method],
         description=f"{description} (OpenAI Responses API compatible)",
         responses={500: RESPONSE_500},

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_openai_compatibility.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_openai_compatibility.py
@@ -693,3 +693,144 @@ async def test_openai_compatible_streaming_response_format():
 
     # At least one non-null finish_reason should appear across the stream (finalization)
     assert valid_final_reason_seen, "Expected a final chunk with non-null finish_reason"
+
+
+
+def test_responses_request_converts_to_chat_request():
+    """Responses API payloads should map to the existing ChatRequest workflow contract."""
+    from nat.data_models.api_server import ResponsesRequest
+
+    request = ResponsesRequest(model="gpt-4o-mini",
+                               input="What time is it?",
+                               instructions="Answer briefly.",
+                               max_output_tokens=12,
+                               tools=[{
+                                   "type": "function",
+                                   "name": "current_datetime",
+                                   "description": "Get the current date and time",
+                                   "parameters": {"type": "object"},
+                               }])
+
+    chat_request = request.to_chat_request()
+
+    assert [message.role.value for message in chat_request.messages] == ["system", "user"]
+    assert chat_request.messages[0].content == "Answer briefly."
+    assert chat_request.messages[1].content == "What time is it?"
+    assert chat_request.model == "gpt-4o-mini"
+    assert chat_request.max_tokens == 12
+    assert chat_request.tools == [{
+        "type": "function",
+        "function": {
+            "name": "current_datetime",
+            "description": "Get the current date and time",
+            "parameters": {"type": "object"},
+        },
+    }]
+
+
+def test_responses_request_converts_untyped_message_input_to_chat_request():
+    """Responses API message items may omit type and should still preserve their content."""
+    from nat.data_models.api_server import ResponsesRequest
+
+    request = ResponsesRequest(model="gpt-4o-mini",
+                               input=[{
+                                   "role": "user",
+                                   "content": "Explain DCO briefly.",
+                               }])
+
+    chat_request = request.to_chat_request()
+
+    assert len(chat_request.messages) == 1
+    assert chat_request.messages[0].role.value == "user"
+    assert chat_request.messages[0].content == "Explain DCO briefly."
+
+
+def test_responses_request_preserves_structured_message_roles():
+    """Structured Responses API message items should preserve their conversation roles."""
+    from nat.data_models.api_server import ResponsesRequest
+
+    request = ResponsesRequest(input=[{
+        "role": "system",
+        "content": "Be terse.",
+    }, {
+        "role": "user",
+        "content": "What is DCO?",
+    }])
+
+    chat_request = request.to_chat_request()
+
+    assert [(message.role.value, message.content) for message in chat_request.messages] == [
+        ("system", "Be terse."),
+        ("user", "What is DCO?"),
+    ]
+
+
+async def test_openai_responses_endpoint_accepts_responses_payload():
+    """A /v1/responses path should accept Responses API input and return Responses API output."""
+    front_end_config = FastApiFrontEndConfig()
+    front_end_config.workflow.openai_api_v1_path = "/v1/responses"
+    front_end_config.workflow.openai_api_path = "/chat"
+
+    config = Config(
+        general=GeneralConfig(front_end=front_end_config),
+        workflow=EchoFunctionConfig(use_openai_api=True),
+    )
+
+    async with build_nat_client(config) as client:
+        response = await client.post("/v1/responses",
+                                     json={
+                                         "model": "gpt-4o-mini",
+                                         "input": "Hello from Responses API",
+                                     })
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["object"] == "response"
+    assert data["status"] == "completed"
+    assert data["model"] == "gpt-4o-mini"
+    assert data["output"][0]["type"] == "message"
+    assert data["output"][0]["role"] == "assistant"
+    assert data["output"][0]["content"][0] == {
+        "type": "output_text",
+        "text": "Hello from Responses API",
+        "annotations": [],
+    }
+    assert data["usage"] == {"input_tokens": 4, "output_tokens": 4, "total_tokens": 8}
+
+
+async def test_openai_responses_endpoint_streams_responses_events():
+    """Streaming /v1/responses should emit Responses API SSE lifecycle events."""
+    front_end_config = FastApiFrontEndConfig()
+    front_end_config.workflow.openai_api_v1_path = "/v1/responses"
+
+    config = Config(
+        general=GeneralConfig(front_end=front_end_config),
+        workflow=StreamingEchoFunctionConfig(use_openai_api=True),
+    )
+
+    async with build_nat_client(config) as client:
+        events = []
+        async with aconnect_sse(client,
+                                "POST",
+                                "/v1/responses",
+                                json={
+                                    "model": "gpt-4o-mini",
+                                    "input": "Hello streaming",
+                                    "stream": True,
+                                }) as event_source:
+            async for sse in event_source.aiter_sse():
+                events.append((sse.event, sse.json()))
+
+    assert event_source.response.status_code == 200
+    assert [event for event, _ in events] == [
+        "response.created",
+        "response.output_item.added",
+        "response.content_part.added",
+        "response.output_text.delta",
+        "response.output_text.done",
+        "response.content_part.done",
+        "response.output_item.done",
+        "response.done",
+    ]
+    assert events[3][1]["delta"] == "Hello streaming"
+    assert events[-1][1]["response"]["output"][0]["content"][0]["text"] == "Hello streaming"


### PR DESCRIPTION
## Summary
- add a Responses API request model that maps Responses payloads onto the existing chat workflow contract
- register /v1/responses-compatible routing when openai_api_v1_path ends with /responses
- return Responses API-shaped non-streaming responses and SSE lifecycle events for streaming responses

Fixes #1278

## Verification
- uv run --extra test --extra async_endpoints pytest packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_openai_compatibility.py -q
- uv run --extra test --extra async_endpoints ruff check packages/nvidia_nat_core/src/nat/data_models/api_server.py packages/nvidia_nat_core/src/nat/front_ends/fastapi/routes/chat.py packages/nvidia_nat_core/src/nat/front_ends/fastapi/routes/v1_responses.py packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_openai_compatibility.py