### PR TITLE
fix(multi_frameworks): correct supervisor routing

### DIFF
--- a/examples/frameworks/multi_frameworks/src/nat_multi_frameworks/register.py
+++ b/examples/frameworks/multi_frameworks/src/nat_multi_frameworks/register.py
@@ -14,6 +14,9 @@
 # limitations under the License.
 
 import logging
+from collections.abc import Mapping
+from typing import Any
+from typing import Literal
 
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
@@ -27,6 +30,14 @@ from . import langchain_research_tool  # noqa: F401, pylint: disable=unused-impo
 from . import llama_index_rag_tool  # noqa: F401, pylint: disable=unused-import
 
 logger = logging.getLogger(__name__)
+
+
+def _route_multi_frameworks_state(state: Mapping[str, Any]) -> Literal["supervisor", "workers", "end"]:
+    if 'final_output' in state:
+        return "end"
+    if 'chosen_worker_agent' in state:
+        return "workers"
+    return "supervisor"
 
 
 class MultiFrameworksWorkflowConfig(FunctionBaseConfig, name="multi_frameworks"):
@@ -117,18 +128,9 @@ async def multi_frameworks_workflow(config: MultiFrameworksWorkflowConfig, build
         Route the response to the appropriate handler
         """
 
-        status = list(state.keys())
-        logger.info("========== inside **router node**  current status = \n %s, %s", Fore.CYAN, status)
-        if 'final_output' in status:
-            route_to = "end"
-        elif 'chosen_worker_agent' not in status:
-            logger.info(" ############# router to --> supervisor %s", Fore.RESET)
-            route_to = "supevisor"
-        elif 'chosen_worker_agent' in status:
-            logger.info(" ############# router to --> workers %s", Fore.RESET)
-            route_to = "workers"
-        else:
-            route_to = "end"
+        route_to = _route_multi_frameworks_state(state)
+        logger.info("========== inside **router node**  current status = \n %s, %s", Fore.CYAN, list(state.keys()))
+        logger.info(" ############# router to --> %s %s", route_to, Fore.RESET)
         return route_to
 
     async def workers(state: AgentState):
@@ -160,10 +162,9 @@ async def multi_frameworks_workflow(config: MultiFrameworksWorkflowConfig, build
         "supervisor",
         router,
         {
-            "workers": "workers", "end": END
+            "supervisor": "supervisor", "workers": "workers", "end": END
         },
     )
-    workflow.add_edge("supervisor", "workers")
     workflow.add_edge("workers", END)
     app = workflow.compile()
 

--- a/examples/frameworks/multi_frameworks/tests/test_multi_frameworks_workflow.py
+++ b/examples/frameworks/multi_frameworks/tests/test_multi_frameworks_workflow.py
@@ -16,6 +16,26 @@
 import pytest
 
 
+def test_multi_frameworks_router_routes_missing_worker_choice_to_supervisor():
+    from nat_multi_frameworks.register import _route_multi_frameworks_state
+
+    assert _route_multi_frameworks_state({"input": "hello"}) == "supervisor"
+
+
+def test_multi_frameworks_router_routes_worker_choice_to_workers():
+    from nat_multi_frameworks.register import _route_multi_frameworks_state
+
+    assert _route_multi_frameworks_state({"input": "hello", "chosen_worker_agent": "General"}) == "workers"
+
+
+def test_multi_frameworks_router_routes_final_output_to_end():
+    from nat_multi_frameworks.register import _route_multi_frameworks_state
+
+    state = {"input": "hello", "chosen_worker_agent": "General", "final_output": "done"}
+
+    assert _route_multi_frameworks_state(state) == "end"
+
+
 @pytest.mark.slow
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key")


### PR DESCRIPTION
## Description
Fixes the `multi_frameworks` LangGraph routing so the supervisor router returns a correctly spelled `supervisor` route, declares that self-route in the conditional path map, and no longer bypasses the router with an unconditional `supervisor -> workers` edge.

This prevents the missing-worker-choice path from raising a `KeyError` and keeps `workers` from running when the router selects `END`.

Closes #2081
Closes #2083

## Validation
- `uv run --project examples/frameworks/multi_frameworks pytest examples/frameworks/multi_frameworks/tests/test_multi_frameworks_workflow.py -q`
- `uv run --group dev pre-commit run --files examples/frameworks/multi_frameworks/src/nat_multi_frameworks/register.py examples/frameworks/multi_frameworks/tests/test_multi_frameworks_workflow.py`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multi-step workflow routing so the app now correctly continues, branches to worker steps, or finishes when output is complete.
  * Added clearer state handling for routing decisions, reducing the chance of getting stuck in the wrong step.

* **Tests**
  * Added coverage for the main routing paths to help keep workflow behavior reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->