### PR TITLE
fix(api-server): Fix OpenAI chat completions tool-call history validation

### DIFF
--- a/ci/markdown-link-check-config.json
+++ b/ci/markdown-link-check-config.json
@@ -26,6 +26,9 @@
         },
         {
             "pattern": "^https://docs\\.docker\\.com"
+        },
+        {
+            "pattern": "^https://www\\.sphinx-doc\\.org/en/master/?$"
         }
     ]
 }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -188,6 +188,7 @@ numpydoc_class_members_toctree = False
 # mysql.com  reports a 403 when requested by linkcheck
 # api.service.com is a placeholder for a service example
 # Ignore example.com/mcp as it is inaccessible when building the docs
+# Ignore sphinx-doc.org because it can rate limit CI link checks
 # docs.dbnl.com is inaccessible and https://www.distributional.com/ says "Something new is coming", putting this on
 # hold for now
 linkcheck_ignore = [
@@ -203,7 +204,8 @@ linkcheck_ignore = [
     r'http://custom-server',
     r'^\?provider=',
     r'https://agent\.example\.com',
-    r'https://github\.com/NVIDIA/NeMo-Agent-Toolkit/(issues|pull)/'
+    r'https://github\.com/NVIDIA/NeMo-Agent-Toolkit/(issues|pull)/',
+    r'https://www\.sphinx-doc\.org/en/master/?'
 ]
 
 templates_path = ['_templates']

--- a/packages/nvidia_nat_core/src/nat/data_models/api_server.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/api_server.py
@@ -45,6 +45,7 @@ class UserMessageContentRoleType(StrEnum):
     USER = "user"
     ASSISTANT = "assistant"
     SYSTEM = "system"
+    TOOL = "tool"
 
 
 class Request(BaseModel):
@@ -114,8 +115,23 @@ UserContent = typing.Annotated[TextContent | ImageContent | AudioContent, Discri
 
 
 class Message(BaseModel):
-    content: str | list[UserContent]
+    model_config = ConfigDict(extra="allow")
+
+    content: str | list[UserContent] | None
     role: UserMessageContentRoleType
+    tool_calls: list[dict[str, typing.Any]] | None = None
+    tool_call_id: str | None = None
+
+    @model_validator(mode="after")
+    def validate_content(self):
+        if self.content is not None:
+            return self
+
+        if self.role == UserMessageContentRoleType.ASSISTANT:
+            if self.tool_calls or (self.model_extra and self.model_extra.get("function_call")):
+                return self
+
+        raise ValueError("content may be null only for assistant messages with tool_calls or function_call")
 
 
 class ChatRequest(BaseModel):
@@ -905,9 +921,12 @@ GlobalTypeConverter.register_converter(_generate_response_to_chat_response)
 
 # ======== ChatRequest Converters ========
 def _nat_chat_request_to_string(data: ChatRequest) -> str:
-    if isinstance(data.messages[-1].content, str):
-        return data.messages[-1].content
-    return str(data.messages[-1].content)
+    content = data.messages[-1].content
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content
+    return str(content)
 
 
 GlobalTypeConverter.register_converter(_nat_chat_request_to_string)

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_openai_compatibility.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_openai_compatibility.py
@@ -106,6 +106,51 @@ def test_nat_chat_request_openai_fields():
     assert request.user == "user123"
 
 
+def test_nat_chat_request_accepts_openai_tool_call_history():
+    """Test that ChatRequest accepts OpenAI-compatible tool-call messages."""
+    request = ChatRequest.model_validate({
+        "messages": [
+            {
+                "role": "user",
+                "content": "Use a tool.",
+            },
+            {
+                "role":
+                    "assistant",
+                "content":
+                    None,
+                "tool_calls": [{
+                    "id": "call_123",
+                    "type": "function",
+                    "function": {
+                        "name": "current_datetime",
+                        "arguments": "{}",
+                    },
+                }, ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_123",
+                "content": "{\"time\":\"2026-06-12T12:00:00Z\"}",
+            },
+            {
+                "role": "user",
+                "content": "Continue.",
+            },
+        ],
+    })
+
+    assistant_message = request.messages[1]
+    assert assistant_message.role == UserMessageContentRoleType.ASSISTANT
+    assert assistant_message.content is None
+    assert assistant_message.tool_calls is not None
+    assert assistant_message.tool_calls[0]["function"]["name"] == "current_datetime"
+
+    tool_message = request.messages[2]
+    assert tool_message.role == UserMessageContentRoleType.TOOL
+    assert tool_message.tool_call_id == "call_123"
+
+
 def test_nat_choice_delta_class():
     """Test that ChoiceDelta class works correctly"""
     # Test empty delta
@@ -281,6 +326,86 @@ async def test_openai_compatible_mode_stream_parameter():
 
         assert event_source.response.status_code == 200
         assert event_source.response.headers["content-type"] == "text/event-stream; charset=utf-8"
+
+
+async def test_openai_compatible_endpoint_accepts_tool_call_history():
+    """Test that OpenAI v1 mode accepts valid tool-call conversation history."""
+    front_end_config = FastApiFrontEndConfig()
+    front_end_config.workflow.openai_api_v1_path = "/v1/chat/completions"
+
+    config = Config(
+        general=GeneralConfig(front_end=front_end_config),
+        workflow=EchoFunctionConfig(use_openai_api=True),
+    )
+
+    payloads = [
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Use a tool.",
+                },
+                {
+                    "role":
+                        "assistant",
+                    "content":
+                        None,
+                    "tool_calls": [{
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "current_datetime",
+                            "arguments": "{}",
+                        },
+                    }, ],
+                },
+                {
+                    "role": "user",
+                    "content": "Continue.",
+                },
+            ],
+        },
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Use a tool.",
+                },
+                {
+                    "role":
+                        "assistant",
+                    "content":
+                        "",
+                    "tool_calls": [{
+                        "id": "call_123",
+                        "type": "function",
+                        "function": {
+                            "name": "current_datetime",
+                            "arguments": "{}",
+                        },
+                    }, ],
+                },
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_123",
+                    "content": "{\"time\":\"2026-06-12T12:00:00Z\"}",
+                },
+                {
+                    "role": "user",
+                    "content": "Continue.",
+                },
+            ],
+        },
+    ]
+
+    async with build_nat_client(config) as client:
+        for payload in payloads:
+            response = await client.post("/v1/chat/completions", json=payload)
+
+            assert response.status_code == 200, response.text
+            data = response.json()
+            assert data["choices"][0]["message"]["role"] == "assistant"
+            assert isinstance(data["choices"][0]["message"]["content"], str)
 
 
 async def test_legacy_non_streaming_response_format():

