### PR TITLE
fix(auth): isolate OAuth2 client per flow in console/MCP auth handler

### DIFF
--- a/packages/nvidia_nat_core/src/nat/front_ends/console/authentication_flow_handler.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/console/authentication_flow_handler.py
@@ -48,6 +48,7 @@ class _FlowState:
     verifier: str | None = None
     token_url: str | None = None
     use_pkce: bool | None = None
+    client: AsyncOAuth2Client | None = None
 
 
 # --------------------------------------------------------------------------- #
@@ -165,6 +166,7 @@ class ConsoleAuthenticationFlowHandler(FlowHandlerBase):
 
         flow_state.token_url = cfg.token_url
         flow_state.use_pkce = cfg.use_pkce
+        flow_state.client = client
 
         # PKCE bits
         if cfg.use_pkce:
@@ -232,7 +234,7 @@ class ConsoleAuthenticationFlowHandler(FlowHandlerBase):
                 return "Invalid state; restart authentication."
             flow_state = self._flows[state]
             try:
-                token = await self._oauth_client.fetch_token(  # type: ignore[arg-type]
+                token = await flow_state.client.fetch_token(  # type: ignore[union-attr]
                     url=flow_state.token_url,
                     authorization_response=str(request.url),
                     code_verifier=flow_state.verifier if flow_state.use_pkce else None,

--- a/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_console_flow_handler.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/auth_flow_handlers/test_console_flow_handler.py
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock
 
 import httpx
 import pytest
+from authlib.integrations.httpx_client import AsyncOAuth2Client
 from httpx import ASGITransport
 from mock_oauth2_server import MockOAuth2Server
 
@@ -160,6 +161,136 @@ async def test_oauth2_flow_in_process(monkeypatch, mock_server):
     # internal cleanup
     assert handler._active_flows == 0
     assert not handler._flows
+
+
+async def test_console_oauth2_concurrent_flows_use_isolated_clients(monkeypatch, mock_server):
+    """
+    Two OAuth2 flows started concurrently on the *same* handler instance must each
+    redeem their authorization code with the OAuth client that was built for that
+    flow, not whichever client happens to have been constructed most recently.
+
+    Regression test for a shared ``self._oauth_client`` that got overwritten by
+    the second flow before the first flow's redirect callback could use it.
+    """
+    port_a, port_b = _free_port(), _free_port()
+
+    mock_server.register_client(client_id="cid-a", client_secret="secret-a", redirect_base=f"http://localhost:{port_a}")
+    mock_server.register_client(client_id="cid-b", client_secret="secret-b", redirect_base=f"http://localhost:{port_b}")
+
+    def _cfg(client_id: str, secret: str, port: int) -> OAuth2AuthCodeFlowProviderConfig:
+        return OAuth2AuthCodeFlowProviderConfig(
+            client_id=client_id,
+            client_secret=secret,
+            authorization_url="http://testserver/oauth/authorize",
+            token_url="http://testserver/oauth/token",
+            scopes=["read"],
+            use_pkce=True,
+            redirect_uri=f"http://localhost:{port}/auth/redirect",
+        )
+
+    cfg_a = _cfg("cid-a", "secret-a", port_a)
+    cfg_b = _cfg("cid-b", "secret-b", port_b)
+
+    handler = _TestHandler(mock_server)
+
+    # Force the interleaving that exposes the bug: flow A's authorization-code
+    # exchange must not reach the token endpoint until *after* flow B has
+    # constructed its own OAuth client (which is what overwrites the shared
+    # `self._oauth_client` attribute). Gate flow A's redirect leg on flow B's
+    # construct_oauth_client() call instead of relying on incidental scheduling.
+    b_client_ready = asyncio.Event()
+    original_construct = handler.construct_oauth_client
+
+    def _construct_and_signal(cfg):
+        client = original_construct(cfg)
+        if cfg.client_id == "cid-b":
+            b_client_ready.set()
+        return client
+
+    monkeypatch.setattr(handler, "construct_oauth_client", _construct_and_signal)
+
+    # Records which OAuth client (by client_id) actually performed the token
+    # exchange for each flow's redirect callback, keyed by the task driving that
+    # flow's redirect so a corrupted `self._oauth_client` shows up as a mismatch.
+    used_client_ids: dict[asyncio.Task, str] = {}
+    original_fetch_token = AsyncOAuth2Client.fetch_token
+
+    async def _spy_fetch_token(self, *args, **kwargs):
+        task = asyncio.current_task()
+        assert task is not None
+        used_client_ids[task] = self.client_id
+        return await original_fetch_token(self, *args, **kwargs)
+
+    monkeypatch.setattr(AsyncOAuth2Client, "fetch_token", _spy_fetch_token, raising=True)
+
+    drive_task_labels: dict[asyncio.Task, str] = {}
+
+    async def _drive(url: str, *, label: str) -> None:
+        async with httpx.AsyncClient(
+                transport=ASGITransport(app=mock_server._app),
+                base_url="http://testserver",
+                follow_redirects=False,
+                timeout=10,
+        ) as c:
+            r = await c.get(url)
+            assert r.status_code == 302
+            redirect_url = r.headers["location"]
+
+        # Flow A must not redeem its code until flow B's client has overwritten
+        # `self._oauth_client` -- that ordering is exactly what the bug depends on.
+        if label == "A":
+            await b_client_ready.wait()
+
+        while handler.redirect_app is None:
+            await asyncio.sleep(0.01)
+
+        async with httpx.AsyncClient(
+                transport=ASGITransport(app=handler.redirect_app),
+                base_url="http://localhost",
+                follow_redirects=True,
+                timeout=10,
+        ) as c:
+            await c.get(redirect_url)
+
+    # webbrowser.open() is called exactly once per flow, synchronously, from within
+    # that flow's own authenticate() call -- flow A's call happens before flow B's
+    # authenticate() is even started (see the ordering below), so call order reliably
+    # identifies which flow each opened URL belongs to (the URL itself is not a safe
+    # signal: redirect_uri is percent-encoded in the query string).
+    open_calls: list[str] = []
+
+    def _open(url: str, *_):
+        label = "A" if not open_calls else "B"
+        open_calls.append(url)
+        t = asyncio.ensure_future(_drive(url, label=label))
+        drive_task_labels[t] = label
+
+    monkeypatch.setattr("webbrowser.open", _open, raising=True)
+    monkeypatch.setattr("click.echo", lambda *_: None, raising=True)
+
+    # Start flow A and let it run up to (and including) opening its browser, then
+    # do the same for flow B -- flow B's construct_oauth_client() overwrites the
+    # shared `self._oauth_client` attribute before flow A's redirect is allowed
+    # to proceed (via the gate above).
+    task_a = asyncio.ensure_future(handler.authenticate(cfg_a, AuthFlowType.OAUTH2_AUTHORIZATION_CODE))
+    await asyncio.sleep(0)
+    task_b = asyncio.ensure_future(handler.authenticate(cfg_b, AuthFlowType.OAUTH2_AUTHORIZATION_CODE))
+    await asyncio.sleep(0)
+
+    ctx_a, ctx_b = await asyncio.gather(task_a, task_b)
+
+    # Map the recorded fetch_token calls back to "A"/"B" via the drive task that made them.
+    results = {drive_task_labels[task]: client_id for task, client_id in used_client_ids.items()}
+
+    assert results == {
+        "A": "cid-a", "B": "cid-b"
+    }, ("Each flow must redeem its own authorization code with its own OAuth client")
+
+    tok_a = ctx_a.headers["Authorization"].split()[1]
+    tok_b = ctx_b.headers["Authorization"].split()[1]
+    assert tok_a in mock_server.tokens
+    assert tok_b in mock_server.tokens
+    assert tok_a != tok_b
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Description

Closes #2164

`ConsoleAuthenticationFlowHandler` supports multiple concurrent OAuth2 authorization-code flows on a single instance -- flows are tracked in `self._flows: dict[str, _FlowState]` keyed by the OAuth `state`, and `self._active_flows` keeps the shared redirect server alive until it drops to zero. However, the OAuth2 client used to redeem an authorization code was kept in a single shared `self._oauth_client` attribute rather than being part of that per-flow state.

`construct_oauth_client()` overwrites `self._oauth_client` on every call, and the `/auth/redirect` callback always reads the *current* `self._oauth_client` instead of the client that was built for the flow being completed. If a second flow starts (e.g. a different OAuth2 provider) before an earlier flow's browser login finishes, the second flow's client silently overwrites the first's, and the first flow's token exchange is attempted with the wrong `client_id`/`client_secret`/`token_endpoint_auth_method` -- causing it to fail or, if the mismatch happens to pass the authorization server's checks, exchange the code under the wrong client. Nothing serializes this: `construct_oauth_client()` runs before `self._server_lock` is even acquired, and the lock is released well before the (up to 5 minute) wait on the browser redirect, so the corruption window spans the whole login duration.

This mirrors a bug class already fixed for the FastAPI HTTP/WebSocket auth flow handlers, which store the client per-flow (`flow_state.client`) instead of on a shared attribute. This PR applies the same fix to the console/MCP handler:
- Add a `client` field to `_FlowState`.
- Populate it in `_handle_oauth2_auth_code_flow` right after `construct_oauth_client()`.
- Use `flow_state.client` in the redirect callback instead of `self._oauth_client`.

`MCPAuthenticationFlowHandler` inherits the fix automatically since it reuses the base class's `_handle_oauth2_auth_code_flow` and `_build_redirect_app`.

Added `test_console_oauth2_concurrent_flows_use_isolated_clients`, which drives two OAuth2 flows concurrently on one handler instance against two different registered clients and asserts each flow's token exchange used its own client. Verified this test fails against the pre-fix code (the corrupted flow's token exchange returns `{"detail": "invalid_grant"}` and the handler raises trying to build the `Bearer` header) and passes after the fix.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth sign-in reliability when multiple authorization flows run at the same time.
  * Ensured each sign-in flow uses its own authorization session, preventing token mix-ups.

* **Tests**
  * Added coverage for concurrent OAuth sign-in flows to verify that each receives the correct token.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->