### PR TITLE
fix(langchain): set a User-Agent for the wiki_search tool

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tools/wikipedia_search.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tools/wikipedia_search.py
@@ -13,6 +13,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from importlib.metadata import version
+
 from nat.builder.builder import Builder
 from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.builder.function_info import FunctionInfo
@@ -37,7 +39,8 @@ async def wiki_search(tool_config: WikiSearchToolConfig, builder: Builder):
     # Wikipedia's API rejects requests without a User-Agent header (returns a non-JSON 403),
     # and the `wikipedia` package (used internally by WikipediaLoader) doesn't set one by
     # default. See https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy
-    wikipedia.set_user_agent("NeMoAgentToolkit/1.0 (https://github.com/NVIDIA/NeMo-Agent-Toolkit)")
+    wikipedia.set_user_agent(
+        f"NeMoAgentToolkit/{version('nvidia-nat-langchain')} (https://github.com/NVIDIA/NeMo-Agent-Toolkit)")
 
     async def _wiki_search(question: str) -> str:
         # Search the web and get the requested amount of results

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tools/wikipedia_search.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/tools/wikipedia_search.py
@@ -31,7 +31,13 @@ class WikiSearchToolConfig(FunctionBaseConfig, name="wiki_search"):
 # Wiki search
 @register_function(config_type=WikiSearchToolConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def wiki_search(tool_config: WikiSearchToolConfig, builder: Builder):
+    import wikipedia
     from langchain_community.document_loaders import WikipediaLoader
+
+    # Wikipedia's API rejects requests without a User-Agent header (returns a non-JSON 403),
+    # and the `wikipedia` package (used internally by WikipediaLoader) doesn't set one by
+    # default. See https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy
+    wikipedia.set_user_agent("NeMoAgentToolkit/1.0 (https://github.com/NVIDIA/NeMo-Agent-Toolkit)")
 
     async def _wiki_search(question: str) -> str:
         # Search the web and get the requested amount of results

--- a/packages/nvidia_nat_langchain/tests/test_wikipedia_search.py
+++ b/packages/nvidia_nat_langchain/tests/test_wikipedia_search.py
@@ -1,0 +1,62 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import AsyncMock
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def tool_config():
+    from nat.plugins.langchain.tools.wikipedia_search import WikiSearchToolConfig
+    return WikiSearchToolConfig(max_results=2)
+
+
+async def test_sets_wikipedia_user_agent(tool_config):
+    # Wikipedia's API rejects requests without a User-Agent header (403, non-JSON body).
+    # The `wikipedia` package used internally by WikipediaLoader doesn't set one by
+    # default, so the tool must configure it explicitly on setup.
+    from nat.plugins.langchain.tools.wikipedia_search import wiki_search
+
+    with patch("wikipedia.set_user_agent") as mock_set_user_agent:
+        async with wiki_search(tool_config, None):
+            pass
+
+        mock_set_user_agent.assert_called_once()
+        user_agent = mock_set_user_agent.call_args[0][0]
+        assert user_agent
+
+
+async def test_formats_search_results(tool_config):
+    from nat.plugins.langchain.tools.wikipedia_search import wiki_search
+
+    mock_doc = MagicMock()
+    mock_doc.metadata = {"source": "https://en.wikipedia.org/wiki/Aardvark", "page": ""}
+    mock_doc.page_content = "The aardvark is a mammal."
+
+    with patch("wikipedia.set_user_agent"), \
+         patch("langchain_community.document_loaders.WikipediaLoader") as mock_loader_cls:
+        mock_loader = MagicMock()
+        mock_loader.aload = AsyncMock(return_value=[mock_doc])
+        mock_loader_cls.return_value = mock_loader
+
+        async with wiki_search(tool_config, None) as func_info:
+            result = await func_info.single_fn("aardvark")
+
+        mock_loader_cls.assert_called_once_with(query="aardvark", load_max_docs=tool_config.max_results)
+        assert "https://en.wikipedia.org/wiki/Aardvark" in result
+        assert "The aardvark is a mammal." in result

--- a/packages/nvidia_nat_langchain/tests/test_wikipedia_search.py
+++ b/packages/nvidia_nat_langchain/tests/test_wikipedia_search.py
@@ -19,14 +19,15 @@ from unittest.mock import patch
 
 import pytest
 
+from nat.plugins.langchain.tools.wikipedia_search import WikiSearchToolConfig
 
-@pytest.fixture
-def tool_config():
-    from nat.plugins.langchain.tools.wikipedia_search import WikiSearchToolConfig
+
+@pytest.fixture(name="tool_config")
+def tool_config_fixture() -> WikiSearchToolConfig:
     return WikiSearchToolConfig(max_results=2)
 
 
-async def test_sets_wikipedia_user_agent(tool_config):
+async def test_sets_wikipedia_user_agent(tool_config: WikiSearchToolConfig):
     # Wikipedia's API rejects requests without a User-Agent header (403, non-JSON body).
     # The `wikipedia` package used internally by WikipediaLoader doesn't set one by
     # default, so the tool must configure it explicitly on setup.
@@ -38,10 +39,11 @@ async def test_sets_wikipedia_user_agent(tool_config):
 
         mock_set_user_agent.assert_called_once()
         user_agent = mock_set_user_agent.call_args[0][0]
-        assert user_agent
+        assert user_agent.startswith("NeMoAgentToolkit/")
+        assert "https://github.com/NVIDIA/NeMo-Agent-Toolkit" in user_agent
 
 
-async def test_formats_search_results(tool_config):
+async def test_formats_search_results(tool_config: WikiSearchToolConfig):
     from nat.plugins.langchain.tools.wikipedia_search import wiki_search
 
     mock_doc = MagicMock()
@@ -58,5 +60,5 @@ async def test_formats_search_results(tool_config):
             result = await func_info.single_fn("aardvark")
 
         mock_loader_cls.assert_called_once_with(query="aardvark", load_max_docs=tool_config.max_results)
-        assert "https://en.wikipedia.org/wiki/Aardvark" in result
-        assert "The aardvark is a mammal." in result
+        assert result == ('<Document source="https://en.wikipedia.org/wiki/Aardvark" page=""/>\n'
+                          'The aardvark is a mammal.\n</Document>')


### PR DESCRIPTION
## Description

Closes #2156

Wikipedia's API now rejects unauthenticated requests with a 403 and a plain-text body ("Please set a user-agent and respect our robot policy"), which the `wikipedia` package's JSON parsing surfaces as a generic `JSONDecodeError`. This breaks the `wiki_search` tool on every call, including the top-level README's Hello World example and `examples/notebooks/hello_world.ipynb` — the agent silently falls back to its own parametric knowledge instead of retrieving Wikipedia content, so the failure is easy to miss.

This sets a descriptive User-Agent via `wikipedia.set_user_agent()` once when the tool is constructed, matching the [Wikimedia Foundation's User-Agent policy](https://foundation.wikimedia.org/wiki/Policy:User-Agent_policy).

## Testing

- Added `packages/nvidia_nat_langchain/tests/test_wikipedia_search.py`: verifies the tool sets a User-Agent on construction, and verifies search-result formatting against a mocked `WikipediaLoader`.
- Ran the full `nvidia_nat_langchain` test suite: 620 passed, 2 new tests passing, 13 skipped, 69 pre-existing failures — all `ModuleNotFoundError` for optional provider extras (`langchain_exa`, OpenAI, OCI, Bedrock, Azure, LiteLLM) not installed in this scoped dev environment, unrelated to this change.
- `ruff check` and `yapf --diff` both clean on the changed files.
- Manually reproduced the original failure and confirmed the fix resolves it end-to-end by running the Hello World workflow against a real NIM endpoint before and after the patch.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- All commits are signed off (DCO).
- New tests cover these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Wikipedia search reliability by configuring the required User-Agent before searches are performed.
  * Search results now consistently include source URLs and page content when loaded asynchronously.

* **Tests**
  * Added coverage for User-Agent configuration, loader behavior, and formatted Wikipedia search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->