### PR TITLE
Track LangChain Runnable callbacks

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/callback_handler.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/callback_handler.py
@@ -80,6 +80,23 @@ def _extract_tools_schema(invocation_params: dict) -> list:
     return tools_schema
 
 
+def _extract_run_name(serialized: dict[str, Any], fallback: str = "") -> str:
+    if not isinstance(serialized, dict):
+        return fallback
+
+    name = serialized.get("name") or serialized.get("lc_name")
+    if name:
+        return str(name)
+
+    serialized_id = serialized.get("id")
+    if isinstance(serialized_id, list) and serialized_id:
+        return str(serialized_id[-1])
+    if serialized_id:
+        return str(serialized_id)
+
+    return fallback
+
+
 class LangchainProfilerHandler(AsyncCallbackHandler, BaseProfilerCallback):
     """Callback Handler that tracks NIM info."""
 
@@ -101,6 +118,8 @@ class LangchainProfilerHandler(AsyncCallbackHandler, BaseProfilerCallback):
         self._run_id_to_model_name = {}
         self._run_id_to_llm_input = {}
         self._run_id_to_tool_input = {}
+        self._run_id_to_chain_input = {}
+        self._run_id_to_chain_name = {}
         self._run_id_to_start_time = {}
 
     def __repr__(self) -> str:
@@ -347,6 +366,86 @@ class LangchainProfilerHandler(AsyncCallbackHandler, BaseProfilerCallback):
         self.step_manager.push_intermediate_step(stats)
         self._run_id_to_tool_input[str(run_id)] = input_str
         self._run_id_to_start_time[str(run_id)] = time.time()
