### PR TITLE
feat(core): add opt-in provider hooks for generated ids and timestamps

### DIFF
--- a/docs/source/run-workflows/observe/observe.md
+++ b/docs/source/run-workflows/observe/observe.md
@@ -310,7 +310,7 @@ This is useful when you call a remote workflow and want its steps to appear unde
 
 ## Deterministic Identifiers and Timestamps
 
-The runtime stamps workflow runs, intermediate steps, spans, and function invocations with generated identifiers (`uuid.uuid4`) and wall-clock timestamps (`time.time`). For reproducible runs — for example, record/replay style tests, golden-file trace comparison, or runtimes that re-execute workflow code and need identifiers to remain stable across re-executions — install process-wide providers that the runtime uses instead:
+The runtime stamps workflow runs, intermediate steps, spans, and function invocations with generated identifiers (`uuid.uuid4`) and wall-clock timestamps (`time.time`). For reproducible runs — for example, record or replay style tests, golden-file trace comparison, or runtimes that re-execute workflow code and need identifiers to remain stable across re-executions — install process-wide providers that the runtime uses instead:
 
 ```python
 import itertools

--- a/docs/source/run-workflows/observe/observe.md
+++ b/docs/source/run-workflows/observe/observe.md
@@ -307,3 +307,21 @@ Context.get().intermediate_step_manager.push_intermediate_steps(remote_intermedi
 ```
 
 This is useful when you call a remote workflow and want its steps to appear under the trace of the current workflow in your observability backend, so you get one connected tree for the full request.
+
+## Deterministic Identifiers and Timestamps
+
+The runtime stamps workflow runs, intermediate steps, spans, and function invocations with generated identifiers (`uuid.uuid4`) and wall-clock timestamps (`time.time`). For reproducible runs — for example, record/replay style tests, golden-file trace comparison, or runtimes that re-execute workflow code and need identifiers to remain stable across re-executions — install process-wide providers that the runtime uses instead:
+
+```python
+import itertools
+import uuid
+
+from nat.utils.providers import set_id_provider
+from nat.utils.providers import set_time_provider
+
+counter = itertools.count(1)
+previous_id_provider = set_id_provider(lambda: str(uuid.uuid5(uuid.NAMESPACE_OID, f"my-run-{next(counter)}")))
+previous_time_provider = set_time_provider(lambda: 1700000000.0)
+```
+
+The id provider must return canonical `UUID` strings. Integer identifiers, such as the OpenTelemetry-style trace and span ids, are derived from the id provider by parsing the returned value. Both hooks default to `uuid.uuid4` and `time.time`, and each setter returns the previously installed provider so it can be restored. When no provider is installed, behavior is unchanged.

--- a/packages/nvidia_nat_core/src/nat/builder/context.py
+++ b/packages/nvidia_nat_core/src/nat/builder/context.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 
 import typing
-import uuid
 from collections.abc import Awaitable
 from collections.abc import Callable
 from contextlib import contextmanager
@@ -36,6 +35,7 @@ from nat.data_models.intermediate_step import TraceMetadata
 from nat.data_models.invocation_node import InvocationNode
 from nat.data_models.runtime_enum import RuntimeTypeEnum
 from nat.runtime.user_metadata import RequestAttributes
+from nat.utils.providers import generate_id
 from nat.utils.reactive.subject import Subject
 
 
