### PR TITLE
feat(plugin-api): export runtime context and interactive HITL models

### DIFF
--- a/docs/source/extend/custom-components/telemetry-exporters.md
+++ b/docs/source/extend/custom-components/telemetry-exporters.md
@@ -1272,7 +1272,7 @@ async def test_export_processed(custom_exporter):
 
 def test_isolated_attributes():
     """Test that isolated attributes work correctly across instances."""
-    from nat.builder.context import ContextState
+    from nat.plugin_api import ContextState
 
     # Create original exporter
     exporter1 = CustomSpanExporter(

--- a/docs/source/extend/plugin-api.md
+++ b/docs/source/extend/plugin-api.md
@@ -47,8 +47,13 @@ The following `nat.plugin_api` exports are intended for plugin authors:
 - Small implementation contracts needed by registered components, including `FunctionMiddleware`,
   `DynamicFunctionMiddleware`, `HITLMiddleware`, `HITLMiddlewareConfig`, `InvocationAction`,
   `MemoryEditor`, `ObjectStore`, `Retriever`, `Document`, `RetrieverOutput`, and their associated context
-  or value models. `HumanPrompt` and `InteractionResponse` are also included as the interactive data
-  models that HITL middleware hooks produce and receive.
+  or value models. The interactive data models that HITL middleware hooks and user-input callbacks produce
+  and receive are also included: `HumanPrompt`, `InteractionPrompt`, `InteractionResponse`, the
+  `HumanResponse` union, and the concrete response models `HumanResponseText`, `HumanResponseBinary`,
+  `HumanResponseNotification`, `HumanResponseRadio`, `HumanResponseCheckbox`, and `HumanResponseDropdown`.
+- Runtime context access through `Context` and `ContextState`, for reading invocation-scoped state
+  such as `workflow_run_id`, `user_id`, and the active function, and for prompting users through
+  `Context.get().user_interaction_manager`.
 - Component reference types, such as `FunctionRef`, `FunctionGroupRef`, `LLMRef`, `EmbedderRef`, `RetrieverRef`,
   `MemoryRef`, `ObjectStoreRef`, and `MiddlewareRef`.
 - Framework wrapper identifiers, including `LLMFrameworkEnum`.
@@ -92,7 +97,8 @@ the current promotion decision for the major plugin-authoring surfaces.
 | Object store | Stable public, trusted plugin | External storage backends need the config base, object-store interface, item model, and standard errors. Plugins must be trusted. |
 | Middleware registration and function middleware | Stable public, trusted plugin | Basic middleware registration and function middleware support caching, policy, auth injection, redaction, and tracing. Middleware can observe or alter calls, so plugins must be trusted. |
 | Dynamic middleware and runtime introspection | Provisional public, trusted plugin | Dynamic middleware reaches deeper into runtime call interception and inventory metadata. The facade exposes the current dynamic middleware types, but inventory and unregister details remain subsystem-specific until the contract is promoted deliberately. |
-| HITL middleware | Provisional public, trusted plugin | HITL middleware is an abstract extension point for human-in-the-loop function interception. The facade exposes `HITLMiddleware`, `HITLMiddlewareConfig`, `InvocationAction`, `HumanPrompt`, and `InteractionResponse` so that concrete subclass authors can import the full authoring and interactive-model surface from `nat.plugin_api`. |
+| HITL middleware | Provisional public, trusted plugin | HITL middleware is an abstract extension point for human-in-the-loop function interception. The facade exposes `HITLMiddleware`, `HITLMiddlewareConfig`, `InvocationAction`, and the interactive data models `HumanPrompt`, `InteractionPrompt`, `InteractionResponse`, and `HumanResponse` with its concrete response models so that concrete subclass authors and user-input integrations can import the full authoring and interactive-model surface from `nat.plugin_api`. |
+| Runtime context access | Provisional public | Middleware, HITL, and telemetry integrations read invocation-scoped state (for example `workflow_run_id`, `user_id`, and the active function) and prompt users through `Context.get().user_interaction_manager`. The facade exposes `Context` and `ContextState`; deeper runtime wiring such as intermediate-step manager internals and exporter management remains subsystem-specific until promoted deliberately. |
 | Telemetry registration | Provisional public, trusted plugin | The facade currently exposes telemetry exporter registration and configuration. Exporter implementation APIs, including raw exporters, span exporters, processors, and intermediate-step models, remain subsystem-specific and may evolve until they are promoted deliberately. Telemetry plugins can observe sensitive workflow data and must be trusted. |
 | Tool wrapper registration | Provisional public | The facade exposes `register_tool_wrapper` for framework integrations. Wrapper callables depend on framework-native tool types and currently return framework-specific objects, so keep this provisional until the wrapper callable contract is promoted deliberately. |
 | Auth provider | Deferred | Authentication provider authoring is still experimental and depends on subsystem APIs such as `AuthProviderBase`, `AuthProviderBaseConfig`, `AuthenticationRef`, and `register_auth_provider`. Keep it out of the stable facade until the auth compatibility and trust contract is promoted deliberately. |

--- a/packages/nvidia_nat_core/src/nat/plugin_api/__init__.py
+++ b/packages/nvidia_nat_core/src/nat/plugin_api/__init__.py
@@ -34,6 +34,8 @@ must be explicitly categorized as stable or deferred.
 
 from nat.builder.builder import Builder
 from nat.builder.builder import EvalBuilder
+from nat.builder.context import Context
+from nat.builder.context import ContextState
 from nat.builder.dataset_loader import DatasetLoaderInfo
 from nat.builder.embedder import EmbedderProviderInfo
 from nat.builder.evaluator import EvaluatorInfo
@@ -80,6 +82,14 @@ from nat.data_models.evaluator import EvaluatorBaseConfig
 from nat.data_models.function import FunctionBaseConfig
 from nat.data_models.function import FunctionGroupBaseConfig
 from nat.data_models.interactive import HumanPrompt
+from nat.data_models.interactive import HumanResponse
+from nat.data_models.interactive import HumanResponseBinary
+from nat.data_models.interactive import HumanResponseCheckbox
+from nat.data_models.interactive import HumanResponseDropdown
+from nat.data_models.interactive import HumanResponseNotification
+from nat.data_models.interactive import HumanResponseRadio
+from nat.data_models.interactive import HumanResponseText
+from nat.data_models.interactive import InteractionPrompt
 from nat.data_models.interactive import InteractionResponse
 from nat.data_models.llm import LLMBaseConfig
 from nat.data_models.memory import MemoryBaseConfig
@@ -114,6 +124,8 @@ from nat.retriever.models import RetrieverOutput
 __all__ = [
     "Builder",
     "ComponentRef",
+    "Context",
+    "ContextState",
     "DatasetLoaderInfo",
     "Document",
     "DynamicFunctionMiddleware",
@@ -138,6 +150,14 @@ __all__ = [
     "HITLMiddleware",
     "HITLMiddlewareConfig",
     "HumanPrompt",
+    "HumanResponse",
+    "HumanResponseBinary",
+    "HumanResponseCheckbox",
+    "HumanResponseDropdown",
+    "HumanResponseNotification",
+    "HumanResponseRadio",
+    "HumanResponseText",
+    "InteractionPrompt",
     "InteractionResponse",
     "InvocationAction",
     "InvocationContext",

--- a/packages/nvidia_nat_core/tests/nat/test_plugin_api.py
+++ b/packages/nvidia_nat_core/tests/nat/test_plugin_api.py
@@ -23,6 +23,8 @@ from nat import plugin_api
 EXPECTED_PLUGIN_API_EXPORTS = {
     "Builder": ("nat.builder.builder", "Builder"),
     "ComponentRef": ("nat.data_models.component_ref", "ComponentRef"),
+    "Context": ("nat.builder.context", "Context"),
+    "ContextState": ("nat.builder.context", "ContextState"),
     "DatasetLoaderInfo": ("nat.builder.dataset_loader", "DatasetLoaderInfo"),
     "Document": ("nat.retriever.models", "Document"),
     "DynamicFunctionMiddleware": ("nat.middleware.dynamic.dynamic_function_middleware", "DynamicFunctionMiddleware"),
@@ -47,6 +49,14 @@ EXPECTED_PLUGIN_API_EXPORTS = {
     "HITLMiddleware": ("nat.middleware.hitl.hitl_middleware", "HITLMiddleware"),
     "HITLMiddlewareConfig": ("nat.middleware.hitl.hitl_middleware_config", "HITLMiddlewareConfig"),
     "HumanPrompt": ("nat.data_models.interactive", "HumanPrompt"),
+    "HumanResponse": ("nat.data_models.interactive", "HumanResponse"),
+    "HumanResponseBinary": ("nat.data_models.interactive", "HumanResponseBinary"),
+    "HumanResponseCheckbox": ("nat.data_models.interactive", "HumanResponseCheckbox"),
+    "HumanResponseDropdown": ("nat.data_models.interactive", "HumanResponseDropdown"),
+    "HumanResponseNotification": ("nat.data_models.interactive", "HumanResponseNotification"),
+    "HumanResponseRadio": ("nat.data_models.interactive", "HumanResponseRadio"),
+    "HumanResponseText": ("nat.data_models.interactive", "HumanResponseText"),
+    "InteractionPrompt": ("nat.data_models.interactive", "InteractionPrompt"),
     "InteractionResponse": ("nat.data_models.interactive", "InteractionResponse"),
     "InvocationAction": ("nat.middleware.middleware", "InvocationAction"),
     "InvocationContext": ("nat.middleware.middleware", "InvocationContext"),
@@ -364,7 +374,11 @@ def test_plugin_authoring_docs_prefer_public_api_imports():
         "from nat.middleware.hitl import HITLMiddlewareConfig",
         "from nat.middleware.hitl import HumanPrompt",
         "from nat.middleware.hitl import InteractionResponse",
+        "from nat.builder.context import Context",
+        "from nat.builder.context import ContextState",
         "from nat.data_models.interactive import HumanPrompt",
+        "from nat.data_models.interactive import HumanResponse",
+        "from nat.data_models.interactive import InteractionPrompt",
         "from nat.data_models.interactive import InteractionResponse",
         "from nat.middleware.middleware import FunctionMiddlewareContext",
         "from nat.middleware.middleware import InvocationAction",
@@ -481,3 +495,46 @@ def test_consumer_style_plugin_group_registration():
     registered = GlobalTypeRegistry.get().get_function_group(_ConsumerTestPluginGroupConfig)
     assert registered.config_type is _ConsumerTestPluginGroupConfig
     assert registered.build_fn is not None
+
+
+def test_consumer_style_context_and_interactive_types():
+    """Exercise the runtime context accessors and interactive models using only ``nat.plugin_api`` imports.
+
+    Middleware and HITL plugin authors read invocation-scoped state through ``Context``/``ContextState`` and
+    consume/produce the interactive prompt and response models, so the public surface must be sufficient for
+    both without falling back to implementation modules.
+    """
+    from nat.plugin_api import Context
+    from nat.plugin_api import ContextState
+    from nat.plugin_api import HumanResponseText
+    from nat.plugin_api import InteractionPrompt
+    from nat.plugin_api import InteractionResponse
+
+    # Context accessors resolve to the shared context state.
+    assert isinstance(Context.get(), Context)
+    assert ContextState.get() is ContextState.get()
+
+    with Context.scope(workflow_run_id="plugin-api-test-run"):
+        assert Context.get().workflow_run_id == "plugin-api-test-run"
+
+    # A prompt as delivered to a user-input callback, and the matching response a plugin would return.
+    prompt = InteractionPrompt(
+        id="interaction-1",
+        timestamp="2026-01-01T00:00:00Z",
+        content={
+            "input_type": "text", "text": "Proceed?"
+        },
+    )
+    assert prompt.content.text == "Proceed?"
+
+    response = InteractionResponse(
+        id="interaction-1",
+        timestamp="2026-01-01T00:00:01Z",
+        content=HumanResponseText(text="yes"),
+    )
+    assert isinstance(response.content, HumanResponseText)
+
+    # The ``HumanResponse`` discriminated union resolves the concrete response models.
+    parsed = InteractionResponse.model_validate(response.model_dump())
+    assert isinstance(parsed.content, HumanResponseText)
+    assert parsed.content.text == "yes"


### PR DESCRIPTION
## Description

Third-party plugin packages are asked to import plugin-authoring symbols only from the stable `nat.plugin_api` facade (per `docs/source/extend/third-party-plugins.md`). However, two groups of symbols that middleware and HITL plugin authors (e.g., I) need are currently only importable from implementation modules:

- The runtime context access points `Context` and `ContextState` (from `nat.builder.context`), needed to read invocation-scoped state such as `workflow_run_id`, `user_id`, and the active function, and to prompt users through `Context.get().user_interaction_manager` (the same prompting path `HITLMiddleware` uses).
- The interactive data models `InteractionPrompt`, the `HumanResponse` union, and its concrete response models from `nat.data_models.interactive`. A `HITLMiddleware` subclass receives an `InteractionResponse` and must discriminate its `content` against these models, and a plugin that installs a `user_input_callback` implements `Callable[[InteractionPrompt], Awaitable[HumanResponse | None]]`.  Currently can't do that with the current facade-only imports.

This change is purely additive:

- Re-export the symbols above through `nat.plugin_api` and extend `__all__`.
- Pin the new symbols in `EXPECTED_PLUGIN_API_EXPORTS` and extend the denied-import patterns in the plugin-authoring docs test.
- Add a consumer-style test that exercises the runtime context and interactive models through `nat.plugin_api` imports alone.
- Document the new surface in `docs/source/extend/plugin-api.md`, including a new "Runtime context access" surface-review row (proposed as provisional public, matching the promotion status of the HITL middleware row).
- Switch the telemetry exporter testing example to import `ContextState` from the facade.

No tracking issue exists for this yet; happy to file one if the team prefers.

## Testing

- `uv run pytest packages/nvidia_nat_core/tests/nat/test_plugin_api.py` — 7 passed (includes the new consumer-style test).
- `uv run pytest packages/nvidia_nat_core/tests/nat/builder packages/nvidia_nat_core/tests/nat/middleware packages/nvidia_nat_core/tests/nat/runtime` — 602 passed.
- `pre-commit run yapf|ruff-check --files <touched files>`, `python ci/scripts/copyright.py --verify-apache-v2`, `vale` on the touched Markdown files, and `python ci/scripts/path_checks.py` all pass.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded the public plugin API with runtime context access and human-in-the-loop interaction models.
  * Added direct access to human response types, interaction prompts, and context state through the plugin API.

* **Documentation**
  * Clarified supported interactive data models and runtime context capabilities.
  * Updated exporter testing guidance to use the public API imports.

* **Tests**
  * Added coverage validating the new public exports, context scoping, and response model behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->