### PR TITLE
fix(mcp): tolerate workflows without aliases

### DIFF
--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/server/front_end_plugin_worker.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/server/front_end_plugin_worker.py
@@ -215,10 +215,12 @@ class MCPFrontEndPluginWorkerBase(ABC):
         for function_group in workflow.function_groups.values():
             functions.update(await function_group.get_accessible_functions())
 
-        if workflow.config.workflow.workflow_alias:
-            functions[workflow.config.workflow.workflow_alias] = workflow
+        workflow_config = workflow.config.workflow
+        workflow_alias = getattr(workflow_config, "workflow_alias", None)
+        if workflow_alias:
+            functions[workflow_alias] = workflow
         else:
-            functions[workflow.config.workflow.type] = workflow
+            functions[workflow_config.type] = workflow
 
         return functions
 

--- a/packages/nvidia_nat_mcp/tests/server/test_mcp_front_end_plugin.py
+++ b/packages/nvidia_nat_mcp/tests/server/test_mcp_front_end_plugin.py
@@ -146,6 +146,27 @@ async def test_workflow_alias_usage_in_mcp_front_end():
     assert "func1" in functions
 
 
+async def test_get_all_functions_falls_back_to_type_without_workflow_alias_field():
+    """Test workflow configs without workflow_alias register under their type."""
+    from types import SimpleNamespace
+    from unittest.mock import MagicMock
+
+    from nat.data_models.config import Config
+    from nat.plugins.mcp.server.front_end_plugin_worker import MCPFrontEndPluginWorker
+
+    mock_workflow = MagicMock()
+    mock_workflow.functions = {}
+    mock_workflow.function_groups = {}
+    mock_workflow.config.workflow = SimpleNamespace(type="langgraph_wrapper")
+
+    config = Config(general=GeneralConfig(front_end=MCPFrontEndConfig()), workflow=EchoFunctionConfig())
+    worker = MCPFrontEndPluginWorker(config)
+
+    functions = await worker._get_all_functions(mock_workflow)
+
+    assert functions == {"langgraph_wrapper": mock_workflow}
+
+
 async def test_workflow_alias_priority_over_type():
     """Test that workflow_alias takes priority over workflow type when both are present."""
     from unittest.mock import MagicMock


### PR DESCRIPTION
## Description
The MCP frontend now handles workflow configs that do not define `workflow_alias` by falling back to the workflow `type`. This keeps agent workflows that do define an alias unchanged while allowing FunctionBaseConfig-backed workflows such as `langgraph_wrapper` to be exposed as MCP tools instead of crashing during route registration.

Adds a regression test covering a workflow config object with only `type=langgraph_wrapper`.

Closes #1991

## Testing
- `PYTHONUTF8=1 UV_PROJECT_ENVIRONMENT=<repo>\packages\nvidia_nat_mcp\.venv uv run --project packages/nvidia_nat_mcp --all-groups --all-extras -- pytest -q packages/nvidia_nat_mcp/tests/server/test_mcp_front_end_plugin.py` (`8 passed`)
- `uvx ruff==0.15.0 check packages/nvidia_nat_mcp/src/nat/plugins/mcp/server/front_end_plugin_worker.py packages/nvidia_nat_mcp/tests/server/test_mcp_front_end_plugin.py`
- `uvx yapf==0.43.0 --diff packages/nvidia_nat_mcp/src/nat/plugins/mcp/server/front_end_plugin_worker.py packages/nvidia_nat_mcp/tests/server/test_mcp_front_end_plugin.py`
- `git diff --check`

Note: `python ci/scripts/run_tests.py --project nvidia_nat_mcp --exitfirst -- packages/nvidia_nat_mcp/tests/server/test_mcp_front_end_plugin.py` synced successfully with `PYTHONUTF8=1`, but the helper appends the full package path after the requested file and therefore also ran unrelated package tests; it stopped at an existing OAuth TTL test failure in `test_mcp_auth_provider.py`. The targeted MCP frontend test above passed.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors sign-off on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Workflows now reliably appear under their alias when one is configured, and fall back to their type name when no alias is available.
  * Improved handling of workflow registration to avoid missing entries in the available functions list.

* **Tests**
  * Added coverage for the fallback behavior when a workflow alias is absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->