### PR TITLE
fix(router_agent): terminate graph after branch execution

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/control_flow/router_agent/agent.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/control_flow/router_agent/agent.py
@@ -22,6 +22,7 @@ from langchain_core.messages.base import BaseMessage
 from langchain_core.messages.human import HumanMessage
 from langchain_core.prompts.chat import ChatPromptTemplate
 from langchain_core.tools import BaseTool
+from langgraph.graph import END
 from langgraph.graph import StateGraph
 from pydantic import BaseModel
 from pydantic import Field
@@ -202,6 +203,7 @@ class RouterAgentGraph(BaseAgent):
         graph.add_node("agent", self.agent_node)
         graph.add_node("branch", self.branch_node)
         graph.add_edge("agent", "branch")
+        graph.add_edge("branch", END)
         graph.set_entry_point("agent")
 
         self.graph = graph.compile()

--- a/packages/nvidia_nat_langchain/tests/agent/test_router_agent.py
+++ b/packages/nvidia_nat_langchain/tests/agent/test_router_agent.py
@@ -24,6 +24,7 @@ from langchain_core.messages import HumanMessage
 from langchain_core.messages import ToolMessage
 from langchain_core.prompts.chat import ChatPromptTemplate
 from langchain_core.tools import BaseTool
+from langgraph.graph import END
 from langgraph.graph.state import CompiledStateGraph
 
 from nat.plugins.langchain.control_flow.router_agent.agent import RouterAgentGraph
@@ -271,7 +272,9 @@ class TestRouterAgentGraph:
             mock_state_graph.assert_called_once_with(RouterAgentGraphState)
             mock_graph_instance.add_node.assert_any_call("agent", router_agent.agent_node)
             mock_graph_instance.add_node.assert_any_call("branch", router_agent.branch_node)
-            mock_graph_instance.add_edge.assert_called_once_with("agent", "branch")
+            mock_graph_instance.add_edge.assert_any_call("agent", "branch")
+            mock_graph_instance.add_edge.assert_any_call("branch", END)
+            assert mock_graph_instance.add_edge.call_count == 2
             mock_graph_instance.set_entry_point.assert_called_once_with("agent")
             mock_graph_instance.compile.assert_called_once()
 
@@ -285,6 +288,14 @@ class TestRouterAgentGraph:
                    side_effect=Exception("Graph error")):
             with pytest.raises(Exception, match="Graph error"):
                 await router_agent.build_graph()
+
+    @pytest.mark.asyncio
+    async def test_build_graph_routes_branch_to_end(self, router_agent):
+        """Test graph building explicitly terminates after branch execution."""
+        graph = await router_agent.build_graph()
+
+        assert ("agent", "branch") in graph.builder.edges
+        assert ("branch", END) in graph.builder.edges
 
 
 class TestPromptValidation:


### PR DESCRIPTION
## Description
Adds an explicit `branch -> END` edge to `RouterAgentGraph` so the graph reaches a declared termination point after the selected branch executes.

This makes router-agent graph termination explicit for streaming and checkpoint consumers, and adds graph-shape test coverage for the edge.

Closes #2082

## Validation
- `uv run --project packages/nvidia_nat_langchain --extra test pytest packages/nvidia_nat_langchain/tests/agent/test_router_agent.py -q`
- `uv run --group dev pre-commit run --files packages/nvidia_nat_langchain/src/nat/plugins/langchain/control_flow/router_agent/agent.py packages/nvidia_nat_langchain/tests/agent/test_router_agent.py`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed router agent flow so execution now cleanly ends after the branch step.
  * Improved graph wiring validation to ensure both routing paths are present.
  
* **Tests**
  * Updated and expanded coverage to verify the expected graph transitions, including the final route to the end state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->