### PR TITLE
docs: document nat serve /health endpoint in REST API guide

### DIFF
--- a/docs/source/reference/rest-api/api-server-endpoints.md
+++ b/docs/source/reference/rest-api/api-server-endpoints.md
@@ -85,6 +85,31 @@ uv pip install -e examples/getting_started/simple_calculator
 nat serve --config_file examples/getting_started/simple_calculator/configs/config.yml
 ```
 
+## Health Check Endpoint
+- **Route:** `/health`
+- **Method:** GET
+- **Description:** A liveness/readiness probe for the running server. It is registered automatically
+  whenever you start `nat serve`, returns immediately without executing a workflow, and requires no
+  model or API credentials. This makes it suitable for reverse proxies, process supervisors, Docker
+  health checks, and Kubernetes-style readiness/liveness probes.
+- **HTTP Request Example:**
+  ```bash
+  curl -s http://localhost:8000/health
+  ```
+- **HTTP Response Example:**
+  ```json
+  {"status":"healthy"}
+  ```
+
+:::{note}
+This endpoint checks the FastAPI server started by `nat serve` (default port `8000`). The MCP and
+FastMCP servers expose their own separate `/health` routes on their own default ports — see
+[Verifying MCP Server Health](../../run-workflows/mcp-server.md#verifying-mcp-server-health)
+(default port `9901`) and
+[Verifying FastMCP Server Health](../../run-workflows/fastmcp-server.md#verifying-fastmcp-server-health)
+(default port `9902`).
+:::
+
 ## Generate Non-Streaming Transaction
 - **Route:** `/v1/workflow` (legacy: `/generate`)
 - **Description:** A non-streaming transaction that waits until all workflow data is available before sending the


### PR DESCRIPTION
## Description

Documents the FastAPI `GET /health` endpoint exposed by `nat serve` in the REST API server endpoints guide. The endpoint is registered automatically by `nat serve` (it is not gated by any config flag), but was previously undocumented for the FastAPI path, even though the MCP and FastMCP guides already document their own health checks.

This adds a **Health Check Endpoint** section to `docs/source/reference/rest-api/api-server-endpoints.md` covering:

- Route `GET /health`, intended for liveness/readiness probes — it returns immediately without executing a workflow and requires no model or API credentials, so it is safe behind reverse proxies, process supervisors, and Docker/Kubernetes health checks.
- A `curl` example and the `{"status":"healthy"}` 200 response.
- A note distinguishing the FastAPI health check (default port `8000`) from the MCP (`9901`) and FastMCP (`9902`) health routes, with cross-links to both existing guides.

Docs-only change; no behavior change.

> Note: I noticed the issue is assigned to @bbednarski9 — happy to defer or hand this off if it's already in progress. Opening this since the maintainer invited a small docs PR and there wasn't a linked PR yet.

Closes #2073

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added reference documentation for the automatically available `GET /health` endpoint when starting `nat serve`.
  * Clarified that it provides an immediate health response without running workflows or requiring model/API credentials.
  * Included curl and JSON examples, readiness probe guidance, and details distinguishing FastAPI, MCP, and FastMCP health routes and their ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->