### PR TITLE
Enable preflight authentication for applicable authentication providers

### DIFF
--- a/docs/source/components/auth/api-authentication.md
+++ b/docs/source/components/auth/api-authentication.md
@@ -115,7 +115,7 @@ authentication:
 | `redirect_uri` | The redirect URI for OAuth 2.0 authentication. Must match the registered redirect URI with the OAuth provider.|
 | `scopes` | List of permissions to the API provider (for example, `read`, `write`). |
 | `use_pkce` | Whether to use PKCE (Proof Key for Code Exchange) in the OAuth 2.0 flow, defaults to `False` |
-| `preflight_auth` | When `True`, authentication is triggered at the earliest opportunity for the active frontend, before any workflow messages are processed. Defaults to `False` (on-demand). Not supported for MCP providers. |
+| `preflight_auth` | When `True`, authentication is triggered at the earliest opportunity for the active frontend, before any workflow messages are processed. |
 | `authorization_kwargs` | Additional keyword arguments to include in the authorization request. |
 
 

--- a/docs/source/components/auth/api-authentication.md
+++ b/docs/source/components/auth/api-authentication.md
@@ -104,7 +104,7 @@ authentication:
 
 ### OAuth2.0 Authorization Code Grant Configuration Reference
 | Field Name | Description |
-|-------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
+|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
 | `test_auth_provider` | A unique name used to identify the client credentials required to access the API provider. |
 | `_type` | Specifies the authentication type. For OAuth 2.0 Authorization Code Grant authentication, set this to `oauth2_auth_code_flow`. |
 | `client_id` | The Identifier provided when registering the OAuth 2.0 client server with an API provider. |
@@ -113,8 +113,9 @@ authentication:
 | `token_url` | URL used to exchange an authorization code for an access token and optional refresh token. |
 | `token_endpoint_auth_method` | Some token provider endpoints require specific types of authentication. For example `client_secret_post`. |
 | `redirect_uri` | The redirect URI for OAuth 2.0 authentication. Must match the registered redirect URI with the OAuth provider.|
-| `scopes` | List of permissions to the API provider (e.g., `read`, `write`). |
+| `scopes` | List of permissions to the API provider (for example, `read`, `write`). |
 | `use_pkce` | Whether to use PKCE (Proof Key for Code Exchange) in the OAuth 2.0 flow, defaults to `False` |
+| `preflight_auth` | When `True`, authentication is triggered at the earliest opportunity for the active frontend, before any workflow messages are processed. Defaults to `False` (on-demand). Not supported for MCP providers. |
 | `authorization_kwargs` | Additional keyword arguments to include in the authorization request. |
 
 
