### PR TITLE
fix(auto_desc): reduce parallel batch summaries

### DIFF
--- a/examples/custom_functions/automated_description_generation/src/nat_automated_description_generation/utils/workflow_utils.py
+++ b/examples/custom_functions/automated_description_generation/src/nat_automated_description_generation/utils/workflow_utils.py
@@ -15,6 +15,8 @@
 
 import asyncio
 import math
+from operator import add
+from typing import Annotated
 from typing import Any
 from typing import TypedDict
 
@@ -27,7 +29,7 @@ from langgraph.types import Send
 class OverallState(TypedDict):
     contents: list[str]
     batches: list[list[str]]
-    summaries: list[Any]
+    summaries: Annotated[list[Any], add]
     collapsed_summaries: list[Document]
     final_summary: str
     bypass_map_reduce: bool

--- a/examples/custom_functions/automated_description_generation/tests/test_auto_desc_generation.py
+++ b/examples/custom_functions/automated_description_generation/tests/test_auto_desc_generation.py
@@ -16,6 +16,37 @@
 import pytest
 
 
+@pytest.mark.asyncio
+async def test_batch_summaries_are_reduced_from_parallel_writes():
+    from langgraph.graph import END
+    from langgraph.graph import START
+    from langgraph.graph import StateGraph
+    from langgraph.types import Send
+
+    from nat_automated_description_generation.utils.workflow_utils import BatchState
+    from nat_automated_description_generation.utils.workflow_utils import OverallState
+
+    async def create_batches(state: OverallState) -> dict[str, list[list[str]]]:
+        return {"batches": [["doc1"], ["doc2"], ["doc3"]]}
+
+    async def create_batch_summary(state: BatchState) -> dict[str, list[str]]:
+        return {"summaries": [f"summary:{state['batch'][0]}"]}
+
+    def dispatch_batches(state: OverallState) -> list[Send]:
+        return [Send("create_batch_summary", {"batch": batch}) for batch in state["batches"]]
+
+    graph = StateGraph(OverallState)
+    graph.add_node("create_batches", create_batches)
+    graph.add_node("create_batch_summary", create_batch_summary)
+    graph.add_edge(START, "create_batches")
+    graph.add_conditional_edges("create_batches", dispatch_batches, ["create_batch_summary"])
+    graph.add_edge("create_batch_summary", END)
+
+    result = await graph.compile().ainvoke({"contents": [], "summaries": []})
+
+    assert sorted(result["summaries"]) == ["summary:doc1", "summary:doc2", "summary:doc3"]
+
+
 @pytest.mark.slow
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key", "populate_milvus")


### PR DESCRIPTION
## Description
Annotates `OverallState.summaries` with an additive reducer so parallel `create_batch_summary` sends can write batch summaries in the same LangGraph superstep.

This preserves the example's map-reduce behavior and prevents `InvalidUpdateError` when multiple batches produce summaries concurrently.

Closes #2084

## Validation
- `uv run --project examples/custom_functions/automated_description_generation pytest examples/custom_functions/automated_description_generation/tests/test_auto_desc_generation.py -q`
- `uv run --group dev pre-commit run --files examples/custom_functions/automated_description_generation/src/nat_automated_description_generation/utils/workflow_utils.py examples/custom_functions/automated_description_generation/tests/test_auto_desc_generation.py`

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved automated description generation to combine multiple summary results produced in parallel, making batch-based workflows more reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->