@@ -247,7 +247,7 @@ class Context:
         AND create an OTel child span for that function call.
         """
         parent_function_node = self._context_state.active_function.get()
-        current_function_id = str(uuid.uuid4())
+        current_function_id = generate_id()
         current_function_node = InvocationNode(function_id=current_function_id,
                                                function_name=function_name,
                                                parent_id=parent_function_node.function_id,

--- a/packages/nvidia_nat_core/src/nat/data_models/intermediate_step.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/intermediate_step.py
@@ -13,9 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import time
 import typing
-import uuid
 from enum import StrEnum
 from typing import Literal
 
@@ -28,6 +26,8 @@ from pydantic import model_validator
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.data_models.invocation_node import InvocationNode
 from nat.data_models.token_usage import TokenUsageBaseModel
+from nat.utils.providers import current_time
+from nat.utils.providers import generate_id
 
 
 class IntermediateStepCategory(StrEnum):
@@ -157,8 +157,8 @@ class IntermediateStepPayload(BaseModel):
     model_config = ConfigDict(extra="allow")
 
     event_type: IntermediateStepType
-    # Create an event timestamp field with the default being a lambda that returns the current time
-    event_timestamp: float = Field(default_factory=lambda: time.time())
+    # The default event timestamp is resolved lazily through the installed time provider
+    event_timestamp: float = Field(default_factory=current_time)
     span_event_timestamp: float | None = None  # Used for tracking the start time of a task if this is end
     framework: LLMFrameworkEnum | None = None
     name: str | None = None
@@ -166,7 +166,7 @@ class IntermediateStepPayload(BaseModel):
     metadata: dict[str, typing.Any] | TraceMetadata | None = None
     data: SerializeAsAny[StreamEventData] | None = None
     usage_info: UsageInfo | None = None
-    UUID: str = Field(default_factory=lambda: str(uuid.uuid4()))
+    UUID: str = Field(default_factory=generate_id)
 
     @property
     def event_category(self) -> IntermediateStepCategory:

--- a/packages/nvidia_nat_core/src/nat/data_models/span.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/span.py
@@ -15,7 +15,6 @@
 
 import logging
 import os
-import time
 import uuid
 from enum import Enum
 from typing import Any
@@ -23,6 +22,10 @@ from typing import Any
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import field_validator
+
+from nat.utils.providers import current_time_ns
+from nat.utils.providers import generate_span_id
+from nat.utils.providers import generate_trace_id
 
 logger = logging.getLogger(__name__)
 
@@ -128,7 +131,7 @@ class SpanStatusCode(Enum):
 
 
 class SpanEvent(BaseModel):
-    timestamp: float = Field(default_factory=lambda: int(time.time() * 1e9), description="The timestamp of the event.")
+    timestamp: float = Field(default_factory=current_time_ns, description="The timestamp of the event.")
     name: str = Field(description="The name of the event.")
     attributes: dict[str, Any] = Field(default_factory=dict, description="The attributes of the event.")
 
@@ -140,12 +143,12 @@ class SpanStatus(BaseModel):
 
 def _generate_nonzero_trace_id() -> int:
     """Generate a non-zero 128-bit trace ID."""
-    return uuid.uuid4().int
+    return generate_trace_id()
 
 
 def _generate_nonzero_span_id() -> int:
     """Generate a non-zero 64-bit span ID."""
-    return uuid.uuid4().int >> 64
+    return generate_span_id()
 
 
 class SpanContext(BaseModel):
@@ -186,7 +189,7 @@ class Span(BaseModel):
     name: str = Field(description="The name of the span.")
     context: SpanContext | None = Field(default=None, description="The context of the span.")
     parent: "Span | None" = Field(default=None, description="The parent span of the span.")
-    start_time: int = Field(default_factory=lambda: int(time.time() * 1e9), description="The start time of the span.")
+    start_time: int = Field(default_factory=current_time_ns, description="The start time of the span.")
     end_time: int | None = Field(default=None, description="The end time of the span.")
     attributes: dict[str, Any] = Field(default_factory=dict, description="The attributes of the span.")
     events: list[SpanEvent] = Field(default_factory=list, description="The events of the span.")
@@ -234,5 +237,5 @@ class Span(BaseModel):
             end_time (int | None): The end time of the span.
         """
         if end_time is None:
-            end_time = int(time.time() * 1e9)
+            end_time = current_time_ns()
         self.end_time = end_time

