### PR TITLE
docs(rest-api): document the FastAPI /health endpoint

### DIFF
--- a/docs/source/reference/rest-api/api-server-endpoints.md
+++ b/docs/source/reference/rest-api/api-server-endpoints.md
@@ -70,6 +70,23 @@ while keeping others.
 Interactive workflows (Human-in-the-Loop and OAuth) can be used over plain HTTP without
 WebSockets. For details, see [HTTP Interactive Execution](./http-interactive-execution.md).
 
+## Health Check Endpoint
+
+- **Route:** `/health`
+- **Method:** GET
+- **Description:** Health check endpoint intended for liveness and readiness probes. Returns HTTP 200 with a fixed JSON payload when the server is running. This endpoint does not execute a workflow and does not require any API credentials, so it is safe to use behind a reverse proxy, in a Docker `HEALTHCHECK`, or as a Kubernetes-style liveness/readiness probe.
+- **HTTP Request Example:**
+  ```bash
+  curl -s http://localhost:8000/health
+  ```
+- **HTTP Response Example:**
+  ```json
+  {"status":"healthy"}
+  ```
+
+:::{note}
+The MCP and FastMCP servers expose their own `/health` routes on separate default ports. For MCP-specific health checks, refer to the [MCP Server](../../run-workflows/mcp-server.md) and [FastMCP Server](../../run-workflows/fastmcp-server.md) guides.
+:::
 
 ## Start the NeMo Agent Toolkit Server
 This section describes how to start the NeMo Agent Toolkit server.


### PR DESCRIPTION
## Summary

Adds a short **Health Check Endpoint** section to the REST API server endpoints guide (`docs/source/reference/rest-api/api-server-endpoints.md`) so that the `GET /health` route exposed by `nat serve` is discoverable in the public docs.

The endpoint was added in #1466 but was never documented in the REST API reference, leaving operators without a documented liveness/readiness URL to use behind reverse proxies, Docker `HEALTHCHECK`, or Kubernetes probes.

## What the new section covers

- Route (`/health`), method (`GET`), and the `{"status":"healthy"}` response.
- Explicit note that the endpoint does not execute a workflow and does not require API credentials, so it is safe as a probe target.
- Cross-links to the existing MCP and FastMCP server guides, which already document their own separate `/health` routes and default ports.

## Placement

Inserted immediately after **HTTP Interactive Extensions** and before **Start the NeMo Agent Toolkit Server**, so a reader scanning "Default Endpoint Paths" hits it early without disturbing the versioned endpoint table (the health route is not versioned).

## Scope

Docs-only. No source, config, or endpoint-registration code changed.

Closes #2073

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added reference documentation for the `GET /health` endpoint.
  * Documented liveness and readiness checks, a sample request, and the expected healthy response.
  * Clarified that MCP/FastMCP provide separate health endpoints on different ports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->