### PR TITLE
fix(profiler): deduplicate Semantic Kernel patch targets

### DIFF
--- a/packages/nvidia_nat_semantic_kernel/src/nat/plugins/semantic_kernel/callback_handler.py
+++ b/packages/nvidia_nat_semantic_kernel/src/nat/plugins/semantic_kernel/callback_handler.py
@@ -83,12 +83,12 @@ class SemanticKernelProfilerHandler(BaseProfilerCallback):
         """
         import semantic_kernel
 
-        functions_to_patch = []
+        functions_to_patch = set()
 
         # Gather the appropriate modules/functions based on your builder config
         for llm in self._builder_llms:
             if self._builder_llms[llm].provider_type == 'openai':
-                functions_to_patch.extend(["openai_non_streaming", "openai_streaming"])
+                functions_to_patch.update(["openai_non_streaming", "openai_streaming"])
 
         # Grab original reference for the tool call
         self._original_tool_call = getattr(semantic_kernel.Kernel, "invoke_function_call", None)

--- a/packages/nvidia_nat_semantic_kernel/tests/test_sk_callback_handler.py
+++ b/packages/nvidia_nat_semantic_kernel/tests/test_sk_callback_handler.py
@@ -13,9 +13,32 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 
 from nat.utils.reactive.subject import Subject
+
+
+async def test_semantic_kernel_handler_deduplicates_llm_patch_methods(reactive_stream: Subject,
+                                                                      monkeypatch: pytest.MonkeyPatch):
+    """Test that multiple OpenAI LLMs do not wrap the same SK methods repeatedly."""
+    from nat.plugins.semantic_kernel.callback_handler import SemanticKernelProfilerHandler
+
+    handler = SemanticKernelProfilerHandler(
+        workflow_llms={
+            "llm_a": SimpleNamespace(provider_type="openai"),
+            "llm_b": SimpleNamespace(provider_type="openai"),
+            "llm_other": SimpleNamespace(provider_type="anthropic"),
+        })
+    build_llm_call_patch = Mock(side_effect=lambda original: original)
+    monkeypatch.setattr(handler, "_build_llm_call_patch", build_llm_call_patch)
+    monkeypatch.setattr(handler, "_build_tool_call_patch", lambda original: original)
+
+    handler.instrument()
+
+    assert build_llm_call_patch.call_count == 2
 
 
 @pytest.mark.slow


### PR DESCRIPTION
Closes #2125

## Summary

`SemanticKernelProfilerHandler.instrument()` added the same Semantic Kernel patch targets once for every configured LLM with the `openai` provider type. Because those targets are shared methods, a configuration with multiple OpenAI-compatible LLMs wrapped each method multiple times, causing one real Semantic Kernel call to emit duplicate profiler events and inflated token totals.

This change collects the patch target keys in a set so each shared method is wrapped once per instrumentation pass. It also adds a deterministic regression test covering multiple matching LLMs and a non-matching LLM.

## Changes

The change is limited to patch-target collection in the Semantic Kernel profiler and its unit test. Configurations with zero or one matching LLM retain the same two target methods; non-OpenAI LLMs remain ignored.

## Verification

```bash
pytest packages/nvidia_nat_semantic_kernel/tests -q --run_slow
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Semantic Kernel instrumentation to prevent duplicate patching when multiple OpenAI providers are configured.
  * Increased reliability and consistency of profiler callback behavior.

* **Tests**
  * Added coverage verifying that language-model instrumentation is applied only once per distinct provider context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->