### PR TITLE
fix(optimizer): reject empty search spaces

### DIFF
--- a/packages/nvidia_nat_config_optimizer/src/nat/plugins/config_optimizer/optimizable_utils.py
+++ b/packages/nvidia_nat_config_optimizer/src/nat/plugins/config_optimizer/optimizable_utils.py
@@ -83,7 +83,9 @@ def walk_optimizables(obj: BaseModel, path: str = "") -> dict[str, SearchSpace]:
                 _, val_t = get_args(ann) or (None, None)
                 if isinstance(val_t, type) and issubclass(val_t, BaseModel):
                     if allowed_params is None or name in allowed_params:
-                        spaces[f"{full}.*"] = SearchSpace(low=None, high=None)  # sentinel
+                        # This is an internal wildcard marker, not a runnable search space.
+                        # Construct it without applying the public configuration validator.
+                        spaces[f"{full}.*"] = SearchSpace.model_construct()
 
     if allowed_params is None and has_optimizable_flag:
         logger.warning(

--- a/packages/nvidia_nat_core/src/nat/data_models/optimizable.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/optimizable.py
@@ -86,6 +86,8 @@ class SearchSpace(BaseModel, Generic[T]):
         # 3. Range-based validation
         if (self.low is None) != (self.high is None):  # XOR using !=
             raise ValueError(f"SearchSpace range requires both 'low' and 'high'; got low={self.low}, high={self.high}")
+        if self.low is None and self.high is None:
+            raise ValueError("SearchSpace requires either 'values' or both 'low' and 'high' to be defined")
         if self.low is not None and self.high is not None and self.low >= self.high:
             raise ValueError(f"SearchSpace 'low' must be less than 'high'; got low={self.low}, high={self.high}")
 

--- a/packages/nvidia_nat_core/tests/nat/data_models/test_optimizable.py
+++ b/packages/nvidia_nat_core/tests/nat/data_models/test_optimizable.py
@@ -229,11 +229,6 @@ class TestSearchSpaceToGridValues:
         with pytest.raises(ValueError, match="Log scale is not yet supported for grid search"):
             space.to_grid_values()
 
-    def test_missing_low_high_raises_error(self):
-        space = SearchSpace(low=None, high=None)
-        with pytest.raises(ValueError, match="requires either 'values' or both 'low' and 'high'"):
-            space.to_grid_values()
-
     def test_categorical_values_returned_as_list(self):
         space = SearchSpace(values=["small", "medium", "large"])
         result = space.to_grid_values()
@@ -309,6 +304,11 @@ class TestSearchSpaceValidation:
         """Test that empty values list raises validation error."""
         with pytest.raises(ValueError, match="'values' must not be empty"):
             SearchSpace(values=[])
+
+    def test_missing_values_and_range_raises_error(self):
+        """Test that a search space must define values or a range."""
+        with pytest.raises(ValueError, match="requires either 'values' or both 'low' and 'high'"):
+            SearchSpace()
 
     def test_low_equals_high_raises_error(self):
         """Test that low == high raises validation error."""


### PR DESCRIPTION
## Description

Reject a non-prompt SearchSpace that defines neither categorical values nor numeric bounds during Pydantic configuration validation. This prevents an empty configuration from reaching Optuna as two None bounds and failing mid-run with an unrelated TypeError.

The existing grid-search runtime test is moved to the shared construction-time validation contract, and the complete SearchSpace test module remains green.

Closes #2172

## By Submitting this PR I confirm:
- I am familiar with the Contributing Guidelines.
- The commit is signed off under the Developer Certificate of Origin.
- Existing and new tests cover these changes.
- No documentation update is required because this only enforces the already documented search-space contract.

## Validation
- python -m pytest packages/nvidia_nat_core/tests/nat/data_models/test_optimizable.py -q (45 passed)
- python -m ruff check on both changed files
- YAPF 0.43.0 diff check on both changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for search space configurations.
  * Configurations must now provide either explicit values or both lower and upper bounds.
  * Invalid configurations are rejected during creation with clearer behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->