### PR TITLE
fix(observability): emit user_id as span attribute in SpanExporter

### DIFF
--- a/packages/nvidia_nat_core/src/nat/observability/exporter/span_exporter.py
+++ b/packages/nvidia_nat_core/src/nat/observability/exporter/span_exporter.py
@@ -198,6 +198,8 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
                 event.payload.framework.value if event.payload.framework else "unknown",
             f"{self._span_prefix}.conversation.id":
                 self._context_state.conversation_id.get() or "unknown",
+            f"{self._span_prefix}.user.id":
+                self._context_state.user_id.get() or "unknown",
             f"{self._span_prefix}.workflow.run_id":
                 self._context_state.workflow_run_id.get() or "unknown",
             f"{self._span_prefix}.workflow.trace_id": (f"{_attr_trace_id:032x}" if _attr_trace_id else "unknown"),
@@ -222,6 +224,14 @@ class SpanExporter(ProcessingExporter[InputSpanT, OutputSpanT], SerializeMixin):
             conversation_id = self._context_state.conversation_id.get()
             if conversation_id:
                 sub_span.set_attribute("session.id", conversation_id)
+        except (AttributeError, LookupError):
+            pass
+
+        # Enable user attribution by setting user.id from user_id (used by Langfuse and OTLP backends)
+        try:
+            user_id = self._context_state.user_id.get()
+            if user_id:
+                sub_span.set_attribute("user.id", user_id)
         except (AttributeError, LookupError):
             pass
 

--- a/packages/nvidia_nat_core/tests/nat/observability/exporter/test_span_exporter.py
+++ b/packages/nvidia_nat_core/tests/nat/observability/exporter/test_span_exporter.py
@@ -661,6 +661,50 @@ class TestSpanExporterFunctionality:
         # Span name should fall back to event type string
         assert span.name == str(IntermediateStepType.WORKFLOW_START)
 
+    def test_user_id_emitted_as_span_attribute(self, span_exporter):
+        """user_id from ContextState is emitted as nat.user.id and user.id span attributes."""
+        from nat.builder.context import ContextState
+
+        ctx_state = ContextState.get()
+        token = ctx_state.user_id.set("USER-42")
+        try:
+            event = create_intermediate_step(event_type=IntermediateStepType.LLM_START,
+                                             framework=LLMFrameworkEnum.LANGCHAIN,
+                                             name="test_llm",
+                                             event_timestamp=datetime.now().timestamp(),
+                                             data=StreamEventData(input="hi"),
+                                             metadata={})
+
+            span_exporter.export(event)
+            span = span_exporter._outstanding_spans[event.payload.UUID]
+
+            assert span.attributes.get("nat.user.id") == "USER-42"
+            assert span.attributes.get("user.id") == "USER-42"
+        finally:
+            ctx_state.user_id.reset(token)
+
+    def test_user_id_absent_when_not_set(self, span_exporter):
+        """When user_id is not set, user.id is not added as a span attribute."""
+        from nat.builder.context import ContextState
+
+        ctx_state = ContextState.get()
+        token = ctx_state.user_id.set(None)
+        try:
+            event = create_intermediate_step(event_type=IntermediateStepType.LLM_START,
+                                             framework=LLMFrameworkEnum.LANGCHAIN,
+                                             name="test_llm",
+                                             event_timestamp=datetime.now().timestamp(),
+                                             data=StreamEventData(input="hi"),
+                                             metadata={})
+
+            span_exporter.export(event)
+            span = span_exporter._outstanding_spans[event.payload.UUID]
+
+            assert span.attributes.get("nat.user.id") == "unknown"
+            assert "user.id" not in span.attributes
+        finally:
+            ctx_state.user_id.reset(token)
+
 
 class TestToJsonStringSerialization:
     """Tests for _to_json_string ensuring OTLP-compatible serialization."""


### PR DESCRIPTION
## Summary

- `ContextState.user_id` was resolved and stored by the runtime but never read by `SpanExporter._process_start_event`, so no span ever carried user identity.
- Add `nat.user.id` to the initial `attributes` dict alongside `nat.conversation.id`.
- Set `user.id` on each span after creation, mirroring the existing `session.id`/`conversation_id` pattern, so Langfuse and other OTLP backends can attribute traces to the correct user.

Fixes #2151

## Test plan

- [x] `test_user_id_emitted_as_span_attribute`: sets `ContextState.user_id` to `"USER-42"`, exports a span, and asserts both `nat.user.id` and `user.id` attributes equal `"USER-42"`.
- [x] `test_user_id_absent_when_not_set`: sets `ContextState.user_id` to `None`, exports a span, and asserts `nat.user.id` is `"unknown"` and `user.id` is absent (matching the `session.id` behavior).
- [x] Full existing test suite for `test_span_exporter.py` continues to pass (39 pass, 6 pre-existing fixture errors unchanged).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Observability spans now include the current user ID for improved trace context.
  * User identifiers are recorded using both standard and application-specific attributes when available.
  * Spans without a user ID are handled gracefully with an “unknown” value and no standard user attribute.

* **Tests**
  * Added coverage for spans with and without user identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->