+
+    async def on_chain_start(
+        self,
+        serialized: dict[str, Any],
+        inputs: dict[str, Any],
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        metadata: dict[str, Any] | None = None,
+        **kwargs: Any,
+    ) -> None:
+
+        run_id_str = str(run_id)
+        start_time = time.time()
+        name = _extract_run_name(serialized, fallback=kwargs.get("name", ""))
+        chain_inputs = copy.deepcopy(inputs)
+
+        stats = IntermediateStepPayload(event_type=IntermediateStepType.FUNCTION_START,
+                                        framework=LLMFrameworkEnum.LANGCHAIN,
+                                        name=name,
+                                        UUID=run_id_str,
+                                        tags=copy.deepcopy(tags),
+                                        data=StreamEventData(input=chain_inputs, payload=copy.deepcopy(serialized)),
+                                        metadata=TraceMetadata(span_inputs=chain_inputs,
+                                                               provided_metadata=copy.deepcopy(metadata)),
+                                        usage_info=UsageInfo(token_usage=TokenUsageBaseModel()))
+
+        self.step_manager.push_intermediate_step(stats)
+        self._run_id_to_chain_input[run_id_str] = chain_inputs
+        self._run_id_to_chain_name[run_id_str] = name
+        self._run_id_to_start_time[run_id_str] = start_time
+
+    def _clear_chain_run_state(self, run_id_str: str) -> None:
+        self._run_id_to_chain_input.pop(run_id_str, None)
+        self._run_id_to_chain_name.pop(run_id_str, None)
+        self._run_id_to_start_time.pop(run_id_str, None)
+
+    async def on_chain_end(
+        self,
+        outputs: dict[str, Any],
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+
+        run_id_str = str(run_id)
+        chain_outputs = copy.deepcopy(outputs)
+        chain_input = self._run_id_to_chain_input.get(run_id_str, "")
+        chain_name = self._run_id_to_chain_name.get(run_id_str, kwargs.get("name", ""))
+        chain_start_time = self._run_id_to_start_time.get(run_id_str, time.time())
+
+        stats = IntermediateStepPayload(event_type=IntermediateStepType.FUNCTION_END,
+                                        span_event_timestamp=chain_start_time,
+                                        framework=LLMFrameworkEnum.LANGCHAIN,
+                                        name=chain_name,
+                                        UUID=run_id_str,
+                                        tags=copy.deepcopy(tags),
+                                        metadata=TraceMetadata(span_outputs=chain_outputs),
+                                        usage_info=UsageInfo(token_usage=TokenUsageBaseModel()),
+                                        data=StreamEventData(input=chain_input,
+                                                             output=chain_outputs,
+                                                             payload=chain_outputs))
+
+        self.step_manager.push_intermediate_step(stats)
+        self._clear_chain_run_state(run_id_str)
+
+    async def on_chain_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        parent_run_id: UUID | None = None,
+        tags: list[str] | None = None,
+        **kwargs: Any,
+    ) -> None:
+
+        self._clear_chain_run_state(str(run_id))
 
     async def on_tool_end(
         self,

--- a/packages/nvidia_nat_langchain/tests/test_langchain_callback_handler.py
+++ b/packages/nvidia_nat_langchain/tests/test_langchain_callback_handler.py
@@ -17,10 +17,20 @@ import asyncio
 import logging
 from uuid import uuid4
 
+import pytest
+
 from nat.data_models.intermediate_step import IntermediateStepType
 from nat.plugins.langchain.callback_handler import LangchainProfilerHandler
 from nat.plugins.langchain.callback_handler import _extract_tools_schema
 from nat.utils.reactive.subject import Subject
+
+
+@pytest.fixture(name="chain_handler_fixture")
+def fixture_chain_handler(reactive_stream: Subject):
+    all_stats = []
+    handler = LangchainProfilerHandler()
+    _ = reactive_stream.subscribe(all_stats.append)
+    return handler, all_stats
 
 
 async def test_langchain_handler(reactive_stream: Subject):
@@ -89,6 +99,108 @@ async def test_langchain_handler(reactive_stream: Subject):
     assert all_stats[3].payload.usage_info.token_usage.prompt_tokens == 15  # Will not populate usage
     assert all_stats[3].payload.usage_info.token_usage.completion_tokens == 15
     assert all_stats[3].payload.data.output == "Hello back!"
+
+
+async def test_langchain_handler_tracks_chain_runnable_events(chain_handler_fixture):
+    """
+    Test that LangChain Runnable/chain callbacks produce paired function stats.
+
+      - on_chain_start -> usage stat with event_type=FUNCTION_START
+      - on_chain_end -> usage stat with event_type=FUNCTION_END
+    """
+
+    handler, all_stats = chain_handler_fixture
+
+    run_id = uuid4()
+    serialized = {
+        "id": ["langchain", "schema", "runnable", "RunnableLambda"],
+        "name": "RunnableLambda",
+    }
+    inputs = {"question": "What is NAT?"}
+    outputs = {"answer": "NeMo Agent Toolkit"}
+    metadata = {"component": "unit-test"}
+    tags = ["chain-test"]
+
+    await handler.on_chain_start(serialized=serialized, inputs=inputs, run_id=run_id, tags=tags, metadata=metadata)
+    await asyncio.sleep(0.01)
+    await handler.on_chain_end(outputs=outputs, run_id=run_id, tags=tags)
+
+    assert len(all_stats) == 2
+    assert all_stats[0].event_type == IntermediateStepType.FUNCTION_START
+    assert all_stats[1].event_type == IntermediateStepType.FUNCTION_END
+    assert all_stats[0].UUID == str(run_id)
+    assert all_stats[1].UUID == str(run_id)
+    assert all_stats[0].payload.name == "RunnableLambda"
+    assert all_stats[1].payload.name == "RunnableLambda"
+    assert all_stats[0].payload.tags == tags
+    assert all_stats[1].payload.tags == tags
+    assert all_stats[0].payload.data.input == inputs
+    assert all_stats[0].payload.data.payload == serialized
+    assert all_stats[0].payload.metadata.span_inputs == inputs
+    assert all_stats[0].payload.metadata.provided_metadata == metadata
+    assert all_stats[1].payload.data.input == inputs
+    assert all_stats[1].payload.data.output == outputs
+    assert all_stats[1].payload.data.payload == outputs
+    assert all_stats[1].payload.metadata.span_outputs == outputs
+    assert all_stats[1].span_event_timestamp is not None
+    assert all_stats[1].span_event_timestamp <= all_stats[1].event_timestamp
+    assert str(run_id) not in handler._run_id_to_chain_input
+    assert str(run_id) not in handler._run_id_to_chain_name
+    assert str(run_id) not in handler._run_id_to_start_time
+
+
+async def test_langchain_handler_tracks_chain_events_with_default_metadata(chain_handler_fixture):
+    """Test chain callback stats when tags and metadata are omitted."""
+
+    handler, all_stats = chain_handler_fixture
+
+    run_id = uuid4()
+    inputs = {"input": "hello"}
+    outputs = {"output": "world"}
+
+    await handler.on_chain_start(
+        serialized={"id": ["langchain", "schema", "runnable", "RunnableSequence"]},
+        inputs=inputs,
+        run_id=run_id,
+    )
+    await handler.on_chain_end(outputs=outputs, run_id=run_id)
+
+    assert len(all_stats) == 2
+    assert all_stats[0].event_type == IntermediateStepType.FUNCTION_START
+    assert all_stats[1].event_type == IntermediateStepType.FUNCTION_END
+    assert all_stats[0].payload.name == "RunnableSequence"
+    assert all_stats[1].payload.name == "RunnableSequence"
+    assert all_stats[0].payload.tags is None
+    assert all_stats[1].payload.tags is None
+    assert all_stats[0].payload.data.input == inputs
+    assert all_stats[0].payload.metadata.span_inputs == inputs
+    assert all_stats[0].payload.metadata.provided_metadata is None
+    assert all_stats[1].payload.data.input == inputs
+    assert all_stats[1].payload.data.output == outputs
+    assert all_stats[1].payload.metadata.span_outputs == outputs
+    assert str(run_id) not in handler._run_id_to_chain_input
+    assert str(run_id) not in handler._run_id_to_chain_name
+    assert str(run_id) not in handler._run_id_to_start_time
+
+
+async def test_langchain_handler_clears_chain_state_on_error(chain_handler_fixture):
+    """Test that failed LangChain Runnable/chain callbacks do not leak run state."""
+
+    handler, all_stats = chain_handler_fixture
+
+    run_id = uuid4()
+    await handler.on_chain_start(
+        serialized={"name": "FailingRunnable"},
+        inputs={"question": "boom?"},
+        run_id=run_id,
+    )
+    await handler.on_chain_error(RuntimeError("boom"), run_id=run_id)
+
+    assert len(all_stats) == 1
+    assert all_stats[0].event_type == IntermediateStepType.FUNCTION_START
+    assert str(run_id) not in handler._run_id_to_chain_input
+    assert str(run_id) not in handler._run_id_to_chain_name
+    assert str(run_id) not in handler._run_id_to_start_time
 
 
 def test_extract_tools_schema_openai_format():


### PR DESCRIPTION
## Summary
- add LangChain `on_chain_start` / `on_chain_end` handling in `LangchainProfilerHandler`
- emit paired `FUNCTION_START` / `FUNCTION_END` intermediate steps for base Runnable/chain invocations
- preserve run id, runnable name, tags, inputs, outputs, and span timing metadata
- clear per-run chain state on normal completion and chain errors
- add regression coverage for paired chain callback events, default metadata/tags, and cleanup behavior

Closes #1787

## Validation
- `PYTHONUTF8=1 uv run --extra langchain --extra test --group dev pytest packages/nvidia_nat_langchain/tests/test_langchain_callback_handler.py -q` (11 passed)
- `PYTHONUTF8=1 uv run --extra langchain --extra test --group dev pytest packages/nvidia_nat_langchain/tests -q` (684 passed, 13 skipped)
- `PYTHONUTF8=1 uv run --extra langchain --extra test --group dev yapf --diff --style ./pyproject.toml packages/nvidia_nat_langchain/src/nat/plugins/langchain/callback_handler.py packages/nvidia_nat_langchain/tests/test_langchain_callback_handler.py`
- `PYTHONUTF8=1 uv run --extra langchain --extra test --group dev ruff check packages/nvidia_nat_langchain/src/nat/plugins/langchain/callback_handler.py packages/nvidia_nat_langchain/tests/test_langchain_callback_handler.py`
- `PYTHONUTF8=1 uv run --extra langchain --extra test --group dev pre-commit run --files packages/nvidia_nat_langchain/src/nat/plugins/langchain/callback_handler.py packages/nvidia_nat_langchain/tests/test_langchain_callback_handler.py`
- `git diff --check origin/develop..HEAD`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced LangChain callback tracking to emit dedicated chain lifecycle events for start and end, including consistent run identifiers, names, tags, and attached input/output details.
  * Added improved chain naming derived from available serialized fields with sensible fallbacks.

* **Bug Fixes**
  * Ensure chain-specific internal state is cleared after both successful completion and error paths to prevent stale data.

* **Tests**
  * Expanded the LangChain callback handler test suite with new coverage for event order, payload/metadata propagation, timestamp consistency, and state cleanup on error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->