### PR TITLE
feat(core): Add CircuitBreakerMiddleware for tool fault tolerance

### DIFF
--- a/docs/source/build-workflows/advanced/middleware.md
+++ b/docs/source/build-workflows/advanced/middleware.md
@@ -404,6 +404,48 @@ Timeout middleware extends `DynamicFunctionMiddleware`, enabling interception of
 - **Streaming**: Enforces the time limit across the entire stream duration, not per-chunk
 - **Error handling**: Raises `TimeoutError` with the configured `timeout_message`
 
+### Circuit Breaker Middleware
+
+The circuit breaker middleware (`_type: circuit_breaker`) implements the Circuit Breaker pattern to protect workflows from cascading failures by isolating failing functions and external services.
+
+#### States
+
+The circuit breaker operates as a state machine with three states:
+
+- **CLOSED** (Normal Operation): Function calls pass through normally. Consecutive downstream exceptions increment the failure counter. When `failure_threshold` is reached, the circuit breaker trips to `OPEN`.
+- **OPEN** (Failing / Short-Circuiting): Function calls are short-circuited immediately without executing the downstream function, raising `CircuitBreakerOpenError`. When `cooldown_period` elapses, the circuit breaker transitions to `HALF_OPEN`.
+- **HALF_OPEN** (Probing): Allows limited probe calls to test if the downstream service has recovered. Concurrent calls while a probe is in flight are short-circuited. If `probe_timeout` is configured, probe calls time out after the specified duration. The circuit breaker recovers to `CLOSED` after `half_open_success_threshold` consecutive successful probes, or re-trips to `OPEN` on failure or timeout.
+
+#### Configuration
+
+```yaml
+middleware:
+  tool_circuit_breaker:
+    _type: circuit_breaker
+    failure_threshold: 3
+    cooldown_period: 60.0
+    half_open_success_threshold: 1
+    probe_timeout: 5.0
+    circuit_breaker_message: "The downstream service is temporarily unavailable. Please retry later."
+```
+
+#### Parameters
+
+- **`failure_threshold`** (`int`, default=`3`): Number of consecutive failures required to trip the circuit breaker into `OPEN` state (must be greater than zero).
+- **`cooldown_period`** (`float`, default=`60.0`): Time in seconds to wait in `OPEN` state before transitioning to `HALF_OPEN` to probe availability (must be greater than zero).
+- **`half_open_success_threshold`** (`int`, default=`1`): Number of consecutive successful probe calls in `HALF_OPEN` state required to recover to `CLOSED` state (must be greater than zero).
+- **`probe_timeout`** (`float | None`, default=`None`): Optional timeout in seconds for probe calls in `HALF_OPEN` state (must be greater than zero if set).
+- **`circuit_breaker_message`** (`str | None`, default=`None`): Optional custom message appended to the error message when calls are short-circuited while the circuit breaker is `OPEN`.
+
+Circuit breaker middleware extends `DynamicFunctionMiddleware`, enabling dynamic component interception as well as targeting specific workflow functions.
+
+#### Behavior
+
+- **Single invocations**: Intercepts downstream execution, short-circuiting calls and raising `CircuitBreakerOpenError` when `OPEN`.
+- **Streaming**: Intercepts streaming generators, enforcing state tracking and timeout per-stream.
+- **Cancellation safety**: Task cancellations (`asyncio.CancelledError`) during `HALF_OPEN` release probe status without counting as a failure or modifying the circuit breaker state.
+- **Target isolation**: Circuit breaker state is tracked independently per tool or target function.
+
 ### HITL Middleware
 
 The HITL (Human-in-the-Loop) middleware (`HITLMiddleware`) is an abstract base class for intercept patterns that require a human decision before or after a function call. It integrates directly with the `UserInteractionManager` to display any configured `HumanPrompt` at two points in the function lifecycle: before the call (`pre_invoke`) and after it returns (`post_invoke`). Each phase delegates the handling of the human response to two abstract methods that subclasses must implement, leaving the decision logic entirely to the implementer.

--- a/docs/source/extend/plugin-api.md
+++ b/docs/source/extend/plugin-api.md
@@ -45,7 +45,8 @@ The following `nat.plugin_api` exports are intended for plugin authors:
 - Registration return helpers, including `LLMProviderInfo`, `EmbedderProviderInfo`, `RetrieverProviderInfo`,
   `EvaluatorInfo`, and `DatasetLoaderInfo`.
 - Small implementation contracts needed by registered components, including `FunctionMiddleware`,
-  `DynamicFunctionMiddleware`, `HITLMiddleware`, `HITLMiddlewareConfig`, `InvocationAction`,
+  `DynamicFunctionMiddleware`, `CircuitBreakerMiddleware`, `CircuitBreakerMiddlewareConfig`,
+  `CircuitBreakerOpenError`, `CircuitBreakerState`, `HITLMiddleware`, `HITLMiddlewareConfig`, `InvocationAction`,
   `MemoryEditor`, `ObjectStore`, `Retriever`, `Document`, `RetrieverOutput`, and their associated context
   or value models. The interactive data models that HITL middleware hooks and user-input callbacks produce
   and receive are also included: `HumanPrompt`, `InteractionPrompt`, `InteractionResponse`, the

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/__init__.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/__init__.py
@@ -15,7 +15,13 @@
 """Circuit breaker middleware package."""
 
 from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerMiddleware
+from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerOpenError
 from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerState
 from nat.middleware.circuit_breaker.circuit_breaker_middleware_config import CircuitBreakerMiddlewareConfig
 
-__all__ = ["CircuitBreakerMiddleware", "CircuitBreakerMiddlewareConfig", "CircuitBreakerState"]
+__all__ = [
+    "CircuitBreakerMiddleware",
+    "CircuitBreakerMiddlewareConfig",
+    "CircuitBreakerOpenError",
+    "CircuitBreakerState",
+]

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/__init__.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/__init__.py
@@ -12,11 +12,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Circuit breaker middleware package."""
 
-# flake8: noqa
+from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerMiddleware
+from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerState
+from nat.middleware.circuit_breaker.circuit_breaker_middleware_config import CircuitBreakerMiddlewareConfig
 
-from nat.middleware.cache import register as register_cache
-from nat.middleware.circuit_breaker import register as register_circuit_breaker
-from nat.middleware.dynamic import register as register_dynamic
-from nat.middleware.logging import register as register_logging
-from nat.middleware.timeout import register as register_timeout
+__all__ = ["CircuitBreakerMiddleware", "CircuitBreakerMiddlewareConfig", "CircuitBreakerState"]

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import logging
 import time
 from collections.abc import AsyncIterator
@@ -36,6 +37,10 @@ from nat.middleware.middleware import FunctionMiddlewareContext
 logger = logging.getLogger(__name__)
 
 
+class CircuitBreakerOpenError(RuntimeError):
+    """Raised when a call is short-circuited because the circuit breaker is OPEN."""
+
+
 class CircuitBreakerState(StrEnum):
     """Possible states for the circuit breaker."""
 
@@ -44,123 +49,154 @@ class CircuitBreakerState(StrEnum):
     HALF_OPEN = "HALF_OPEN"
 
 
-class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
-    """Middleware that implements the Circuit Breaker pattern for intercepted calls.
+@dataclasses.dataclass
+class _ToolState:
+    """Internal state record tracking failures, successes, and probing status per target."""
 
-    Monitors execution failures and short-circuits calls when downstream services/functions fail
-    repeatedly, transitioning through CLOSED, OPEN, and HALF_OPEN states.
+    state: CircuitBreakerState = CircuitBreakerState.CLOSED
+    failure_count: int = 0
+    success_count: int = 0
+    last_state_change: float = dataclasses.field(default_factory=time.monotonic)
+    half_open_probing: bool = False
+
+
+class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
+    """Middleware implementing the Circuit Breaker pattern with per-target isolation.
+
+    Monitors execution failures and short-circuits calls when downstream functions fail
+    repeatedly, transitioning through CLOSED, OPEN, and HALF_OPEN states per target.
     """
 
     def __init__(self, config: CircuitBreakerMiddlewareConfig, builder: Builder) -> None:
         super().__init__(config=config, builder=builder)
         self._cb_config: CircuitBreakerMiddlewareConfig = config
-        self._state: CircuitBreakerState = CircuitBreakerState.CLOSED
-        self._failure_count: int = 0
-        self._success_count: int = 0
-        self._last_state_change: float = time.monotonic()
-        self._half_open_probing: bool = False
+        self._states: dict[str, _ToolState] = {}
         self._lock: asyncio.Lock = asyncio.Lock()
 
-    @property
-    def state(self) -> CircuitBreakerState:
-        """Return the current circuit breaker state."""
-        return self._state
+    def _get_tool_state(self, target: str) -> _ToolState:
+        if target not in self._states:
+            self._states[target] = _ToolState(last_state_change=time.monotonic())
+        return self._states[target]
 
-    @property
-    def failure_count(self) -> int:
-        """Return the current consecutive failure count."""
-        return self._failure_count
+    def get_state(self, target: str) -> CircuitBreakerState:
+        """Return the current circuit breaker state for a specific target."""
+        if target in self._states:
+            return self._states[target].state
+        return CircuitBreakerState.CLOSED
 
-    @property
-    def success_count(self) -> int:
-        """Return the current consecutive success count in HALF_OPEN state."""
-        return self._success_count
+    def get_failure_count(self, target: str) -> int:
+        """Return the consecutive failure count for a specific target."""
+        if target in self._states:
+            return self._states[target].failure_count
+        return 0
 
-    @property
-    def last_state_change(self) -> float:
-        """Return the monotonic timestamp of the last state change."""
-        return self._last_state_change
+    def get_success_count(self, target: str) -> int:
+        """Return consecutive successes in HALF_OPEN state towards recovery for a target."""
+        if target in self._states:
+            return self._states[target].success_count
+        return 0
 
-    async def _before_invocation(self, context_name: str) -> bool:
-        """Check state and determine whether call should proceed or be short-circuited."""
-        async with self._lock:
-            now = time.monotonic()
-            if self._state == CircuitBreakerState.OPEN:
-                if (now - self._last_state_change) >= self._cb_config.cooldown_period:
-                    logger.info(
-                        "Circuit breaker for '%s' cooldown period (%ss) elapsed. "
-                        "Transitioning from OPEN to HALF_OPEN.",
-                        context_name,
-                        self._cb_config.cooldown_period,
-                    )
-                    self._state = CircuitBreakerState.HALF_OPEN
-                    self._last_state_change = now
-                    self._success_count = 0
-                    self._half_open_probing = True
-                    return True
-                return False
+    def get_last_state_change(self, target: str) -> float:
+        """Return the monotonic timestamp of the last state change for a specific target."""
+        if target in self._states:
+            return self._states[target].last_state_change
+        return 0.0
 
-            if self._state == CircuitBreakerState.HALF_OPEN:
-                if self._half_open_probing:
-                    return False
-                self._half_open_probing = True
-                return True
-
-            return True
-
-    async def _after_invocation_success(self, context_name: str) -> None:
-        """Handle successful execution state update."""
-        async with self._lock:
-            if self._state == CircuitBreakerState.CLOSED:
-                self._failure_count = 0
-            elif self._state == CircuitBreakerState.HALF_OPEN:
-                self._success_count += 1
-                self._half_open_probing = False
-                if self._success_count >= self._cb_config.half_open_success_threshold:
-                    logger.info(
-                        "Circuit breaker for '%s' recovered (%d successes). "
-                        "Transitioning from HALF_OPEN to CLOSED.",
-                        context_name,
-                        self._success_count,
-                    )
-                    self._state = CircuitBreakerState.CLOSED
-                    self._failure_count = 0
-                    self._success_count = 0
-                    self._last_state_change = time.monotonic()
-
-    async def _after_invocation_failure(self, context_name: str) -> None:
-        """Handle failed execution state update."""
-        async with self._lock:
-            now = time.monotonic()
-            if self._state == CircuitBreakerState.CLOSED:
-                self._failure_count += 1
-                if self._failure_count >= self._cb_config.failure_threshold:
-                    logger.warning(
-                        "Circuit breaker for '%s' tripped! "
-                        "Transitioning from CLOSED to OPEN after %d consecutive failures.",
-                        context_name,
-                        self._failure_count,
-                    )
-                    self._state = CircuitBreakerState.OPEN
-                    self._last_state_change = now
-            elif self._state == CircuitBreakerState.HALF_OPEN:
-                logger.warning(
-                    "Circuit breaker for '%s' probe failed! Retripping from HALF_OPEN to OPEN.",
-                    context_name,
-                )
-
-                self._state = CircuitBreakerState.OPEN
-                self._last_state_change = now
-                self._half_open_probing = False
-                self._failure_count = self._cb_config.failure_threshold
-                self._success_count = 0
-
-    def _get_short_circuit_message(self, context_name: str) -> str:
-        """Format the short-circuit message when OPEN or blocked in HALF_OPEN."""
-        msg = f"Circuit breaker is OPEN for '{context_name}'. Tool is temporarily unavailable."
+    def _get_short_circuit_message(self, target: str) -> str:
+        msg = f"Circuit breaker is OPEN for '{target}'. Tool is temporarily unavailable."
         if self._cb_config.circuit_breaker_message:
             msg = f"{msg} {self._cb_config.circuit_breaker_message}"
         return msg
