### PR TITLE
fix(core): resolve string annotations against the defining module in FunctionInfo

### DIFF
--- a/packages/nvidia_nat_core/src/nat/builder/function_info.py
+++ b/packages/nvidia_nat_core/src/nat/builder/function_info.py
@@ -214,7 +214,10 @@ class FunctionDescriptor:
 
         converters = []
 
-        sig = inspect.signature(func)
+        # Resolve string annotations (e.g. from modules using `from __future__ import annotations`) against the
+        # defining module's namespace. The inspected types are interpolated into the annotations of wrappers
+        # synthesized in this module, so unresolved strings would later be evaluated against the wrong globals.
+        sig = inspect.signature(func, eval_str=True)
 
         arg_count = len(sig.parameters)
 
@@ -582,7 +585,9 @@ class FunctionInfo:
         if (inspect.isasyncgenfunction(fn)):
             stream_fn = fn
 
-            sig = inspect.signature(fn)
+            # Resolve string annotations against the defining module's namespace so the return annotation can be
+            # introspected for `Streaming` metadata regardless of `from __future__ import annotations`.
+            sig = inspect.signature(fn, eval_str=True)
 
             output_origin = typing.get_origin(sig.return_annotation)
             output_args = typing.get_args(sig.return_annotation)

--- a/packages/nvidia_nat_core/tests/nat/builder/test_function_info_future_annotations.py
+++ b/packages/nvidia_nat_core/tests/nat/builder/test_function_info_future_annotations.py
@@ -1,0 +1,103 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Regression tests for components defined in modules using ``from __future__ import annotations``.
+
+With the future import, every annotation in this module is stored as a string and must be resolved against this
+module's namespace. ``FunctionInfo``/``FunctionDescriptor`` interpolate the inspected input and output types into
+wrappers synthesized inside ``nat.builder.function_info``, so if the string annotations are not resolved against
+the defining module first, they are later evaluated against the wrong module globals and fail with ``NameError``
+(or produce unresolved Pydantic forward references).
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+
+from pydantic import BaseModel
+
+from nat.builder.function_info import FunctionDescriptor
+from nat.builder.function_info import FunctionInfo
+
+
+class EchoInput(BaseModel):
+    text: str
+
+
+class EchoOutput(BaseModel):
+    text: str
+
+
+async def echo_single(message: EchoInput) -> EchoOutput:
+    return EchoOutput(text=message.text)
+
+
+async def echo_stream(message: EchoInput) -> AsyncGenerator[EchoOutput]:
+    yield EchoOutput(text=message.text)
+
+
+async def concat(first: str, second: EchoInput) -> str:
+    return first + second.text
+
+
+def test_function_descriptor_resolves_future_annotations():
+    descriptor = FunctionDescriptor.from_function(echo_single)
+
+    assert descriptor.input_type is EchoInput
+    assert descriptor.output_type is EchoOutput
+    assert descriptor.input_type_is_base_model
+    assert descriptor.output_type_is_base_model
+
+
+async def test_from_fn_single_fn_resolves_future_annotations():
+    info = FunctionInfo.from_fn(echo_single, description="echo")
+
+    assert info.input_type is EchoInput
+    assert info.single_output_type is EchoOutput
+    assert info.input_schema is EchoInput
+    assert info.single_output_schema is EchoOutput
+
+    assert info.single_fn is not None
+    assert await info.single_fn(EchoInput(text="hello")) == EchoOutput(text="hello")
+
+    # The auto-synthesized streaming wrapper is defined inside nat.builder.function_info, so it only works if
+    # the string annotations were resolved against this module before being interpolated into the wrapper.
+    assert info.stream_fn is not None
+    chunks = [chunk async for chunk in info.stream_fn(EchoInput(text="hello"))]
+    assert chunks == [EchoOutput(text="hello")]
+
+
+async def test_from_fn_stream_fn_resolves_future_annotations():
+    info = FunctionInfo.from_fn(echo_stream, description="echo stream")
+
+    assert info.input_type is EchoInput
+    assert info.stream_output_type is EchoOutput
+    assert info.stream_output_schema is EchoOutput
+
+    assert info.stream_fn is not None
+    chunks = [chunk async for chunk in info.stream_fn(EchoInput(text="hello"))]
+    assert chunks == [EchoOutput(text="hello")]
+
+
+async def test_from_fn_multi_argument_resolves_future_annotations():
+    info = FunctionInfo.from_fn(concat, description="concat")
+
+    assert info.input_schema is not None
+    assert set(info.input_schema.model_fields) == {"first", "second"}
+    assert info.input_schema.model_fields["first"].annotation is str
+    assert info.input_schema.model_fields["second"].annotation is EchoInput
+
+    assert info.single_fn is not None
+    value = info.input_schema(first="a: ", second=EchoInput(text="b"))
+    assert await info.single_fn(value) == "a: b"


### PR DESCRIPTION
## Description

`FunctionInfo` breaks for components defined in modules that use `from __future__ import annotations`. With the future import, annotations are stored as strings, and `FunctionDescriptor.from_function()` / `FunctionInfo.from_fn()` read them raw off `inspect.signature(...)` and interpolate them into the annotations of wrappers synthesized inside `nat.builder.function_info` (for example the auto-generated streaming wrapper and the multi-argument input adapter). The strings are then resolved against the synthesizing module's globals instead of the defining module's, so plugin authors hit:

- `NameError: name '<UserType>' is not defined` from `typing.get_type_hints` on the synthesized wrapper for any user-defined input/output type.
- Generated input schemas containing unresolved `ForwardRef('<UserType>')` field annotations.
- `BaseModel` outputs wrapped in a spurious `OutputArgsSchema` value-wrapper instead of being used directly.
- Silent loss of `Streaming` metadata introspection on annotated async-generator returns (`typing.get_origin` of a string is `None`).

### Fix

Resolve string annotations at the inspection boundary with `inspect.signature(..., eval_str=True)`, which evaluates them against the defining function's own globals. Two call sites change: `FunctionDescriptor.from_function()` and the async-generator branch of `FunctionInfo.from_fn()`. Non-string annotations are passed through unchanged, so modules that do not use the future import are unaffected.

### Reproduction

The new regression test module `packages/nvidia_nat_core/tests/nat/builder/test_function_info_future_annotations.py` uses `from __future__ import annotations` itself. Before the fix, its four tests fail with exactly the symptoms above; after the fix they pass.

No tracking issue exists for this yet; happy to file one if the team prefers.

## Testing

- New regression tests: descriptor inspection, single-function path (including the auto-synthesized streaming wrapper), stream-function path, and multi-argument input schema generation — 4 passed (all fail before the fix).
- `uv run pytest packages/nvidia_nat_core` — 2721 passed, 54 skipped.
- `uv run pytest packages/nvidia_nat_langchain packages/nvidia_nat_security packages/nvidia_nat_a365` (packages containing registration modules that already use the future import) — 1035 passed, 43 skipped.
- `pre-commit run yapf|ruff-check --files <touched files>` and `python ci/scripts/copyright.py --verify-apache-v2` pass.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of functions using postponed or forward-referenced type annotations.
  - Correctly derives input/output types and schemas for regular, streaming, and multi-argument functions.
  - Preserves field-level annotation details in generated schemas.

- **Tests**
  - Added regression coverage for annotation resolution across supported function patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->