@@ -150,7 +151,7 @@ Full source code for the above example can be found in `examples/front_ends/simp
 ## 4. Authentication by Application Configuration
 Authentication methods not needing consent prompts, such as API Keys are supported uniformly across all deployment methods.
 In contrast, support for methods that require user interaction can vary depending on the application's deployment and available
-components. In some configurations, the system’s default browser handles the redirect directly, while in others, the
+components. In some configurations, the system's default browser handles the redirect directly, while in others, the
 front-end UI is responsible for rendering the consent prompt.
 
 Below is a table listing the current support for the various authentication methods based on the application
@@ -167,3 +168,14 @@ The sections below detail how OAuth2.0 authentication is handled in each support
 > If using the OAuth2.0 Authorization Code Grant Flow, ensure that the `redirect_uri` in your workflow configuration matches the
 > registered redirect URI in the API provider's console. Mismatched URIs will result in authentication failures. If you are using it
 > in conjunction with the front-end UI, ensure that your browser supports popups and that the redirect URI is accessible from the browser.
+
+### Preflight Authentication
+
+By default, OAuth2.0 authentication is triggered on-demand when a workflow tool first requests credentials. Setting `preflight_auth: true` on an OAuth2.0 provider changes this so the full authentication flow is initiated at the earliest opportunity for the active frontend, before any workflow messages are processed.
+
+- **`nat serve` (WebSocket)**: Authentication runs on WebSocket connect, before the first user message is received. If a provider fails, an error message is sent to the UI and authentication proceeds to the next configured provider.
+- **`nat run` (console)**: Authentication runs before the first query is processed. If a provider fails, a warning is logged and authentication proceeds to the next configured provider.
+
+When multiple providers have `preflight_auth: true`, each is authenticated in order. On-demand authentication serves as the fallback for any provider that did not complete preflight authentication successfully.
+
+`preflight_auth` is not supported for MCP authentication providers (`_type: mcp_oauth2`). MCP has its own authentication handshake that is triggered automatically when the MCP server returns a 401 response.

--- a/examples/front_ends/simple_auth/src/nat_simple_auth/configs/config.yml
+++ b/examples/front_ends/simple_auth/src/nat_simple_auth/configs/config.yml
@@ -57,6 +57,7 @@ authentication:
     client_id: ${NAT_OAUTH_CLIENT_ID}
     client_secret: ${NAT_OAUTH_CLIENT_SECRET}
     use_pkce: false
+    preflight_auth: true
 
 workflow:
   _type: react_agent

--- a/packages/nvidia_nat_core/src/nat/data_models/authentication.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/authentication.py
@@ -36,6 +36,10 @@ class AuthProviderBaseConfig(TypedBaseModel, BaseModelRegistryTag):
     # Default, forbid extra fields to prevent unexpected behavior or miss typed options
     model_config = ConfigDict(extra="forbid")
 
+    preflight_auth: bool = Field(default=False,
+                                 description="When True, authentication is triggered at session start rather than "
+                                 "on first use by a tool. Preserves existing on-demand behavior when False.")
+
 
 AuthProviderBaseConfigT = typing.TypeVar("AuthProviderBaseConfigT", bound=AuthProviderBaseConfig)
 

--- a/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
@@ -118,8 +118,8 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
                 provider = await session_manager.shared_builder.get_auth_provider(name)
                 try:
                     await provider.authenticate()
-                except Exception as e:
-                    logger.warning("Preflight auth failed for provider '%s': %s", name, e)
+                except Exception:
+                    logger.exception("Preflight auth failed for provider '%s'", name)
 
     async def pre_run(self):
         if (self.front_end_config.input_query is not None and self.front_end_config.input_file is not None):

--- a/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/console/console_front_end_plugin.py
@@ -105,6 +105,22 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
         # Set the authentication flow handler
         self.auth_flow_handler = ConsoleAuthenticationFlowHandler()
 
+    async def _run_preflight_auth(self, session_manager: SessionManager) -> None:
+        """Authenticate providers with ``preflight_auth=True``.
+
+        Must be called inside an already-open session context so the auth
+        challenge can reach the user and the token is stored for the
+        workflow run that follows.
+        """
+        for name, cfg in session_manager.config.authentication.items():
+            if cfg.preflight_auth:
+                logger.debug("Preflight auth: authenticating provider '%s'", name)
+                provider = await session_manager.shared_builder.get_auth_provider(name)
+                try:
+                    await provider.authenticate()
+                except Exception as e:
+                    logger.warning("Preflight auth failed for provider '%s': %s", name, e)
+
     async def pre_run(self):
         if (self.front_end_config.input_query is not None and self.front_end_config.input_file is not None):
             raise click.UsageError("Must specify either --input or --input_file, not both")
@@ -114,6 +130,7 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
     async def run_workflow(self, session_manager: SessionManager):
 
         assert session_manager is not None, "Session manager must be provided"
+
         runner_outputs = None
 
         run_user_id = self.front_end_config.user_id
@@ -128,6 +145,7 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
                         conversation_id=conversation_id,
                         user_input_callback=prompt_for_input_cli,
                         user_authentication_callback=self.auth_flow_handler.authenticate) as session:
+                    await self._run_preflight_auth(session_manager)
                     async with session.run(query) as runner:
                         base_output = await runner.result(to_type=str)
 
@@ -146,7 +164,11 @@ class ConsoleFrontEndPlugin(SimpleFrontEndPluginBase[ConsoleFrontEndConfig]):
             # Run the workflow
             with open(self.front_end_config.input_file, encoding="utf-8") as f:
                 input_content = f.read()
-            async with session_manager.session(user_id=run_user_id, conversation_id=conversation_id) as session:
+            async with session_manager.session(
+                    user_id=run_user_id,
+                    conversation_id=conversation_id,
+                    user_authentication_callback=self.auth_flow_handler.authenticate) as session:
+                await self._run_preflight_auth(session_manager)
                 async with session.run(input_content) as runner:
                     runner_outputs = await runner.result(to_type=str)
         else:

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
@@ -175,10 +175,35 @@ class WebSocketMessageHandler:
     async def __aexit__(self, exc_type, exc_value, traceback) -> None:
         pass
 
+    async def _run_preflight_auth(self) -> None:
+        """Authenticate all providers with ``preflight_auth=True`` at WebSocket connect time."""
+        if self._flow_handler is None or not any(cfg.preflight_auth
+                                                 for cfg in self._session_manager.config.authentication.values()):
+            return
+        async with self._session_manager.session(
+                http_connection=self._socket,
+                user_authentication_callback=self._flow_handler.authenticate,
+        ):
+            for name, cfg in self._session_manager.config.authentication.items():
+                if cfg.preflight_auth:
+                    logger.debug("Preflight auth: authenticating provider '%s'", name)
+                    provider = await self._session_manager.shared_builder.get_auth_provider(name)
+                    try:
+                        await provider.authenticate()
+                    except Exception as e:
+                        logger.warning("Preflight auth failed for provider '%s': %s", name, e)
+                        await self._socket.send_json(
+                            Error(
+                                code=ErrorTypes.USER_AUTH_ERROR,
+                                message=f"Preflight authentication failed for provider '{name}'",
+                            ).model_dump())
+
     async def run(self) -> None:
         """
         Processes received messages from websocket and routes them appropriately.
         """
+        await self._run_preflight_auth()
+
         while True:
 
             try:

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/message_handler.py
@@ -190,8 +190,8 @@ class WebSocketMessageHandler:
                     provider = await self._session_manager.shared_builder.get_auth_provider(name)
                     try:
                         await provider.authenticate()
-                    except Exception as e:
-                        logger.warning("Preflight auth failed for provider '%s': %s", name, e)
+                    except Exception:
+                        logger.exception("Preflight auth failed for provider '%s'", name)
                         await self._socket.send_json(
                             Error(
                                 code=ErrorTypes.USER_AUTH_ERROR,

--- a/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_console_flow_handler.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_console_flow_handler.py
@@ -280,18 +280,3 @@ async def test_console_preflight_auth_continues_remaining_providers_after_one_fa
 
     provider_a.authenticate.assert_awaited_once()
     provider_b.authenticate.assert_awaited_once()
-
-
-async def test_console_preflight_auth_logs_one_warning_per_failed_provider(caplog):
-    provider_a, provider_b = AsyncMock(), AsyncMock()
-    provider_a.authenticate.side_effect = RuntimeError("a failed")
-    provider_b.authenticate.side_effect = RuntimeError("b failed")
-    sm = _sm({"provider_a": _cfg(), "provider_b": _cfg()})
-    sm.shared_builder.get_auth_provider.side_effect = [provider_a, provider_b]
-
-    with caplog.at_level(logging.WARNING):
-        await _run(sm)
-
-    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
-    assert any("provider_a" in m for m in warnings)
-    assert any("provider_b" in m for m in warnings)

--- a/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_console_flow_handler.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_console_flow_handler.py
@@ -14,7 +14,10 @@
 # limitations under the License.
 
 import asyncio
+import logging
 import socket
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 
 import httpx
 import pytest
@@ -24,6 +27,7 @@ from mock_oauth2_server import MockOAuth2Server
 from nat.authentication.oauth2.oauth2_auth_code_flow_provider_config import OAuth2AuthCodeFlowProviderConfig
 from nat.data_models.authentication import AuthFlowType
 from nat.front_ends.console.authentication_flow_handler import ConsoleAuthenticationFlowHandler
+from nat.front_ends.console.console_front_end_plugin import ConsoleFrontEndPlugin
 
 
 # --------------------------------------------------------------------------- #
@@ -196,3 +200,98 @@ async def test_console_oauth2_flow_error_handling(monkeypatch, mock_server):
     # Verify the error message contains the original exception information
     error_message = str(exc_info.value)
     assert "Invalid OAuth client configuration" in error_message
+
+
+# ---------------------------------------------------------------------------
+# ConsoleFrontEndPlugin – preflight authentication
+# ---------------------------------------------------------------------------
+
+
+def _sm(auth_providers: dict) -> MagicMock:
+    sm = MagicMock()
+    sm.config.authentication = auth_providers
+    sm.shared_builder.get_auth_provider = AsyncMock()
+    return sm
+
+
+def _cfg(preflight_auth: bool = True) -> MagicMock:
+    cfg = MagicMock()
+    cfg.preflight_auth = preflight_auth
+    return cfg
+
+
+async def _run(sm: MagicMock) -> None:
+    """Call _run_preflight_auth without instantiating the full plugin."""
+    await ConsoleFrontEndPlugin._run_preflight_auth(MagicMock(), sm)
+
+
+async def test_console_preflight_auth_authenticates_single_provider():
+    provider = AsyncMock()
+    sm = _sm({"provider_a": _cfg()})
+    sm.shared_builder.get_auth_provider.return_value = provider
+
+    await _run(sm)
+
+    sm.shared_builder.get_auth_provider.assert_awaited_once_with("provider_a")
+    provider.authenticate.assert_awaited_once()
+
+
+async def test_console_preflight_auth_authenticates_all_preflight_providers():
+    provider_a, provider_b = AsyncMock(), AsyncMock()
+    sm = _sm({"provider_a": _cfg(), "provider_b": _cfg()})
+    sm.shared_builder.get_auth_provider.side_effect = [provider_a, provider_b]
+
+    await _run(sm)
+
+    assert sm.shared_builder.get_auth_provider.await_count == 2
+    provider_a.authenticate.assert_awaited_once()
+    provider_b.authenticate.assert_awaited_once()
+
+
+async def test_console_preflight_auth_skips_non_preflight_providers():
+    provider_a = AsyncMock()
+    sm = _sm({"provider_a": _cfg(), "provider_b": _cfg(preflight_auth=False)})
+    sm.shared_builder.get_auth_provider.return_value = provider_a
+
+    await _run(sm)
+
+    sm.shared_builder.get_auth_provider.assert_awaited_once_with("provider_a")
+
+
+async def test_console_preflight_auth_logs_warning_and_does_not_raise_on_failure(caplog):
+    provider = AsyncMock()
+    provider.authenticate.side_effect = RuntimeError("OAuth server unreachable")
+    sm = _sm({"provider_a": _cfg()})
+    sm.shared_builder.get_auth_provider.return_value = provider
+
+    with caplog.at_level(logging.WARNING):
+        await _run(sm)
+
+    assert any("provider_a" in r.message for r in caplog.records)
+
+
+async def test_console_preflight_auth_continues_remaining_providers_after_one_fails():
+    provider_a, provider_b = AsyncMock(), AsyncMock()
+    provider_a.authenticate.side_effect = RuntimeError("a failed")
+    sm = _sm({"provider_a": _cfg(), "provider_b": _cfg()})
+    sm.shared_builder.get_auth_provider.side_effect = [provider_a, provider_b]
+
+    await _run(sm)
+
+    provider_a.authenticate.assert_awaited_once()
+    provider_b.authenticate.assert_awaited_once()
+
+
+async def test_console_preflight_auth_logs_one_warning_per_failed_provider(caplog):
+    provider_a, provider_b = AsyncMock(), AsyncMock()
+    provider_a.authenticate.side_effect = RuntimeError("a failed")
+    provider_b.authenticate.side_effect = RuntimeError("b failed")
+    sm = _sm({"provider_a": _cfg(), "provider_b": _cfg()})
+    sm.shared_builder.get_auth_provider.side_effect = [provider_a, provider_b]
+
+    with caplog.at_level(logging.WARNING):
+        await _run(sm)
+
+    warnings = [r.message for r in caplog.records if r.levelno == logging.WARNING]
+    assert any("provider_a" in m for m in warnings)
+    assert any("provider_b" in m for m in warnings)

--- a/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_console_flow_handler.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_console_flow_handler.py
@@ -203,7 +203,7 @@ async def test_console_oauth2_flow_error_handling(monkeypatch, mock_server):
 
 
 # ---------------------------------------------------------------------------
-# ConsoleFrontEndPlugin – preflight authentication
+# ConsoleFrontEndPlugin - preflight authentication
 # ---------------------------------------------------------------------------
 
 

--- a/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_websocket_flow_handler.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_websocket_flow_handler.py
@@ -245,6 +245,7 @@ def _preflight_session_manager(auth_providers: dict) -> MagicMock:
     sm.get_workflow_single_output_schema.return_value = None
     sm.get_workflow_streaming_output_schema.return_value = None
     sm.config.authentication = auth_providers
+    sm.shared_builder.get_auth_provider = AsyncMock()
     cm = MagicMock()
     cm.__aenter__ = AsyncMock(return_value=MagicMock())
     cm.__aexit__ = AsyncMock(return_value=False)
@@ -325,7 +326,6 @@ async def test_preflight_auth_sends_error_and_does_not_raise_on_failure():
     payload: dict = socket.send_json.call_args[0][0]
     assert payload["code"] == ErrorTypes.USER_AUTH_ERROR
     assert "provider_a" in payload["message"]
-    assert not payload.get("details")
 
 
 async def test_preflight_auth_continues_remaining_providers_after_one_fails():

--- a/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_websocket_flow_handler.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_websocket_flow_handler.py
@@ -230,7 +230,7 @@ async def test_websocket_oauth2_flow_error_handling(monkeypatch, mock_server, tm
 
 
 # ---------------------------------------------------------------------------
-# WebSocketMessageHandler – preflight authentication
+# WebSocketMessageHandler - preflight authentication
 # ---------------------------------------------------------------------------
 
 

--- a/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_websocket_flow_handler.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_websocket_flow_handler.py
@@ -14,6 +14,8 @@
 # limitations under the License.
 
 import socket
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
 from urllib.parse import parse_qs
 from urllib.parse import urlparse
 
@@ -23,10 +25,12 @@ from httpx import ASGITransport
 from mock_oauth2_server import MockOAuth2Server
 
 from nat.authentication.oauth2.oauth2_auth_code_flow_provider_config import OAuth2AuthCodeFlowProviderConfig
+from nat.data_models.api_server import ErrorTypes
 from nat.data_models.authentication import AuthFlowType
 from nat.data_models.config import Config
 from nat.front_ends.fastapi.auth_flow_handlers.websocket_flow_handler import WebSocketAuthenticationFlowHandler
 from nat.front_ends.fastapi.fastapi_front_end_plugin_worker import FastApiFrontEndPluginWorker
+from nat.front_ends.fastapi.message_handler import WebSocketMessageHandler
 from nat.test.functions import EchoFunctionConfig
 
 
@@ -223,3 +227,141 @@ async def test_websocket_oauth2_flow_error_handling(monkeypatch, mock_server, tm
     # Verify timeout RuntimeError is raised (demonstrates partial error handling)
     error_message = str(exc_info.value)
     assert "Authentication flow timed out" in error_message
+
+
+# ---------------------------------------------------------------------------
+# WebSocketMessageHandler – preflight authentication
+# ---------------------------------------------------------------------------
+
+
+def _preflight_provider_cfg(preflight_auth: bool = True) -> MagicMock:
+    cfg = MagicMock()
+    cfg.preflight_auth = preflight_auth
+    return cfg
+
+
+def _preflight_session_manager(auth_providers: dict) -> MagicMock:
+    sm = MagicMock()
+    sm.get_workflow_single_output_schema.return_value = None
+    sm.get_workflow_streaming_output_schema.return_value = None
+    sm.config.authentication = auth_providers
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=MagicMock())
+    cm.__aexit__ = AsyncMock(return_value=False)
+    sm.session.return_value = cm
+    return sm
+
+
+def _preflight_handler(session_manager: MagicMock) -> tuple:
+    socket = AsyncMock()
+    handler = WebSocketMessageHandler(
+        socket=socket,
+        session_manager=session_manager,
+        step_adaptor=MagicMock(),
+        worker=MagicMock(),
+    )
+    return handler, socket
+
+
+async def test_preflight_auth_authenticates_single_provider():
+    provider = AsyncMock()
+    sm = _preflight_session_manager({"provider_a": _preflight_provider_cfg()})
+    sm.shared_builder.get_auth_provider.return_value = provider
+    handler, socket = _preflight_handler(sm)
+    handler.set_flow_handler(MagicMock())
+
+    await handler._run_preflight_auth()
+
+    sm.shared_builder.get_auth_provider.assert_awaited_once_with("provider_a")
+    provider.authenticate.assert_awaited_once()
+    socket.send_json.assert_not_called()
+
+
+async def test_preflight_auth_authenticates_all_preflight_providers():
+    provider_a, provider_b = AsyncMock(), AsyncMock()
+    sm = _preflight_session_manager({
+        "provider_a": _preflight_provider_cfg(),
+        "provider_b": _preflight_provider_cfg(),
+    })
+    sm.shared_builder.get_auth_provider.side_effect = [provider_a, provider_b]
+    handler, socket = _preflight_handler(sm)
+    handler.set_flow_handler(MagicMock())
+
+    await handler._run_preflight_auth()
+
+    assert sm.shared_builder.get_auth_provider.await_count == 2
+    provider_a.authenticate.assert_awaited_once()
+    provider_b.authenticate.assert_awaited_once()
+    socket.send_json.assert_not_called()
+
+
+async def test_preflight_auth_skips_non_preflight_providers():
+    provider_a = AsyncMock()
+    sm = _preflight_session_manager({
+        "provider_a": _preflight_provider_cfg(),
+        "provider_b": _preflight_provider_cfg(preflight_auth=False),
+    })
+    sm.shared_builder.get_auth_provider.return_value = provider_a
+    handler, socket = _preflight_handler(sm)
+    handler.set_flow_handler(MagicMock())
+
+    await handler._run_preflight_auth()
+
+    sm.shared_builder.get_auth_provider.assert_awaited_once_with("provider_a")
+    socket.send_json.assert_not_called()
+
+
+async def test_preflight_auth_sends_error_and_does_not_raise_on_failure():
+    provider = AsyncMock()
+    provider.authenticate.side_effect = RuntimeError("OAuth server unreachable")
+    sm = _preflight_session_manager({"provider_a": _preflight_provider_cfg()})
+    sm.shared_builder.get_auth_provider.return_value = provider
+    handler, socket = _preflight_handler(sm)
+    handler.set_flow_handler(MagicMock())
+
+    await handler._run_preflight_auth()
+
+    socket.send_json.assert_awaited_once()
+    payload: dict = socket.send_json.call_args[0][0]
+    assert payload["code"] == ErrorTypes.USER_AUTH_ERROR
+    assert "provider_a" in payload["message"]
+    assert not payload.get("details")
+
+
+async def test_preflight_auth_continues_remaining_providers_after_one_fails():
+    provider_a, provider_b = AsyncMock(), AsyncMock()
+    provider_a.authenticate.side_effect = RuntimeError("a failed")
+    sm = _preflight_session_manager({
+        "provider_a": _preflight_provider_cfg(),
+        "provider_b": _preflight_provider_cfg(),
+    })
+    sm.shared_builder.get_auth_provider.side_effect = [provider_a, provider_b]
+    handler, socket = _preflight_handler(sm)
+    handler.set_flow_handler(MagicMock())
+
+    await handler._run_preflight_auth()
+
+    provider_a.authenticate.assert_awaited_once()
+    provider_b.authenticate.assert_awaited_once()
+    socket.send_json.assert_awaited_once()
+    assert "provider_a" in socket.send_json.call_args[0][0]["message"]
+
+
+async def test_preflight_auth_sends_one_error_per_failed_provider():
+    provider_a, provider_b = AsyncMock(), AsyncMock()
+    provider_a.authenticate.side_effect = RuntimeError("a failed")
+    provider_b.authenticate.side_effect = RuntimeError("b failed")
+    sm = _preflight_session_manager({
+        "provider_a": _preflight_provider_cfg(),
+        "provider_b": _preflight_provider_cfg(),
+    })
+    sm.shared_builder.get_auth_provider.side_effect = [provider_a, provider_b]
+    handler, socket = _preflight_handler(sm)
+    handler.set_flow_handler(MagicMock())
+
+    await handler._run_preflight_auth()
+
+    assert socket.send_json.await_count == 2
+    messages = {c[0][0]["message"] for c in socket.send_json.call_args_list}
+    assert any("provider_a" in m for m in messages)
+    assert any("provider_b" in m for m in messages)

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider_config.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/auth/auth_provider_config.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Literal
+
 from pydantic import Field
 from pydantic import HttpUrl
 from pydantic import model_validator
@@ -71,6 +73,9 @@ class MCPOAuth2ProviderConfig(AuthProviderBaseConfig, name="mcp_oauth2"):
     token_storage_object_store: str | None = Field(
         default=None,
         description="Reference to object store for secure token storage. If None, uses in-memory storage.")
+
+    # MCP authentication is handled internally via 401-triggered discovery and does not support preflight.
+    preflight_auth: Literal[False] = False
 
     @model_validator(mode="after")
     def validate_auth_config(self):


### PR DESCRIPTION
## Summary
- Adds `preflight_auth` field to `AuthProviderBaseConfig` — when `True`, the full OAuth2 authentication flow is initiated at the earliest opportunity for the active frontend, before any workflow messages are processed
- `nat serve` (WebSocket): authenticates on WebSocket connect; sends an error message to the UI per failed provider and continues to the next
- `nat run` (console): authenticates before the first query; logs a warning per failed provider and continues to the next
- On-demand authentication serves as the fallback for any provider that did not complete preflight successfully
- Locks `preflight_auth` to `Literal[False]` on `MCPOAuth2ProviderConfig` — MCP has its own 401-triggered authentication handshake
- Adds unit tests for both WebSocket and console preflight authentication (happy path, multi-provider, failure handling, ordering)
- Documents `preflight_auth` in the authentication provider API reference
- Enables `preflight_auth` in the `simple_auth` example config
- UI: companion PR [NVIDIA/NeMo-Agent-Toolkit-UI#147](https://github.com/NVIDIA/NeMo-Agent-Toolkit-UI/pull/147) moves OAuth consent message handling before conversation ID validation so preflight messages with `conversation_id: null` are not rejected

Closes #1836

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added preflight authentication so eligible OAuth2 providers authenticate when a session starts (console and WebSocket/API flows), improving early error detection.
* **Documentation**
  * Updated OAuth2 configuration docs to describe `preflight_auth`, including deployment-specific behavior and provider failure handling; noted MCP OAuth2 does not support preflight.
* **Tests**
  * Added unit tests covering preflight-enabled/disabled providers and failure scenarios for console and WebSocket handlers.
* **Chores**
  * Updated the `nat-ui` subproject reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->