### PR TITLE
fix(mcp): recover the MCP client when the lifecycle worker dies

### DIFF
--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
@@ -291,7 +291,7 @@ class MCPBaseClient(ABC):
             if last_error:
                 raise last_error
 
-    def _ensure_lifecycle_worker(self) -> None:
+    def _ensure_lifecycle_worker(self) -> asyncio.Task:
         """Respawn the lifecycle worker if it died, so the client can recover (#2111).
 
         A failing transport background child task cancels the worker that hosts the
@@ -299,11 +299,13 @@ class MCPBaseClient(ABC):
         loop, so it never clears connection state and the task is left ``done``. Rather
         than bricking the client for the rest of the process, drop the orphaned transport
         references and start a fresh worker that the next command can drive to reconnect.
+
+        Returns the live worker task, so callers can watch it alongside their command.
         """
         if self._lifecycle_commands is None:
             raise RuntimeError("MCPBaseClient not initialized. Use async with to initialize.")
         if self._lifecycle_task is not None and not self._lifecycle_task.done():
-            return
+            return self._lifecycle_task
         # The previous worker's transport context was entered in that (now dead) task.
         # Do not close _exit_stack here: closing it off-task raises "cancel scope in a
         # different task". Drop the stale references and let a fresh connect start clean.
@@ -312,14 +314,26 @@ class MCPBaseClient(ABC):
         self._tools = None
         self._connection_established = False
         self._lifecycle_task = asyncio.create_task(self._lifecycle_worker(), name=f"mcp-client-{self.server_name}")
+        return self._lifecycle_task
 
     async def _run_lifecycle_command(self, command: str) -> None:
         """Run a connection lifecycle command in the task that owns the transport stack."""
-        self._ensure_lifecycle_worker()
+        worker = self._ensure_lifecycle_worker()
 
         future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         await self._lifecycle_commands.put((command, future))
-        await future
+        # The worker can die between the liveness check above and resolving the
+        # future (the same transport-child cancellation this class recovers from),
+        # which would leave the future unresolved forever. Watch both.
+        await asyncio.wait({future, worker}, return_when=asyncio.FIRST_COMPLETED)
+        if future.done():
+            future.result()
+            return
+        # The worker died before resolving our command. Abandon the queued command
+        # (the worker loop skips commands whose future is already done) and surface
+        # a retryable error so _reconnect / the next call can relaunch a worker.
+        future.cancel()
+        raise ConnectionError(f"MCP client lifecycle worker for {self.server_name} exited while running '{command}'")
 
     async def _lifecycle_worker(self) -> None:
         """Own MCP transport context entry and exit to keep AnyIO cancel scopes task-local."""
@@ -328,6 +342,11 @@ class MCPBaseClient(ABC):
 
         while True:
             command, future = await self._lifecycle_commands.get()
+
+            if future.done():
+                # The caller abandoned this command (its previous worker died before
+                # consuming it). Executing it now would replay a stale request.
+                continue
 
             if command == "close":
                 try:

--- a/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
+++ b/packages/nvidia_nat_mcp/src/nat/plugins/mcp/client/client_base.py
@@ -239,6 +239,13 @@ class MCPBaseClient(ABC):
     @property
     def is_connected(self) -> bool:
         """Whether the client has an active, initialized connection."""
+        # A transport background child task can cancel the lifecycle worker
+        # (which hosts the transport's task group) without running the worker's
+        # state-clearing, leaving _connection_established stale-True (#2111).
+        # Treat a dead worker as not connected so callers do not proceed into
+        # tool calls against a torn-down transport.
+        if self._lifecycle_task is None or self._lifecycle_task.done():
+            return False
         return self._exit_stack is not None and self._connection_established
 
     @property
@@ -284,10 +291,31 @@ class MCPBaseClient(ABC):
             if last_error:
                 raise last_error
 
+    def _ensure_lifecycle_worker(self) -> None:
+        """Respawn the lifecycle worker if it died, so the client can recover (#2111).
+
+        A failing transport background child task cancels the worker that hosts the
+        transport's AnyIO task group. That cancellation bypasses the worker's command
+        loop, so it never clears connection state and the task is left ``done``. Rather
+        than bricking the client for the rest of the process, drop the orphaned transport
+        references and start a fresh worker that the next command can drive to reconnect.
+        """
+        if self._lifecycle_commands is None:
+            raise RuntimeError("MCPBaseClient not initialized. Use async with to initialize.")
+        if self._lifecycle_task is not None and not self._lifecycle_task.done():
+            return
+        # The previous worker's transport context was entered in that (now dead) task.
+        # Do not close _exit_stack here: closing it off-task raises "cancel scope in a
+        # different task". Drop the stale references and let a fresh connect start clean.
+        self._exit_stack = None
+        self._session = None
+        self._tools = None
+        self._connection_established = False
+        self._lifecycle_task = asyncio.create_task(self._lifecycle_worker(), name=f"mcp-client-{self.server_name}")
+
     async def _run_lifecycle_command(self, command: str) -> None:
         """Run a connection lifecycle command in the task that owns the transport stack."""