+
+    async def _before_invocation(self, target: str) -> bool:
+        """Evaluate circuit breaker state and determine whether invocation can proceed.
+
+        Returns:
+            bool: True if execution is admitted as a HALF_OPEN probe, False if normal CLOSED.
+
+        Raises:
+            CircuitBreakerOpenError: If the circuit breaker is OPEN or busy probing in HALF_OPEN.
+        """
+        async with self._lock:
+            state_record = self._get_tool_state(target)
+            now = time.monotonic()
+
+            if state_record.state == CircuitBreakerState.OPEN:
+                if (now - state_record.last_state_change) >= self._cb_config.cooldown_period:
+                    logger.info(
+                        "Circuit breaker for '%s' cooldown period (%ss) elapsed. Transitioning to HALF_OPEN.",
+                        target,
+                        self._cb_config.cooldown_period,
+                    )
+                    state_record.state = CircuitBreakerState.HALF_OPEN
+                    state_record.last_state_change = now
+                    state_record.success_count = 0
+                    state_record.half_open_probing = True
+                    return True
+
+                logger.warning("Circuit breaker for '%s' is OPEN. Short-circuiting call.", target)
+                raise CircuitBreakerOpenError(self._get_short_circuit_message(target))
+
+            if state_record.state == CircuitBreakerState.HALF_OPEN:
+                if state_record.half_open_probing:
+                    logger.warning(
+                        "Circuit breaker for '%s' is HALF_OPEN and probing. Short-circuiting concurrent call.",
+                        target,
+                    )
+                    raise CircuitBreakerOpenError(self._get_short_circuit_message(target))
+
+                state_record.half_open_probing = True
+                return True
+
+            return False
+
+    async def _after_invocation_success(self, target: str, *, is_probe: bool = False) -> None:
+        async with self._lock:
+            state_record = self._get_tool_state(target)
+            # Only admitted probe calls in HALF_OPEN modify probe success counters and recover to CLOSED
+            if is_probe:
+                state_record.success_count += 1
+                state_record.half_open_probing = False
+                if state_record.success_count >= self._cb_config.half_open_success_threshold:
+                    logger.info(
+                        "Circuit breaker for '%s' recovered (%d successes). Transitioning to CLOSED.",
+                        target,
+                        state_record.success_count,
+                    )
+                    state_record.state = CircuitBreakerState.CLOSED
+                    state_record.failure_count = 0
+                    state_record.success_count = 0
+                    state_record.last_state_change = time.monotonic()
+            elif state_record.state == CircuitBreakerState.CLOSED:
+                state_record.failure_count = 0
+
+    async def _after_invocation_failure(self, target: str, *, is_probe: bool = False) -> None:
+        async with self._lock:
+            state_record = self._get_tool_state(target)
+            now = time.monotonic()
+            # Only admitted probe calls in HALF_OPEN retrip the breaker back to OPEN
+            if is_probe:
+                logger.warning("Circuit breaker probe for '%s' failed! Retripping to OPEN.", target)
+                state_record.state = CircuitBreakerState.OPEN
+                state_record.last_state_change = now
+                state_record.half_open_probing = False
+                state_record.failure_count = self._cb_config.failure_threshold
+                state_record.success_count = 0
+            elif state_record.state == CircuitBreakerState.CLOSED:
+                state_record.failure_count += 1
+                if state_record.failure_count >= self._cb_config.failure_threshold:
+                    logger.warning(
+                        "Circuit breaker for '%s' tripped! Transitioning to OPEN after %d consecutive failures.",
+                        target,
+                        state_record.failure_count,
+                    )
+                    state_record.state = CircuitBreakerState.OPEN
+                    state_record.last_state_change = now
+
+    async def _after_invocation_cancellation(self, target: str) -> None:
+        async with self._lock:
+            state_record = self._get_tool_state(target)
+            state_record.half_open_probing = False
 
     async def function_middleware_invoke(
         self,
@@ -169,19 +205,31 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         context: FunctionMiddlewareContext,
         **kwargs: Any,
     ) -> Any:
-        """Wrap downstream invocation with circuit breaker monitoring and short-circuiting."""
-        should_execute = await self._before_invocation(context.name)
-        if not should_execute:
-            logger.warning("Circuit breaker for '%s' is active. Short-circuiting call.", context.name)
-            return self._get_short_circuit_message(context.name)
+        # Target state is scoped to context.name as FunctionMiddlewareContext exposes no component-level namespace.
+        # This is a known limitation if different components expose identically named functions.
+        target = context.name
+        is_probe = await self._before_invocation(target)
 
         try:
-            result = await super().function_middleware_invoke(*args, call_next=call_next, context=context, **kwargs)
+            if is_probe and self._cb_config.probe_timeout is not None:
+                coro = super().function_middleware_invoke(*args, call_next=call_next, context=context, **kwargs)
+                result = await asyncio.wait_for(coro, timeout=self._cb_config.probe_timeout)
+            else:
+                result = await super().function_middleware_invoke(
+                    *args,
+                    call_next=call_next,
+                    context=context,
+                    **kwargs,
+                )
+        except asyncio.CancelledError:
+            # Cancellation must not count as a failure
+            await self._after_invocation_cancellation(target)
+            raise
         except Exception:
-            await self._after_invocation_failure(context.name)
+            await self._after_invocation_failure(target, is_probe=is_probe)
             raise
         else:
-            await self._after_invocation_success(context.name)
+            await self._after_invocation_success(target, is_probe=is_probe)
             return result
 
     async def function_middleware_stream(
@@ -191,22 +239,51 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         context: FunctionMiddlewareContext,
         **kwargs: Any,
     ) -> AsyncIterator[Any]:
-        """Wrap downstream streaming call with circuit breaker monitoring and short-circuiting."""
-        should_execute = await self._before_invocation(context.name)
-        if not should_execute:
-            logger.warning("Circuit breaker for '%s' is active. Short-circuiting stream.", context.name)
-            yield self._get_short_circuit_message(context.name)
-            return
+        # Target state is scoped to context.name as FunctionMiddlewareContext exposes no component-level namespace.
+        # This is a known limitation if different components expose identically named functions.
+        target = context.name
+        is_probe = await self._before_invocation(target)
 
+        handled = False
         try:
-            async for chunk in super().function_middleware_stream(*args, call_next=call_next, context=context,
-                                                                  **kwargs):
-                yield chunk
+            if is_probe and self._cb_config.probe_timeout is not None:
+                # Wrap only each downstream __anext__ in timeout so consumer delays during yield do not trigger timeouts
+                stream_iter = super().function_middleware_stream(
+                    *args,
+                    call_next=call_next,
+                    context=context,
+                    **kwargs,
+                ).__aiter__()
+                while True:
+                    try:
+                        async with asyncio.timeout(self._cb_config.probe_timeout):
+                            chunk = await stream_iter.__anext__()
+                    except StopAsyncIteration:
+                        break
+                    yield chunk
+            else:
+                async for chunk in super().function_middleware_stream(
+                        *args,
+                        call_next=call_next,
+                        context=context,
+                        **kwargs,
+                ):
+                    yield chunk
+        except asyncio.CancelledError:
+            handled = True
+            await self._after_invocation_cancellation(target)
+            raise
         except Exception:
-            await self._after_invocation_failure(context.name)
+            handled = True
+            await self._after_invocation_failure(target, is_probe=is_probe)
             raise
         else:
-            await self._after_invocation_success(context.name)
+            handled = True
+            await self._after_invocation_success(target, is_probe=is_probe)
+        finally:
+            # Finalize abandoned generators where no explicit handler ran (e.g. GeneratorExit on early break)
+            if is_probe and not handled:
+                await self._after_invocation_cancellation(target)
 
 
-__all__ = ["CircuitBreakerMiddleware", "CircuitBreakerState"]
+__all__ = ["CircuitBreakerMiddleware", "CircuitBreakerOpenError", "CircuitBreakerState"]

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware.py
@@ -1,0 +1,212 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Circuit breaker middleware that prevents cascading failures by isolating failing functions."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections.abc import AsyncIterator
+from enum import StrEnum
+from typing import TYPE_CHECKING
+from typing import Any
+
+if TYPE_CHECKING:
+    from nat.builder.builder import Builder
+
+from nat.middleware.circuit_breaker.circuit_breaker_middleware_config import CircuitBreakerMiddlewareConfig
+from nat.middleware.dynamic.dynamic_function_middleware import DynamicFunctionMiddleware
+from nat.middleware.middleware import CallNext
+from nat.middleware.middleware import CallNextStream
+from nat.middleware.middleware import FunctionMiddlewareContext
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitBreakerState(StrEnum):
+    """Possible states for the circuit breaker."""
+
+    CLOSED = "CLOSED"
+    OPEN = "OPEN"
+    HALF_OPEN = "HALF_OPEN"
+
+
+class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
+    """Middleware that implements the Circuit Breaker pattern for intercepted calls.
+
+    Monitors execution failures and short-circuits calls when downstream services/functions fail
+    repeatedly, transitioning through CLOSED, OPEN, and HALF_OPEN states.
+    """
+
+    def __init__(self, config: CircuitBreakerMiddlewareConfig, builder: Builder) -> None:
+        super().__init__(config=config, builder=builder)
+        self._cb_config: CircuitBreakerMiddlewareConfig = config
+        self._state: CircuitBreakerState = CircuitBreakerState.CLOSED
+        self._failure_count: int = 0
+        self._success_count: int = 0
+        self._last_state_change: float = time.monotonic()
+        self._half_open_probing: bool = False
+        self._lock: asyncio.Lock = asyncio.Lock()
+
+    @property
+    def state(self) -> CircuitBreakerState:
+        """Return the current circuit breaker state."""
+        return self._state
+
+    @property
+    def failure_count(self) -> int:
+        """Return the current consecutive failure count."""
+        return self._failure_count
+
+    @property
+    def success_count(self) -> int:
+        """Return the current consecutive success count in HALF_OPEN state."""
+        return self._success_count
+
+    @property
+    def last_state_change(self) -> float:
+        """Return the monotonic timestamp of the last state change."""
+        return self._last_state_change
+
+    async def _before_invocation(self, context_name: str) -> bool:
+        """Check state and determine whether call should proceed or be short-circuited."""
+        async with self._lock:
+            now = time.monotonic()
+            if self._state == CircuitBreakerState.OPEN:
+                if (now - self._last_state_change) >= self._cb_config.cooldown_period:
+                    logger.info(
+                        "Circuit breaker for '%s' cooldown period (%ss) elapsed. "
+                        "Transitioning from OPEN to HALF_OPEN.",
+                        context_name,
+                        self._cb_config.cooldown_period,
+                    )
+                    self._state = CircuitBreakerState.HALF_OPEN
+                    self._last_state_change = now
+                    self._success_count = 0
+                    self._half_open_probing = True
+                    return True
+                return False
+
+            if self._state == CircuitBreakerState.HALF_OPEN:
+                if self._half_open_probing:
+                    return False
+                self._half_open_probing = True
+                return True
+
+            return True
+
+    async def _after_invocation_success(self, context_name: str) -> None:
+        """Handle successful execution state update."""
+        async with self._lock:
+            if self._state == CircuitBreakerState.CLOSED:
+                self._failure_count = 0
+            elif self._state == CircuitBreakerState.HALF_OPEN:
+                self._success_count += 1
+                self._half_open_probing = False
+                if self._success_count >= self._cb_config.half_open_success_threshold:
+                    logger.info(
+                        "Circuit breaker for '%s' recovered (%d successes). "
+                        "Transitioning from HALF_OPEN to CLOSED.",
+                        context_name,
+                        self._success_count,
+                    )
+                    self._state = CircuitBreakerState.CLOSED
+                    self._failure_count = 0
+                    self._success_count = 0
+                    self._last_state_change = time.monotonic()
+
+    async def _after_invocation_failure(self, context_name: str) -> None:
+        """Handle failed execution state update."""
+        async with self._lock:
+            now = time.monotonic()
+            if self._state == CircuitBreakerState.CLOSED:
+                self._failure_count += 1
+                if self._failure_count >= self._cb_config.failure_threshold:
+                    logger.warning(
+                        "Circuit breaker for '%s' tripped! "
+                        "Transitioning from CLOSED to OPEN after %d consecutive failures.",
+                        context_name,
+                        self._failure_count,
+                    )
+                    self._state = CircuitBreakerState.OPEN
+                    self._last_state_change = now
+            elif self._state == CircuitBreakerState.HALF_OPEN:
+                logger.warning(
+                    "Circuit breaker for '%s' probe failed! Retripping from HALF_OPEN to OPEN.",
+                    context_name,
+                )
+
+                self._state = CircuitBreakerState.OPEN
+                self._last_state_change = now
+                self._half_open_probing = False
+                self._failure_count = self._cb_config.failure_threshold
+                self._success_count = 0
+
+    def _get_short_circuit_message(self, context_name: str) -> str:
+        """Format the short-circuit message when OPEN or blocked in HALF_OPEN."""
+        msg = f"Circuit breaker is OPEN for '{context_name}'. Tool is temporarily unavailable."
+        if self._cb_config.circuit_breaker_message:
+            msg = f"{msg} {self._cb_config.circuit_breaker_message}"
+        return msg
+
+    async def function_middleware_invoke(
+        self,
+        *args: Any,
+        call_next: CallNext,
+        context: FunctionMiddlewareContext,
+        **kwargs: Any,
+    ) -> Any:
+        """Wrap downstream invocation with circuit breaker monitoring and short-circuiting."""
+        should_execute = await self._before_invocation(context.name)
+        if not should_execute:
+            logger.warning("Circuit breaker for '%s' is active. Short-circuiting call.", context.name)
+            return self._get_short_circuit_message(context.name)
+
+        try:
+            result = await super().function_middleware_invoke(*args, call_next=call_next, context=context, **kwargs)
+        except Exception:
+            await self._after_invocation_failure(context.name)
+            raise
+        else:
+            await self._after_invocation_success(context.name)
+            return result
+
+    async def function_middleware_stream(
+        self,
+        *args: Any,
+        call_next: CallNextStream,
+        context: FunctionMiddlewareContext,
+        **kwargs: Any,
+    ) -> AsyncIterator[Any]:
+        """Wrap downstream streaming call with circuit breaker monitoring and short-circuiting."""
+        should_execute = await self._before_invocation(context.name)
+        if not should_execute:
+            logger.warning("Circuit breaker for '%s' is active. Short-circuiting stream.", context.name)
+            yield self._get_short_circuit_message(context.name)
+            return
+
+        try:
+            async for chunk in super().function_middleware_stream(*args, call_next=call_next, context=context,
+                                                                  **kwargs):
+                yield chunk
+        except Exception:
+            await self._after_invocation_failure(context.name)
+            raise
+        else:
+            await self._after_invocation_success(context.name)
+
+
+__all__ = ["CircuitBreakerMiddleware", "CircuitBreakerState"]

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware.py
@@ -39,7 +39,7 @@ logger = logging.getLogger(__name__)
 
 
 class CircuitBreakerOpenError(RuntimeError):
