### PR TITLE
fix(core): isolate retry context per call chain instead of per instance

### DIFF
--- a/packages/nvidia_nat_core/src/nat/utils/exception_handlers/automatic_retries.py
+++ b/packages/nvidia_nat_core/src/nat/utils/exception_handlers/automatic_retries.py
@@ -19,15 +19,16 @@ the initial call plus any retries. Values below 1 are normalized to 1, so a
 wrapped callable always executes at least once.
 """
 import asyncio
+import contextvars
 import copy
 import functools
 import gc
 import inspect
 import logging
 import re
+import threading
 import time
 import types
-import weakref
 from collections.abc import Callable
 from collections.abc import Iterable
 from collections.abc import Sequence
@@ -38,6 +39,26 @@ T = TypeVar("T")
 Exc = tuple[type[BaseException], ...]  # exception classes
 CodePattern = int | str | range  # for retry_codes argument
 logger = logging.getLogger(__name__)
+
+# (patched object id, owning task/thread id) pairs the current call chain is already
+# retrying. A ContextVar (not an instance attribute) keeps this per-call-chain: concurrent
+# tasks/threads sharing one instance never see each other's entry, and nested calls within
+# one task do. The owner id is checked, not just inherited, because asyncio.create_task()
+# copies the current ContextVar value into the child task: without an owner check, a task
+# spawned from inside a retry-wrapped call would inherit its parent's "already retrying"
+# entry for an instance it has never itself entered, and silently skip its own retries.
+_in_retry_context: contextvars.ContextVar[frozenset[tuple[int, int]]] = contextvars.ContextVar("_in_retry_context",
+                                                                                               default=frozenset())
+
+
+def _current_owner_id() -> int:
+    """Identify the running asyncio task, or the OS thread when there is none."""
+    try:
+        task = asyncio.current_task()
+    except RuntimeError:
+        task = None
+    return id(task) if task is not None else threading.get_ident()
+
 
 # ─────────────────────────────────────────────────────────────
 #  Memory-optimized helpers
@@ -217,53 +238,39 @@ def _retry_decorator(
         skip_self_in_deepcopy = instance_context_aware
 
         class _RetryContext:
-            """Context manager for instance-level retry gating."""
+            """Context manager for retry gating.
 
-            __slots__ = ("_obj_ref", "_enabled", "_active")
+            Scoped to the (object, owning task/thread) pair via the module-level
+            `_in_retry_context`, not to the patched instance alone."""
+
+            __slots__ = ("_key", "_enabled", "_token")
 
             def __init__(self, args: tuple[Any, ...]):
                 if use_context_aware and args:
-                    try:
-                        # Use weak reference to avoid keeping objects alive
-                        self._obj_ref = weakref.ref(args[0])
-                        self._enabled = True
-                    except TypeError:
-                        # Object doesn't support weak references
-                        self._obj_ref = None
-                        self._enabled = False
+                    self._key = (id(args[0]), _current_owner_id())
+                    self._enabled = True
                 else:
-                    self._obj_ref = None
+                    self._key = None
                     self._enabled = False
-                self._active = False
+                self._token = None
 
-            def __enter__(self):
-                if not self._enabled or self._obj_ref is None:
+            def __enter__(self) -> bool:
+                if not self._enabled:
                     return False
 
-                obj = self._obj_ref()
-                if obj is None:
-                    return False
+                # If already in retry context, skip retries
+                if self._key in _in_retry_context.get():
+                    return True
 
-                try:
-                    # If already in retry context, skip retries
-                    if getattr(obj, "_in_retry_context", False):
-                        return True
-                    object.__setattr__(obj, "_in_retry_context", True)
-                    self._active = True
-                    return False
-                except Exception:
-                    # Cannot set attribute, disable context
-                    self._enabled = False
-                    return False
+                self._token = _in_retry_context.set(_in_retry_context.get() | {self._key})
+                return False
 
-            def __exit__(self, _exc_type, _exc, _tb):
-                if (self._enabled and self._active and self._obj_ref is not None):
-                    obj = self._obj_ref()
-                    if obj is not None:
-                        try:
-                            object.__setattr__(obj, "_in_retry_context", False)
-                        except Exception:
-                            pass
+            def __exit__(self,
+                         _exc_type: type[BaseException] | None,
+                         _exc: BaseException | None,
+                         _tb: types.TracebackType | None) -> None:
+                if self._token is not None:
+                    _in_retry_context.reset(self._token)
 
         async def _call_with_retry_async(*args, **kw) -> T:
             with _RetryContext(args) as already_in_context:

--- a/packages/nvidia_nat_core/src/nat/utils/exception_handlers/automatic_retries.py
+++ b/packages/nvidia_nat_core/src/nat/utils/exception_handlers/automatic_retries.py
@@ -219,9 +219,12 @@ def _retry_decorator(
         at least once.
 
     instance_context_aware:
-        If True, the decorator will check for a retry context flag on the first
-        argument (assumed to be 'self'). If the flag is set, retries are skipped
-        to prevent retry storms in nested method calls.
+        If True, the decorator tracks retry state in the module-level
+        `_in_retry_context` ContextVar, keyed by the wrapped object and its
+        owning task or thread (see `_RetryContext`), rather than a flag on the
+        first argument. Nested calls within the same call chain then skip
+        their own retries, while concurrent callers sharing the same instance
+        retry independently.
     """
 
     # ``retries`` counts total attempts. A non-positive budget would make the