--- a/packages/nvidia_nat_core/src/nat/runtime/runner.py
+++ b/packages/nvidia_nat_core/src/nat/runtime/runner.py
@@ -16,7 +16,6 @@
 import contextvars
 import logging
 import typing
-import uuid
 from enum import Enum
 
 from nat.builder.component_utils import WORKFLOW_COMPONENT_NAME
@@ -30,6 +29,8 @@ from nat.data_models.intermediate_step import TraceMetadata
 from nat.data_models.invocation_node import InvocationNode
 from nat.data_models.runtime_enum import RuntimeTypeEnum
 from nat.observability.exporter_manager import ExporterManager
+from nat.utils.providers import generate_id
+from nat.utils.providers import generate_trace_id
 from nat.utils.reactive.subject import Subject
 
 logger = logging.getLogger(__name__)
@@ -180,15 +181,15 @@ class Runner:
             existing_run_id = self._context_state.workflow_run_id.get()
             existing_trace_id = self._context_state.workflow_trace_id.get()
 
-            workflow_run_id = existing_run_id or str(uuid.uuid4())
+            workflow_run_id = existing_run_id or generate_id()
 
-            workflow_trace_id = existing_trace_id or uuid.uuid4().int
+            workflow_trace_id = existing_trace_id or generate_trace_id()
 
             token_run_id = self._context_state.workflow_run_id.set(workflow_run_id)
             token_trace_id = self._context_state.workflow_trace_id.set(workflow_trace_id)
 
             # Prepare workflow-level intermediate step identifiers
-            workflow_step_uuid = str(uuid.uuid4())
+            workflow_step_uuid = generate_id()
 
             # Get workflow name with backwards-compatible fallback chain:
             # 1. Check for explicit 'name' in config (allows user customization in config yaml)
@@ -271,15 +272,15 @@ class Runner:
             existing_run_id = self._context_state.workflow_run_id.get()
             existing_trace_id = self._context_state.workflow_trace_id.get()
 
-            workflow_run_id = existing_run_id or str(uuid.uuid4())
+            workflow_run_id = existing_run_id or generate_id()
 
-            workflow_trace_id = existing_trace_id or uuid.uuid4().int
+            workflow_trace_id = existing_trace_id or generate_trace_id()
 
             token_run_id = self._context_state.workflow_run_id.set(workflow_run_id)
             token_trace_id = self._context_state.workflow_trace_id.set(workflow_trace_id)
 
             # Prepare workflow-level intermediate step identifiers
-            workflow_step_uuid = str(uuid.uuid4())
+            workflow_step_uuid = generate_id()
 
             # Get workflow name with backwards-compatible fallback chain:
             # 1. Check for explicit 'name' in config (allows user customization in config yaml)

--- a/packages/nvidia_nat_core/src/nat/utils/providers.py
+++ b/packages/nvidia_nat_core/src/nat/utils/providers.py
@@ -108,17 +108,33 @@ def generate_id() -> str:
 def generate_trace_id() -> int:
     """Return a new 128-bit integer id derived from the installed id provider.
 
-    With the default provider this is equivalent to ``uuid.uuid4().int`` and is always non-zero.
+    With the default provider this is equivalent to ``uuid.uuid4().int``. A provider UUID that
+    derives an all-zero trace ID (the nil UUID) is rejected, upholding the non-zero contract
+    enforced by ``SpanContext``.
+
+    Raises:
+        ValueError: If the installed id provider generated a UUID whose derived trace ID is zero.
     """
-    return uuid.UUID(generate_id()).int
+    trace_id = uuid.UUID(generate_id()).int
+    if trace_id == 0:
+        raise ValueError("The installed id provider generated a UUID with an all-zero trace ID")
+    return trace_id
 
 
 def generate_span_id() -> int:
     """Return a new 64-bit integer id derived from the installed id provider.
 
-    With the default provider this is equivalent to ``uuid.uuid4().int >> 64`` and is always non-zero.
+    With the default provider this is equivalent to ``uuid.uuid4().int >> 64``. A provider UUID
+    whose high 64 bits are zero derives an all-zero span ID and is rejected, upholding the
+    non-zero contract enforced by ``SpanContext``.
+
+    Raises:
+        ValueError: If the installed id provider generated a UUID whose derived span ID is zero.
     """