-    """Raised when a call is short-circuited because the circuit breaker is OPEN."""
+    """Raised when a call is short-circuited because the circuit breaker is ``OPEN``."""
 
 
 class CircuitBreakerState(StrEnum):
@@ -65,7 +65,7 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
     """Middleware implementing the Circuit Breaker pattern with per-target isolation.
 
     Monitors execution failures and short-circuits calls when downstream functions fail
-    repeatedly, transitioning through CLOSED, OPEN, and HALF_OPEN states per target.
+    repeatedly, transitioning through ``CLOSED``, ``OPEN``, and ``HALF_OPEN`` states per target.
     """
 
     def __init__(self, config: CircuitBreakerMiddlewareConfig, builder: Builder) -> None:
@@ -81,19 +81,19 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         self._lock: asyncio.Lock = asyncio.Lock()
 
     def _get_tool_state(self, target: str) -> _ToolState:
-        """Get or initialize state record for a given target name.
+        """Get or initialize state record for a given target name under lock.
 
         Args:
             target: Identifier for the target function or tool.
 
         Returns:
-            _ToolState: State record for the target.
+            ``_ToolState``: State record for the target.
         """
         if target not in self._states:
             self._states[target] = _ToolState(last_state_change=time.monotonic())
         return self._states[target]
 
-    def get_state(self, target: str) -> CircuitBreakerState:
+    async def get_state(self, target: str) -> CircuitBreakerState:
         """Return the current circuit breaker state for a specific target.
 
         Args:
@@ -102,11 +102,12 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         Returns:
             CircuitBreakerState: Current state of the target.
         """
-        if target in self._states:
-            return self._states[target].state
-        return CircuitBreakerState.CLOSED
+        async with self._lock:
+            if target in self._states:
+                return self._states[target].state
+            return CircuitBreakerState.CLOSED
 
-    def get_failure_count(self, target: str) -> int:
+    async def get_failure_count(self, target: str) -> int:
         """Return the consecutive failure count for a specific target.
 
         Args:
@@ -115,12 +116,13 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         Returns:
             int: Number of consecutive failures.
         """
-        if target in self._states:
-            return self._states[target].failure_count
-        return 0
+        async with self._lock:
+            if target in self._states:
+                return self._states[target].failure_count
+            return 0
 
-    def get_success_count(self, target: str) -> int:
-        """Return consecutive successes in HALF_OPEN state towards recovery for a target.
+    async def get_success_count(self, target: str) -> int:
+        """Return consecutive successes in ``HALF_OPEN`` state towards recovery for a target.
 
         Args:
             target: Identifier for the target function or tool.
@@ -128,11 +130,12 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         Returns:
             int: Number of consecutive probe successes.
         """
-        if target in self._states:
-            return self._states[target].success_count
-        return 0
+        async with self._lock:
+            if target in self._states:
+                return self._states[target].success_count
+            return 0
 
-    def get_last_state_change(self, target: str) -> float:
+    async def get_last_state_change(self, target: str) -> float:
         """Return the monotonic timestamp of the last state change for a specific target.
 
         Args:
@@ -141,12 +144,27 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         Returns:
             float: Timestamp in seconds.
         """
-        if target in self._states:
-            return self._states[target].last_state_change
-        return 0.0
+        async with self._lock:
+            if target in self._states:
+                return self._states[target].last_state_change
+            return 0.0
+
+    async def is_half_open_probing(self, target: str) -> bool:
+        """Return whether a probe execution is actively in-flight for a target in ``HALF_OPEN`` state.
+
+        Args:
+            target: Identifier for the target function or tool.
+
+        Returns:
+            bool: True if a probe call is in-flight in ``HALF_OPEN`` state.
+        """
+        async with self._lock:
+            if target in self._states:
+                return self._states[target].half_open_probing
+            return False
 
     def _get_short_circuit_message(self, target: str) -> str:
-        """Format the short-circuit message when OPEN or busy probing.
+        """Format the short-circuit message when ``OPEN`` or busy probing.
 
         Args:
             target: Identifier for the target function or tool.
@@ -166,10 +184,10 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
             target: Identifier for the target function or tool.
 
         Returns:
-            bool: True if execution is admitted as a HALF_OPEN probe, False if normal CLOSED.
+            bool: True if execution is admitted as a ``HALF_OPEN`` probe, False if normal ``CLOSED``.
 
         Raises:
-            CircuitBreakerOpenError: If the circuit breaker is OPEN or busy probing in HALF_OPEN.
+            CircuitBreakerOpenError: If the circuit breaker is ``OPEN`` or busy probing in ``HALF_OPEN``.
         """
         async with self._lock:
             state_record = self._get_tool_state(target)
@@ -209,7 +227,7 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
 
         Args:
             target: Identifier for the target function or tool.
-            is_probe: Whether this execution was an admitted probe call in HALF_OPEN state.
+            is_probe: Whether this execution was an admitted probe call in ``HALF_OPEN`` state.
         """
         async with self._lock:
             state_record = self._get_tool_state(target)
@@ -235,7 +253,7 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
 
         Args:
             target: Identifier for the target function or tool.
-            is_probe: Whether this execution was an admitted probe call in HALF_OPEN state.
+            is_probe: Whether this execution was an admitted probe call in ``HALF_OPEN`` state.
         """
         async with self._lock:
             state_record = self._get_tool_state(target)
@@ -279,16 +297,16 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         """Wrap downstream invocation with circuit breaker monitoring and short-circuiting.
 
         Args:
-            *args: Positional arguments for the intercepted function.
+            args: Positional arguments for the intercepted function.
             call_next: Callable to invoke next middleware or target function.
             context: Static function metadata describing the tool being invoked.
-            **kwargs: Keyword arguments for the intercepted function.
+            kwargs: Keyword arguments for the intercepted function.
 
         Returns:
             Any: The tool result.
 
         Raises:
-            CircuitBreakerOpenError: If the circuit breaker is OPEN or busy probing.
+            CircuitBreakerOpenError: If the circuit breaker is ``OPEN`` or busy probing.
             Exception: Any exception raised by the downstream callable.
         """
         # Target state is scoped to context.name as FunctionMiddlewareContext exposes no component-level namespace.
@@ -328,16 +346,16 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         """Wrap downstream streaming call with circuit breaker monitoring and short-circuiting.
 
         Args:
-            *args: Positional arguments for the intercepted function.
+            args: Positional arguments for the intercepted function.
             call_next: Callable to invoke next middleware or target stream.
             context: Static function metadata describing the tool being invoked.
-            **kwargs: Keyword arguments for the intercepted function.
+            kwargs: Keyword arguments for the intercepted function.
 
         Yields:
             Any: Stream chunks from downstream execution.
 
         Raises:
-            CircuitBreakerOpenError: If the circuit breaker is OPEN or busy probing.
+            CircuitBreakerOpenError: If the circuit breaker is ``OPEN`` or busy probing.
             Exception: Any exception raised by the downstream stream.
         """
         # Target state is scoped to context.name as FunctionMiddlewareContext exposes no component-level namespace.
@@ -349,10 +367,12 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         try:
             if is_probe and self._cb_config.probe_timeout is not None:
                 # Wrap only each downstream __anext__ in timeout so consumer delays during yield do not trigger timeouts
-                async with contextlib.aclosing(super().function_middleware_stream(*args,
-                                                                                  call_next=call_next,
-                                                                                  context=context,
-                                                                                  **kwargs)) as stream:
+                async with contextlib.aclosing(super().function_middleware_stream(
+                        *args,
+                        call_next=call_next,
+                        context=context,
+                        **kwargs,
+                )) as stream:
                     stream_iter = stream.__aiter__()
                     while True:
                         try:

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware.py
@@ -17,6 +17,7 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import dataclasses
 import logging
 import time
@@ -68,41 +69,91 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
     """
 
     def __init__(self, config: CircuitBreakerMiddlewareConfig, builder: Builder) -> None:
+        """Initialize CircuitBreakerMiddleware.
+
+        Args:
+            config: Circuit breaker configuration parameters.
+            builder: Workflow builder instance.
+        """
         super().__init__(config=config, builder=builder)
         self._cb_config: CircuitBreakerMiddlewareConfig = config
         self._states: dict[str, _ToolState] = {}
         self._lock: asyncio.Lock = asyncio.Lock()
 
     def _get_tool_state(self, target: str) -> _ToolState:
+        """Get or initialize state record for a given target name.
+
+        Args:
+            target: Identifier for the target function or tool.
+
+        Returns:
+            _ToolState: State record for the target.
+        """
         if target not in self._states:
             self._states[target] = _ToolState(last_state_change=time.monotonic())
         return self._states[target]
 
     def get_state(self, target: str) -> CircuitBreakerState:
-        """Return the current circuit breaker state for a specific target."""
+        """Return the current circuit breaker state for a specific target.
+
+        Args:
+            target: Identifier for the target function or tool.
+
+        Returns:
+            CircuitBreakerState: Current state of the target.
+        """
         if target in self._states:
             return self._states[target].state
         return CircuitBreakerState.CLOSED
 
     def get_failure_count(self, target: str) -> int:
-        """Return the consecutive failure count for a specific target."""
+        """Return the consecutive failure count for a specific target.
+
+        Args:
+            target: Identifier for the target function or tool.
+
+        Returns:
+            int: Number of consecutive failures.
+        """
         if target in self._states:
             return self._states[target].failure_count
         return 0
 
     def get_success_count(self, target: str) -> int:
-        """Return consecutive successes in HALF_OPEN state towards recovery for a target."""
+        """Return consecutive successes in HALF_OPEN state towards recovery for a target.
+
+        Args:
+            target: Identifier for the target function or tool.
+
+        Returns:
+            int: Number of consecutive probe successes.
+        """
         if target in self._states:
             return self._states[target].success_count
         return 0
 
     def get_last_state_change(self, target: str) -> float:
-        """Return the monotonic timestamp of the last state change for a specific target."""
+        """Return the monotonic timestamp of the last state change for a specific target.
+
+        Args:
+            target: Identifier for the target function or tool.
+
+        Returns:
+            float: Timestamp in seconds.
+        """
         if target in self._states:
             return self._states[target].last_state_change
         return 0.0
 
     def _get_short_circuit_message(self, target: str) -> str:
+        """Format the short-circuit message when OPEN or busy probing.
+
+        Args:
+            target: Identifier for the target function or tool.
+
+        Returns:
+            str: Explanatory error message.
+        """
         msg = f"Circuit breaker is OPEN for '{target}'. Tool is temporarily unavailable."
         if self._cb_config.circuit_breaker_message:
             msg = f"{msg} {self._cb_config.circuit_breaker_message}"