--- a/packages/nvidia_nat_core/tests/nat/server/test_unified_api_server.py
+++ b/packages/nvidia_nat_core/tests/nat/server/test_unified_api_server.py
@@ -1186,6 +1186,15 @@ async def test_invalid_openai_chat_request_fields():
         ChatRequest(messages=[{"role": "user", "content": "Hello"}], stream="not_a_boolean")
 
     with pytest.raises(ValidationError):
+        ChatRequest(messages=[{"role": "user", "content": None}])
+
+    with pytest.raises(ValidationError):
+        ChatRequest(messages=[{"role": "assistant", "content": None}])
+
+    with pytest.raises(ValidationError):
+        ChatRequest(messages=[{"role": "tool", "tool_call_id": "call_123", "content": None}])
+
+    with pytest.raises(ValidationError):
         ChatRequest(messages="not_a_list")
 
     with pytest.raises(ValidationError):


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->

- Accept OpenAI-compatible `role: "tool"` messages in chat completion request history.
- Allow assistant messages with content: null when paired with `tool_calls` or `function_call`.
- Preserve `tool_calls` and `tool_call_id` fields on parsed request messages.
- Avoid converting `content: null` into the literal string "None".

Closes #2068

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for tool messages and tool calls in chat conversations, enabling function-calling workflows
  * Tool role and tool call metadata now supported in message history

* **Improvements**
  * Enhanced OpenAI compatibility for tool-call conversation handling
  * Improved validation for assistant messages with tool calls
<!-- end of auto-generated comment: release notes by coderabbit.ai -->