-    return uuid.UUID(generate_id()).int >> 64
+    span_id = uuid.UUID(generate_id()).int >> 64
+    if span_id == 0:
+        raise ValueError("The installed id provider generated a UUID with an all-zero span ID")
+    return span_id
 
 
 def current_time() -> float:

--- a/packages/nvidia_nat_core/src/nat/utils/providers.py
+++ b/packages/nvidia_nat_core/src/nat/utils/providers.py
@@ -1,0 +1,131 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Process-wide provider hooks for generated identifiers and timestamps.
+
+The runtime stamps workflow runs, intermediate steps, spans, and function invocations with freshly generated
+UUIDs and wall-clock timestamps. By default these come from :func:`uuid.uuid4` and :func:`time.time`, which is
+correct for normal execution but makes two otherwise identical runs produce different identifiers and timings.
+
+Integrations that need reproducible runs can install their own providers. Examples include record/replay style
+testing, golden-file trace comparison, and integrations with runtimes that re-execute workflow code and require
+identifiers to be stable across re-executions.
+
+Both hooks are process-wide and opt-in. When no provider is installed, behavior is unchanged. The setters return
+the previously installed provider so callers can restore it.
+
+The id provider must return strings in canonical UUID form. Integer identifiers, such as the OpenTelemetry-style
+128-bit trace ids and 64-bit span ids, are derived from the id provider by parsing the returned string, so a
+value that is not a valid UUID string raises :class:`ValueError` at generation time.
+"""
+
+import time
+import uuid
+from collections.abc import Callable
+
+IdProvider = Callable[[], str]
+"""Zero-argument callable returning a new identifier as a canonical UUID string."""
+
+TimeProvider = Callable[[], float]
+"""Zero-argument callable returning the current time in fractional seconds since the Unix epoch."""
+
+
+def default_id_provider() -> str:
+    """Return a random UUID4 string. This is the default id provider."""
+    return str(uuid.uuid4())
+
+
+def default_time_provider() -> float:
+    """Return the current wall-clock time in fractional seconds. This is the default time provider."""
+    return time.time()
+
+
+class _ProviderState:
+    """Mutable holder for the process-wide providers. Mutated only through the module-level setters."""
+
+    def __init__(self) -> None:
+        self.id_provider: IdProvider = default_id_provider
+        self.time_provider: TimeProvider = default_time_provider
+
+
+_state = _ProviderState()
+
+
+def set_id_provider(provider: IdProvider) -> IdProvider:
+    """Install ``provider`` as the process-wide id provider.
+
+    Args:
+        provider: Zero-argument callable returning a new identifier as a canonical UUID string.
+
+    Returns:
+        IdProvider: The previously installed id provider, so callers can restore it.
+    """
+    previous = _state.id_provider
+    _state.id_provider = provider
+    return previous
+
+
+def get_id_provider() -> IdProvider:
+    """Return the currently installed id provider."""
+    return _state.id_provider
+
+
+def set_time_provider(provider: TimeProvider) -> TimeProvider:
+    """Install ``provider`` as the process-wide time provider.
+
+    Args:
+        provider: Zero-argument callable returning the current time in fractional seconds since the Unix epoch.
+
+    Returns:
+        TimeProvider: The previously installed time provider, so callers can restore it.
+    """
+    previous = _state.time_provider
+    _state.time_provider = provider
+    return previous
+
+
+def get_time_provider() -> TimeProvider:
+    """Return the currently installed time provider."""
+    return _state.time_provider
+
+
+def generate_id() -> str:
+    """Return a new identifier string from the installed id provider."""
+    return _state.id_provider()
+
+
+def generate_trace_id() -> int:
+    """Return a new 128-bit integer id derived from the installed id provider.
+
+    With the default provider this is equivalent to ``uuid.uuid4().int`` and is always non-zero.
+    """
+    return uuid.UUID(generate_id()).int
+
+
+def generate_span_id() -> int:
+    """Return a new 64-bit integer id derived from the installed id provider.
+
+    With the default provider this is equivalent to ``uuid.uuid4().int >> 64`` and is always non-zero.
+    """
+    return uuid.UUID(generate_id()).int >> 64
+
+
+def current_time() -> float:
+    """Return the current time in fractional seconds from the installed time provider."""
+    return _state.time_provider()
+
+
+def current_time_ns() -> int:
+    """Return the current time in integer nanoseconds from the installed time provider."""
+    return int(current_time() * 1e9)

--- a/packages/nvidia_nat_core/src/nat/utils/providers.py
+++ b/packages/nvidia_nat_core/src/nat/utils/providers.py
@@ -108,9 +108,7 @@ def generate_id() -> str:
 def generate_trace_id() -> int:
     """Return a new 128-bit integer id derived from the installed id provider.
 
