### PR TITLE
docs: document nat serve /health endpoint in REST API guide

### DIFF
--- a/docs/source/reference/rest-api/api-server-endpoints.md
+++ b/docs/source/reference/rest-api/api-server-endpoints.md
@@ -42,6 +42,7 @@ Legacy paths are registered by default for backward compatibility unless explici
 | Chat (non-streaming) | `/v1/chat` | `/chat` |
 | Chat (streaming) | `/v1/chat/stream` | `/chat/stream` |
 | OpenAI v1 Completions | `/v1/chat/completions` | (none) |
+| Health Check | `/health` | (none) |
 
 ### Configuring Legacy Routes
 
@@ -64,6 +65,49 @@ general:
 Setting `disable_legacy_routes` to `true` removes the legacy paths entirely. Set `legacy_path`
 or `legacy_openai_api_path` to `null` on individual endpoints to disable specific legacy routes
 while keeping others.
+
+## Health Check Endpoint
+
+The NeMo Agent Toolkit server exposes a health check endpoint for liveness and readiness probes.
+This endpoint is useful for Kubernetes-style health checks, Docker health checks, reverse proxies,
+and process supervisors. It does not execute any workflow and does not require API credentials.
+
+- **Route:** `/health`
+- **Method:** GET
+- **Description:** Returns the health status of the server. Intended for liveness/readiness probes.
+- **Response:** HTTP 200 with `{"status": "healthy"}` when the server is running normally.
+
+### HTTP Request Example:
+
+```bash
+curl --request GET \
+  --url http://localhost:8000/health
+```
+
+### HTTP Response Example:
+
+```json
+{
+  "status": "healthy"
+}
+```
+
+### Use Cases
+
+- **Kubernetes liveness/readiness probes**: Configure `livenessProbe` and `readinessProbe` to
+  check `GET /health` for container health management.
+- **Docker health checks**: Use `HEALTHCHECK CMD curl -f http://localhost:8000/health || exit 1`
+  in your Dockerfile.
+- **Reverse proxy health checks**: Configure load balancers (NGINX, HAProxy, etc.) to route
+  traffic only to healthy instances.
+- **Process supervisors**: Monitor server uptime without sending actual workflow requests.
+
+:::{note}
+The health check endpoint is always available when using `nat serve` with the FastAPI front-end.
+It is separate from the MCP and FastMCP server health endpoints, which are documented in their
+respective guides.
+:::
+
 
 ### HTTP Interactive Extensions
 


### PR DESCRIPTION
- Add /health to Default Endpoint Paths table
- Add Health Check Endpoint section with request/response examples
- Document use cases for liveness/readiness probes
- Cross-reference MCP/FastMCP health endpoints

Closes #2073

## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->
<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added the `/health` endpoint to the REST API reference.
  * Documented its GET request, successful response, examples, availability, and use for service health checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->