### PR TITLE
fix(latency_sensitivity_demo): wire draft_response fan-in as a barrier

### DIFF
--- a/docs/source/resources/contributing/index.md
+++ b/docs/source/resources/contributing/index.md
@@ -218,7 +218,7 @@ Remember, if you are unsure about anything, don't hesitate to comment on issues 
 
 ### Seasoned developers
 
-Once you have gotten your feet wet and are more comfortable with the code, you can review the prioritized issues for our next release in our [project boards](https://github.com/NVIDIA/NeMo-Agent-Toolkit/projects).
+Once you have gotten your feet wet and are more comfortable with the code, you can review the prioritized issues for our next release in our [issue tracker](https://github.com/NVIDIA/NeMo-Agent-Toolkit/issues).
 
 :::{tip}
 Always review the release board with the highest number for issues to work on. This is where NeMo Agent Toolkit developers also focus their efforts.

--- a/docs/source/run-workflows/observe/observe.md
+++ b/docs/source/run-workflows/observe/observe.md
@@ -79,7 +79,7 @@ The following table lists each exporter with its supported features and configur
 | [LangSmith](https://www.langchain.com/langsmith) | [Observing with LangSmith](?provider=LangSmith#provider-integration-guides){.external} | Logging, Tracing, Evaluation Metrics |
 | [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) | [Observing with OTel Collector](?provider=OTel-collector#provider-integration-guides){.external} | Logging, Tracing |
 | [Patronus](https://www.patronus.ai/) | Refer to the `examples/observability/simple_calculator_observability` example for usage details | Logging, Tracing |
-| [Phoenix](https://phoenix.arize.com/) | [Observing with Phoenix](?provider=Phoenix#provider-integration-guides){.external} | Logging, Tracing |
+| [Phoenix](http://arize.com/phoenix/) | [Observing with Phoenix](?provider=Phoenix#provider-integration-guides){.external} | Logging, Tracing |
 | [W&B Weave](https://wandb.ai/site/weave/) | [Observing with W&B Weave](?provider=Wandb-Weave#provider-integration-guides){.external} | Logging, Tracing, W&B Weave Redaction, Evaluation Metrics |
 
 Additional options:

--- a/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/workflow.py
+++ b/examples/dynamo_integration/latency_sensitivity_demo/src/latency_sensitivity_demo/workflow.py
@@ -435,11 +435,11 @@ async def latency_sensitivity_demo_function(config: LatencySensitivityDemoConfig
     graph.add_edge("classify", "check_compliance")
     graph.add_edge("classify", "analyze_sentiment")
 
-    # Converge: all 4 branches feed into draft
-    graph.add_edge("research_context", "draft_response")
-    graph.add_edge("lookup_policy", "draft_response")
-    graph.add_edge("check_compliance", "draft_response")
-    graph.add_edge("analyze_sentiment", "draft_response")
+    # Converge: all 4 branches feed into draft  (wait-for-all barrier)
+    graph.add_edge(
+        ["research_context", "lookup_policy", "check_compliance", "analyze_sentiment"],
+        "draft_response",
+    )
 
     # Sequential tail
     graph.add_edge("draft_response", "review")


### PR DESCRIPTION
## Description

Fixes the `draft_response` convergence in `examples/dynamo_integration/latency_sensitivity_demo` so it fires **exactly once** after all four parallel branches complete.

The `customer_support_triage_workflow` fans out from `classify` into four parallel branches (`research_context`, `lookup_policy`, `check_compliance`, `analyze_sentiment`) and is intended to converge into a single `draft_response` call. The convergence was expressed as four separate `graph.add_edge(src, "draft_response")` statements.

In LangGraph's Pregel/BSP model this registers **four independent triggers** (fire-on-either semantics), not a wait-for-all barrier. When the branches finish in the same superstep the barrier collapses to one call and the bug is hidden, but the moment any branch slips a superstep — retry, sub-flow expansion, a slower NAT function, or the Dynamo router prioritizing other branches — `draft_response` (and downstream `review`) fire once per surviving trigger group, multiplying LLM calls and downstream side effects. Since the demo exists to showcase Dynamo's latency-sensitive scheduling, that timing divergence is exactly the workload that surfaces the bug.

## Fix

Replace the four edges with a single list-source `add_edge`, which LangGraph treats as a wait-for-all barrier:

```python
# Converge: all 4 branches feed into draft  (wait-for-all barrier)
graph.add_edge(
    ["research_context", "lookup_policy", "check_compliance", "analyze_sentiment"],
    "draft_response",
)
```

## Verification

Reproduced against the installed `langgraph 1.2.4` using a faithful model of the workflow shape (one branch delayed by an extra superstep, then converging):

- **Buggy** (four separate edges): `draft_response` fired **2×**
- **Fixed** (list-source barrier): `draft_response` fired **1×**

Note: the literal MRE in the issue still reports 2× even with this fix, because it wires an extra `a_extra -> draft` edge *outside* the barrier — an artifact of the simplified repro that does not exist in the real workflow. The barrier fix is correct for the actual workflow structure.

Closes #2080


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved coordination of parallel low-priority tasks so the final response is generated only after all required inputs are ready, reducing premature output in latency-sensitive runs.
* **Documentation**
  * Updated the Phoenix tracing exporter documentation link under “Available Tracing Exporters”.
  * Refreshed contribution guidance for “Seasoned developers” to point to the issues tracker for prioritized next-release work.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->