### PR TITLE
docs(get-started): mark native Windows x86_64 unsupported

### DIFF
--- a/docs/source/get-started/installation.md
+++ b/docs/source/get-started/installation.md
@@ -80,7 +80,7 @@ To install these first-party plugin libraries, you can use the full distribution
 | macOS | aarch64 | 3.11, 3.12, 3.13 | ✅ Tested |
 | [Windows (WSL2)](#windows-wsl2) | x86_64 | 3.11, 3.12, 3.13 | ✅ Tested |
 | [Windows (WSL2)](#windows-wsl2) | aarch64 | 3.11, 3.12, 3.13 | ❓ Untested, Should Work |
-| Windows | x86_64 | 3.11, 3.12, 3.13 | ❓ Untested, Should Work |
+| Windows | x86_64 | 3.11, 3.12, 3.13 | ❌ Unsupported |
 | Windows | aarch64 | 3.11, 3.12, 3.13 | ❌ Unsupported |
 
 ## Software Prerequisites


### PR DESCRIPTION
## Description

The Supported Platforms table listed native Windows x86_64 as `❓ Untested, Should Work`. That cell is marked "Untested", so I tested it: it does not work.

`nat workflow create` — the command in the first tutorial — calls `os.symlink()` unconditionally at `packages/nvidia_nat_core/src/nat/cli/commands/workflow/workflow_commands.py:308-309`. On a default Windows install (Developer Mode off, non-elevated) that raises `OSError [WinError 1314] A required privilege is not held by the client`. Full reproduction and measurements are in #2168.

This is a one-cell change to `❌ Unsupported`, matching the `Windows | aarch64` row directly below. It brings the table in line with what the same page already says in prose — "For Windows users, it is recommended to run NeMo Agent Toolkit inside WSL2" and "NeMo Agent Toolkit is developed and tested on Linux and macOS" — and with #427, closed with "Please use WSL2 for testing on windows. Windows is not natively supported." The two `Windows (WSL2)` rows immediately above already point readers at the supported path.

I did not change `workflow_commands.py`. Adding a Windows fallback there would be a behaviour change on a platform #427 says is not supported, and that is your call rather than mine — noted as an alternative in the issue if you would prefer the row kept and made true.

Closes #2168

### Verification

- `pre-commit run markdown-link-check --files docs/source/get-started/installation.md` — Passed.
- Rendered the table to confirm column alignment and that only the one cell changed; the diff is a single line.
- I did not run the full test suite or a docs build. This change touches one table cell in one Markdown file and no code, and I did not have the project installed.

### AI assistance

AI assistance was used to investigate this and draft the change. I reviewed the diff and ran the verification above myself, and the WinError 1314 output in #2168 is from my own machine.

I have not added a `Co-authored-by:` commit trailer — my attribution policy is that commits carry only my identity and AI involvement is disclosed in prose, as here. Say the word if you would rather it were in the commit metadata.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- The commit is signed off (DCO).
- No new or existing tests are affected — this is a documentation-only change.
- The documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the supported-platforms table to indicate that native Windows x86_64 is unsupported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->