@@ -243,7 +246,7 @@ def _retry_decorator(
             Scoped to the (object, owning task/thread) pair via the module-level
             `_in_retry_context`, not to the patched instance alone."""
 
-            __slots__ = ("_key", "_enabled", "_token")
+            __slots__ = ("_enabled", "_key", "_token")
 
             def __init__(self, args: tuple[Any, ...]):
                 if use_context_aware and args:
@@ -269,8 +272,32 @@ def _retry_decorator(
                          _exc_type: type[BaseException] | None,
                          _exc: BaseException | None,
                          _tb: types.TracebackType | None) -> None:
-                if self._token is not None:
+                if self._token is None:
+                    return
+                try:
                     _in_retry_context.reset(self._token)
+                except ValueError:
+                    # The token was minted by __enter__ running in a different
+                    # Context than the one __exit__ is running in now. This is
+                    # reachable for _agen_with_retry: if a caller does not fully
+                    # drain the async generator (an early `break`, an exception
+                    # elsewhere, or the caller task being cancelled), CPython's
+                    # async-generator finalizer later resumes this generator's
+                    # `with` block to run GeneratorExit cleanup inside a freshly
+                    # created task that only holds a *copy* of the original
+                    # Context, not the Context object the token belongs to.
+                    # ContextVar.reset() requires that exact Context object, so
+                    # resetting is impossible there. It is also unnecessary: that
+                    # copied context is discarded the moment this cleanup task
+                    # finishes, so leaving its copy of _in_retry_context
+                    # unreset never leaks into any later call chain.
+                    logger.debug(
+                        "Retry context for key %s was entered in a different task's "
+                        "context than the one running cleanup now (likely async-generator "
+                        "finalization after the generator was not fully consumed); skipping "
+                        "the ContextVar reset.",
+                        self._key,
+                    )
 
         async def _call_with_retry_async(*args, **kw) -> T:
             with _RetryContext(args) as already_in_context:

--- a/packages/nvidia_nat_core/tests/nat/utils/test_retry_wrapper.py
+++ b/packages/nvidia_nat_core/tests/nat/utils/test_retry_wrapper.py
@@ -374,6 +374,98 @@ def test_multiple_instances_dont_interfere():
     assert svc2.inner_calls == 3
 
 
+class ConcurrentService:
+    """Service whose async method lets a test control task interleaving explicitly."""
+
+    def __init__(self):
+        self.calls_b = 0
+        self.a_started = asyncio.Event()
+        self.b_done = asyncio.Event()
+
+    async def call_a(self):
+        """Hold the retry context open across an await point.
+
+        Simulates an in-flight request on a client instance shared with a
+        concurrent caller."""
+        self.a_started.set()
+        await self.b_done.wait()
+        return "a-ok"
+
+    async def call_b(self):
+        """Fails once with a retryable error, then succeeds."""
+        self.calls_b += 1
+        if self.calls_b == 1:
+            raise APIError(429, "Too Many Requests")
+        return "b-ok"
+
+
+async def test_concurrent_calls_on_shared_instance_retry_independently():
+    """Two concurrent requests sharing one patched instance must not share retry context.
+
+    Request A stays mid-attempt (past its first await point) while request B
+    starts, fails once, and must still be retried on its own budget."""
+    svc = ConcurrentService()
+    svc = ar.patch_with_retry(svc, retries=3, base_delay=0, retry_codes=["4xx"])
+
+    async def call_b_once_a_is_in_flight():
+        await svc.a_started.wait()
+        result = await svc.call_b()
+        svc.b_done.set()
+        return result
+
+    result_a, result_b = await asyncio.gather(svc.call_a(), call_b_once_a_is_in_flight())
+
+    assert result_a == "a-ok"
+    assert result_b == "b-ok"
+    assert svc.calls_b == 2  # failed once, retried, succeeded
+
+
+class SpawningService:
+    """Service whose method spawns a child task calling a wrapped sibling method."""
+
+    def __init__(self):
+        self.child_calls = 0
+        self.spawned_task = None
+
+    async def call_child(self):
+        """Fail once with a retryable error, then succeed."""
+        self.child_calls += 1
+        if self.child_calls == 1:
+            raise APIError(429, "Too Many Requests")
+        return "child-ok"
+
+    async def call_parent(self):
+        """Spawn a child task calling a wrapped sibling method, without awaiting it.
+
+        The task is awaited by the caller, after this call (and the retry
+        context it opened) has already returned, so a failure in the child
+        can only be explained by the child's own retry budget, never by this
+        method's."""
+        self.spawned_task = asyncio.create_task(self.call_child())
+        return "parent-ok"
+
+
+async def test_child_task_created_inside_retry_context_still_retries():
+    """A task spawned via asyncio.create_task() from inside a retry-wrapped call
+    must not inherit the parent's already-retrying entry for the same instance.
+
+    contextvars.ContextVar copies the parent's value into the child task at
+    creation time, so without an owner check the child's own wrapped call on the
+    same instance would see itself as nested and skip its own retries. The child
+    task is awaited only after call_parent has returned, so its retry behavior
+    cannot be explained by call_parent's own retry loop catching the failure."""
+    svc = SpawningService()
+    svc = ar.patch_with_retry(svc, retries=3, base_delay=0, retry_codes=["4xx"])
+
+    result = await svc.call_parent()
+    assert result == "parent-ok"
+
+    child_result = await svc.spawned_task
+
+    assert child_result == "child-ok"
+    assert svc.child_calls == 2  # failed once, retried, succeeded
+
+
 def test_exception_propagation_in_nested_calls():
     """Test that exceptions still propagate correctly in nested calls."""
     svc = NestedService()

--- a/packages/nvidia_nat_core/tests/nat/utils/test_retry_wrapper.py
+++ b/packages/nvidia_nat_core/tests/nat/utils/test_retry_wrapper.py
@@ -877,6 +877,53 @@ async def test_minimal_budget_async_generator_executes_once(retries):
     assert call_count == 1
 
 
+class StreamingService:
+    """Service with a public async-generator method, the same shape as the
+    streaming methods (e.g. `astream`) that `patch_with_retry` wraps on real
+    LLM clients."""
+
+    async def stream(self):
+        yield 1
+        yield 2
+        yield 3
+
+
+async def test_agen_cleanup_from_a_different_task_does_not_raise():
+    """Closing a wrapped async generator from a task other than the one that
+    started iterating it must not raise out of the retry context's cleanup.
+
+    A caller that does not fully drain an `instance_context_aware`-wrapped
+    async generator (an early `break`, an exception elsewhere, or simply
+    letting it be garbage-collected) has its `GeneratorExit` cleanup driven by
+    asyncio's async-generator finalizer, which runs inside a freshly created
+    task holding only a *copy* of the original Context. `ContextVar.reset()`
+    requires the exact Context object the token was minted in, so without a
+    guard this raises `ValueError: ... was created in a different Context`
+    from inside asyncio's own finalizer machinery, where nothing in ordinary
+    calling code can catch it: it surfaces as an unhandled "Task exception was
+    never retrieved" error on the event loop instead."""
+    svc = StreamingService()
+    svc = ar.patch_with_retry(svc, retries=2, base_delay=0)
+
+    loop = asyncio.get_running_loop()
+    loop_exceptions = []
+    loop.set_exception_handler(lambda _loop, context: loop_exceptions.append(context))
+
+    agen = svc.stream()
+    assert await agen.__anext__() == 1
+
+    async def close_from_other_task():
+        await agen.aclose()
+
+    # asyncio.create_task() copies the current Context; even though the copy's
+    # values match, it is a distinct Context object from the one __enter__ ran
+    # in above, reproducing the same mismatch the async-generator finalizer
+    # hits in the wild.
+    await asyncio.create_task(close_from_other_task())
+
+    assert loop_exceptions == []
+
+
 @pytest.mark.parametrize("retries", [0, -1, 1])
 def test_minimal_budget_failure_raises_after_single_attempt(retries):
     """A budget of 1 or below makes exactly one attempt and surfaces the failure."""


### PR DESCRIPTION
## Description

`patch_with_retry` wraps every LLM, embedder, memory-editor and eval-judge client NAT
builds (`packages/nvidia_nat_core/src/nat/utils/exception_handlers/automatic_retries.py`).
Its `instance_context_aware` guard stored one plain attribute, `_in_retry_context`, on the
patched object itself to detect a nested call (a retried outer method calling another
patched method on the same instance) and skip re-wrapping the retry loop for it.

NAT builds these clients once per workflow, and a shared (non-per-user) workflow serves
concurrent requests through one `SessionManager` semaphore, so two logically independent
requests can call methods on the same patched instance at the same time. They race on
that single attribute: whichever call's `__enter__` runs second sees the flag already set
by the still in-flight first call and takes the already-in-context branch, invoking the
wrapped method exactly once with none of the configured retry/backoff logic. A transient,
genuinely retryable error (429, 500, etc.) on that second, unrelated request then
propagates immediately instead of being retried, silently defeating its `num_retries` for
that request only.

## Fix

Replace the per-instance attribute with a `ContextVar` holding the ids of patched objects
currently retrying in the current logical call chain. `asyncio.Task` copies its context at
creation and a plain `threading.Thread` starts with a fresh one, so two calls that share
one instance but run in different concurrent tasks or threads no longer observe each
other's entry. A call chain that re-enters the same instance synchronously, which is what
the attribute was built for, still gates exactly as before: all existing nested-retry
tests pass unmodified.

Closes #2177

## By Submitting this PR I confirm:
- I am familiar with the Contributing Guidelines.
- The commit is signed off under the Developer Certificate of Origin.
- Existing and new tests cover these changes.
- No documentation update is required; this is an internal concurrency fix with no
  change to any public API or configuration surface.

## Validation
- `packages/nvidia_nat_core/tests/nat/utils/test_retry_wrapper.py::test_concurrent_calls_on_shared_instance_retry_independently`
  (new): fails on `develop` (the concurrent request's error propagates unretried after
  exactly one attempt), passes on this branch. Confirmed both ways in the same container.
- Full `packages/nvidia_nat_core` suite: 2669 passed, 261 skipped, both before and after.
- `pre-commit run --files` on the two changed files: yapf and ruff-check both clean.
  `ci/scripts/copyright.py --verify-apache-v2` passes.
- Not verified: the arm64 and Python 3.12/3.13 CI legs (this ran on amd64 / Python 3.11
  only); non-async framework plugins (llama_index, crewai, autogen, etc.) beyond the
  langchain path this bug was traced through, since they all call the same shared
  `patch_with_retry` helper this fix changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved retry handling for nested and concurrent operations.
  * Prevented duplicate retries within the same operation while keeping simultaneous operations independent.
  * Preserved retry budgets for later calls and nested streaming operations.
  * Prevented stale retry state and cleanup errors when streaming operations finish in a different task.
  * Kept retries correctly scoped during streamed-item suspension, cancellation, and post-yield failures.

* **Tests**
  * Added coverage for nested, concurrent, suspended, cancelled, and cross-task streaming operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->