### PR TITLE
Fix multi_frameworks supervisor routing

### DIFF
--- a/examples/frameworks/multi_frameworks/src/nat_multi_frameworks/register.py
+++ b/examples/frameworks/multi_frameworks/src/nat_multi_frameworks/register.py
@@ -123,7 +123,7 @@ async def multi_frameworks_workflow(config: MultiFrameworksWorkflowConfig, build
             route_to = "end"
         elif 'chosen_worker_agent' not in status:
             logger.info(" ############# router to --> supervisor %s", Fore.RESET)
-            route_to = "supevisor"
+            route_to = "supervisor"
         elif 'chosen_worker_agent' in status:
             logger.info(" ############# router to --> workers %s", Fore.RESET)
             route_to = "workers"
@@ -160,7 +160,7 @@ async def multi_frameworks_workflow(config: MultiFrameworksWorkflowConfig, build
         "supervisor",
         router,
         {
-            "workers": "workers", "end": END
+            "supervisor": "supervisor", "workers": "workers", "end": END
         },
     )
     workflow.add_edge("supervisor", "workers")


### PR DESCRIPTION
## Summary

- fix the supervisor route label typo
- add the supervisor self-route to the LangGraph conditional path map

Fixes #2081

## Testing

- `python -m py_compile examples/frameworks/multi_frameworks/src/nat_multi_frameworks/register.py`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workflow routing for multi-framework executions by correcting the supervisor transition so the workflow follows the intended execution path when no final output is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->