### PR TITLE
fix(core): prevent duplicate middleware registrations in function chains

### DIFF
--- a/packages/nvidia_nat_core/src/nat/middleware/function_middleware.py
+++ b/packages/nvidia_nat_core/src/nat/middleware/function_middleware.py
@@ -30,6 +30,7 @@ the next callable.
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator
 from collections.abc import Sequence
 from typing import Any
@@ -40,6 +41,8 @@ from nat.middleware.middleware import FunctionMiddlewareContext
 from nat.middleware.middleware import InvocationAction
 from nat.middleware.middleware import InvocationContext
 from nat.middleware.middleware import Middleware
+
+logger = logging.getLogger(__name__)
 
 
 class FunctionMiddleware(Middleware):
@@ -362,7 +365,12 @@ class FunctionMiddlewareChain:
 
 
 def validate_middleware(middleware: Sequence[Middleware] | None) -> tuple[Middleware, ...]:
-    """Validate a sequence of middleware, enforcing ordering guarantees."""
+    """Validate a sequence of middleware, enforcing ordering guarantees.
+
+    Repeated instances of the same middleware are dropped (the first occurrence keeps its
+    position so that an explicitly configured middleware wins over a later auto-registered
+    one), since the same instance must not execute more than once per invocation.
+    """
 
     if not middleware:
         return tuple()