-        if self._lifecycle_commands is None or self._lifecycle_task is None or self._lifecycle_task.done():
-            raise RuntimeError("MCPBaseClient not initialized. Use async with to initialize.")
+        self._ensure_lifecycle_worker()
 
         future: asyncio.Future[None] = asyncio.get_running_loop().create_future()
         await self._lifecycle_commands.put((command, future))

--- a/packages/nvidia_nat_mcp/tests/client/test_mcp_client_base.py
+++ b/packages/nvidia_nat_mcp/tests/client/test_mcp_client_base.py
@@ -690,7 +690,9 @@ async def test_transport_child_failure_does_not_brick_client():
 
         # Fire exactly one transient transport error while the worker is parked.
         client.fire_blip.set()
-        await asyncio.sleep(0.05)  # let the cancellation propagate
+        with anyio.fail_after(5):  # deterministic: wait for the cancellation, bounded
+            while not worker_before.done():
+                await asyncio.sleep(0.005)
 
         # The worker that hosted the transport was cancelled by the child...
         assert worker_before.done()
@@ -702,6 +704,69 @@ async def test_transport_child_failure_does_not_brick_client():
         await client._reconnect()
         assert client.is_connected is True
         assert client._lifecycle_task is not worker_before  # a fresh worker was spawned
