### PR TITLE
fix(langchain): pass conversation_id as LangGraph thread_id

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
@@ -38,6 +38,7 @@ from pydantic import Field
 from pydantic import FilePath
 
 from nat.builder.builder import Builder
+from nat.builder.context import Context
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function import Function
 from nat.cli.register_workflow import register_function
@@ -103,30 +104,47 @@ class LanggraphWrapperFunction(Function[LanggraphWrapperInput, LanggraphWrapperO
 
         self._graph = graph
 
+    @staticmethod
+    def _build_runnable_config() -> RunnableConfig | None:
+        """Build a ``RunnableConfig`` carrying the LangGraph ``thread_id``.
+
+        NAT's ``conversation_id`` (set per chat conversation) maps to LangGraph's
+        ``thread_id``, which checkpointer-backed graphs require for conversation
+        continuity. Without it, invoking a graph compiled with a checkpointer
+        raises a ``ValueError``. Returns ``None`` when no conversation is in
+        context, preserving the prior behavior for stateless graphs.
+        """
+        conversation_id = Context.get().conversation_id
+        if conversation_id is None:
+            return None
+        return RunnableConfig(configurable={"thread_id": conversation_id})
+
     async def _ainvoke(self, value: LanggraphWrapperInput) -> LanggraphWrapperOutput:
 
+        config = self._build_runnable_config()
         try:
             # Check if the graph is an async context manager (e.g., from @asynccontextmanager)
             if hasattr(self._graph, '__aenter__') and hasattr(self._graph, '__aexit__'):
                 logger.info("Graph is an async context manager")
                 async with self._graph as graph:
-                    output = await graph.ainvoke(value.model_dump())
+                    output = await graph.ainvoke(value.model_dump(), config=config)
             else:
-                output = await self._graph.ainvoke(value.model_dump())
+                output = await self._graph.ainvoke(value.model_dump(), config=config)
             return LanggraphWrapperOutput.model_validate(output)
         except Exception as e:
             raise RuntimeError(f"Error in LangGraph workflow: {e}") from e
 
     async def _astream(self, value: LanggraphWrapperInput) -> AsyncGenerator[LanggraphWrapperOutput, None]:
+        config = self._build_runnable_config()
         try:
 
             if hasattr(self._graph, '__aenter__') and hasattr(self._graph, '__aexit__'):
                 logger.info("Graph is an async context manager")
                 async with self._graph as graph:
-                    async for output in graph.astream(value.model_dump()):
+                    async for output in graph.astream(value.model_dump(), config=config):
                         yield self._parse_stream_output(output)
             else:
-                async for output in self._graph.astream(value.model_dump()):
+                async for output in self._graph.astream(value.model_dump(), config=config):
                     yield self._parse_stream_output(output)
         except Exception as e:
             raise RuntimeError(f"Error in LangGraph workflow: {e}") from e

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
@@ -108,11 +108,12 @@ class LanggraphWrapperFunction(Function[LanggraphWrapperInput, LanggraphWrapperO
     def _build_runnable_config() -> RunnableConfig | None:
         """Build a ``RunnableConfig`` carrying the LangGraph ``thread_id``.
 
-        NAT's ``conversation_id`` (set per chat conversation) maps to LangGraph's
-        ``thread_id``, which checkpointer-backed graphs require for conversation
-        continuity. Without it, invoking a graph compiled with a checkpointer
-        raises a ``ValueError``. Returns ``None`` when no conversation is in
-        context, preserving the prior behavior for stateless graphs.
+        The ``conversation_id`` from the request context (set per chat
+        conversation) maps to LangGraph's ``thread_id``, which checkpointer-backed
+        graphs require for conversation continuity. Without it, invoking a graph
+        compiled with a checkpointer raises a ``ValueError``. Returns ``None``
+        when no conversation is in context, preserving the prior behavior for
+        stateless graphs.
         """
         conversation_id = Context.get().conversation_id
         if conversation_id is None:

--- a/packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py
+++ b/packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py
@@ -206,7 +206,7 @@ class TestParseStreamOutput:
 
 
 class TestBuildRunnableConfig:
-    """Tests for LanggraphWrapperFunction._build_runnable_config: NAT conversation_id -> LangGraph thread_id."""
+    """Tests for LanggraphWrapperFunction._build_runnable_config: conversation_id -> LangGraph thread_id."""
 
     def test_conversation_id_maps_to_thread_id(self):
         """When a conversation_id is in context, it is passed as the LangGraph thread_id."""

--- a/packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py
+++ b/packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch
+
 import pytest
 from langchain_core.messages import AIMessage
 from langchain_core.messages import HumanMessage
@@ -201,3 +203,26 @@ class TestParseStreamOutput:
         }
         with pytest.raises(Exception):
             LanggraphWrapperFunction._parse_stream_output(raw)
+
+
+class TestBuildRunnableConfig:
+    """Tests for LanggraphWrapperFunction._build_runnable_config: NAT conversation_id -> LangGraph thread_id."""
+
+    def test_conversation_id_maps_to_thread_id(self):
+        """When a conversation_id is in context, it is passed as the LangGraph thread_id."""
+        with patch("nat.plugins.langchain.langgraph_workflow.Context") as mock_context:
+            mock_context.get.return_value.conversation_id = "conv-123"
+
+            config = LanggraphWrapperFunction._build_runnable_config()
+
+        assert config is not None
+        assert config["configurable"]["thread_id"] == "conv-123"
+
+    def test_no_conversation_id_returns_none(self):
+        """When no conversation_id is in context, no config is built (prior behavior preserved)."""
+        with patch("nat.plugins.langchain.langgraph_workflow.Context") as mock_context:
+            mock_context.get.return_value.conversation_id = None
+
+            config = LanggraphWrapperFunction._build_runnable_config()
+
+        assert config is None


### PR DESCRIPTION
## Description

The `langgraph_wrapper` invoked the wrapped graph without a `RunnableConfig`, so any graph compiled with a checkpointer raised:

```
ValueError: Checkpointer requires one or more of the following 'configurable' keys: thread_id, checkpoint_ns, checkpoint_id
```

As a result, checkpoint-backed thread memory never worked when a LangGraph agent was served through NAT (per #1994).

This maps NAT's `conversation_id` to LangGraph's `thread_id` and passes it to all `ainvoke`/`astream` calls, following the existing `zep_cloud` plugin convention (`zep_editor.py` uses `Context.get().conversation_id` as the thread id). When no `conversation_id` is in context, the config is `None`, preserving the current behavior for stateless graphs.

Verified empirically against `langgraph` 1.x:
- With a checkpointer + `thread_id`: memory persists across turns and threads are isolated.
- Without a checkpointer: passing a `thread_id` is a harmless no-op, so the change is safe for all graphs.

### Open questions for maintainers
1. Should the `thread_id` be namespaced by `user_id` (e.g. `f"{user_id}:{conversation_id}"`) for stronger multi-user isolation? I followed the `conversation_id`-only convention already used by `zep_cloud`, but happy to change.
2. When no `conversation_id` is present, the current behavior (no thread id, no persistence) is preserved. Let me know if a synthesized fallback is preferred.

Closes #1994

## By Submitting this PR I confirm:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- [x] We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license. (Commit is signed off.)
- [x] When the PR is ready for review, new or existing tests cover these changes. (Added `TestBuildRunnableConfig`; full file: 19 passed.)
- [x] When the PR is ready for review, the documentation is up to date with these changes. (No user-facing doc/API change; behavior fix only.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LangGraph workflow continuity by ensuring invocations consistently pass a runnable configuration with the proper thread identifier derived from the current conversation context (and omitting it when no conversation ID is available).
* **Tests**
  * Added unit tests to verify runnable configuration generation: it sets the thread identifier when a conversation ID exists, and returns no configuration when absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->