@@ -110,6 +161,9 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
 
     async def _before_invocation(self, target: str) -> bool:
         """Evaluate circuit breaker state and determine whether invocation can proceed.
+
+        Args:
+            target: Identifier for the target function or tool.
 
         Returns:
             bool: True if execution is admitted as a HALF_OPEN probe, False if normal CLOSED.
@@ -151,6 +205,12 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
             return False
 
     async def _after_invocation_success(self, target: str, *, is_probe: bool = False) -> None:
+        """Update circuit breaker state upon a successful execution.
+
+        Args:
+            target: Identifier for the target function or tool.
+            is_probe: Whether this execution was an admitted probe call in HALF_OPEN state.
+        """
         async with self._lock:
             state_record = self._get_tool_state(target)
             # Only admitted probe calls in HALF_OPEN modify probe success counters and recover to CLOSED
@@ -171,6 +231,12 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
                 state_record.failure_count = 0
 
     async def _after_invocation_failure(self, target: str, *, is_probe: bool = False) -> None:
+        """Update circuit breaker state upon a failed execution.
+
+        Args:
+            target: Identifier for the target function or tool.
+            is_probe: Whether this execution was an admitted probe call in HALF_OPEN state.
+        """
         async with self._lock:
             state_record = self._get_tool_state(target)
             now = time.monotonic()
@@ -194,6 +260,11 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
                     state_record.last_state_change = now
 
     async def _after_invocation_cancellation(self, target: str) -> None:
+        """Reset probing flag on cancellation without counting as failure.
+
+        Args:
+            target: Identifier for the target function or tool.
+        """
         async with self._lock:
             state_record = self._get_tool_state(target)
             state_record.half_open_probing = False
@@ -205,6 +276,21 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         context: FunctionMiddlewareContext,
         **kwargs: Any,
     ) -> Any:
+        """Wrap downstream invocation with circuit breaker monitoring and short-circuiting.
+
+        Args:
+            *args: Positional arguments for the intercepted function.
+            call_next: Callable to invoke next middleware or target function.
+            context: Static function metadata describing the tool being invoked.
+            **kwargs: Keyword arguments for the intercepted function.
+
+        Returns:
+            Any: The tool result.
+
+        Raises:
+            CircuitBreakerOpenError: If the circuit breaker is OPEN or busy probing.
+            Exception: Any exception raised by the downstream callable.
+        """
         # Target state is scoped to context.name as FunctionMiddlewareContext exposes no component-level namespace.
         # This is a known limitation if different components expose identically named functions.
         target = context.name
@@ -239,6 +325,21 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         context: FunctionMiddlewareContext,
         **kwargs: Any,
     ) -> AsyncIterator[Any]:
+        """Wrap downstream streaming call with circuit breaker monitoring and short-circuiting.
+
+        Args:
+            *args: Positional arguments for the intercepted function.
+            call_next: Callable to invoke next middleware or target stream.
+            context: Static function metadata describing the tool being invoked.
+            **kwargs: Keyword arguments for the intercepted function.
+
+        Yields:
+            Any: Stream chunks from downstream execution.
+
+        Raises:
+            CircuitBreakerOpenError: If the circuit breaker is OPEN or busy probing.
+            Exception: Any exception raised by the downstream stream.
+        """
         # Target state is scoped to context.name as FunctionMiddlewareContext exposes no component-level namespace.
         # This is a known limitation if different components expose identically named functions.
         target = context.name
@@ -248,19 +349,18 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
         try:
             if is_probe and self._cb_config.probe_timeout is not None:
                 # Wrap only each downstream __anext__ in timeout so consumer delays during yield do not trigger timeouts
-                stream_iter = super().function_middleware_stream(
-                    *args,
-                    call_next=call_next,
-                    context=context,
-                    **kwargs,
-                ).__aiter__()
-                while True:
-                    try:
-                        async with asyncio.timeout(self._cb_config.probe_timeout):
-                            chunk = await stream_iter.__anext__()
-                    except StopAsyncIteration:
-                        break
-                    yield chunk
+                async with contextlib.aclosing(super().function_middleware_stream(*args,
+                                                                                  call_next=call_next,
+                                                                                  context=context,
+                                                                                  **kwargs)) as stream:
+                    stream_iter = stream.__aiter__()
+                    while True:
+                        try:
+                            async with asyncio.timeout(self._cb_config.probe_timeout):
+                                chunk = await stream_iter.__anext__()
+                        except StopAsyncIteration:
+                            break
+                        yield chunk
             else:
                 async for chunk in super().function_middleware_stream(
                         *args,
@@ -281,7 +381,7 @@ class CircuitBreakerMiddleware(DynamicFunctionMiddleware):
             handled = True
             await self._after_invocation_success(target, is_probe=is_probe)
         finally:
-            # Finalize abandoned generators where no explicit handler ran (e.g. GeneratorExit on early break)
+            # Finalize abandoned generators where no explicit handler ran during generator finalization (via aclose())
             if is_probe and not handled:
                 await self._after_invocation_cancellation(target)
 

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware_config.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware_config.py
@@ -44,6 +44,12 @@ class CircuitBreakerMiddlewareConfig(DynamicMiddlewareConfig, name="circuit_brea
         "Number of consecutive successful probe calls in HALF_OPEN state required to recover to CLOSED state.",
     )
 
+    probe_timeout: float | None = Field(
+        default=None,
+        gt=0,
+        description="Optional timeout in seconds for probe calls in HALF_OPEN state.",
+    )
+
     circuit_breaker_message: str | None = Field(
         default=None,
         description=("Optional custom message returned when calls are "

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware_config.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware_config.py
@@ -26,9 +26,9 @@ class CircuitBreakerMiddlewareConfig(DynamicMiddlewareConfig, name="circuit_brea
 
     Attributes:
         failure_threshold: Number of consecutive failures required to trip the circuit breaker.
-        cooldown_period: Time in seconds to wait in OPEN state before probing.
-        half_open_success_threshold: Consecutive successful probes required to recover to CLOSED.
-        probe_timeout: Optional timeout in seconds for probe calls in HALF_OPEN state.
+        cooldown_period: Time in seconds to wait in ``OPEN`` state before probing.
+        half_open_success_threshold: Consecutive successful probes required to recover to ``CLOSED``.
+        probe_timeout: Optional timeout in seconds for probe calls in ``HALF_OPEN`` state.
         circuit_breaker_message: Optional custom message returned when short-circuited.
     """
 

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware_config.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware_config.py
@@ -23,6 +23,13 @@ from nat.middleware.dynamic.dynamic_middleware_config import DynamicMiddlewareCo
 
 class CircuitBreakerMiddlewareConfig(DynamicMiddlewareConfig, name="circuit_breaker"):
     """Configuration for circuit breaker middleware.
+
+    Attributes:
+        failure_threshold: Number of consecutive failures required to trip the circuit breaker.
+        cooldown_period: Time in seconds to wait in OPEN state before probing.
+        half_open_success_threshold: Consecutive successful probes required to recover to CLOSED.
+        probe_timeout: Optional timeout in seconds for probe calls in HALF_OPEN state.
+        circuit_breaker_message: Optional custom message returned when short-circuited.
     """
 
     failure_threshold: int = Field(
@@ -40,8 +47,8 @@ class CircuitBreakerMiddlewareConfig(DynamicMiddlewareConfig, name="circuit_brea
     half_open_success_threshold: int = Field(
         default=1,
         gt=0,
-        description=
-        "Number of consecutive successful probe calls in HALF_OPEN state required to recover to CLOSED state.",
+        description=(
+            "Number of consecutive successful probe calls in HALF_OPEN state required to recover to CLOSED state."),
     )
 
     probe_timeout: float | None = Field(

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware_config.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/circuit_breaker_middleware_config.py
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Configuration for circuit breaker middleware."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from nat.middleware.dynamic.dynamic_middleware_config import DynamicMiddlewareConfig
+
+
+class CircuitBreakerMiddlewareConfig(DynamicMiddlewareConfig, name="circuit_breaker"):
+    """Configuration for circuit breaker middleware.
+    """
+
+    failure_threshold: int = Field(
+        default=3,
+        gt=0,
+        description="Number of consecutive failures required to trip the circuit breaker into OPEN state.",
+    )
+
+    cooldown_period: float = Field(
+        default=60.0,
+        gt=0,
+        description="Time in seconds to wait in OPEN state before transitioning to HALF_OPEN to probe availability.",
+    )
+
+    half_open_success_threshold: int = Field(
+        default=1,
+        gt=0,
+        description=
+        "Number of consecutive successful probe calls in HALF_OPEN state required to recover to CLOSED state.",
+    )
+
+    circuit_breaker_message: str | None = Field(
+        default=None,
+        description=("Optional custom message returned when calls are "
+                     "short-circuited while the circuit breaker is OPEN."),
+    )

--- a/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/register.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/circuit_breaker/register.py
@@ -1,0 +1,44 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Registration for circuit breaker middleware."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncGenerator
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nat.builder.builder import Builder
+
+from nat.cli.register_workflow import register_middleware
+from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerMiddleware
+from nat.middleware.circuit_breaker.circuit_breaker_middleware_config import CircuitBreakerMiddlewareConfig
+
+
+@register_middleware(config_type=CircuitBreakerMiddlewareConfig)
+async def circuit_breaker_middleware(
+    config: CircuitBreakerMiddlewareConfig,
+    builder: Builder,
+) -> AsyncGenerator[CircuitBreakerMiddleware, None]:
+    """Build a circuit breaker middleware from configuration.
+
+    Args:
+        config: The circuit breaker middleware configuration
+        builder: The workflow builder
+
+    Yields:
+        A configured circuit breaker middleware instance
+    """
+    yield CircuitBreakerMiddleware(config=config, builder=builder)

--- a/packages/nvidia_nat_core/src/nat/plugin_api/__init__.py
+++ b/packages/nvidia_nat_core/src/nat/plugin_api/__init__.py
@@ -113,6 +113,9 @@ from nat.memory.interfaces import MemoryManager
 from nat.memory.interfaces import MemoryReader
 from nat.memory.interfaces import MemoryWriter
 from nat.memory.models import MemoryItem
+from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerMiddleware
+from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerState
+from nat.middleware.circuit_breaker.circuit_breaker_middleware_config import CircuitBreakerMiddlewareConfig
 from nat.middleware.dynamic.dynamic_function_middleware import DynamicFunctionMiddleware
 from nat.middleware.dynamic.dynamic_middleware_config import DynamicMiddlewareConfig
 from nat.middleware.function_middleware import FunctionMiddleware
@@ -132,6 +135,9 @@ from nat.retriever.models import RetrieverOutput
 __all__ = [
     "BinaryHumanPromptOption",
     "Builder",
+    "CircuitBreakerMiddleware",
+    "CircuitBreakerMiddlewareConfig",
+    "CircuitBreakerState",
     "ComponentRef",
     "Context",
     "ContextState",

--- a/packages/nvidia_nat_core/src/nat/plugin_api/__init__.py
+++ b/packages/nvidia_nat_core/src/nat/plugin_api/__init__.py
@@ -114,6 +114,7 @@ from nat.memory.interfaces import MemoryReader
 from nat.memory.interfaces import MemoryWriter
 from nat.memory.models import MemoryItem
 from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerMiddleware
+from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerOpenError
 from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerState
 from nat.middleware.circuit_breaker.circuit_breaker_middleware_config import CircuitBreakerMiddlewareConfig
 from nat.middleware.dynamic.dynamic_function_middleware import DynamicFunctionMiddleware
@@ -137,6 +138,7 @@ __all__ = [
     "Builder",
     "CircuitBreakerMiddleware",
     "CircuitBreakerMiddlewareConfig",
+    "CircuitBreakerOpenError",
     "CircuitBreakerState",
     "ComponentRef",
     "Context",

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_circuit_breaker_middleware.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_circuit_breaker_middleware.py
@@ -1,0 +1,292 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for CircuitBreakerMiddleware."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+from unittest.mock import AsyncMock
+from unittest.mock import Mock
+
+import pytest
+
+from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerMiddleware
+from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerState
+from nat.middleware.circuit_breaker.circuit_breaker_middleware_config import CircuitBreakerMiddlewareConfig
+from nat.middleware.middleware import FunctionMiddlewareContext
+
+# ==================== Fixtures ====================
+
+
+@pytest.fixture(name="mock_builder")
+def fixture_mock_builder():
+    """Create a mock builder for middleware instantiation."""
+    builder: Mock = Mock()
+    builder._functions = {}
+    builder.get_llm = AsyncMock()
+    builder.get_embedder = AsyncMock()
+    builder.get_retriever = AsyncMock()
+    builder.get_memory_client = AsyncMock()
+    builder.get_object_store_client = AsyncMock()
+    builder.get_auth_provider = AsyncMock()
+    builder.get_function = AsyncMock()
+    builder.get_function_config = Mock()
+    return builder
+
+
+@pytest.fixture(name="function_context")
+def fixture_function_context():
+    """Create a test FunctionMiddlewareContext."""
+    return FunctionMiddlewareContext(
+        name="test_tool",
+        config=Mock(),
+        description="A test tool",
+        input_schema=None,
+        single_output_schema=type(None),
+        stream_output_schema=type(None),
+    )
+
+
+def _make_middleware(
+    mock_builder: Mock,
+    *,
+    failure_threshold: int = 3,
+    cooldown_period: float = 0.2,
+    half_open_success_threshold: int = 1,
+    circuit_breaker_message: str | None = None,
+) -> CircuitBreakerMiddleware:
+    """Create a CircuitBreakerMiddleware with test configurations."""
+    kwargs: dict[str, Any] = {
+        "failure_threshold": failure_threshold,
+        "cooldown_period": cooldown_period,
+        "half_open_success_threshold": half_open_success_threshold,
+    }
+    if circuit_breaker_message is not None:
+        kwargs["circuit_breaker_message"] = circuit_breaker_message
+    config: CircuitBreakerMiddlewareConfig = CircuitBreakerMiddlewareConfig(**kwargs)
+    return CircuitBreakerMiddleware(config=config, builder=mock_builder)
+
+
+# ==================== Single Invocation Tests ====================
+
+
+class TestCircuitBreakerMiddlewareInvoke:
+    """Tests for function_middleware_invoke circuit breaker state machine."""
+
+    async def test_closed_state_success(self, mock_builder, function_context):
+        """Normal successful calls pass through in CLOSED state."""
+        middleware = _make_middleware(mock_builder, failure_threshold=3)
+        assert middleware.state == CircuitBreakerState.CLOSED
+
+        async def success_fn(*args, **kwargs):
+            return "ok"
+
+        call_next = AsyncMock(side_effect=success_fn)
+
+        res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert res == "ok"
+        assert middleware.state == CircuitBreakerState.CLOSED
+        assert middleware.failure_count == 0
+        call_next.assert_called_once()
+
+    async def test_closed_to_open_transition(self, mock_builder, function_context):
+        """Failure threshold consecutive exceptions trip circuit breaker to OPEN."""
+        middleware = _make_middleware(mock_builder, failure_threshold=3)
+
+        async def failing_fn(*args, **kwargs):
+            raise RuntimeError("Backend service down")
+
+        call_next = AsyncMock(side_effect=failing_fn)
+
+        # 1st failure
+        with pytest.raises(RuntimeError, match="Backend service down"):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.state == CircuitBreakerState.CLOSED
+        assert middleware.failure_count == 1
+
+        # 2nd failure
+        with pytest.raises(RuntimeError, match="Backend service down"):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.state == CircuitBreakerState.CLOSED
+        assert middleware.failure_count == 2
+
+        # 3rd failure -> Trips to OPEN
+        with pytest.raises(RuntimeError, match="Backend service down"):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.state == CircuitBreakerState.OPEN
+        assert middleware.failure_count == 3
+        assert call_next.call_count == 3
+
+    async def test_short_circuit_when_open(self, mock_builder, function_context):
+        """Immediate short-circuiting in OPEN state without calling downstream target."""
+        middleware = _make_middleware(
+            mock_builder,
+            failure_threshold=1,
+            cooldown_period=10.0,
+            circuit_breaker_message="Please try again later.",
+        )
+
+        call_next = AsyncMock(side_effect=RuntimeError("Failure"))
+
+        # Trip to OPEN
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.state == CircuitBreakerState.OPEN
+
+        call_next.reset_mock()
+
+        # Subsequent call should short-circuit immediately
+        res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert "Circuit breaker is OPEN for 'test_tool'" in res
+        assert "Please try again later." in res
+        call_next.assert_not_called()
+
+    async def test_open_to_half_open_recovery(self, mock_builder, function_context):
+        """Cooldown period elapsing transitions to HALF_OPEN and successful probe recovers to CLOSED."""
+        middleware = _make_middleware(mock_builder,
+                                      failure_threshold=1,
+                                      cooldown_period=0.1,
+                                      half_open_success_threshold=1)
+
+        call_next = AsyncMock(side_effect=RuntimeError("Failure"))
+
+        # Trip to OPEN
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.state == CircuitBreakerState.OPEN
+
+        # Wait for cooldown
+        await asyncio.sleep(0.15)
+
+        # Update call_next to succeed
+        call_next.side_effect = None
+        call_next.return_value = "recovered_result"
+
+        # Probe call in HALF_OPEN
+        res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert res == "recovered_result"
+        assert middleware.state == CircuitBreakerState.CLOSED
+        assert middleware.failure_count == 0
+
+    async def test_half_open_failed_probe_retrips(self, mock_builder, function_context):
+        """Failed probe in HALF_OPEN trips back to OPEN and resets cooldown."""
+        middleware = _make_middleware(mock_builder, failure_threshold=1, cooldown_period=0.1)
+
+        call_next = AsyncMock(side_effect=RuntimeError("Failure"))
+
+        # Trip to OPEN
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.state == CircuitBreakerState.OPEN
+
+        # Wait for cooldown
+        await asyncio.sleep(0.15)
+
+        # Probe call fails
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+
+        # Re-tripped to OPEN
+        assert middleware.state == CircuitBreakerState.OPEN
+
+    async def test_half_open_concurrency_safety(self, mock_builder, function_context):
+        """Only one probe call is allowed during HALF_OPEN; concurrent calls short-circuit."""
+        middleware = _make_middleware(mock_builder, failure_threshold=1, cooldown_period=0.1)
+
+        call_next = AsyncMock(side_effect=RuntimeError("Initial failure"))
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.state == CircuitBreakerState.OPEN
+
+        await asyncio.sleep(0.15)
+
+        probe_started = asyncio.Event()
+        probe_release = asyncio.Event()
+
+        async def slow_probe(*args, **kwargs):
+            probe_started.set()
+            await probe_release.wait()
+            return "probe_success"
+
+        call_next.side_effect = slow_probe
+
+        # Start probe call in background
+        task = asyncio.create_task(
+            middleware.function_middleware_invoke("input", call_next=call_next, context=function_context))
+        await probe_started.wait()
+
+        # Concurrent call while probe is in flight should short-circuit
+        res_concurrent = await middleware.function_middleware_invoke("input",
+                                                                     call_next=call_next,
+                                                                     context=function_context)
+        assert "Circuit breaker is OPEN for 'test_tool'" in res_concurrent
+
+        # Finish probe
+        probe_release.set()
+        res_probe = await task
+        assert res_probe == "probe_success"
+        assert middleware.state == CircuitBreakerState.CLOSED
+
+
+# ==================== Streaming Invocation Tests ====================
+
+
+class TestCircuitBreakerMiddlewareStream:
+    """Tests for function_middleware_stream circuit breaker state machine."""
+
+    async def test_streaming_success(self, mock_builder, function_context):
+        """Successful stream passes through in CLOSED state."""
+        middleware = _make_middleware(mock_builder, failure_threshold=2)
+
+        async def stream_fn(*args, **kwargs):
+            yield "chunk1"
+            yield "chunk2"
+
+        call_next = Mock(side_effect=stream_fn)
+
+        chunks = []
+        async for chunk in middleware.function_middleware_stream("input", call_next=call_next,
+                                                                 context=function_context):
+            chunks.append(chunk)
+
+        assert chunks == ["chunk1", "chunk2"]
+        assert middleware.state == CircuitBreakerState.CLOSED
+
+    async def test_streaming_failure_trips_breaker(self, mock_builder, function_context):
+        """Exception during streaming increments failure count and trips to OPEN."""
+        middleware = _make_middleware(mock_builder, failure_threshold=1)
+
+        async def failing_stream(*args, **kwargs):
+            yield "chunk1"
+            raise RuntimeError("Stream broken")
+
+        call_next = Mock(side_effect=failing_stream)
+
+        with pytest.raises(RuntimeError, match="Stream broken"):
+            async for _ in middleware.function_middleware_stream("input", call_next=call_next,
+                                                                 context=function_context):
+                pass
+
+        assert middleware.state == CircuitBreakerState.OPEN
+
+        # Subsequent stream should short circuit
+        chunks_open = []
+        async for chunk in middleware.function_middleware_stream("input", call_next=call_next,
+                                                                 context=function_context):
+            chunks_open.append(chunk)
+
+        assert len(chunks_open) == 1
+        assert "Circuit breaker is OPEN" in chunks_open[0]

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_circuit_breaker_middleware.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_circuit_breaker_middleware.py
@@ -165,7 +165,7 @@ class TestCircuitBreakerMiddlewareInvoke:
     ) -> None:
         """Verify successful call in CLOSED state returns result and resets failure count."""
         middleware = _make_middleware(mock_builder, failure_threshold=3)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
         async def success_fn(*args: Any, **kwargs: Any) -> str:
             """Simulate successful downstream execution."""
@@ -174,8 +174,8 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next = AsyncMock(side_effect=success_fn)
         res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res == "ok"
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
-        assert middleware.get_failure_count("test_tool") == 0
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_failure_count("test_tool") == 0
         call_next.assert_called_once()
 
     async def test_closed_to_open_transition(
@@ -194,18 +194,18 @@ class TestCircuitBreakerMiddlewareInvoke:
 
         with pytest.raises(RuntimeError, match="Backend service down"):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
-        assert middleware.get_failure_count("test_tool") == 1
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_failure_count("test_tool") == 1
 
         with pytest.raises(RuntimeError, match="Backend service down"):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
-        assert middleware.get_failure_count("test_tool") == 2
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_failure_count("test_tool") == 2
 
         with pytest.raises(RuntimeError, match="Backend service down"):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
-        assert middleware.get_failure_count("test_tool") == 3
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_failure_count("test_tool") == 3
         assert call_next.call_count == 3
 
     async def test_short_circuit_raises_circuit_breaker_open_error(
@@ -224,7 +224,7 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next = AsyncMock(side_effect=RuntimeError("Failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         call_next.reset_mock()
         match_pattern = re.escape("Circuit breaker is OPEN for 'test_tool'.") + ".*" + re.escape("Please retry later.")
@@ -248,7 +248,7 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next = AsyncMock(side_effect=RuntimeError("Failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         with pytest.raises(CircuitBreakerOpenError) as exc_info:
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
@@ -270,7 +270,7 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next = AsyncMock(side_effect=RuntimeError("Failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
@@ -279,8 +279,8 @@ class TestCircuitBreakerMiddlewareInvoke:
 
         res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res == "recovered_result"
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
-        assert middleware.get_failure_count("test_tool") == 0
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_failure_count("test_tool") == 0
 
     async def test_half_open_multiple_success_threshold(
         self,
@@ -298,7 +298,7 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next = AsyncMock(side_effect=RuntimeError("Failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
@@ -307,15 +307,15 @@ class TestCircuitBreakerMiddlewareInvoke:
 
         res1 = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res1 == "probe_1_ok"
-        assert middleware.get_state("test_tool") == CircuitBreakerState.HALF_OPEN
-        assert middleware.get_success_count("test_tool") == 1
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.HALF_OPEN
+        assert await middleware.get_success_count("test_tool") == 1
 
         call_next.return_value = "probe_2_ok"
         res2 = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res2 == "probe_2_ok"
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
-        assert middleware.get_success_count("test_tool") == 0
-        assert middleware.get_failure_count("test_tool") == 0
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_success_count("test_tool") == 0
+        assert await middleware.get_failure_count("test_tool") == 0
 
     async def test_half_open_failed_probe_retrips(
         self,
@@ -328,15 +328,15 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next = AsyncMock(side_effect=RuntimeError("Failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
 
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
-        assert middleware.get_failure_count("test_tool") == 1
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_failure_count("test_tool") == 1
 
     async def test_half_open_probe_timeout(
         self,
@@ -354,7 +354,7 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next = AsyncMock(side_effect=RuntimeError("Initial failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
@@ -368,8 +368,8 @@ class TestCircuitBreakerMiddlewareInvoke:
         with pytest.raises(TimeoutError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
 
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
-        assert middleware._get_tool_state("test_tool").half_open_probing is False
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.is_half_open_probing("test_tool") is False
 
     async def test_probe_timeout_none_waits_for_completion(
         self,
@@ -387,7 +387,7 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next = AsyncMock(side_effect=RuntimeError("Initial failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
@@ -399,7 +399,7 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next.side_effect = slow_successful_probe
         res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res == "slow_success"
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
     async def test_half_open_cancellation_does_not_trip_or_increment_failures(
         self,
@@ -414,7 +414,7 @@ class TestCircuitBreakerMiddlewareInvoke:
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
@@ -435,14 +435,14 @@ class TestCircuitBreakerMiddlewareInvoke:
         with pytest.raises(asyncio.CancelledError):
             await task
 
-        assert middleware.get_state("test_tool") == CircuitBreakerState.HALF_OPEN
-        assert middleware._get_tool_state("test_tool").half_open_probing is False
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.HALF_OPEN
+        assert await middleware.is_half_open_probing("test_tool") is False
 
         call_next.side_effect = None
         call_next.return_value = "recovered_after_cancellation"
         res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res == "recovered_after_cancellation"
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
     async def test_half_open_concurrency_safety(
         self,
@@ -455,7 +455,7 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next = AsyncMock(side_effect=RuntimeError("Initial failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
@@ -480,7 +480,7 @@ class TestCircuitBreakerMiddlewareInvoke:
         probe_release.set()
         res_probe = await task
         assert res_probe == "probe_success"
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
     async def test_tool_target_isolation(self, mock_builder: Mock) -> None:
         """Verify failure and recovery states are tracked independently per target function."""
@@ -496,12 +496,28 @@ class TestCircuitBreakerMiddlewareInvoke:
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next_a, context=ctx_a)
 
-        assert middleware.get_state("tool_a") == CircuitBreakerState.OPEN
-        assert middleware.get_state("tool_b") == CircuitBreakerState.CLOSED
+        assert await middleware.get_state("tool_a") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("tool_b") == CircuitBreakerState.CLOSED
 
         res_b = await middleware.function_middleware_invoke("input", call_next=call_next_b, context=ctx_b)
         assert res_b == "tool_b ok"
-        assert middleware.get_state("tool_b") == CircuitBreakerState.CLOSED
+        assert await middleware.get_state("tool_b") == CircuitBreakerState.CLOSED
+
+    async def test_get_last_state_change(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify get_last_state_change returns monotonic timestamp for tracked targets."""
+        middleware = _make_middleware(mock_builder, failure_threshold=1)
+        assert await middleware.get_last_state_change("unseen_tool") == 0.0
+
+        call_next = AsyncMock(side_effect=RuntimeError("Failure"))
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+
+        timestamp = await middleware.get_last_state_change("test_tool")
+        assert timestamp > 0.0
 
 
 class TestCircuitBreakerMiddlewareStream:
@@ -528,7 +544,7 @@ class TestCircuitBreakerMiddlewareStream:
             chunks.append(chunk)
 
         assert chunks == ["chunk1", "chunk2"]
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
     async def test_streaming_failure_trips_breaker(
         self,
@@ -550,7 +566,7 @@ class TestCircuitBreakerMiddlewareStream:
                                                                  context=function_context):
                 pass
 
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         with pytest.raises(CircuitBreakerOpenError):
             async for _ in middleware.function_middleware_stream("input", call_next=call_next,
@@ -573,7 +589,7 @@ class TestCircuitBreakerMiddlewareStream:
         call_next = Mock(side_effect=RuntimeError("Initial failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
@@ -590,8 +606,8 @@ class TestCircuitBreakerMiddlewareStream:
                                                                  context=function_context):
                 pass
 
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
-        assert middleware._get_tool_state("test_tool").half_open_probing is False
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.is_half_open_probing("test_tool") is False
 
     async def test_streaming_probe_timeout_does_not_trigger_on_consumer_delay(
         self,
@@ -609,7 +625,7 @@ class TestCircuitBreakerMiddlewareStream:
         call_next = Mock(side_effect=RuntimeError("Initial failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
@@ -627,7 +643,7 @@ class TestCircuitBreakerMiddlewareStream:
             await asyncio.sleep(0.15)
 
         assert chunks == ["chunk1", "chunk2"]
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
     async def test_streaming_early_break_resets_probing_and_admits_next_call(
         self,
@@ -640,7 +656,7 @@ class TestCircuitBreakerMiddlewareStream:
         call_next = Mock(side_effect=RuntimeError("Initial failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
@@ -661,9 +677,9 @@ class TestCircuitBreakerMiddlewareStream:
                 assert chunk == "chunk_0"
                 break
 
-        assert middleware._get_tool_state("test_tool").half_open_probing is False
+        assert await middleware.is_half_open_probing("test_tool") is False
 
         call_next = AsyncMock(return_value="probe_success")
         res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res == "probe_success"
-        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert await middleware.get_state("test_tool") == CircuitBreakerState.CLOSED

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_circuit_breaker_middleware.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_circuit_breaker_middleware.py
@@ -17,6 +17,8 @@
 from __future__ import annotations
 
 import asyncio
+import contextlib
+import re
 from typing import Any
 from unittest.mock import AsyncMock
 from unittest.mock import Mock
@@ -32,7 +34,8 @@ from nat.middleware.middleware import FunctionMiddlewareContext
 
 
 @pytest.fixture(name="mock_builder")
-def fixture_mock_builder():
+def fixture_mock_builder() -> Mock:
+    """Create a mock Builder instance."""
     builder: Mock = Mock()
     builder._functions = {}
     builder.get_llm = AsyncMock()
@@ -47,7 +50,8 @@ def fixture_mock_builder():
 
 
 @pytest.fixture(name="function_context")
-def fixture_function_context():
+def fixture_function_context() -> FunctionMiddlewareContext:
+    """Create a default FunctionMiddlewareContext for testing."""
     return FunctionMiddlewareContext(
         name="test_tool",
         config=Mock(),
@@ -59,6 +63,14 @@ def fixture_function_context():
 
 
 def _make_context(name: str) -> FunctionMiddlewareContext:
+    """Create a FunctionMiddlewareContext with a given name.
+
+    Args:
+        name: Name for the function context.
+
+    Returns:
+        FunctionMiddlewareContext: Initialized context object.
+    """
     return FunctionMiddlewareContext(
         name=name,
         config=Mock(),
@@ -78,6 +90,19 @@ def _make_middleware(
     probe_timeout: float | None = None,
     circuit_breaker_message: str | None = None,
 ) -> CircuitBreakerMiddleware:
+    """Construct a CircuitBreakerMiddleware with test parameters.
+
+    Args:
+        mock_builder: Mock workflow builder.
+        failure_threshold: Number of failures before tripping.
+        cooldown_period: Cooldown duration in seconds.
+        half_open_success_threshold: Success threshold in HALF_OPEN.
+        probe_timeout: Optional probe timeout in seconds.
+        circuit_breaker_message: Optional custom short-circuit message.
+
+    Returns:
+        CircuitBreakerMiddleware: Configured middleware instance.
+    """
     kwargs: dict[str, Any] = {
         "failure_threshold": failure_threshold,
         "cooldown_period": cooldown_period,
@@ -94,7 +119,8 @@ def _make_middleware(
 class TestCircuitBreakerMiddlewareConfig:
     """Test validation and defaults for CircuitBreakerMiddlewareConfig."""
 
-    def test_valid_config(self):
+    def test_valid_config(self) -> None:
+        """Verify valid configuration parameters are accepted."""
         config = CircuitBreakerMiddlewareConfig(
             failure_threshold=5,
             cooldown_period=30.0,
@@ -108,19 +134,23 @@ class TestCircuitBreakerMiddlewareConfig:
         assert config.probe_timeout == 5.0
         assert config.circuit_breaker_message == "Custom msg"
 
-    def test_invalid_failure_threshold(self):
+    def test_invalid_failure_threshold(self) -> None:
+        """Verify failure_threshold must be greater than zero."""
         with pytest.raises(ValidationError):
             CircuitBreakerMiddlewareConfig(failure_threshold=0)
 
-    def test_invalid_cooldown_period(self):
+    def test_invalid_cooldown_period(self) -> None:
+        """Verify cooldown_period must be greater than zero."""
         with pytest.raises(ValidationError):
             CircuitBreakerMiddlewareConfig(cooldown_period=-1.0)
 
-    def test_invalid_half_open_success_threshold(self):
+    def test_invalid_half_open_success_threshold(self) -> None:
+        """Verify half_open_success_threshold must be greater than zero."""
         with pytest.raises(ValidationError):
             CircuitBreakerMiddlewareConfig(half_open_success_threshold=0)
 
-    def test_invalid_probe_timeout(self):
+    def test_invalid_probe_timeout(self) -> None:
+        """Verify probe_timeout must be greater than zero when specified."""
         with pytest.raises(ValidationError):
             CircuitBreakerMiddlewareConfig(probe_timeout=-0.5)
 
@@ -128,11 +158,17 @@ class TestCircuitBreakerMiddlewareConfig:
 class TestCircuitBreakerMiddlewareInvoke:
     """Test invocation behavior and state transitions for CircuitBreakerMiddleware."""
 
-    async def test_closed_state_success(self, mock_builder, function_context):
+    async def test_closed_state_success(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify successful call in CLOSED state returns result and resets failure count."""
         middleware = _make_middleware(mock_builder, failure_threshold=3)
         assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
-        async def success_fn(*args, **kwargs):
+        async def success_fn(*args: Any, **kwargs: Any) -> str:
+            """Simulate successful downstream execution."""
             return "ok"
 
         call_next = AsyncMock(side_effect=success_fn)
@@ -142,10 +178,16 @@ class TestCircuitBreakerMiddlewareInvoke:
         assert middleware.get_failure_count("test_tool") == 0
         call_next.assert_called_once()
 
-    async def test_closed_to_open_transition(self, mock_builder, function_context):
+    async def test_closed_to_open_transition(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify repeated downstream exceptions trip circuit breaker from CLOSED to OPEN."""
         middleware = _make_middleware(mock_builder, failure_threshold=3)
 
-        async def failing_fn(*args, **kwargs):
+        async def failing_fn(*args: Any, **kwargs: Any) -> None:
+            """Simulate failing downstream execution."""
             raise RuntimeError("Backend service down")
 
         call_next = AsyncMock(side_effect=failing_fn)
@@ -166,7 +208,12 @@ class TestCircuitBreakerMiddlewareInvoke:
         assert middleware.get_failure_count("test_tool") == 3
         assert call_next.call_count == 3
 
-    async def test_short_circuit_raises_circuit_breaker_open_error(self, mock_builder, function_context):
+    async def test_short_circuit_raises_circuit_breaker_open_error(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify calls in OPEN state are short-circuited by raising CircuitBreakerOpenError."""
         middleware = _make_middleware(
             mock_builder,
             failure_threshold=1,
@@ -180,12 +227,17 @@ class TestCircuitBreakerMiddlewareInvoke:
         assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         call_next.reset_mock()
-        with pytest.raises(CircuitBreakerOpenError,
-                           match="Circuit breaker is OPEN for 'test_tool'.*Please retry later."):
+        match_pattern = re.escape("Circuit breaker is OPEN for 'test_tool'.") + ".*" + re.escape("Please retry later.")
+        with pytest.raises(CircuitBreakerOpenError, match=match_pattern):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         call_next.assert_not_called()
 
-    async def test_default_open_error_message(self, mock_builder, function_context):
+    async def test_default_open_error_message(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify default error message format when custom message is not configured."""
         middleware = _make_middleware(
             mock_builder,
             failure_threshold=1,
@@ -202,7 +254,12 @@ class TestCircuitBreakerMiddlewareInvoke:
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert str(exc_info.value) == "Circuit breaker is OPEN for 'test_tool'. Tool is temporarily unavailable."
 
-    async def test_open_to_half_open_recovery_single_probe(self, mock_builder, function_context):
+    async def test_open_to_half_open_recovery_single_probe(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify successful probe after cooldown period recovers breaker from HALF_OPEN to CLOSED."""
         middleware = _make_middleware(
             mock_builder,
             failure_threshold=1,
@@ -225,7 +282,12 @@ class TestCircuitBreakerMiddlewareInvoke:
         assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
         assert middleware.get_failure_count("test_tool") == 0
 
-    async def test_half_open_multiple_success_threshold(self, mock_builder, function_context):
+    async def test_half_open_multiple_success_threshold(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify recovery requires configured number of consecutive successful probe calls."""
         middleware = _make_middleware(
             mock_builder,
             failure_threshold=1,
@@ -243,13 +305,11 @@ class TestCircuitBreakerMiddlewareInvoke:
         call_next.side_effect = None
         call_next.return_value = "probe_1_ok"
 
-        # Probe #1 succeeds, but breaker requires 2 consecutive successes to close
         res1 = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res1 == "probe_1_ok"
         assert middleware.get_state("test_tool") == CircuitBreakerState.HALF_OPEN
         assert middleware.get_success_count("test_tool") == 1
 
-        # Probe #2 succeeds and meets threshold, closing breaker
         call_next.return_value = "probe_2_ok"
         res2 = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res2 == "probe_2_ok"
@@ -257,7 +317,12 @@ class TestCircuitBreakerMiddlewareInvoke:
         assert middleware.get_success_count("test_tool") == 0
         assert middleware.get_failure_count("test_tool") == 0
 
-    async def test_half_open_failed_probe_retrips(self, mock_builder, function_context):
+    async def test_half_open_failed_probe_retrips(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify failed probe call in HALF_OPEN immediately retrips breaker to OPEN."""
         middleware = _make_middleware(mock_builder, failure_threshold=1, cooldown_period=0.1)
 
         call_next = AsyncMock(side_effect=RuntimeError("Failure"))
@@ -270,11 +335,15 @@ class TestCircuitBreakerMiddlewareInvoke:
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
 
-        # On failed probe, failure count is reset to threshold rather than incremented
         assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
         assert middleware.get_failure_count("test_tool") == 1
 
-    async def test_half_open_probe_timeout(self, mock_builder, function_context):
+    async def test_half_open_probe_timeout(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify probe timeout enforcement retrips breaker to OPEN and clears probing flag."""
         middleware = _make_middleware(
             mock_builder,
             failure_threshold=1,
@@ -289,7 +358,8 @@ class TestCircuitBreakerMiddlewareInvoke:
 
         await asyncio.sleep(0.15)
 
-        async def slow_probe(*args, **kwargs):
+        async def slow_probe(*args: Any, **kwargs: Any) -> str:
+            """Simulate slow probe execution."""
             await asyncio.sleep(0.3)
             return "too_late"
 
@@ -301,7 +371,12 @@ class TestCircuitBreakerMiddlewareInvoke:
         assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
         assert middleware._get_tool_state("test_tool").half_open_probing is False
 
-    async def test_probe_timeout_none_waits_for_completion(self, mock_builder, function_context):
+    async def test_probe_timeout_none_waits_for_completion(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify probe calls without timeout wait for downstream completion."""
         middleware = _make_middleware(
             mock_builder,
             failure_threshold=1,
@@ -316,7 +391,8 @@ class TestCircuitBreakerMiddlewareInvoke:
 
         await asyncio.sleep(0.15)
 
-        async def slow_successful_probe(*args, **kwargs):
+        async def slow_successful_probe(*args: Any, **kwargs: Any) -> str:
+            """Simulate slow successful probe."""
             await asyncio.sleep(0.1)
             return "slow_success"
 
@@ -325,7 +401,12 @@ class TestCircuitBreakerMiddlewareInvoke:
         assert res == "slow_success"
         assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
-    async def test_half_open_cancellation_does_not_trip_or_increment_failures(self, mock_builder, function_context):
+    async def test_half_open_cancellation_does_not_trip_or_increment_failures(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify task cancellation during probe resets probing flag without recording failure."""
         middleware = _make_middleware(mock_builder, failure_threshold=2, cooldown_period=0.1)
 
         call_next = AsyncMock(side_effect=RuntimeError("Initial failure"))
@@ -339,7 +420,8 @@ class TestCircuitBreakerMiddlewareInvoke:
 
         probe_started = asyncio.Event()
 
-        async def hung_probe(*args, **kwargs):
+        async def hung_probe(*args: Any, **kwargs: Any) -> None:
+            """Simulate hanging probe call."""
             probe_started.set()
             await asyncio.sleep(10.0)
 
@@ -362,7 +444,12 @@ class TestCircuitBreakerMiddlewareInvoke:
         assert res == "recovered_after_cancellation"
         assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
-    async def test_half_open_concurrency_safety(self, mock_builder, function_context):
+    async def test_half_open_concurrency_safety(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify concurrent calls in HALF_OPEN are short-circuited while a probe is active."""
         middleware = _make_middleware(mock_builder, failure_threshold=1, cooldown_period=0.1)
 
         call_next = AsyncMock(side_effect=RuntimeError("Initial failure"))
@@ -375,7 +462,8 @@ class TestCircuitBreakerMiddlewareInvoke:
         probe_started = asyncio.Event()
         probe_release = asyncio.Event()
 
-        async def slow_probe(*args, **kwargs):
+        async def slow_probe(*args: Any, **kwargs: Any) -> str:
+            """Simulate slow probe under synchronization."""
             probe_started.set()
             await probe_release.wait()
             return "probe_success"
@@ -394,7 +482,8 @@ class TestCircuitBreakerMiddlewareInvoke:
         assert res_probe == "probe_success"
         assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
-    async def test_tool_target_isolation(self, mock_builder):
+    async def test_tool_target_isolation(self, mock_builder: Mock) -> None:
+        """Verify failure and recovery states are tracked independently per target function."""
         middleware = _make_middleware(mock_builder, failure_threshold=2)
         ctx_a = _make_context("tool_a")
         ctx_b = _make_context("tool_b")
@@ -418,10 +507,16 @@ class TestCircuitBreakerMiddlewareInvoke:
 class TestCircuitBreakerMiddlewareStream:
     """Test streaming behavior for CircuitBreakerMiddleware."""
 
-    async def test_streaming_success(self, mock_builder, function_context):
+    async def test_streaming_success(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify streaming execution passes through chunks and resets failure count."""
         middleware = _make_middleware(mock_builder, failure_threshold=2)
 
-        async def stream_fn(*args, **kwargs):
+        async def stream_fn(*args: Any, **kwargs: Any):
+            """Simulate successful stream generator."""
             yield "chunk1"
             yield "chunk2"
 
@@ -435,10 +530,16 @@ class TestCircuitBreakerMiddlewareStream:
         assert chunks == ["chunk1", "chunk2"]
         assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
-    async def test_streaming_failure_trips_breaker(self, mock_builder, function_context):
+    async def test_streaming_failure_trips_breaker(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify downstream stream exception trips circuit breaker and short-circuits subsequent streams."""
         middleware = _make_middleware(mock_builder, failure_threshold=1)
 
-        async def failing_stream(*args, **kwargs):
+        async def failing_stream(*args: Any, **kwargs: Any):
+            """Simulate stream generator that fails."""
             yield "chunk1"
             raise RuntimeError("Stream broken")
 
@@ -456,7 +557,12 @@ class TestCircuitBreakerMiddlewareStream:
                                                                  context=function_context):
                 pass
 
-    async def test_streaming_probe_timeout(self, mock_builder, function_context):
+    async def test_streaming_probe_timeout(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify probe timeout during streaming retrips breaker and clears probing flag."""
         middleware = _make_middleware(
             mock_builder,
             failure_threshold=1,
@@ -471,7 +577,8 @@ class TestCircuitBreakerMiddlewareStream:
 
         await asyncio.sleep(0.15)
 
-        async def slow_stream(*args, **kwargs):
+        async def slow_stream(*args: Any, **kwargs: Any):
+            """Simulate slow stream generator."""
             yield "chunk1"
             await asyncio.sleep(0.3)
             yield "chunk2"
@@ -486,8 +593,12 @@ class TestCircuitBreakerMiddlewareStream:
         assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
         assert middleware._get_tool_state("test_tool").half_open_probing is False
 
-    async def test_streaming_probe_timeout_does_not_trigger_on_consumer_delay(self, mock_builder, function_context):
-        """Consumer delays between yielded chunks must not trigger downstream probe timeouts."""
+    async def test_streaming_probe_timeout_does_not_trigger_on_consumer_delay(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify consumer delays between yielded chunks do not trigger downstream probe timeouts."""
         middleware = _make_middleware(
             mock_builder,
             failure_threshold=1,
@@ -502,7 +613,8 @@ class TestCircuitBreakerMiddlewareStream:
 
         await asyncio.sleep(0.15)
 
-        async def fast_stream(*args, **kwargs):
+        async def fast_stream(*args: Any, **kwargs: Any):
+            """Simulate fast stream generator."""
             yield "chunk1"
             yield "chunk2"
 
@@ -512,14 +624,17 @@ class TestCircuitBreakerMiddlewareStream:
         async for chunk in middleware.function_middleware_stream("input", call_next=call_next,
                                                                  context=function_context):
             chunks.append(chunk)
-            # Consumer delay exceeds probe_timeout, but does not trip timeout because __anext__ was fast
             await asyncio.sleep(0.15)
 
         assert chunks == ["chunk1", "chunk2"]
         assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
-    async def test_streaming_early_break_resets_probing_and_admits_next_call(self, mock_builder, function_context):
-        """Early break from streaming probe cleans up probing state and admits subsequent calls."""
+    async def test_streaming_early_break_resets_probing_and_admits_next_call(
+        self,
+        mock_builder: Mock,
+        function_context: FunctionMiddlewareContext,
+    ) -> None:
+        """Verify early break from streaming probe cleans up probing state and admits subsequent calls."""
         middleware = _make_middleware(mock_builder, failure_threshold=1, cooldown_period=0.1)
 
         call_next = Mock(side_effect=RuntimeError("Initial failure"))
@@ -529,7 +644,8 @@ class TestCircuitBreakerMiddlewareStream:
 
         await asyncio.sleep(0.15)
 
-        async def infinite_stream(*args, **kwargs):
+        async def infinite_stream(*args: Any, **kwargs: Any):
+            """Simulate infinite stream generator."""
             count = 0
             while True:
                 yield f"chunk_{count}"
@@ -538,14 +654,15 @@ class TestCircuitBreakerMiddlewareStream:
 
         call_next.side_effect = infinite_stream
 
-        async for chunk in middleware.function_middleware_stream("input", call_next=call_next,
-                                                                 context=function_context):
-            assert chunk == "chunk_0"
-            break
+        async with contextlib.aclosing(
+                middleware.function_middleware_stream("input", call_next=call_next,
+                                                      context=function_context)) as stream:
+            async for chunk in stream:
+                assert chunk == "chunk_0"
+                break
 
         assert middleware._get_tool_state("test_tool").half_open_probing is False
 
-        # Verify next probe call is admitted without being short-circuited
         call_next = AsyncMock(return_value="probe_success")
         res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res == "probe_success"

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_circuit_breaker_middleware.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_circuit_breaker_middleware.py
@@ -22,18 +22,17 @@ from unittest.mock import AsyncMock
 from unittest.mock import Mock
 
 import pytest
+from pydantic import ValidationError
 
 from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerMiddleware
+from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerOpenError
 from nat.middleware.circuit_breaker.circuit_breaker_middleware import CircuitBreakerState
 from nat.middleware.circuit_breaker.circuit_breaker_middleware_config import CircuitBreakerMiddlewareConfig
 from nat.middleware.middleware import FunctionMiddlewareContext
 
-# ==================== Fixtures ====================
-
 
 @pytest.fixture(name="mock_builder")
 def fixture_mock_builder():
-    """Create a mock builder for middleware instantiation."""
     builder: Mock = Mock()
     builder._functions = {}
     builder.get_llm = AsyncMock()
@@ -49,11 +48,21 @@ def fixture_mock_builder():
 
 @pytest.fixture(name="function_context")
 def fixture_function_context():
-    """Create a test FunctionMiddlewareContext."""
     return FunctionMiddlewareContext(
         name="test_tool",
         config=Mock(),
         description="A test tool",
+        input_schema=None,
+        single_output_schema=type(None),
+        stream_output_schema=type(None),
+    )
+
+
+def _make_context(name: str) -> FunctionMiddlewareContext:
+    return FunctionMiddlewareContext(
+        name=name,
+        config=Mock(),
+        description=f"Test tool {name}",
         input_schema=None,
         single_output_schema=type(None),
         stream_output_schema=type(None),
@@ -66,44 +75,74 @@ def _make_middleware(
     failure_threshold: int = 3,
     cooldown_period: float = 0.2,
     half_open_success_threshold: int = 1,
+    probe_timeout: float | None = None,
     circuit_breaker_message: str | None = None,
 ) -> CircuitBreakerMiddleware:
-    """Create a CircuitBreakerMiddleware with test configurations."""
     kwargs: dict[str, Any] = {
         "failure_threshold": failure_threshold,
         "cooldown_period": cooldown_period,
         "half_open_success_threshold": half_open_success_threshold,
     }
+    if probe_timeout is not None:
+        kwargs["probe_timeout"] = probe_timeout
     if circuit_breaker_message is not None:
         kwargs["circuit_breaker_message"] = circuit_breaker_message
     config: CircuitBreakerMiddlewareConfig = CircuitBreakerMiddlewareConfig(**kwargs)
     return CircuitBreakerMiddleware(config=config, builder=mock_builder)
 
 
-# ==================== Single Invocation Tests ====================
+class TestCircuitBreakerMiddlewareConfig:
+    """Test validation and defaults for CircuitBreakerMiddlewareConfig."""
+
+    def test_valid_config(self):
+        config = CircuitBreakerMiddlewareConfig(
+            failure_threshold=5,
+            cooldown_period=30.0,
+            half_open_success_threshold=2,
+            probe_timeout=5.0,
+            circuit_breaker_message="Custom msg",
+        )
+        assert config.failure_threshold == 5
+        assert config.cooldown_period == 30.0
+        assert config.half_open_success_threshold == 2
+        assert config.probe_timeout == 5.0
+        assert config.circuit_breaker_message == "Custom msg"
+
+    def test_invalid_failure_threshold(self):
+        with pytest.raises(ValidationError):
+            CircuitBreakerMiddlewareConfig(failure_threshold=0)
+
+    def test_invalid_cooldown_period(self):
+        with pytest.raises(ValidationError):
+            CircuitBreakerMiddlewareConfig(cooldown_period=-1.0)
+
+    def test_invalid_half_open_success_threshold(self):
+        with pytest.raises(ValidationError):
+            CircuitBreakerMiddlewareConfig(half_open_success_threshold=0)
+
+    def test_invalid_probe_timeout(self):
+        with pytest.raises(ValidationError):
+            CircuitBreakerMiddlewareConfig(probe_timeout=-0.5)
 
 
 class TestCircuitBreakerMiddlewareInvoke:
-    """Tests for function_middleware_invoke circuit breaker state machine."""
+    """Test invocation behavior and state transitions for CircuitBreakerMiddleware."""
 
     async def test_closed_state_success(self, mock_builder, function_context):
-        """Normal successful calls pass through in CLOSED state."""
         middleware = _make_middleware(mock_builder, failure_threshold=3)
-        assert middleware.state == CircuitBreakerState.CLOSED
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
         async def success_fn(*args, **kwargs):
             return "ok"
 
         call_next = AsyncMock(side_effect=success_fn)
-
         res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res == "ok"
-        assert middleware.state == CircuitBreakerState.CLOSED
-        assert middleware.failure_count == 0
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert middleware.get_failure_count("test_tool") == 0
         call_next.assert_called_once()
 
     async def test_closed_to_open_transition(self, mock_builder, function_context):
-        """Failure threshold consecutive exceptions trip circuit breaker to OPEN."""
         middleware = _make_middleware(mock_builder, failure_threshold=3)
 
         async def failing_fn(*args, **kwargs):
@@ -111,105 +150,225 @@ class TestCircuitBreakerMiddlewareInvoke:
 
         call_next = AsyncMock(side_effect=failing_fn)
 
-        # 1st failure
         with pytest.raises(RuntimeError, match="Backend service down"):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.state == CircuitBreakerState.CLOSED
-        assert middleware.failure_count == 1
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert middleware.get_failure_count("test_tool") == 1
 
-        # 2nd failure
         with pytest.raises(RuntimeError, match="Backend service down"):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.state == CircuitBreakerState.CLOSED
-        assert middleware.failure_count == 2
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert middleware.get_failure_count("test_tool") == 2
 
-        # 3rd failure -> Trips to OPEN
         with pytest.raises(RuntimeError, match="Backend service down"):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.state == CircuitBreakerState.OPEN
-        assert middleware.failure_count == 3
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert middleware.get_failure_count("test_tool") == 3
         assert call_next.call_count == 3
 
-    async def test_short_circuit_when_open(self, mock_builder, function_context):
-        """Immediate short-circuiting in OPEN state without calling downstream target."""
+    async def test_short_circuit_raises_circuit_breaker_open_error(self, mock_builder, function_context):
         middleware = _make_middleware(
             mock_builder,
             failure_threshold=1,
             cooldown_period=10.0,
-            circuit_breaker_message="Please try again later.",
+            circuit_breaker_message="Please retry later.",
         )
 
         call_next = AsyncMock(side_effect=RuntimeError("Failure"))
-
-        # Trip to OPEN
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.state == CircuitBreakerState.OPEN
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         call_next.reset_mock()
-
-        # Subsequent call should short-circuit immediately
-        res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert "Circuit breaker is OPEN for 'test_tool'" in res
-        assert "Please try again later." in res
+        with pytest.raises(CircuitBreakerOpenError,
+                           match="Circuit breaker is OPEN for 'test_tool'.*Please retry later."):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         call_next.assert_not_called()
 
-    async def test_open_to_half_open_recovery(self, mock_builder, function_context):
-        """Cooldown period elapsing transitions to HALF_OPEN and successful probe recovers to CLOSED."""
-        middleware = _make_middleware(mock_builder,
-                                      failure_threshold=1,
-                                      cooldown_period=0.1,
-                                      half_open_success_threshold=1)
+    async def test_default_open_error_message(self, mock_builder, function_context):
+        middleware = _make_middleware(
+            mock_builder,
+            failure_threshold=1,
+            cooldown_period=10.0,
+            circuit_breaker_message=None,
+        )
 
         call_next = AsyncMock(side_effect=RuntimeError("Failure"))
-
-        # Trip to OPEN
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.state == CircuitBreakerState.OPEN
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
-        # Wait for cooldown
+        with pytest.raises(CircuitBreakerOpenError) as exc_info:
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert str(exc_info.value) == "Circuit breaker is OPEN for 'test_tool'. Tool is temporarily unavailable."
+
+    async def test_open_to_half_open_recovery_single_probe(self, mock_builder, function_context):
+        middleware = _make_middleware(
+            mock_builder,
+            failure_threshold=1,
+            cooldown_period=0.1,
+            half_open_success_threshold=1,
+        )
+
+        call_next = AsyncMock(side_effect=RuntimeError("Failure"))
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+
         await asyncio.sleep(0.15)
 
-        # Update call_next to succeed
         call_next.side_effect = None
         call_next.return_value = "recovered_result"
 
-        # Probe call in HALF_OPEN
         res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
         assert res == "recovered_result"
-        assert middleware.state == CircuitBreakerState.CLOSED
-        assert middleware.failure_count == 0
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert middleware.get_failure_count("test_tool") == 0
+
+    async def test_half_open_multiple_success_threshold(self, mock_builder, function_context):
+        middleware = _make_middleware(
+            mock_builder,
+            failure_threshold=1,
+            cooldown_period=0.1,
+            half_open_success_threshold=2,
+        )
+
+        call_next = AsyncMock(side_effect=RuntimeError("Failure"))
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+
+        await asyncio.sleep(0.15)
+
+        call_next.side_effect = None
+        call_next.return_value = "probe_1_ok"
+
+        # Probe #1 succeeds, but breaker requires 2 consecutive successes to close
+        res1 = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert res1 == "probe_1_ok"
+        assert middleware.get_state("test_tool") == CircuitBreakerState.HALF_OPEN
+        assert middleware.get_success_count("test_tool") == 1
+
+        # Probe #2 succeeds and meets threshold, closing breaker
+        call_next.return_value = "probe_2_ok"
+        res2 = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert res2 == "probe_2_ok"
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+        assert middleware.get_success_count("test_tool") == 0
+        assert middleware.get_failure_count("test_tool") == 0
 
     async def test_half_open_failed_probe_retrips(self, mock_builder, function_context):
-        """Failed probe in HALF_OPEN trips back to OPEN and resets cooldown."""
         middleware = _make_middleware(mock_builder, failure_threshold=1, cooldown_period=0.1)
 
         call_next = AsyncMock(side_effect=RuntimeError("Failure"))
-
-        # Trip to OPEN
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.state == CircuitBreakerState.OPEN
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
-        # Wait for cooldown
         await asyncio.sleep(0.15)
 
-        # Probe call fails
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
 
-        # Re-tripped to OPEN
-        assert middleware.state == CircuitBreakerState.OPEN
+        # On failed probe, failure count is reset to threshold rather than incremented
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert middleware.get_failure_count("test_tool") == 1
+
+    async def test_half_open_probe_timeout(self, mock_builder, function_context):
+        middleware = _make_middleware(
+            mock_builder,
+            failure_threshold=1,
+            cooldown_period=0.1,
+            probe_timeout=0.05,
+        )
+
+        call_next = AsyncMock(side_effect=RuntimeError("Initial failure"))
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+
+        await asyncio.sleep(0.15)
+
+        async def slow_probe(*args, **kwargs):
+            await asyncio.sleep(0.3)
+            return "too_late"
+
+        call_next.side_effect = slow_probe
+
+        with pytest.raises(TimeoutError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert middleware._get_tool_state("test_tool").half_open_probing is False
+
+    async def test_probe_timeout_none_waits_for_completion(self, mock_builder, function_context):
+        middleware = _make_middleware(
+            mock_builder,
+            failure_threshold=1,
+            cooldown_period=0.1,
+            probe_timeout=None,
+        )
+
+        call_next = AsyncMock(side_effect=RuntimeError("Initial failure"))
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+
+        await asyncio.sleep(0.15)
+
+        async def slow_successful_probe(*args, **kwargs):
+            await asyncio.sleep(0.1)
+            return "slow_success"
+
+        call_next.side_effect = slow_successful_probe
+        res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert res == "slow_success"
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+
+    async def test_half_open_cancellation_does_not_trip_or_increment_failures(self, mock_builder, function_context):
+        middleware = _make_middleware(mock_builder, failure_threshold=2, cooldown_period=0.1)
+
+        call_next = AsyncMock(side_effect=RuntimeError("Initial failure"))
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+
+        await asyncio.sleep(0.15)
+
+        probe_started = asyncio.Event()
+
+        async def hung_probe(*args, **kwargs):
+            probe_started.set()
+            await asyncio.sleep(10.0)
+
+        call_next.side_effect = hung_probe
+
+        task = asyncio.create_task(
+            middleware.function_middleware_invoke("input", call_next=call_next, context=function_context))
+        await probe_started.wait()
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        assert middleware.get_state("test_tool") == CircuitBreakerState.HALF_OPEN
+        assert middleware._get_tool_state("test_tool").half_open_probing is False
+
+        call_next.side_effect = None
+        call_next.return_value = "recovered_after_cancellation"
+        res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert res == "recovered_after_cancellation"
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
     async def test_half_open_concurrency_safety(self, mock_builder, function_context):
-        """Only one probe call is allowed during HALF_OPEN; concurrent calls short-circuit."""
         middleware = _make_middleware(mock_builder, failure_threshold=1, cooldown_period=0.1)
 
         call_next = AsyncMock(side_effect=RuntimeError("Initial failure"))
         with pytest.raises(RuntimeError):
             await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
-        assert middleware.state == CircuitBreakerState.OPEN
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
         await asyncio.sleep(0.15)
 
@@ -223,32 +382,43 @@ class TestCircuitBreakerMiddlewareInvoke:
 
         call_next.side_effect = slow_probe
 
-        # Start probe call in background
         task = asyncio.create_task(
             middleware.function_middleware_invoke("input", call_next=call_next, context=function_context))
         await probe_started.wait()
 
-        # Concurrent call while probe is in flight should short-circuit
-        res_concurrent = await middleware.function_middleware_invoke("input",
-                                                                     call_next=call_next,
-                                                                     context=function_context)
-        assert "Circuit breaker is OPEN for 'test_tool'" in res_concurrent
+        with pytest.raises(CircuitBreakerOpenError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
 
-        # Finish probe
         probe_release.set()
         res_probe = await task
         assert res_probe == "probe_success"
-        assert middleware.state == CircuitBreakerState.CLOSED
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
+    async def test_tool_target_isolation(self, mock_builder):
+        middleware = _make_middleware(mock_builder, failure_threshold=2)
+        ctx_a = _make_context("tool_a")
+        ctx_b = _make_context("tool_b")
 
-# ==================== Streaming Invocation Tests ====================
+        call_next_a = AsyncMock(side_effect=RuntimeError("tool_a failed"))
+        call_next_b = AsyncMock(return_value="tool_b ok")
+
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next_a, context=ctx_a)
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next_a, context=ctx_a)
+
+        assert middleware.get_state("tool_a") == CircuitBreakerState.OPEN
+        assert middleware.get_state("tool_b") == CircuitBreakerState.CLOSED
+
+        res_b = await middleware.function_middleware_invoke("input", call_next=call_next_b, context=ctx_b)
+        assert res_b == "tool_b ok"
+        assert middleware.get_state("tool_b") == CircuitBreakerState.CLOSED
 
 
 class TestCircuitBreakerMiddlewareStream:
-    """Tests for function_middleware_stream circuit breaker state machine."""
+    """Test streaming behavior for CircuitBreakerMiddleware."""
 
     async def test_streaming_success(self, mock_builder, function_context):
-        """Successful stream passes through in CLOSED state."""
         middleware = _make_middleware(mock_builder, failure_threshold=2)
 
         async def stream_fn(*args, **kwargs):
@@ -263,10 +433,9 @@ class TestCircuitBreakerMiddlewareStream:
             chunks.append(chunk)
 
         assert chunks == ["chunk1", "chunk2"]
-        assert middleware.state == CircuitBreakerState.CLOSED
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
 
     async def test_streaming_failure_trips_breaker(self, mock_builder, function_context):
-        """Exception during streaming increments failure count and trips to OPEN."""
         middleware = _make_middleware(mock_builder, failure_threshold=1)
 
         async def failing_stream(*args, **kwargs):
@@ -280,13 +449,104 @@ class TestCircuitBreakerMiddlewareStream:
                                                                  context=function_context):
                 pass
 
-        assert middleware.state == CircuitBreakerState.OPEN
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
 
-        # Subsequent stream should short circuit
-        chunks_open = []
+        with pytest.raises(CircuitBreakerOpenError):
+            async for _ in middleware.function_middleware_stream("input", call_next=call_next,
+                                                                 context=function_context):
+                pass
+
+    async def test_streaming_probe_timeout(self, mock_builder, function_context):
+        middleware = _make_middleware(
+            mock_builder,
+            failure_threshold=1,
+            cooldown_period=0.1,
+            probe_timeout=0.05,
+        )
+
+        call_next = Mock(side_effect=RuntimeError("Initial failure"))
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+
+        await asyncio.sleep(0.15)
+
+        async def slow_stream(*args, **kwargs):
+            yield "chunk1"
+            await asyncio.sleep(0.3)
+            yield "chunk2"
+
+        call_next.side_effect = slow_stream
+
+        with pytest.raises(TimeoutError):
+            async for _ in middleware.function_middleware_stream("input", call_next=call_next,
+                                                                 context=function_context):
+                pass
+
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+        assert middleware._get_tool_state("test_tool").half_open_probing is False
+
+    async def test_streaming_probe_timeout_does_not_trigger_on_consumer_delay(self, mock_builder, function_context):
+        """Consumer delays between yielded chunks must not trigger downstream probe timeouts."""
+        middleware = _make_middleware(
+            mock_builder,
+            failure_threshold=1,
+            cooldown_period=0.1,
+            probe_timeout=0.1,
+        )
+
+        call_next = Mock(side_effect=RuntimeError("Initial failure"))
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+
+        await asyncio.sleep(0.15)
+
+        async def fast_stream(*args, **kwargs):
+            yield "chunk1"
+            yield "chunk2"
+
+        call_next.side_effect = fast_stream
+
+        chunks = []
         async for chunk in middleware.function_middleware_stream("input", call_next=call_next,
                                                                  context=function_context):
-            chunks_open.append(chunk)
+            chunks.append(chunk)
+            # Consumer delay exceeds probe_timeout, but does not trip timeout because __anext__ was fast
+            await asyncio.sleep(0.15)
 
-        assert len(chunks_open) == 1
-        assert "Circuit breaker is OPEN" in chunks_open[0]
+        assert chunks == ["chunk1", "chunk2"]
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED
+
+    async def test_streaming_early_break_resets_probing_and_admits_next_call(self, mock_builder, function_context):
+        """Early break from streaming probe cleans up probing state and admits subsequent calls."""
+        middleware = _make_middleware(mock_builder, failure_threshold=1, cooldown_period=0.1)
+
+        call_next = Mock(side_effect=RuntimeError("Initial failure"))
+        with pytest.raises(RuntimeError):
+            await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert middleware.get_state("test_tool") == CircuitBreakerState.OPEN
+
+        await asyncio.sleep(0.15)
+
+        async def infinite_stream(*args, **kwargs):
+            count = 0
+            while True:
+                yield f"chunk_{count}"
+                count += 1
+                await asyncio.sleep(0.01)
+
+        call_next.side_effect = infinite_stream
+
+        async for chunk in middleware.function_middleware_stream("input", call_next=call_next,
+                                                                 context=function_context):
+            assert chunk == "chunk_0"
+            break
+
+        assert middleware._get_tool_state("test_tool").half_open_probing is False
+
+        # Verify next probe call is admitted without being short-circuited
+        call_next = AsyncMock(return_value="probe_success")
+        res = await middleware.function_middleware_invoke("input", call_next=call_next, context=function_context)
+        assert res == "probe_success"
+        assert middleware.get_state("test_tool") == CircuitBreakerState.CLOSED

--- a/packages/nvidia_nat_core/tests/nat/test_plugin_api.py
+++ b/packages/nvidia_nat_core/tests/nat/test_plugin_api.py
@@ -23,6 +23,11 @@ from nat import plugin_api
 EXPECTED_PLUGIN_API_EXPORTS = {
     "BinaryHumanPromptOption": ("nat.data_models.interactive", "BinaryHumanPromptOption"),
     "Builder": ("nat.builder.builder", "Builder"),
+    "CircuitBreakerMiddleware": ("nat.middleware.circuit_breaker.circuit_breaker_middleware",
+                                 "CircuitBreakerMiddleware"),
+    "CircuitBreakerMiddlewareConfig": ("nat.middleware.circuit_breaker.circuit_breaker_middleware_config",
+                                       "CircuitBreakerMiddlewareConfig"),
+    "CircuitBreakerState": ("nat.middleware.circuit_breaker.circuit_breaker_middleware", "CircuitBreakerState"),
     "ComponentRef": ("nat.data_models.component_ref", "ComponentRef"),
     "Context": ("nat.builder.context", "Context"),
     "ContextState": ("nat.builder.context", "ContextState"),

--- a/packages/nvidia_nat_core/tests/nat/test_plugin_api.py
+++ b/packages/nvidia_nat_core/tests/nat/test_plugin_api.py
@@ -27,6 +27,7 @@ EXPECTED_PLUGIN_API_EXPORTS = {
                                  "CircuitBreakerMiddleware"),
     "CircuitBreakerMiddlewareConfig": ("nat.middleware.circuit_breaker.circuit_breaker_middleware_config",
                                        "CircuitBreakerMiddlewareConfig"),
+    "CircuitBreakerOpenError": ("nat.middleware.circuit_breaker.circuit_breaker_middleware", "CircuitBreakerOpenError"),
     "CircuitBreakerState": ("nat.middleware.circuit_breaker.circuit_breaker_middleware", "CircuitBreakerState"),
     "ComponentRef": ("nat.data_models.component_ref", "ComponentRef"),
     "Context": ("nat.builder.context", "Context"),


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes #2154

This PR introduces `CircuitBreakerMiddleware` (`DynamicFunctionMiddleware`) and `CircuitBreakerOpenError` to `packages/nvidia_nat_core/` to prevent cascading stalls, latency spikes, and LLM token waste during tool outages.

### Key Changes
- **State Machine:** Implements thread-safe `CLOSED`, `OPEN`, and `HALF_OPEN` state transitions using `asyncio.Lock` and monotonic timestamps (`time.monotonic()`).
- **Short-Circuiting via Typed Exception:** Trips to `OPEN` after `failure_threshold` consecutive exhausted failures, raising `CircuitBreakerOpenError` without invoking downstream `call_next`.
- **Probe Safety & Recovery:** In `HALF_OPEN` state, probes service health with optional `probe_timeout` wrapping. Consecutive successful probes (`half_open_success_threshold`) transition the state back to `CLOSED`, while probe failures immediately re-trip to `OPEN`.
- **Cancellation Isolation:** Differentiates `asyncio.CancelledError` from service failure so caller task abortions reset probe concurrency flags without falsely incrementing the failure counter.
- **Registration & Plugin API:** Registers `@register_middleware(config_type=CircuitBreakerMiddlewareConfig)` and exports all symbols in `nat.plugin_api`.
- **Unit Tests:** Adds comprehensive test coverage in `packages/nvidia_nat_core/tests/nat/middleware/test_circuit_breaker_middleware.py` covering state transitions, streaming invocations, timeouts, concurrency safety, cancellation handling, and Pydantic validation.

## By Submitting this PR I confirm:
- [x] I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- [x] We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- [x] When the PR is ready for review, new or existing tests cover these changes.
- [x] When the PR is ready for review, the documentation is up to date with these changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable circuit breaker middleware with closed, open, and half-open states.
  * Added failure thresholds, cooldowns, recovery probes, timeouts, and customizable messages.
  * Added support for standard and streaming operations, including cancellation handling.
  * Exposed circuit breaker components through the plugin API.

* **Documentation**
  * Added guidance covering configuration, state transitions, interception, streaming, timeouts, and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->