### PR TITLE
build(ruff): enforce B019 to prevent lru_cache/cache memory leaks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -335,7 +335,9 @@ select = [
   # Enable partial pylint support
   "PL",
   # Enable pyupgrade support
-  "UP"
+  "UP",
+  # flake8-bugbear: enforce the memory-leak rule
+  "B019"
 ]
 
 extend-ignore = [


### PR DESCRIPTION
Add flake8-bugbear rule B019 (cached-instance-method) to the ruff lint select list. Using `functools.lru_cache`/`cache` on instance methods keeps a reference to `self` in the cache, leaking instances for the process lifetime.

The full "B" category is intentionally not enabled to avoid noisy, low-value warnings; only the memory-leak rule is selected. All existing B019 violations were fixed on develop beforehand in [PR-2105](https://github.com/NVIDIA/NeMo-Agent-Toolkit/pull/2105), so this change is green and blocks regressions in CI via pre-commit.

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Expanded code quality checks to catch additional potential issues before release.
  * Improved static analysis coverage for safer, more consistent maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->