### PR TITLE
fix(agent): Fix router agent graph termination

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/control_flow/router_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/control_flow/router_agent/agent.py
@@ -203,6 +203,7 @@ class RouterAgentGraph(BaseAgent):
         graph.add_node("branch", self.branch_node)
         graph.add_edge("agent", "branch")
         graph.set_entry_point("agent")
+        graph.set_finish_point("branch")
 
         self.graph = graph.compile()
         logger.debug("%s Router Agent Graph built and compiled successfully", AGENT_LOG_PREFIX)

--- a/packages/nvidia_nat_langchain/tests/agent/test_router_agent.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_router_agent.py
@@ -24,6 +24,7 @@ from langchain_core.messages import HumanMessage
 from langchain_core.messages import ToolMessage
 from langchain_core.prompts.chat import ChatPromptTemplate
 from langchain_core.tools import BaseTool
+from langgraph.constants import END
 from langgraph.graph.state import CompiledStateGraph
 
 from nat.plugins.langchain.control_flow.router_agent.agent import RouterAgentGraph
@@ -273,10 +274,20 @@ class TestRouterAgentGraph:
             mock_graph_instance.add_node.assert_any_call("branch", router_agent.branch_node)
             mock_graph_instance.add_edge.assert_called_once_with("agent", "branch")
             mock_graph_instance.set_entry_point.assert_called_once_with("agent")
+            mock_graph_instance.set_finish_point.assert_called_once_with("branch")
             mock_graph_instance.compile.assert_called_once()
 
             assert result == mock_compiled_graph
             assert router_agent.graph == mock_compiled_graph
+
+    @pytest.mark.asyncio
+    async def test_build_graph_terminates_after_branch(self, router_agent):
+        """Test that the router graph terminates after the branch node."""
+        graph = await router_agent.build_graph()
+
+        assert ("agent", "branch") in graph.builder.edges
+        assert ("branch", END) in graph.builder.edges
+        assert graph.builder.branches.get("branch") is None
 
     @pytest.mark.asyncio
     async def test_build_graph_exception(self, router_agent):


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
- Declare the RouterAgentGraph `branch` node as the graph finish point.
- Add regression coverage asserting the compiled router graph includes `branch -> END`.


Closes #2082 
## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated routing behavior so graph execution now reliably finishes after the branching step.
  * Improved validation to ensure the flow terminates as expected and does not continue past the final branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->