### PR TITLE
fix(core): resolve lru_cache memory retention in DiscoveryMetadata

### DIFF
--- a/packages/nvidia_nat_core/src/nat/data_models/discovery_metadata.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/discovery_metadata.py
@@ -135,7 +135,6 @@ class DiscoveryMetadata(BaseModel):
         return "nvidia-nat"
 
     @staticmethod
-    @lru_cache
     def get_distribution_name_from_config_type(config_type: type["TypedBaseModelT"]) -> str:
         """Get the distribution name from the config type using the mapping of module names to distro names.
 

--- a/packages/nvidia_nat_core/src/nat/data_models/discovery_metadata.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/discovery_metadata.py
@@ -17,6 +17,7 @@ import importlib.metadata
 import inspect
 import logging
 import typing
+import weakref
 from enum import StrEnum
 from functools import lru_cache
 from types import ModuleType
@@ -34,6 +35,9 @@ if TYPE_CHECKING:
     from nat.data_models.common import TypedBaseModelT
 
 logger = logging.getLogger(__name__)
+
+_module_distro_cache = weakref.WeakKeyDictionary()
+_config_type_distro_cache = weakref.WeakKeyDictionary()
 
 
 class DiscoveryStatusEnum(StrEnum):
@@ -100,7 +104,6 @@ class DiscoveryMetadata(BaseModel):
         return distro_name if distro_name else root_package_name
 
     @staticmethod
-    @lru_cache
     def get_distribution_name_from_module(module: ModuleType | None) -> str:
         """Get the distribution name from the config type using the mapping of module names to distro names.
 
@@ -114,6 +117,12 @@ class DiscoveryMetadata(BaseModel):
 
         if module is None:
             return "nvidia-nat"
+
+        try:
+            if module in _module_distro_cache:
+                return _module_distro_cache[module]
+        except TypeError:
+            pass
 
         # Get the mapping of module names to distro names
         mapping = get_all_entrypoints_distro_mapping()
@@ -130,8 +139,16 @@ class DiscoveryMetadata(BaseModel):
             candidate_module_name = ".".join(module_package_parts[0:part_idx])
             candidate_distro_name = mapping.get(candidate_module_name, None)
             if candidate_distro_name is not None:
+                try:
+                    _module_distro_cache[module] = candidate_distro_name
+                except TypeError:
+                    pass
                 return candidate_distro_name
 
+        try:
+            _module_distro_cache[module] = "nvidia-nat"
+        except TypeError:
+            pass
         return "nvidia-nat"
 
     @staticmethod
@@ -144,8 +161,21 @@ class DiscoveryMetadata(BaseModel):
         Returns:
             str: The distribution name of the NAT component.
         """
+        try:
+            if config_type in _config_type_distro_cache:
+                return _config_type_distro_cache[config_type]
+        except TypeError:
+            pass
+
         module = inspect.getmodule(config_type)
-        return DiscoveryMetadata.get_distribution_name_from_module(module)
+        distro_name = DiscoveryMetadata.get_distribution_name_from_module(module)
+
+        try:
+            _config_type_distro_cache[config_type] = distro_name
+        except TypeError:
+            pass
+
+        return distro_name
 
     @staticmethod
     def from_config_type(config_type: type["TypedBaseModelT"],

--- a/packages/nvidia_nat_core/src/nat/utils/type_utils.py
+++ b/packages/nvidia_nat_core/src/nat/utils/type_utils.py
@@ -57,13 +57,20 @@ else:
 
 
 class read_only_cached_property:
+    """Descriptor that caches a computed value per-instance while remaining read-only.
 
-    def __init__(self, func):
+    Unlike `functools.cached_property`, this descriptor rejects attribute assignment,
+    preserving the read-only contract of the original `@property` it replaces, while
+    still avoiding the strong-reference memory leak caused by `functools.lru_cache`
+    on instance methods.
+    """
+
+    def __init__(self, func: collections.abc.Callable[[typing.Any], typing.Any]) -> None:
         self.func = func
         self.attrname = func.__name__
         self.__doc__ = func.__doc__
 
-    def __get__(self, instance, owner=None):
+    def __get__(self, instance: typing.Any, owner: type | None = None) -> typing.Any:
         if instance is None:
             return self
         if self.attrname in instance.__dict__:
@@ -72,10 +79,10 @@ class read_only_cached_property:
         instance.__dict__[self.attrname] = value
         return value
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: typing.Any, value: typing.Any) -> None:
         raise AttributeError(f"'{self.attrname}' is read-only")
 
-    def __delete__(self, instance):
+    def __delete__(self, instance: typing.Any) -> None:
         if self.attrname in instance.__dict__:
             del instance.__dict__[self.attrname]
 


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
This PR resolves a memory retention issue in `DiscoveryMetadata` caused by bare `@lru_cache` decorators (which default to `maxsize=128`). While this doesn't cause an unbounded leak, it permanently pins the 128 most-recently-seen dynamic Pydantic models (and modules) in memory, evicting them only when 128 newer distinct classes come through. Since the cached operation (`inspect.getmodule()`) is extremely cheap (~0.18µs), this buys negligible performance while needlessly extending the lifetime of dynamically generated classes in long-running processes like `nat mcp serve`.

*(Note: The newly enforced `B019` ruff rule successfully catches `lru_cache` memory leaks on regular instance methods, but it explicitly does not flag `@staticmethod`s. Because both of the leaking methods in `DiscoveryMetadata` were static methods, this leak slipped past both the original sweep and the new lint enforcement).*

### Fix Details:

**Replaced `@lru_cache` with `WeakKeyDictionary` in `discovery_metadata.py`:**
To ensure the caching performance is maintained without leaking memory (following the same spirit as my PR #2105 — replacing unsafe `@lru_cache` with GC-safe caching — but using `WeakKeyDictionary` here since the keys are classes/modules, not `self`), we implemented a safe caching strategy for both `get_distribution_name_from_config_type` and `get_distribution_name_from_module`. We replaced the problematic decorators with module-level `weakref.WeakKeyDictionary` caches. Because these dictionaries hold "weak" references to the dynamically generated Pydantic models (and modules), they allow the garbage collector to automatically clean up the classes when they are no longer needed.

**Addressed CodeRabbit typing/docstring feedback in `type_utils.py`:**
Added proper Google-style docstrings and explicit type hints (`typing.Any`) to the `read_only_cached_property` descriptor to fully satisfy the public API contract requirements flagged during my PR #2105 review.

Closes #2117

## By Submitting this PR I confirm:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- [x] We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- [x] When the PR is ready for review, new or existing tests cover these changes.
- [x] When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved package metadata resolution by using a more memory-friendly caching approach for repeated distribution-name lookups.

* **Reliability**
  * Enhanced distribution-name resolution across both module and configuration types with safer handling of edge cases.

* **Documentation**
  * Added clearer documentation and stricter type annotations for the read-only cached property utility, improving maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->