+
+
+class HangingConnectMockClient(MCPBaseClient):
+    """Mock client whose second connect parks until released, exposing the mid-command race.
+
+    Used to hold the lifecycle worker inside a command (its future still pending) so a
+    test can cancel the worker at exactly that point — the race where the transport child
+    dies after ``_run_lifecycle_command``'s liveness check but before the future resolves.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.connect_started = asyncio.Event()
+        self._park_next_connect = False
+
+    def arm_parking(self):
+        self._park_next_connect = True
+
+    @asynccontextmanager
+    async def connect_to_server(self):  # type: ignore
+        if self._park_next_connect:
+            self._park_next_connect = False
+            self.connect_started.set()
+            await asyncio.Event().wait()  # park until cancelled
+        session = AsyncMock(spec=ClientSession)
+        session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
+        yield session
+
+
+async def test_worker_death_mid_command_raises_instead_of_hanging():
+    """A worker cancelled while a command is in flight must fail that command, not hang it.
+
+    Covers the race past the ``_ensure_lifecycle_worker`` liveness check: the command's
+    future is pending when the worker dies, so without watching the worker task the
+    caller would await forever. The command must fail with a retryable error and the
+    client must still recover afterwards.
+    """
+    client = HangingConnectMockClient(
+        transport="streamable-http",
+        reconnect_enabled=True,
+        reconnect_max_attempts=2,
+        reconnect_initial_backoff=0.01,
+        reconnect_max_backoff=0.02,
+    )
+
+    async with client:
+        worker = client._lifecycle_task
+        client.arm_parking()
+        command = asyncio.create_task(client._run_lifecycle_command("reconnect"))
+
+        # Wait until the worker is inside the command (future pending), then kill it —
+        # the same effect as the transport child cancelling the worker mid-command.
+        with anyio.fail_after(5):
+            await client.connect_started.wait()
+        worker.cancel()
+
+        with anyio.fail_after(5):  # before the fix this await hung forever
+            with pytest.raises(ConnectionError, match="exited while running"):
+                await command
+
+        # The abandoned command must not brick the client: recovery still works.
+        await client._reconnect()
+        assert client.is_connected is True
 
 
 class TestMCPToolClient:

--- a/packages/nvidia_nat_mcp/tests/client/test_mcp_client_base.py
+++ b/packages/nvidia_nat_mcp/tests/client/test_mcp_client_base.py
@@ -21,6 +21,7 @@ from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+import anyio
 import pytest
 import uvicorn
 from mcp.client.session import ClientSession
@@ -630,6 +631,77 @@ async def test_is_connected_false_after_reconnect_failure():
         with pytest.raises(MCPConnectionError):
             await client.get_tools()
         assert client.is_connected is False
+
+
+class TransportChildFailureMockClient(MCPBaseClient):
+    """Mock client whose connect_to_server mirrors the real transports' structure (#2111).
+
+    Every MCP transport enters an ``anyio.create_task_group()`` and spawns background
+    child tasks with ``start_soon`` (streamable_http/sse/stdio). That task group is hosted
+    by the lifecycle worker. This mock reproduces exactly that shape: a background child
+    that raises once on command, so a single transient transport error cancels the parked
+    worker. Prior to the fix this permanently bricked the client.
+    """
+
+    def __init__(self, **kwargs):
+        super().__init__(**kwargs)
+        self.fire_blip = asyncio.Event()
+        self.connect_call_count = 0
+        # Only the first connection's child parks awaiting the blip; connections
+        # made after recovery get a benign child so the transport closes cleanly.
+        self._arm_blip = True
+
+    async def _background_child(self):
+        # Models the transport's background POST/read task (e.g. handle_request_async).
+        if not self._arm_blip:
+            return
+        self._arm_blip = False
+        await self.fire_blip.wait()
+        raise ConnectionError("INJECTED transient transport error")
+
+    @asynccontextmanager
+    async def connect_to_server(self):  # type: ignore
+        self.connect_call_count += 1
+        async with anyio.create_task_group() as tg:
+            tg.start_soon(self._background_child)
+            session = AsyncMock(spec=ClientSession)
+            session.list_tools = AsyncMock(return_value=MagicMock(tools=[]))
+            yield session
+
+
+async def test_transport_child_failure_does_not_brick_client():
+    """A transient transport-child failure must not permanently brick the client (#2111).
+
+    Regression for the uncovered path: the failure originates in a transport background
+    child task while the lifecycle worker is parked, cancelling the worker. The client
+    must report itself disconnected (not stale-connected) and recover on reconnect.
+    """
+    client = TransportChildFailureMockClient(
+        transport="streamable-http",
+        reconnect_enabled=True,
+        reconnect_max_attempts=2,
+        reconnect_initial_backoff=0.01,
+        reconnect_max_backoff=0.02,
+    )
+
+    async with client:
+        assert client.is_connected is True
+        worker_before = client._lifecycle_task
+
+        # Fire exactly one transient transport error while the worker is parked.
+        client.fire_blip.set()
+        await asyncio.sleep(0.05)  # let the cancellation propagate
+
+        # The worker that hosted the transport was cancelled by the child...
+        assert worker_before.done()
+        # ...and is_connected must NOT be stale-True (the core #2111 symptom).
+        assert client.is_connected is False
+
+        # The transport is healthy again: reconnect must succeed and re-establish
+        # the connection instead of raising "MCPBaseClient not initialized" forever.
+        await client._reconnect()
+        assert client.is_connected is True
+        assert client._lifecycle_task is not worker_before  # a fresh worker was spawned
 
 
 class TestMCPToolClient:


### PR DESCRIPTION
## Description
Closes #2111

A transient transport failure permanently bricks a shared MCP client. The failure chain (confirmed by construction in [this comment](https://github.com/NVIDIA/NeMo-Agent-Toolkit/issues/2111#issuecomment-4957979762)): the SDK's streamable-http transport starts `handle_request_async` unguarded on the transport task group (`streamable_http.py:569` in `mcp` 1.28.1), so a failing request-child cancels the lifecycle worker that hosts the transport's task group. That cancellation bypasses the worker's `except Exception` (`CancelledError` is not caught), so `_connection_established` stays stale-`True` while the worker is gone; every lifecycle command then raises `MCPBaseClient not initialized` and `_reconnect()` loops on the same error forever.

This implements the issue's **direction 2** (make the worker relaunchable) as the minimal user-facing fix:

- `is_connected` returns `False` once the worker task is done — no more stale-`True` after a transport-child cancellation.
- `_run_lifecycle_command` relaunches a dead worker via the new `_ensure_lifecycle_worker()`, which abandons the orphaned transport refs rather than closing them off-task (closing `_exit_stack` off-task raises "cancel scope in a different task").

The regression test's mock client mirrors the real transports' structure — a real `anyio.create_task_group()` with an unguarded background child — which is the path existing mocks don't exercise (why this was uncovered, as the issue notes).

**Verification (executed):**
- Regression test fails on unfixed source, passes with the fix (cross-checked by stashing only the source change).
- Full `test_mcp_client_base.py` suite: 33 passed, 8 skipped.
- `ruff` (0.15.0) and `yapf` (0.43.0) clean at the repo's pinned versions; copyright check clean (`ci/scripts/copyright.py --git-diff-commits`).

**Known limit (deliberate):** recovery abandons the dead worker's transport context instead of cleaning it up. Against the real streamable-http transport, that orphaned context can still surface the off-task cancel-scope complaint at teardown/GC (the regression test's mock does not reproduce that warning). Isolating the transport in a dedicated task — the issue's direction 1 — is the structural follow-up; happy to take that on separately if maintainers want it.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Updated connection status to accurately report disconnected state when the underlying lifecycle worker is missing or stopped.
  - Improved resilience by recreating the worker and clearing stale session/tool state before executing new lifecycle commands.
  - Prevented stuck/hanging lifecycle commands; failures now raise a retryable connection error and the client can recover via reconnection.
- **Tests**
  - Added regression coverage for transport task failures, mid-command worker death, and successful recovery without “bricking” the client.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->