### PR TITLE
fix(profiler): import the CrewAI profiler handler from its real module

### DIFF
--- a/packages/nvidia_nat_profiler/src/nat/plugins/profiler/decorators/framework_wrapper.py
+++ b/packages/nvidia_nat_profiler/src/nat/plugins/profiler/decorators/framework_wrapper.py
@@ -109,7 +109,7 @@ def set_framework_profiler_handler(
 
             if LLMFrameworkEnum.CREWAI in frameworks and not _library_instrumented["crewai"]:
                 try:
-                    from nat.plugins.crewai.callback_handler import CrewAIProfilerHandler
+                    from nat.plugins.crewai.crewai_callback_handler import CrewAIProfilerHandler
                     handler = CrewAIProfilerHandler()
                     handler.instrument()
                     _library_instrumented["crewai"] = True

--- a/packages/nvidia_nat_profiler/tests/decorators/test_framework_wrapper.py
+++ b/packages/nvidia_nat_profiler/tests/decorators/test_framework_wrapper.py
@@ -1,0 +1,48 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from types import ModuleType
+
+from nat.builder.framework_enum import LLMFrameworkEnum
+from nat.plugins.profiler.decorators import framework_wrapper
+
+
+async def test_crewai_profiler_loads_handler_from_real_module(monkeypatch):
+    """The CrewAI branch must load the profiler handler from crewai_callback_handler, not callback_handler."""
+    instrument_calls = []
+
+    class _StubHandler:
+
+        def instrument(self):
+            instrument_calls.append(True)
+
+    stub_module = ModuleType("nat.plugins.crewai.crewai_callback_handler")
+    stub_module.CrewAIProfilerHandler = _StubHandler
+    monkeypatch.setitem(sys.modules, "nat.plugins.crewai.crewai_callback_handler", stub_module)
+    monkeypatch.setitem(framework_wrapper._library_instrumented, "crewai", False)
+
+    @asynccontextmanager
+    async def build_fn(config, builder) -> AsyncIterator[str]:
+        yield "workflow"
+
+    wrapped = framework_wrapper.set_framework_profiler_handler(None, [LLMFrameworkEnum.CREWAI])(build_fn)
+    async with wrapped(None, None) as result:
+        assert result == "workflow"
+
+    assert instrument_calls == [True]
+    assert framework_wrapper._library_instrumented["crewai"] is True


### PR DESCRIPTION
`set_framework_profiler_handler` imported the CrewAI handler from a module that does not exist, so the `ModuleNotFoundError` was swallowed as a missing-extra warning and CrewAI agents got no instrumentation, even with the crewai extra installed.

## Description
The profiler's CrewAI branch imported `CrewAIProfilerHandler` from `nat.plugins.crewai.callback_handler`, but the crewai plugin ships the handler in `crewai_callback_handler.py`. The langchain, llama_index and semantic_kernel branches in the same file import `<plugin>.callback_handler`, which those plugins provide; crewai is the only one whose module carries a prefix. `ModuleNotFoundError` subclasses `ImportError`, so the surrounding `except ImportError` swallowed the failure and logged a warning to install the crewai extra while CrewAI agents received no LLM events, no tool events, and no tokens, even with `nvidia-nat[crewai]` installed.

Closes [#2127](https://github.com/NVIDIA/NeMo-Agent-Toolkit/issues/2127)

## Changes
- Import `CrewAIProfilerHandler` from `nat.plugins.crewai.crewai_callback_handler` in `framework_wrapper.py`
- Add a regression test that registers a stand-in handler at the real module path and asserts the CrewAI branch loads and instruments it

## Validation
- [x] `pytest packages/nvidia_nat_profiler/tests/decorators/test_framework_wrapper.py` passes with the fix
- [x] Without the fix the test fails (`instrument_calls == []`) and logs the reported `CrewAI profiler not available ... No module named 'nat.plugins.crewai'` warning
- [x] `ruff check` clean on both files
- [x] No other reference to the old `nat.plugins.crewai.callback_handler` path remains in the repo

## Note
The reporter also flagged that CrewAI `*_END` events are dropped because the step manager's `ContextVar` does not follow CrewAI's worker thread, so token capture stays broken after the import is fixed. That is a separate defect and is left for its own issue, as they suggested.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CrewAI framework profiling to load the correct profiler handler, ensuring instrumentation is applied as expected during initialization.

* **Tests**
  * Added an asynchronous pytest that verifies the CrewAI profiling path selects the proper handler and that instrumentation becomes active when the wrapped async context runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->