### PR TITLE
Make the async job submit timeout configurable

### DIFF
--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/async_jobs/job_store.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/async_jobs/job_store.py
@@ -133,6 +133,31 @@ class JobInfo(Base):
         return f"JobInfo(job_id={self.job_id}, status={self.status})"
 
 
+DEFAULT_SUBMIT_TIMEOUT_SECONDS = 30
+
+
+def _submit_timeout_seconds() -> int:
+    """Resolve the Dask ``Variable.set`` acknowledgement timeout, in seconds.
+
+    ``submit_job`` waits for the Dask scheduler to acknowledge registration of the
+    job's ``Future``. A large task graph can block the scheduler event loop for
+    several seconds, so a too-small timeout makes the backend drop tracking of a
+    job that is in fact still running (see issue #2124). Defaults to
+    ``DEFAULT_SUBMIT_TIMEOUT_SECONDS`` and is overridable via the
+    ``NAT_JOB_STORE_SUBMIT_TIMEOUT`` environment variable.
+    """
+    raw = os.environ.get("NAT_JOB_STORE_SUBMIT_TIMEOUT")
+    if raw is None:
+        return DEFAULT_SUBMIT_TIMEOUT_SECONDS
+    try:
+        seconds = int(raw)
+    except ValueError as e:
+        raise ValueError(f"NAT_JOB_STORE_SUBMIT_TIMEOUT must be an integer number of seconds, got {raw!r}") from e
+    if seconds <= 0:
+        raise ValueError(f"NAT_JOB_STORE_SUBMIT_TIMEOUT must be a positive integer number of seconds, got {raw!r}")
+    return seconds
+
+
 class JobStore(DaskClientMixin):
     """
     Tracks and manages jobs submitted to the Dask scheduler, along with persisting job metadata (JobInfo objects) in a
@@ -295,7 +320,7 @@ class JobStore(DaskClientMixin):
 
         # Store the future in a variable, this allows us to potentially cancel the future later if needed
         future_var = Variable(name=job_id, client=self.dask_client)
-        future_var.set(future, timeout="5 s")
+        future_var.set(future, timeout=f"{_submit_timeout_seconds()} s")
         if sync_timeout > 0:
             try:
                 future.result(timeout=sync_timeout)

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_job_store.py
@@ -858,3 +858,44 @@ async def test_job_info_default_time_fields(db_engine: "AsyncEngine", dask_sched
     job = await job_store.get_job(job_id)
     assert job.status == JobStatus.RUNNING
     assert job.updated_at > initial_updated_at
+
+
+def test_submit_timeout_seconds_default(monkeypatch: pytest.MonkeyPatch):
+    """With no env override, the submit timeout falls back to the default."""
+    from nat.front_ends.fastapi.async_jobs.job_store import DEFAULT_SUBMIT_TIMEOUT_SECONDS
+    from nat.front_ends.fastapi.async_jobs.job_store import _submit_timeout_seconds
+
+    monkeypatch.delenv("NAT_JOB_STORE_SUBMIT_TIMEOUT", raising=False)
+
+    assert _submit_timeout_seconds() == DEFAULT_SUBMIT_TIMEOUT_SECONDS
+
+
+def test_submit_timeout_seconds_env_override(monkeypatch: pytest.MonkeyPatch):
+    """NAT_JOB_STORE_SUBMIT_TIMEOUT overrides the default (issue #2124)."""
+    from nat.front_ends.fastapi.async_jobs.job_store import _submit_timeout_seconds
+
+    monkeypatch.setenv("NAT_JOB_STORE_SUBMIT_TIMEOUT", "45")
+
+    assert _submit_timeout_seconds() == 45
+
+
+@pytest.mark.parametrize("bad_value", ["abc", "5 s", "", "1.5"])
+def test_submit_timeout_seconds_rejects_non_integer(monkeypatch: pytest.MonkeyPatch, bad_value: str):
+    """A non-integer override is rejected with a clear error."""
+    from nat.front_ends.fastapi.async_jobs.job_store import _submit_timeout_seconds
+
+    monkeypatch.setenv("NAT_JOB_STORE_SUBMIT_TIMEOUT", bad_value)
+
+    with pytest.raises(ValueError, match="NAT_JOB_STORE_SUBMIT_TIMEOUT"):
+        _submit_timeout_seconds()
+
+
+@pytest.mark.parametrize("bad_value", ["0", "-5"])
+def test_submit_timeout_seconds_rejects_non_positive(monkeypatch: pytest.MonkeyPatch, bad_value: str):
+    """A non-positive override is rejected."""
+    from nat.front_ends.fastapi.async_jobs.job_store import _submit_timeout_seconds
+
+    monkeypatch.setenv("NAT_JOB_STORE_SUBMIT_TIMEOUT", bad_value)
+
+    with pytest.raises(ValueError, match="positive"):
+        _submit_timeout_seconds()


### PR DESCRIPTION
# Make the async job submit timeout configurable (fixes #2124)

## Reference Issues/PRs
Closes #2124.

## What does this implement/fix? Explain your changes.
`JobStore.submit_job` registers the job's Dask `Future` in a `Variable` and
waits for the scheduler to acknowledge it with a hardcoded `timeout="5 s"`. When
a large task graph briefly blocks the Dask scheduler event loop for more than 5
seconds (for example a big Deep Research prompt on a distributed cluster), that
`set` raises `TimeoutError` and the backend stops tracking the job. The worker
still runs the job to completion, but the result is never pulled back, so the API
reports the job as "running" forever.

### Fix
Make the acknowledgement timeout configurable and raise the default from 5s to
30s, following the module's existing `NAT_JOB_STORE_*` environment-variable
convention (`NAT_JOB_STORE_POOL_PRE_PING`, `NAT_JOB_STORE_POOL_RECYCLE`,
`NAT_JOB_STORE_DB_URL`):

- New `NAT_JOB_STORE_SUBMIT_TIMEOUT` env var (integer seconds).
- Default `DEFAULT_SUBMIT_TIMEOUT_SECONDS = 30`.
- `submit_job` now calls `future_var.set(future, timeout=f"{_submit_timeout_seconds()} s")`.
- Invalid values (non-integer or non-positive) raise a clear `ValueError`,
  matching how the existing pool env vars are validated.

The default bump alone resolves the reported case, and the env var lets
operators on heavily loaded or distributed schedulers tune it further without a
code change. No signature or API change.

## Testing
Added unit tests in `test_job_store.py` for the new resolver: default value,
env-var override, and rejection of non-integer and non-positive values. These do
not require a Dask scheduler. `ruff check` and `yapf` are clean on both changed
files.

## Checklist
- [x] "closes #2124" is in the PR body.
- [x] New/changed code is tested.
- [ ] Documentation updated where applicable (env var documented in the resolver docstring; no public API change).
- [x] Commits are signed off (DCO).