-    With the default provider this is equivalent to ``uuid.uuid4().int``. A provider UUID that
-    derives an all-zero trace ID (the nil UUID) is rejected, upholding the non-zero contract
-    enforced by ``SpanContext``.
+    With the default provider this is equivalent to ``uuid.uuid4().int``.
 
     Raises:
         ValueError: If the installed id provider generated a UUID whose derived trace ID is zero.
@@ -124,9 +122,7 @@ def generate_trace_id() -> int:
 def generate_span_id() -> int:
     """Return a new 64-bit integer id derived from the installed id provider.
 
-    With the default provider this is equivalent to ``uuid.uuid4().int >> 64``. A provider UUID
-    whose high 64 bits are zero derives an all-zero span ID and is rejected, upholding the
-    non-zero contract enforced by ``SpanContext``.
+    With the default provider this is equivalent to ``uuid.uuid4().int >> 64``.
 
     Raises:
         ValueError: If the installed id provider generated a UUID whose derived span ID is zero.

--- a/packages/nvidia_nat_core/tests/nat/utils/test_providers.py
+++ b/packages/nvidia_nat_core/tests/nat/utils/test_providers.py
@@ -39,8 +39,8 @@ _FIXED_ID = "12345678-1234-4321-8765-123456789abc"
 _FIXED_TIME = 1700000000.5
 
 
-@pytest.fixture(autouse=True)
-def restore_providers():
+@pytest.fixture(name="restore_providers", autouse=True)
+def restore_providers_fixture():
     """Restore the previously installed providers after each test to avoid cross-test leakage."""
     previous_id = providers.get_id_provider()
     previous_time = providers.get_time_provider()
@@ -55,6 +55,23 @@ def _sequential_uuid_provider(start: int = 1) -> typing.Callable[[], str]:
     """Return an id provider yielding UUIDs with sequential high 64 bits (valid trace and span ids)."""
     counter = itertools.count(start)
     return lambda: str(uuid.UUID(int=next(counter) << 64))
+
+
+def test_zero_derived_trace_and_span_ids_are_rejected():
+    # The nil UUID derives an all-zero trace ID and an all-zero span ID.
+    providers.set_id_provider(lambda: "00000000-0000-0000-0000-000000000000")
+    with pytest.raises(ValueError, match="all-zero trace ID"):
+        providers.generate_trace_id()
+    with pytest.raises(ValueError, match="all-zero span ID"):
+        providers.generate_span_id()
+
+
+def test_high_word_zero_uuid_is_rejected_for_span_ids_only():
+    # High 64 bits zero: a valid non-zero trace ID, but an all-zero span ID.
+    providers.set_id_provider(lambda: "00000000-0000-0000-0000-000000000001")
+    assert providers.generate_trace_id() == 1
+    with pytest.raises(ValueError, match="all-zero span ID"):
+        providers.generate_span_id()
 
 
 def test_default_providers_match_uuid4_and_wall_clock():

--- a/packages/nvidia_nat_core/tests/nat/utils/test_providers.py
+++ b/packages/nvidia_nat_core/tests/nat/utils/test_providers.py
@@ -1,0 +1,236 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import itertools
+import time
+import typing
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from nat.builder.context import Context
+from nat.builder.context import ContextState
+from nat.builder.function import Function
+from nat.builder.intermediate_step_manager import IntermediateStepManager
+from nat.data_models.intermediate_step import IntermediateStepPayload
+from nat.data_models.intermediate_step import IntermediateStepType
+from nat.data_models.span import Span
+from nat.data_models.span import SpanContext
+from nat.data_models.span import SpanEvent
+from nat.observability.exporter_manager import ExporterManager
+from nat.runtime.runner import Runner
+from nat.utils import providers
+
+# A fixed, valid UUID4-form string used to make every generated identifier predictable.
+_FIXED_ID = "12345678-1234-4321-8765-123456789abc"
+_FIXED_TIME = 1700000000.5
+
+
+@pytest.fixture(autouse=True)
+def restore_providers():
+    """Restore the previously installed providers after each test to avoid cross-test leakage."""
+    previous_id = providers.get_id_provider()
+    previous_time = providers.get_time_provider()
+    try:
+        yield
+    finally:
+        providers.set_id_provider(previous_id)
+        providers.set_time_provider(previous_time)
+
+
+def _sequential_uuid_provider(start: int = 1) -> typing.Callable[[], str]:
+    """Return an id provider yielding UUIDs with sequential high 64 bits (valid trace and span ids)."""
+    counter = itertools.count(start)
+    return lambda: str(uuid.UUID(int=next(counter) << 64))
+
+
+def test_default_providers_match_uuid4_and_wall_clock():
+    value = providers.generate_id()
+    assert uuid.UUID(value).version == 4
+    assert providers.generate_id() != value
+
+    before = time.time()
+    current = providers.current_time()
+    after = time.time()
+    assert before <= current <= after
+
+    assert providers.get_id_provider() is providers.default_id_provider
+    assert providers.get_time_provider() is providers.default_time_provider
+
+    assert 0 < providers.generate_trace_id() < 2**128
+    assert 0 < providers.generate_span_id() < 2**64
+    assert abs(providers.current_time_ns() / 1e9 - time.time()) < 60.0
+
+
+def test_setters_install_provider_and_return_previous():
+
+    def _fixed_id() -> str:
+        return _FIXED_ID
+
+    def _fixed_time() -> float:
+        return _FIXED_TIME
+
+    previous_id = providers.set_id_provider(_fixed_id)
+    previous_time = providers.set_time_provider(_fixed_time)
+
+    assert previous_id is providers.default_id_provider
+    assert previous_time is providers.default_time_provider
+    assert providers.get_id_provider() is _fixed_id
+    assert providers.get_time_provider() is _fixed_time
+
+    assert providers.generate_id() == _FIXED_ID
+    assert providers.generate_trace_id() == uuid.UUID(_FIXED_ID).int
+    assert providers.generate_span_id() == uuid.UUID(_FIXED_ID).int >> 64
+    assert providers.current_time() == _FIXED_TIME
+    assert providers.current_time_ns() == int(_FIXED_TIME * 1e9)
+
+    assert providers.set_id_provider(previous_id) is _fixed_id
+    assert providers.set_time_provider(previous_time) is _fixed_time
+    assert providers.generate_id() != _FIXED_ID
+
+
+def test_integer_id_derivation_requires_uuid_strings():
+    providers.set_id_provider(lambda: "not-a-uuid")
+
+    assert providers.generate_id() == "not-a-uuid"
+
+    with pytest.raises(ValueError):
+        providers.generate_trace_id()
+
+    with pytest.raises(ValueError):
+        providers.generate_span_id()
+
+
+def test_intermediate_step_payload_defaults_use_installed_providers():
+    """Model default factories must resolve the installed providers lazily, not capture them at import."""
+    providers.set_id_provider(_sequential_uuid_provider())
+    providers.set_time_provider(lambda: _FIXED_TIME)
+
+    first = IntermediateStepPayload(event_type=IntermediateStepType.CUSTOM_START)
+    second = IntermediateStepPayload(event_type=IntermediateStepType.CUSTOM_END)
+
+    assert first.UUID == str(uuid.UUID(int=1 << 64))
+    assert second.UUID == str(uuid.UUID(int=2 << 64))
+    assert first.event_timestamp == _FIXED_TIME
+    assert second.event_timestamp == _FIXED_TIME
+
+
+def test_span_models_use_installed_providers():
+    providers.set_id_provider(_sequential_uuid_provider())
+    providers.set_time_provider(lambda: _FIXED_TIME)
+
+    span_context = SpanContext()
+    assert span_context.trace_id == 1 << 64
+    assert span_context.span_id == 2
+
+    event = SpanEvent(name="event")
+    assert event.timestamp == int(_FIXED_TIME * 1e9)
+
+    span = Span(name="span")
+    assert span.start_time == int(_FIXED_TIME * 1e9)
+
+    span.end()
+    assert span.end_time == int(_FIXED_TIME * 1e9)
+
+
+async def test_push_active_function_uses_installed_id_provider():
+    providers.set_id_provider(lambda: _FIXED_ID)
+
+    context = Context.get()
+    with context.push_active_function("my_function", input_data=None):
+        assert context.active_function.function_id == _FIXED_ID
+
+
+class _DummyConfig:
+    """Mock config for _DummyFunction."""
+    name = None
+    type = "dummy_workflow"
+
+
+class _DummyFunction:
+    has_single_output = True
+    has_streaming_output = True
+    instance_name = "workflow"
+    display_name = "workflow"
+    config = _DummyConfig()
+
+    def convert(self, v, to_type):
+        return v
+
+    async def ainvoke(self, _message, to_type=None):
+        return {"ok": True}
+
+    async def astream(self, _message, to_type=None):
+        yield "chunk-1"
+
+
+class _DummyExporterManager:
+
+    def start(self, context_state=None):
+
+        class _Ctx:
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, exc_type, exc, tb):
+                return False
+
+        return _Ctx()
+
+
+@pytest.mark.parametrize("method", ["result", "result_stream"])
+async def test_runner_run_is_deterministic_with_installed_providers(method: str):
+    """A minimal run stamps run, trace, and step identifiers plus timestamps from the installed providers."""
+    providers.set_id_provider(lambda: _FIXED_ID)
+    providers.set_time_provider(lambda: _FIXED_TIME)
+
+    captured: list[IntermediateStepPayload] = []
+    original_push = IntermediateStepManager.push_intermediate_step
+
+    def capture_push(self, payload):
+        captured.append(payload)
+        return original_push(self, payload)
+
+    ctx_state = ContextState.get()
+    tkn_run = ctx_state.workflow_run_id.set(None)
+    tkn_trace = ctx_state.workflow_trace_id.set(None)
+
+    try:
+        with patch.object(IntermediateStepManager, "push_intermediate_step", capture_push):
+            runner = Runner(
+                "msg",
+                typing.cast(Function, _DummyFunction()),
+                ctx_state,
+                typing.cast(ExporterManager, _DummyExporterManager()),
+            )
+            async with runner:
+                if method == "result":
+                    assert await runner.result() == {"ok": True}
+                else:
+                    assert [c async for c in runner.result_stream()] == ["chunk-1"]
+    finally:
+        ctx_state.workflow_run_id.reset(tkn_run)
+        ctx_state.workflow_trace_id.reset(tkn_trace)
+
+    start = next(p for p in captured if p.event_type == IntermediateStepType.WORKFLOW_START)
+    end = next(p for p in captured if p.event_type == IntermediateStepType.WORKFLOW_END)
+
+    for payload in (start, end):
+        assert payload.UUID == _FIXED_ID
+        assert payload.event_timestamp == _FIXED_TIME
+        assert payload.metadata.provided_metadata["workflow_run_id"] == _FIXED_ID
+        assert payload.metadata.provided_metadata["workflow_trace_id"] == f"{uuid.UUID(_FIXED_ID).int:032x}"


### PR DESCRIPTION
## Description

The runtime currently stamps workflow runs, intermediate steps, spans, and function invocations with `uuid.uuid4()` and `time.time()` values called inline at each site (`runtime/runner.py`, `builder/context.py`, `data_models/intermediate_step.py`, `data_models/span.py`). Two otherwise identical runs therefore never produce the same identifiers or timings. That gets in the way of several third-party and testing use cases:

- Record or replay style testing, where a test harness replays a captured run and asserts on stable step identifiers.
- Golden-file trace comparison and reproducible traces in CI.
- Integrations with runtimes that re-execute workflow code (for example plugins that relocate or instrument function execution) and need identifiers to remain stable across re-executions, so steps and spans correlate across systems.

This PR adds a small additive module, `nat.utils.providers`, with process-wide, opt-in hooks:

- `set_id_provider` / `get_id_provider` — a zero-argument callable returning a new identifier as a canonical UUID string (default: `uuid.uuid4`).
- `set_time_provider` / `get_time_provider` — a zero-argument callable returning the current time in fractional seconds (default: `time.time`).
- Derivation helpers used by the runtime: `generate_id`, `generate_trace_id` (128-bit), `generate_span_id` (64-bit), `current_time`, and `current_time_ns`. Integer identifiers are derived by parsing the id provider's UUID string, so the default distribution is identical to `uuid.uuid4().int`.

The existing call sites are routed through these hooks:

- `Runner` workflow run id, trace id, and workflow step id (single and streaming paths).
- `Context.push_active_function` invocation id.
- `IntermediateStepPayload` `UUID` and `event_timestamp` default factories.
- `Span`/`SpanContext`/`SpanEvent` trace ids, span ids, and start/end/event timestamps.

Pydantic `default_factory` sites reference the module-level functions, so the installed provider is resolved lazily at model construction time rather than captured at import.

**Zero behavior change by default:** when no provider is installed, the defaults are `uuid.uuid4` and `time.time`, exactly as before. Setters return the previously installed provider so callers can restore it. The hook is documented briefly in the observability guide, and the module is picked up by the auto-generated API reference.

No tracking issue exists for this yet; happy to file one if the team prefers.

## Testing

- New `packages/nvidia_nat_core/tests/nat/utils/test_providers.py` (8 tests): default provider behavior, setter install/restore semantics, UUID-string contract for integer id derivation, lazy resolution through Pydantic default factories, span model injection, `push_active_function` injection, and an end-to-end minimal `Runner` run (single and streaming) asserting deterministic run ids, trace ids, step UUIDs, and timestamps.
- Full core suite: `uv run pytest packages/nvidia_nat_core` — 2725 passed, 54 skipped (defaults unchanged).
- `pre-commit run yapf|ruff-check --files <touched files>`, `python ci/scripts/copyright.py --verify-apache-v2`, `vale` on the touched Markdown, and `python ci/scripts/path_checks.py` all pass.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added process-wide, opt-in hooks to customize workflow/function identifiers and timestamps.
  * Workflow runs, spans, intermediate steps, and active function invocations now use the installed providers for deterministic observability values.
  * Added validation to reject provider outputs that produce invalid/zero-derived trace and span identifiers.

* **Documentation**
  * Documented how to configure, restore, and override default ID/timestamp providers, including deterministic examples and ID derivation behavior.

* **Tests**
  * Added deterministic test coverage for default behavior, provider installation/restoration, validation failures, and end-to-end runtime output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