@@ -371,17 +379,28 @@ def validate_middleware(middleware: Sequence[Middleware] | None) -> tuple[Middle
         if not isinstance(mw, Middleware):
             raise TypeError("All middleware must be instances of Middleware")
 
-    final_indices: list[int] = [i for i, mw in enumerate(middleware) if mw.is_final]
+    deduplicated: list[Middleware] = []
+    for mw in middleware:
+        if any(m is mw for m in deduplicated):
+            logger.warning(
+                "Middleware %s is registered more than once; the duplicate registration is ignored. "
+                "The same middleware instance must not be added to a function more than once.",
+                type(mw).__name__,
+            )
+            continue
+        deduplicated.append(mw)
+
+    final_indices: list[int] = [i for i, mw in enumerate(deduplicated) if mw.is_final]
 
     if len(final_indices) > 1:
-        names: str = ", ".join(type(middleware[i]).__name__ for i in final_indices)
+        names: str = ", ".join(type(deduplicated[i]).__name__ for i in final_indices)
         raise ValueError(f"Only one final middleware may be specified per function, but found multiple: {names}")
 
-    if final_indices and final_indices[0] != len(middleware) - 1:
-        name: str = type(middleware[final_indices[0]]).__name__
+    if final_indices and final_indices[0] != len(deduplicated) - 1:
+        name: str = type(deduplicated[final_indices[0]]).__name__
         raise ValueError(f"{name} is marked as final but is not the last middleware in the chain")
 
-    return tuple(middleware)
+    return tuple(deduplicated)
 
 
 __all__ = [

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_dynamic_middleware.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_dynamic_middleware.py
@@ -20,6 +20,7 @@ from unittest.mock import Mock
 import pytest
 
 from nat.authentication.interfaces import AuthProviderBase
+from nat.builder.builder import Builder
 from nat.builder.function import Function
 from nat.builder.function import FunctionInfo
 from nat.builder.function import LambdaFunction
@@ -30,6 +31,7 @@ from nat.data_models.function import FunctionBaseConfig
 from nat.memory.interfaces import MemoryEditor
 from nat.middleware.dynamic.dynamic_function_middleware import DynamicFunctionMiddleware
 from nat.middleware.dynamic.dynamic_middleware_config import DynamicMiddlewareConfig
+from nat.middleware.middleware import InvocationContext
 from nat.middleware.utils.workflow_inventory import DiscoveredComponent
 from nat.middleware.utils.workflow_inventory import DiscoveredFunction
 from nat.object_store.interfaces import ObjectStore
@@ -583,13 +585,13 @@ async def test_patch_add_function_group_skips_patch_when_no_workflow_functions_c
 
 
 class _CountingDynamicMiddleware(DynamicFunctionMiddleware):
-    """Records how many times its pre_invoke hook actually executes."""
+    """Records how many times its `pre_invoke` hook actually executes."""
 
-    def __init__(self, config, builder):
+    def __init__(self, config: DynamicMiddlewareConfig, builder: Builder):
         super().__init__(config=config, builder=builder)
         self.pre_invoke_calls: list[bool] = []
 
-    async def pre_invoke(self, context):
+    async def pre_invoke(self, context: InvocationContext) -> None:
         self.pre_invoke_calls.append(True)
 
 

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_dynamic_middleware.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_dynamic_middleware.py
@@ -21,6 +21,8 @@ import pytest
 
 from nat.authentication.interfaces import AuthProviderBase
 from nat.builder.function import Function
+from nat.builder.function import FunctionInfo
+from nat.builder.function import LambdaFunction
 from nat.data_models.authentication import AuthProviderBaseConfig
 from nat.data_models.authentication import AuthResult
 from nat.data_models.component import ComponentGroup
@@ -578,6 +580,43 @@ async def test_patch_add_function_group_skips_patch_when_no_workflow_functions_c
 
 
 # ==================== Registration Tests ====================
+
+
+class _CountingDynamicMiddleware(DynamicFunctionMiddleware):
+    """Records how many times its pre_invoke hook actually executes."""
+
+    def __init__(self, config, builder):
+        super().__init__(config=config, builder=builder)
+        self.pre_invoke_calls: list[bool] = []
+
+    async def pre_invoke(self, context):
+        self.pre_invoke_calls.append(True)
+
+
+async def test_register_function_does_not_duplicate_middleware_already_in_chain():
+    """Regression test for #2093: when a function is explicitly configured with a dynamic
+    middleware instance and the dynamic registration later appends the same instance, the
+    chain must contain the instance only once and it must execute once per invocation.
+    """
+    config = DynamicMiddlewareConfig(register_workflow_functions=True)
+    middleware = _CountingDynamicMiddleware(config=config, builder=Mock(_functions={}))
+
+    async def work(value: int) -> int:
+        return value
+
+    info = FunctionInfo.from_fn(work, description="example function")
+    func = LambdaFunction.from_info(config=FunctionBaseConfig(), info=info, instance_name="example_function")
+
+    # Explicit per-function middleware configuration (as WorkflowBuilder does when building functions)
+    func.configure_middleware([middleware])
+
+    discovered = DiscoveredFunction(name="example_function", config=FunctionBaseConfig(), instance=func)
+    middleware._register_function(discovered)
+
+    assert func.middleware == (middleware, ), "middleware instance must not appear twice in the chain"
+
+    await func._middlewared_single(1)
+    assert len(middleware.pre_invoke_calls) == 1, "middleware must execute exactly once per invocation"
 
 
 def test_register_function_prevents_duplicates(mock_function):

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_middleware_components.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_middleware_components.py
@@ -420,6 +420,38 @@ class TestMiddlewareErrorHandling:
         with pytest.raises(ValueError, match="found multiple"):
             validate_middleware([final1, final2])
 
+    def test_validate_middleware_deduplicates_repeated_instances(self):
+        """validate_middleware drops repeated instances of the same middleware, keeping the first occurrence."""
+        from nat.middleware.function_middleware import validate_middleware
+
+        shared = _TestMiddleware(test_param="shared", call_order=[])
+        other = _NonFinalTestMiddleware()
+
+        result = validate_middleware([shared, other, shared, shared])
+
+        assert result == (shared, other)
+
+    def test_validate_middleware_keeps_distinct_instances_of_same_class(self):
+        """validate_middleware keeps distinct middleware instances of the same class in order."""
+        from nat.middleware.function_middleware import validate_middleware
+
+        first = _NonFinalTestMiddleware()
+        second = _NonFinalTestMiddleware()
+
+        result = validate_middleware([first, second])
+
+        assert result == (first, second)
+
+    def test_validate_middleware_deduplicated_final_is_accepted(self):
+        """A final middleware listed twice is deduplicated to a single last entry, not a 'multiple finals' error."""
+        from nat.middleware.function_middleware import validate_middleware
+
+        final = _FinalTestMiddleware()
+
+        result = validate_middleware([final, final])
+
+        assert result == (final, )
+
     def test_configure_middleware_final_not_last_raises_error(self):
         """configure_middleware raises ValueError when a final middleware is not last (build-path regression)."""
         from nat.builder.function import FunctionGroup

--- a/packages/nvidia_nat_core/tests/nat/middleware/test_middleware_components.py
+++ b/packages/nvidia_nat_core/tests/nat/middleware/test_middleware_components.py
@@ -421,7 +421,7 @@ class TestMiddlewareErrorHandling:
             validate_middleware([final1, final2])
 
     def test_validate_middleware_deduplicates_repeated_instances(self):
-        """validate_middleware drops repeated instances of the same middleware, keeping the first occurrence."""
+        """`validate_middleware` drops repeated instances of the same middleware, keeping the first occurrence."""
         from nat.middleware.function_middleware import validate_middleware
 
         shared = _TestMiddleware(test_param="shared", call_order=[])
@@ -432,7 +432,7 @@ class TestMiddlewareErrorHandling:
         assert result == (shared, other)
 
     def test_validate_middleware_keeps_distinct_instances_of_same_class(self):
-        """validate_middleware keeps distinct middleware instances of the same class in order."""
+        """`validate_middleware` keeps distinct middleware instances of the same class in order."""
         from nat.middleware.function_middleware import validate_middleware
 
         first = _NonFinalTestMiddleware()
@@ -443,7 +443,7 @@ class TestMiddlewareErrorHandling:
         assert result == (first, second)
 
     def test_validate_middleware_deduplicated_final_is_accepted(self):
-        """A final middleware listed twice is deduplicated to a single last entry, not a 'multiple finals' error."""
+        """A final middleware listed twice is deduplicated to a single last entry, not a `multiple finals` error."""
         from nat.middleware.function_middleware import validate_middleware
 
         final = _FinalTestMiddleware()


### PR DESCRIPTION
## Problem

A middleware instance could appear more than once in a function's middleware chain when it was both explicitly configured for the function and later auto-registered by a DynamicFunctionMiddleware. The middleware then executed multiple times per invocation — causing repeated pre/post handling, duplicate logs, extra latency, and incorrect behavior for non-idempotent middleware.

**Reproduced on develop @ ad7f4a47:**

```text
after explicit config    : [<DynamicMiddleware object at 0x...>]
after runtime discovery  : [<DynamicMiddleware object at 0x...>, <DynamicMiddleware object at 0x...>]  # same instance twice
middleware executions for one call: 2
```

## Root cause

All middleware configuration paths (explicit per-function config, function-group config, and dynamic auto-registration) flow through `validate_middleware` in `packages/nvidia_nat_core/src/nat/middleware/function_middleware.py`, which validated types and final-middleware ordering but never checked for duplicate instances. `DynamicFunctionMiddleware._register_function` appends itself to the function's existing chain without a membership check, so a middleware already present in the chain via explicit configuration was added a second time.

## Solution

Deduplicate middleware instances by identity in `validate_middleware` (the single choke point for every configuration path). The first occurrence keeps its position, so an explicitly configured middleware wins over a later auto-registered duplicate. Repeated registrations log a warning instead of silently duplicating chain entries. The final-middleware ordering guarantees are now evaluated on the deduplicated list. No public API changes.

## Tests

- `test_register_function_does_not_duplicate_middleware_already_in_chain` — regression test reproducing the exact collision (explicit config + dynamic registration); asserts the chain contains the instance once and it executes exactly once per invocation. **Failed before the fix, passes after.**
- `test_validate_middleware_deduplicates_repeated_instances`
- `test_validate_middleware_keeps_distinct_instances_of_same_class`
- `test_validate_middleware_deduplicated_final_is_accepted`

## Validation

- `pytest packages/nvidia_nat_core` → **2842 passed, 54 skipped, 0 failed** (Python 3.13)
- pre-commit (yapf, ruff, uv-lock, etc.) → all pass on changed files
- `ci/scripts/copyright.py --verify-apache-v2`, `documentation_checks.sh` (nbconvert + vale: 0 errors), `path_checks.sh` → all pass

## Limitations

- Integration tests not run (change is not covered by them); CI will cover Python 3.11–3.13.

Closes #2093

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate middleware from running more than once during a function invocation.
  - Preserved the order of configured middleware while removing repeated references.
  - Correctly handles duplicated final middleware after deduplication.
  - Keeps separate middleware instances independent, even when they share the same type.
  - Added logging when duplicate middleware entries are ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->