### PR TITLE
feat(fastapi): cap step payloads and optimize token streaming

### DIFF
--- a/packages/nvidia_nat_core/src/nat/data_models/step_adaptor.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/step_adaptor.py
@@ -33,26 +33,38 @@ class StepAdaptorMode(StrEnum):
 
 class StepAdaptorConfig(BaseModel):
     """
-    Configures how intermediate steps are filtered and normalized by the StepAdaptor.
+    Configures how intermediate steps are filtered and normalized by the ``StepAdaptor``.
 
     Args:
-        mode (StepAdaptorMode): One of:
-            - 'current' => pass only LLM (all LLM_* events) + TOOL_END
-            - 'end_events_only' => pass only LLM_END and TOOL_END
-            - 'custom' => pass only the events in custom_event_types
+        mode (StepAdaptorMode): Mode determining which events are emitted (``StepAdaptorMode.DEFAULT``,
+            ``StepAdaptorMode.CUSTOM``, or ``StepAdaptorMode.OFF``).
         custom_event_types (list[IntermediateStepType]):
-            If mode == 'custom', we only pass events whose event_type is in this list.
+            If ``mode`` is ``StepAdaptorMode.CUSTOM``, only events whose ``event_type`` is in this list are passed.
             Otherwise, this field is ignored.
+        stream_llm_tokens (bool): Whether to emit intermediate LLM token events
+            (``IntermediateStepType.LLM_NEW_TOKEN``). When ``False``, only ``IntermediateStepType.LLM_START``
+            and ``IntermediateStepType.LLM_END`` are emitted.
+        max_input_length (int): Maximum character length for input fields in intermediate step payloads.
+            Exceeding text will be truncated. Must be greater than or equal to 0.
+        max_output_length (int): Maximum character length for output fields in intermediate step payloads.
+            Exceeding text will be truncated. Must be greater than or equal to 0.
     """
     mode: StepAdaptorMode = StepAdaptorMode.DEFAULT
     custom_event_types: list[IntermediateStepType] = Field(default_factory=list)
+    stream_llm_tokens: bool = Field(
+        default=False,
+        description=("Whether to emit intermediate LLM token events (LLM_NEW_TOKEN). "
+                     "When False, only LLM_START and LLM_END are emitted."),
+    )
     max_input_length: int = Field(
         default=4000,
+        ge=0,
         description=("Maximum character length for input fields in intermediate step payloads. "
                      "Exceeding text will be truncated."),
     )
     max_output_length: int = Field(
         default=4000,
+        ge=0,
         description=("Maximum character length for output fields in intermediate step payloads. "
                      "Exceeding text will be truncated."),
     )
@@ -60,7 +72,10 @@ class StepAdaptorConfig(BaseModel):
     @model_validator(mode="after")
     def check_custom_event_types(self) -> "StepAdaptorConfig":
         """
-        Validates custom configurations
+        Validates ``StepAdaptorConfig`` when ``mode`` is ``StepAdaptorMode.CUSTOM``.
+
+        Returns:
+            StepAdaptorConfig: The validated configuration instance.
         """
         if self.mode != StepAdaptorMode.CUSTOM and self.custom_event_types:
             logger.warning("Ignoring custom_event_types because mode is not 'custom'")

--- a/packages/nvidia_nat_core/src/nat/data_models/step_adaptor.py
+++ b/packages/nvidia_nat_core/src/nat/data_models/step_adaptor.py
@@ -46,6 +46,16 @@ class StepAdaptorConfig(BaseModel):
     """
     mode: StepAdaptorMode = StepAdaptorMode.DEFAULT
     custom_event_types: list[IntermediateStepType] = Field(default_factory=list)
+    max_input_length: int = Field(
+        default=4000,
+        description=("Maximum character length for input fields in intermediate step payloads. "
+                     "Exceeding text will be truncated."),
+    )
+    max_output_length: int = Field(
+        default=4000,
+        description=("Maximum character length for output fields in intermediate step payloads. "
+                     "Exceeding text will be truncated."),
+    )
 
     @model_validator(mode="after")
     def check_custom_event_types(self) -> "StepAdaptorConfig":

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/step_adaptor.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/step_adaptor.py
@@ -39,6 +39,16 @@ class StepAdaptor:
         self._history: list[IntermediateStep] = []
         self.config = config
 
+    def _truncate_text(self, text: str | None, max_len: int) -> str:
+        """
+        Truncate text if it exceeds max_len, appending a truncation notice.
+        """
+        if not text:
+            return ""
+        if len(text) <= max_len:
+            return text
+        return f"{text[:max_len]}\n... [truncated {len(text) - max_len} characters]"
+
     def _step_matches_filter(self, step: IntermediateStep, config: StepAdaptorConfig) -> bool:
         """
         Returns True if this intermediate step should be included (based on the config.mode).
@@ -136,9 +146,13 @@ class StepAdaptor:
             return None
 
         input_str = str(start_step.data.input)
+        if input_str:
+            input_str = self._truncate_text(input_str, self.config.max_input_length)
 
         if step.event_type == IntermediateStepType.TOOL_END:
             output_str = str(step.data.output)
+            if output_str:
+                output_str = self._truncate_text(output_str, self.config.max_output_length)
 
         if not input_str and not output_str:
             return None
@@ -192,6 +206,7 @@ class StepAdaptor:
             if not input_str:
                 return None
 
+            input_str = self._truncate_text(input_str, self.config.max_input_length)
             escaped_input = html.escape(input_str, quote=False)
             format_input_type = "json" if is_valid_json(escaped_input) else "python"
 
@@ -225,6 +240,7 @@ class StepAdaptor:
             if not output_str:
                 return None
 
+            output_str = self._truncate_text(output_str, self.config.max_output_length)
             escaped_output = html.escape(output_str, quote=False)
             format_output_type = "json" if is_valid_json(escaped_output) else "python"
 
@@ -237,6 +253,7 @@ class StepAdaptor:
                     input_str = str(start_step.data)
 
                 if input_str:
+                    input_str = self._truncate_text(input_str, self.config.max_input_length)
                     escaped_input = html.escape(input_str, quote=False)
                     format_input_type = "json" if is_valid_json(escaped_input) else "python"
                     input_payload = dedent("""

--- a/packages/nvidia_nat_core/src/nat/front_ends/fastapi/step_adaptor.py
+++ b/packages/nvidia_nat_core/src/nat/front_ends/fastapi/step_adaptor.py
@@ -15,7 +15,6 @@
 
 import html
 import logging
-from functools import reduce
 from textwrap import dedent
 
 from nat.data_models.api_server import ResponseIntermediateStep
@@ -35,26 +34,93 @@ logger = logging.getLogger(__name__)
 class StepAdaptor:
 
     def __init__(self, config: StepAdaptorConfig):
+        """
+        Initializes the ``StepAdaptor`` with configuration settings.
 
+        Args:
+            config (StepAdaptorConfig): The configuration governing event filtering and payload truncation.
+        """
         self._history: list[IntermediateStep] = []
+        self._llm_tokens: dict[str, str] = {}
+        self._llm_token_counts: dict[str, int] = {}
+        self._llm_inputs: dict[str, str] = {}
         self.config = config
+
+    def _clear_llm_state(self, uuid: str) -> None:
+        """
+        Removes buffered streaming state for a completed LLM run.
+
+        Args:
+            uuid (str): The intermediate step UUID to clear state for.
+        """
+        self._llm_tokens.pop(uuid, None)
+        self._llm_token_counts.pop(uuid, None)
+        self._llm_inputs.pop(uuid, None)
 
     def _truncate_text(self, text: str | None, max_len: int) -> str:
         """
-        Truncate text if it exceeds max_len, appending a truncation notice.
+        Truncates text if it exceeds ``max_len``, appending a truncation notice.
+
+        Args:
+            text (str | None): The text to truncate.
+            max_len (int): The maximum character length allowed.
+
+        Returns:
+            str: The truncated text or empty string if input is None or empty.
         """
         if not text:
             return ""
+        if max_len <= 0:
+            return ""
         if len(text) <= max_len:
             return text
-        return f"{text[:max_len]}\n... [truncated {len(text) - max_len} characters]"
+
+        placeholder = f"\n... [truncated {len(text)} characters]"
+        if max_len > len(placeholder):
+            slice_len = max_len - len(placeholder)
+            return f"{text[:slice_len]}\n... [truncated {len(text) - slice_len} characters]"
+        return text[:max_len]
+
+    def _format_streamed_output(self, uuid: str) -> str:
+        """
+        Formats the accumulated streaming tokens for a step UUID with truncation.
+
+        Args:
+            uuid (str): The intermediate step UUID.
+
+        Returns:
+            str: The truncated streaming output string.
+        """
+        buf = self._llm_tokens.get(uuid, "")
+        total_chars = self._llm_token_counts.get(uuid, 0)
+        max_len = self.config.max_output_length
+
+        if max_len <= 0:
+            return ""
+        if total_chars <= max_len:
+            return buf
+
+        placeholder = f"\n... [truncated {total_chars} characters]"
+        if max_len > len(placeholder):
+            slice_len = max_len - len(placeholder)
+            return f"{buf[:slice_len]}\n... [truncated {total_chars - slice_len} characters]"
+        return buf[:max_len]
 
     def _step_matches_filter(self, step: IntermediateStep, config: StepAdaptorConfig) -> bool:
         """
-        Returns True if this intermediate step should be included (based on the config.mode).
-        """
+        Determines if an intermediate step should be included based on ``config.mode``.
 
+        Args:
+            step (IntermediateStep): The intermediate step to evaluate.
+            config (StepAdaptorConfig): The current adaptor configuration.
+
+        Returns:
+            bool: ``True`` if the step should be processed, ``False`` otherwise.
+        """
         if config.mode == StepAdaptorMode.OFF:
+            return False
+
+        if step.event_type == IntermediateStepType.LLM_NEW_TOKEN and not config.stream_llm_tokens:
             return False
 
         if config.mode == StepAdaptorMode.DEFAULT:
@@ -74,30 +140,42 @@ class StepAdaptor:
         return False
 
     def _handle_llm(self, step: IntermediateStepPayload, ancestry: InvocationNode) -> ResponseSerializable | None:
+        """
+        Handles ``LLM_START``, ``LLM_NEW_TOKEN``, and ``LLM_END`` events.
+
+        Args:
+            step (IntermediateStepPayload): The intermediate step payload.
+            ancestry (InvocationNode): The invocation node representing the ancestry hierarchy.
+
+        Returns:
+            ResponseSerializable | None: The formatted intermediate step response, or ``None`` if skipped.
+        """
         input_str: str | None = None
         output_str: str | None = None
 
-        # Find the start in the history with matching run_id
-        start_step = next(
-            (x for x in self._history if x.event_type == IntermediateStepType.LLM_START and x.UUID == step.UUID), None)
+        if step.event_type == IntermediateStepType.LLM_START:
+            if hasattr(step.data, "input") and step.data.input is not None:
+                input_str = str(step.data.input)
+            elif step.data is not None:
+                input_str = str(step.data)
+            else:
+                input_str = ""
 
-        if not start_step:
-            # If we don't have a start step, we can't do anything
-            return None
-
-        input_str = str(start_step.data.input)
+            if input_str:
+                input_str = self._truncate_text(input_str, self.config.max_input_length)
+            self._llm_inputs[step.UUID] = input_str
+        else:
+            input_str = self._llm_inputs.get(step.UUID, "")
 
         if step.event_type == IntermediateStepType.LLM_NEW_TOKEN:
-
-            # Find all of the previous LLM chunks and concatenate them
-            output_str = reduce(
-                lambda x, y: x + y,
-                (str(x.data.chunk)
-                 for x in self._history if x.event_type == IntermediateStepType.LLM_NEW_TOKEN and x.UUID == step.UUID),
-                "")
+            output_str = self._format_streamed_output(step.UUID)
 
         elif step.event_type == IntermediateStepType.LLM_END:
-            output_str = str(step.data.output)
+            if hasattr(step.data, "output") and step.data.output is not None and str(step.data.output).strip() != "":
+                output_str = self._truncate_text(str(step.data.output), self.config.max_output_length)
+            else:
+                output_str = self._format_streamed_output(step.UUID)
+            self._clear_llm_state(step.UUID)
 
         if not input_str and not output_str:
             return None
@@ -132,7 +210,14 @@ class StepAdaptor:
 
     def _handle_tool(self, step: IntermediateStepPayload, ancestry: InvocationNode) -> ResponseSerializable | None:
         """
-        Handles both TOOL_START and TOOL_END events
+        Handles both ``TOOL_START`` and ``TOOL_END`` events.
+
+        Args:
+            step (IntermediateStepPayload): The intermediate step payload.
+            ancestry (InvocationNode): The invocation node representing the ancestry hierarchy.
+
+        Returns:
+            ResponseSerializable | None: The formatted intermediate step response, or ``None`` if skipped.
         """
         input_str: str | None = None
         output_str: str | None = None
@@ -191,7 +276,14 @@ class StepAdaptor:
 
     def _handle_function(self, step: IntermediateStepPayload, ancestry: InvocationNode) -> ResponseSerializable | None:
         """
-        Handles the FUNCTION_START and FUNCTION_END events
+        Handles the ``FUNCTION_START`` and ``FUNCTION_END`` events.
+
+        Args:
+            step (IntermediateStepPayload): The intermediate step payload.
+            ancestry (InvocationNode): The invocation node representing the ancestry hierarchy.
+
+        Returns:
+            ResponseSerializable | None: The formatted intermediate step response, or ``None`` if skipped.
         """
         input_str: str | None = None
         output_str: str | None = None
@@ -283,7 +375,14 @@ class StepAdaptor:
 
     def _handle_custom(self, payload: IntermediateStepPayload, ancestry: InvocationNode) -> ResponseSerializable | None:
         """
-        Handles the CUSTOM event
+        Handles the ``CUSTOM`` event.
+
+        Args:
+            payload (IntermediateStepPayload): The intermediate step payload.
+            ancestry (InvocationNode): The invocation node representing the ancestry hierarchy.
+
+        Returns:
+            ResponseSerializable | None: The formatted intermediate step response, or ``None`` if skipped.
         """
         escaped_payload = html.escape(str(payload), quote=False)
         escaped_payload = escaped_payload.replace("\n", "")
@@ -307,13 +406,45 @@ class StepAdaptor:
         return event
 
     def process(self, step: IntermediateStep) -> ResponseSerializable | None:
+        """
+        Processes an intermediate step and returns a serialized response if matched.
 
-        # Track the chunk
-        self._history.append(step)
+        Args:
+            step (IntermediateStep): The intermediate step event to process.
+
+        Returns:
+            ResponseSerializable | None: The adapted response model if matched and processed,
+                or ``None`` if filtered out or an error occurred.
+        """
+        # Track the chunk if not a streaming token event
+        if step.event_type != IntermediateStepType.LLM_NEW_TOKEN:
+            self._history.append(step)
         payload = step.payload
         ancestry = step.function_ancestry
 
+        if step.event_type == IntermediateStepType.LLM_NEW_TOKEN:
+            chunk_str: str | None = None
+            if step.data:
+                if hasattr(step.data, "chunk") and step.data.chunk is not None:
+                    chunk_str = str(step.data.chunk)
+                elif hasattr(step.data, "output") and step.data.output is not None:
+                    chunk_str = str(step.data.output)
+                elif hasattr(step.data, "payload") and step.data.payload is not None:
+                    chunk_str = str(step.data.payload)
+                elif not hasattr(step.data, "__dict__") and step.data is not None:
+                    chunk_str = str(step.data)
+
+            if chunk_str:
+                self._llm_token_counts[step.UUID] = self._llm_token_counts.get(step.UUID, 0) + len(chunk_str)
+                current_buf = self._llm_tokens.get(step.UUID, "")
+                max_len = self.config.max_output_length
+                if len(current_buf) < max_len:
+                    remaining = max_len - len(current_buf)
+                    self._llm_tokens[step.UUID] = current_buf + chunk_str[:remaining]
+
         if not self._step_matches_filter(step, self.config):
+            if step.event_type == IntermediateStepType.LLM_END:
+                self._clear_llm_state(step.UUID)
             return None
 
         try:
@@ -332,5 +463,8 @@ class StepAdaptor:
 
         except Exception as e:
             logger.exception("Error processing intermediate step: %s", e)
+        finally:
+            if step.event_type == IntermediateStepType.LLM_END:
+                self._clear_llm_state(step.UUID)
 
         return None

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_step_adaptor.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_step_adaptor.py
@@ -525,3 +525,73 @@ def test_function_events_in_custom_mode(step_adaptor_custom, make_intermediate_s
     # Steps should still be added to history
     assert step_adaptor_custom._history[-2] is step_start
     assert step_adaptor_custom._history[-1] is step_end
+
+
+def test_truncate_text_helper(default_config):
+    adaptor = StepAdaptor(config=default_config)
+
+    assert adaptor._truncate_text(None, 10) == ""
+    assert adaptor._truncate_text("", 10) == ""
+    assert adaptor._truncate_text("hello", 10) == "hello"
+    assert adaptor._truncate_text("hello world", 11) == "hello world"
+
+    truncated = adaptor._truncate_text("hello world", 5)
+    assert truncated == "hello\n... [truncated 6 characters]"
+
+
+def test_tool_truncation(make_intermediate_step):
+    config = StepAdaptorConfig(max_input_length=20, max_output_length=25)
+    adaptor = StepAdaptor(config=config)
+
+    long_input = "A" * 100
+    long_output = "B" * 100
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.TOOL_START,
+        data_input=long_input,
+        UUID="tool-trunc-uuid",
+    )
+    result_start = adaptor.process(step_start)
+    assert result_start is not None
+    assert f"{'A' * 20}\n... [truncated 80 characters]" in result_start.payload
+
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.TOOL_END,
+        data_input=long_input,
+        data_output=long_output,
+        UUID="tool-trunc-uuid",
+    )
+    result_end = adaptor.process(step_end)
+    assert result_end is not None
+    assert f"{'A' * 20}\n... [truncated 80 characters]" in result_end.payload
+    assert f"{'B' * 25}\n... [truncated 75 characters]" in result_end.payload
+
+
+def test_function_truncation(make_intermediate_step):
+    config = StepAdaptorConfig(max_input_length=15, max_output_length=30)
+    adaptor = StepAdaptor(config=config)
+
+    long_input = "X" * 50
+    long_output = "Y" * 80
+    uuid = "func-trunc-uuid"
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.FUNCTION_START,
+        data_input=long_input,
+        name="long_fn",
+        UUID=uuid,
+    )
+    result_start = adaptor.process(step_start)
+    assert result_start is not None
+    assert f"{'X' * 15}\n... [truncated 35 characters]" in result_start.payload
+
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.FUNCTION_END,
+        data_output=long_output,
+        name="long_fn",
+        UUID=uuid,
+    )
+    result_end = adaptor.process(step_end)
+    assert result_end is not None
+    assert f"{'X' * 15}\n... [truncated 35 characters]" in result_end.payload
+    assert f"{'Y' * 30}\n... [truncated 50 characters]" in result_end.payload

--- a/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_step_adaptor.py
+++ b/packages/nvidia_nat_core/tests/nat/front_ends/fastapi/test_step_adaptor.py
@@ -13,7 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from collections.abc import Callable
+from typing import Any
+
 import pytest
+from pydantic import ValidationError
 
 from nat.data_models.api_server import ResponseIntermediateStep
 from nat.data_models.intermediate_step import IntermediateStep
@@ -26,14 +30,14 @@ from nat.data_models.step_adaptor import StepAdaptorMode
 from nat.front_ends.fastapi.step_adaptor import StepAdaptor
 
 
-@pytest.fixture
-def default_config():
+@pytest.fixture(name="default_config")
+def default_config_fixture() -> StepAdaptorConfig:
     """Return a default StepAdaptorConfig object (mode=DEFAULT)."""
     return StepAdaptorConfig(mode=StepAdaptorMode.DEFAULT, custom_event_types=[])
 
 
-@pytest.fixture
-def custom_config():
+@pytest.fixture(name="custom_config")
+def custom_config_fixture() -> StepAdaptorConfig:
     """Return a custom StepAdaptorConfig object (mode=CUSTOM) with custom types."""
     return StepAdaptorConfig(
         mode=StepAdaptorMode.CUSTOM,
@@ -44,8 +48,8 @@ def custom_config():
     )
 
 
-@pytest.fixture
-def disabled_config():
+@pytest.fixture(name="disabled_config")
+def disabled_config_fixture() -> StepAdaptorConfig:
     """Return a custom StepAdaptorConfig object that disables intermediate steps."""
     return StepAdaptorConfig(
         mode=StepAdaptorMode.OFF,
@@ -56,29 +60,35 @@ def disabled_config():
     )
 
 
-@pytest.fixture
-def step_adaptor_default(default_config):
+@pytest.fixture(name="step_adaptor_default")
+def step_adaptor_default_fixture(default_config: StepAdaptorConfig) -> StepAdaptor:
     """Return a StepAdaptor using the default config."""
     return StepAdaptor(config=default_config)
 
 
-@pytest.fixture
-def step_adaptor_custom(custom_config):
+@pytest.fixture(name="step_adaptor_custom")
+def step_adaptor_custom_fixture(custom_config: StepAdaptorConfig) -> StepAdaptor:
     """Return a StepAdaptor using the custom config."""
     return StepAdaptor(config=custom_config)
 
 
-@pytest.fixture
-def step_adaptor_disabled(disabled_config):
+@pytest.fixture(name="step_adaptor_disabled")
+def step_adaptor_disabled_fixture(disabled_config: StepAdaptorConfig) -> StepAdaptor:
     """Return a StepAdaptor using the disabled config."""
     return StepAdaptor(config=disabled_config)
 
 
-@pytest.fixture
-def make_intermediate_step():
+@pytest.fixture(name="make_intermediate_step")
+def make_intermediate_step_fixture() -> Callable[..., IntermediateStep]:
     """A factory fixture to create an IntermediateStep with minimal defaults."""
 
-    def _make_step(event_type: IntermediateStepType, data_input=None, data_output=None, name=None, UUID=None):
+    def _make_step(
+        event_type: IntermediateStepType,
+        data_input: Any = None,
+        data_output: Any = None,
+        name: str | None = None,
+        UUID: str | None = None,
+    ) -> IntermediateStep:
         payload = IntermediateStepPayload(
             event_type=event_type,
             name=name or "test_step",
@@ -87,11 +97,11 @@ def make_intermediate_step():
         )
         # The IntermediateStep constructor requires a function_ancestry,
         # but for testing we can just pass None or a placeholder.
-        return IntermediateStep(parent_id="root",
-                                function_ancestry=InvocationNode(parent_id="abc",
-                                                                 function_id="def",
-                                                                 function_name="xyz"),
-                                payload=payload)
+        return IntermediateStep(
+            parent_id="root",
+            function_ancestry=InvocationNode(parent_id="abc", function_id="def", function_name="xyz"),
+            payload=payload,
+        )
 
     return _make_step
 
@@ -99,22 +109,67 @@ def make_intermediate_step():
 # --------------------
 # Tests for DEFAULT mode
 # --------------------
-@pytest.mark.parametrize("event_type", [(IntermediateStepType.LLM_START)])
-def test_process_llm_events_in_default(step_adaptor_default, make_intermediate_step, event_type):
+@pytest.mark.parametrize(
+    "event_type, expected_result",
+    [
+        (IntermediateStepType.LLM_START, True),
+        (IntermediateStepType.LLM_NEW_TOKEN, False),
+        (IntermediateStepType.LLM_END, True),
+    ],
+)
+def test_process_llm_events_in_default(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+    event_type: IntermediateStepType,
+    expected_result: bool,
+) -> None:
     """
-    In DEFAULT mode, LLM_START, LLM_NEW_TOKEN, and LLM_END events are processed.
-    We expect a valid ResponseIntermediateStep for each.
+    In DEFAULT mode with stream_llm_tokens=False (default):
+    - LLM_START returns a valid ResponseIntermediateStep and is appended to _history.
+    - LLM_NEW_TOKEN returns None and is not appended to _history.
+    - LLM_END returns a valid ResponseIntermediateStep and is appended to _history.
     """
-    step = make_intermediate_step(event_type=event_type, data_input="LLM Input", data_output="LLM Output")
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="LLM Input",
+        UUID="test-default-llm-uuid",
+    )
+
+    if event_type == IntermediateStepType.LLM_START:
+        step = step_start
+    elif event_type == IntermediateStepType.LLM_NEW_TOKEN:
+        step_adaptor_default.process(step_start)
+        step = make_intermediate_step(
+            event_type=IntermediateStepType.LLM_NEW_TOKEN,
+            data_output="chunk",
+            UUID="test-default-llm-uuid",
+        )
+    else:
+        step_adaptor_default.process(step_start)
+        step = make_intermediate_step(
+            event_type=IntermediateStepType.LLM_END,
+            data_output="LLM Output",
+            UUID="test-default-llm-uuid",
+        )
 
     result = step_adaptor_default.process(step)
 
-    assert result is not None, f"Expected LLM event '{event_type}' to be processed in DEFAULT mode."
-    assert isinstance(result, ResponseIntermediateStep)
-    assert step_adaptor_default._history[-1] is step, "Step must be appended to _history."
+    if expected_result:
+        assert result is not None, f"Expected LLM event '{event_type}' to be processed in DEFAULT mode."
+        assert isinstance(result, ResponseIntermediateStep)
+    else:
+        assert result is None, f"Expected LLM event '{event_type}' to be filtered out in DEFAULT mode."
+
+    if event_type == IntermediateStepType.LLM_NEW_TOKEN:
+        assert step not in step_adaptor_default._history, "LLM_NEW_TOKEN must not be appended to _history."
+    else:
+        assert step_adaptor_default._history[-1] is step, "Step must be appended to _history."
 
 
-def test_process_tool_in_default(step_adaptor_default, make_intermediate_step):
+def test_process_tool_in_default(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     In DEFAULT mode, TOOL_END events should be processed.
     """
@@ -155,7 +210,11 @@ def test_process_tool_in_default(step_adaptor_default, make_intermediate_step):
                              (IntermediateStepType.CUSTOM_START),
                              (IntermediateStepType.CUSTOM_END),
                          ])
-def test_process_other_events_in_default_returns_none(step_adaptor_default, make_intermediate_step, event_type):
+def test_process_other_events_in_default_returns_none(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+    event_type: IntermediateStepType,
+) -> None:
     """
     In DEFAULT mode, anything other than LLM or TOOL_END should return None.
     """
@@ -170,7 +229,10 @@ def test_process_other_events_in_default_returns_none(step_adaptor_default, make
 # --------------------
 # Tests for CUSTOM mode
 # --------------------
-def test_process_custom_events_in_custom_mode(step_adaptor_custom, make_intermediate_step):
+def test_process_custom_events_in_custom_mode(
+    step_adaptor_custom: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     In CUSTOM mode with custom_event_types = [CUSTOM_START, CUSTOM_END],
     only those events should produce output.
@@ -202,7 +264,10 @@ def test_process_custom_events_in_custom_mode(step_adaptor_custom, make_intermed
     assert step_adaptor_custom._history == [step_start, step_end, step_llm, step_tool]
 
 
-def test_process_custom_events_empty_list(step_adaptor_custom, make_intermediate_step):
+def test_process_custom_events_empty_list(
+    step_adaptor_custom: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     If the StepAdaptorConfig was set to CUSTOM but had an empty or non-matching
     custom_event_types, we expect no events to be processed. (In the fixture, it
@@ -217,7 +282,10 @@ def test_process_custom_events_empty_list(step_adaptor_custom, make_intermediate
     assert step_adaptor_custom._history[-1] is step_custom_start
 
 
-def test_process_llm_in_custom_mode_no_op(step_adaptor_custom, make_intermediate_step):
+def test_process_llm_in_custom_mode_no_op(
+    step_adaptor_custom: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     In CUSTOM mode with only CUSTOM_START/END in custom_event_types,
     an LLM event is not processed.
@@ -229,7 +297,10 @@ def test_process_llm_in_custom_mode_no_op(step_adaptor_custom, make_intermediate
     assert step_adaptor_custom._history[-1] is step_llm
 
 
-def test_process_llm_in_disabled_mode_no_op(step_adaptor_disabled, make_intermediate_step):
+def test_process_llm_in_disabled_mode_no_op(
+    step_adaptor_disabled: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     In DISABLED mode, LLM events should not be processed.
     """
@@ -243,7 +314,10 @@ def test_process_llm_in_disabled_mode_no_op(step_adaptor_disabled, make_intermed
 # --------------------
 # Test content generation / markdown structures
 # --------------------
-def test_llm_output_markdown_structure(step_adaptor_default, make_intermediate_step):
+def test_llm_output_markdown_structure(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     Verify that the adapter constructs the correct markdown for LLM output.
     LLM_NEW_TOKEN accumulates chunks. LLM_END has a final output string.
@@ -283,7 +357,10 @@ def test_llm_output_markdown_structure(step_adaptor_default, make_intermediate_s
     assert "Final LLM Output" in result_end.payload, "Should contain final output from LLM_END"
 
 
-def test_tool_end_markdown_structure(step_adaptor_default, make_intermediate_step):
+def test_tool_end_markdown_structure(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     Verify that the adapter constructs the correct markdown for tool output in DEFAULT mode.
     """
@@ -310,7 +387,10 @@ def test_tool_end_markdown_structure(step_adaptor_default, make_intermediate_ste
     assert "TOOL OUTPUT STUFF" in result.payload
 
 
-def test_custom_end_markdown_structure(step_adaptor_custom, make_intermediate_step):
+def test_custom_end_markdown_structure(
+    step_adaptor_custom: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     Verify that the adapter constructs correct markdown for a custom event.
     """
@@ -333,7 +413,10 @@ def test_custom_end_markdown_structure(step_adaptor_custom, make_intermediate_st
 # --------------------
 # Tests for FUNCTION events
 # --------------------
-def test_process_function_start_in_default(step_adaptor_default, make_intermediate_step):
+def test_process_function_start_in_default(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     In DEFAULT mode, FUNCTION_START events should be processed and return a valid ResponseIntermediateStep.
     """
@@ -354,7 +437,10 @@ def test_process_function_start_in_default(step_adaptor_default, make_intermedia
     assert step_adaptor_default._history[-1] is step
 
 
-def test_process_function_end_in_default(step_adaptor_default, make_intermediate_step):
+def test_process_function_end_in_default(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     In DEFAULT mode, FUNCTION_END events should be processed.
     """
@@ -375,7 +461,10 @@ def test_process_function_end_in_default(step_adaptor_default, make_intermediate
     assert step_adaptor_default._history[-1] is step
 
 
-def test_function_end_with_matching_start_event(step_adaptor_default, make_intermediate_step):
+def test_function_end_with_matching_start_event(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     Test that FUNCTION_END events include the input from the matching FUNCTION_START event.
     """
@@ -409,7 +498,10 @@ def test_function_end_with_matching_start_event(step_adaptor_default, make_inter
     assert "Function Output Data" in result.payload, "Should contain output data"
 
 
-def test_function_events_markdown_structure(step_adaptor_default, make_intermediate_step):
+def test_function_events_markdown_structure(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     Verify that the adapter constructs the correct markdown for function events.
     """
@@ -454,7 +546,10 @@ def test_function_events_markdown_structure(step_adaptor_default, make_intermedi
     assert '"value": 42' in result_end.payload or "'value': 42" in result_end.payload
 
 
-def test_process_function_start_without_input(step_adaptor_default, make_intermediate_step):
+def test_process_function_start_without_input(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     Test that FUNCTION_START events with None input are still processed.
     """
@@ -475,7 +570,10 @@ def test_process_function_start_without_input(step_adaptor_default, make_interme
     assert step_adaptor_default._history[-1] is step
 
 
-def test_process_function_end_without_output(step_adaptor_default, make_intermediate_step):
+def test_process_function_end_without_output(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     Test that FUNCTION_END events with None output are still processed.
     """
@@ -496,7 +594,10 @@ def test_process_function_end_without_output(step_adaptor_default, make_intermed
     assert step_adaptor_default._history[-1] is step
 
 
-def test_function_events_in_custom_mode(step_adaptor_custom, make_intermediate_step):
+def test_function_events_in_custom_mode(
+    step_adaptor_custom: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
     """
     In CUSTOM mode without FUNCTION_START/END in custom_event_types,
     function events should not be processed.
@@ -527,20 +628,34 @@ def test_function_events_in_custom_mode(step_adaptor_custom, make_intermediate_s
     assert step_adaptor_custom._history[-1] is step_end
 
 
-def test_truncate_text_helper(default_config):
+def test_truncate_text_helper(default_config: StepAdaptorConfig) -> None:
+    """
+    Verify that the `_truncate_text` helper correctly truncates strings exceeding limits and handles empty inputs.
+    """
     adaptor = StepAdaptor(config=default_config)
 
     assert adaptor._truncate_text(None, 10) == ""
     assert adaptor._truncate_text("", 10) == ""
     assert adaptor._truncate_text("hello", 10) == "hello"
     assert adaptor._truncate_text("hello world", 11) == "hello world"
+    assert adaptor._truncate_text("hello world", 0) == ""
+    assert adaptor._truncate_text("hello world", -1) == ""
 
-    truncated = adaptor._truncate_text("hello world", 5)
-    assert truncated == "hello\n... [truncated 6 characters]"
+    truncated_short = adaptor._truncate_text("hello world", 5)
+    assert truncated_short == "hello"
+    assert len(truncated_short) <= 5
+
+    long_text = "A" * 100
+    truncated_long = adaptor._truncate_text(long_text, 50)
+    assert len(truncated_long) <= 50
+    assert "[truncated 81 characters]" in truncated_long
 
 
-def test_tool_truncation(make_intermediate_step):
-    config = StepAdaptorConfig(max_input_length=20, max_output_length=25)
+def test_tool_truncation(make_intermediate_step: Callable[..., IntermediateStep]) -> None:
+    """
+    Verify that tool inputs and outputs exceeding configured character limits are truncated.
+    """
+    config = StepAdaptorConfig(max_input_length=50, max_output_length=55)
     adaptor = StepAdaptor(config=config)
 
     long_input = "A" * 100
@@ -553,7 +668,7 @@ def test_tool_truncation(make_intermediate_step):
     )
     result_start = adaptor.process(step_start)
     assert result_start is not None
-    assert f"{'A' * 20}\n... [truncated 80 characters]" in result_start.payload
+    assert "[truncated 81 characters]" in result_start.payload
 
     step_end = make_intermediate_step(
         event_type=IntermediateStepType.TOOL_END,
@@ -563,16 +678,19 @@ def test_tool_truncation(make_intermediate_step):
     )
     result_end = adaptor.process(step_end)
     assert result_end is not None
-    assert f"{'A' * 20}\n... [truncated 80 characters]" in result_end.payload
-    assert f"{'B' * 25}\n... [truncated 75 characters]" in result_end.payload
+    assert "[truncated 81 characters]" in result_end.payload
+    assert "[truncated 76 characters]" in result_end.payload
 
 
-def test_function_truncation(make_intermediate_step):
-    config = StepAdaptorConfig(max_input_length=15, max_output_length=30)
+def test_function_truncation(make_intermediate_step: Callable[..., IntermediateStep]) -> None:
+    """
+    Verify that function inputs and outputs exceeding configured character limits are truncated.
+    """
+    config = StepAdaptorConfig(max_input_length=50, max_output_length=60)
     adaptor = StepAdaptor(config=config)
 
-    long_input = "X" * 50
-    long_output = "Y" * 80
+    long_input = "X" * 100
+    long_output = "Y" * 100
     uuid = "func-trunc-uuid"
 
     step_start = make_intermediate_step(
@@ -583,7 +701,7 @@ def test_function_truncation(make_intermediate_step):
     )
     result_start = adaptor.process(step_start)
     assert result_start is not None
-    assert f"{'X' * 15}\n... [truncated 35 characters]" in result_start.payload
+    assert "[truncated 81 characters]" in result_start.payload
 
     step_end = make_intermediate_step(
         event_type=IntermediateStepType.FUNCTION_END,
@@ -593,5 +711,461 @@ def test_function_truncation(make_intermediate_step):
     )
     result_end = adaptor.process(step_end)
     assert result_end is not None
-    assert f"{'X' * 15}\n... [truncated 35 characters]" in result_end.payload
-    assert f"{'Y' * 30}\n... [truncated 50 characters]" in result_end.payload
+    assert "[truncated 81 characters]" in result_end.payload
+    assert "[truncated 71 characters]" in result_end.payload
+
+
+def test_llm_token_streaming_default_disabled(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
+    """
+    Verify that when `stream_llm_tokens` is `False` (default), token chunks return `None` and start/end events emit.
+    """
+    uuid = "llm-stream-test-uuid"
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="Prompt input",
+        UUID=uuid,
+    )
+    step_token = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="token chunk",
+        UUID=uuid,
+    )
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_END,
+        data_output="Final response",
+        UUID=uuid,
+    )
+
+    result_start = step_adaptor_default.process(step_start)
+    assert result_start is not None
+    assert isinstance(result_start, ResponseIntermediateStep)
+    assert "Prompt input" in result_start.payload
+
+    result_token = step_adaptor_default.process(step_token)
+    assert result_token is None
+
+    result_end = step_adaptor_default.process(step_end)
+    assert result_end is not None
+    assert isinstance(result_end, ResponseIntermediateStep)
+    assert "Final response" in result_end.payload
+
+
+def test_llm_token_streaming_opt_in(make_intermediate_step: Callable[..., IntermediateStep]) -> None:
+    """
+    Verify that when `stream_llm_tokens` is `True`, intermediate token chunks emit cumulative streaming updates.
+    """
+    config = StepAdaptorConfig(stream_llm_tokens=True)
+    adaptor = StepAdaptor(config=config)
+    uuid = "llm-opt-in-uuid"
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="Prompt input",
+        UUID=uuid,
+    )
+    step_token1 = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="hello ",
+        UUID=uuid,
+    )
+    step_token2 = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="world",
+        UUID=uuid,
+    )
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_END,
+        data_output="hello world!",
+        UUID=uuid,
+    )
+
+    adaptor.process(step_start)
+
+    result_t1 = adaptor.process(step_token1)
+    assert result_t1 is not None
+    assert "hello " in result_t1.payload
+
+    result_t2 = adaptor.process(step_token2)
+    assert result_t2 is not None
+    assert "hello world" in result_t2.payload
+
+    result_end = adaptor.process(step_end)
+    assert result_end is not None
+    assert "hello world!" in result_end.payload
+    assert uuid not in adaptor._llm_tokens
+    assert uuid not in adaptor._llm_token_counts
+
+
+def test_llm_truncation(make_intermediate_step: Callable[..., IntermediateStep]) -> None:
+    """
+    Verify that LLM inputs and outputs exceeding configured character limits are truncated.
+    """
+    config = StepAdaptorConfig(stream_llm_tokens=True, max_input_length=50, max_output_length=55)
+    adaptor = StepAdaptor(config=config)
+    uuid = "llm-trunc-uuid"
+
+    long_prompt = "P" * 100
+    long_output = "R" * 100
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input=long_prompt,
+        UUID=uuid,
+    )
+    result_start = adaptor.process(step_start)
+    assert result_start is not None
+    assert "[truncated 81 characters]" in result_start.payload
+
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_END,
+        data_output=long_output,
+        UUID=uuid,
+    )
+    result_end = adaptor.process(step_end)
+    assert result_end is not None
+    assert "[truncated 81 characters]" in result_end.payload
+    assert "[truncated 76 characters]" in result_end.payload
+
+
+def test_config_negative_length_validation() -> None:
+    """
+    Verify that `StepAdaptorConfig` raises a `ValidationError` when negative lengths are supplied.
+    """
+    with pytest.raises(ValidationError):
+        StepAdaptorConfig(max_input_length=-1)
+
+    with pytest.raises(ValidationError):
+        StepAdaptorConfig(max_output_length=-1)
+
+
+def test_llm_chunk_payload_fallback(make_intermediate_step: Callable[..., IntermediateStep]) -> None:
+    """
+    Verify that `_handle_llm` extracts token chunks from `step.data.payload` if `chunk` and `output` are `None`.
+    """
+    config = StepAdaptorConfig(stream_llm_tokens=True)
+    adaptor = StepAdaptor(config=config)
+    uuid = "llm-payload-fallback-uuid"
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="Prompt input",
+        UUID=uuid,
+    )
+    adaptor.process(step_start)
+
+    step_token = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        UUID=uuid,
+    )
+    assert step_token.data is not None
+    step_token.data.payload = "chunk from payload"
+
+    result_token = adaptor.process(step_token)
+    assert result_token is not None
+    assert "chunk from payload" in result_token.payload
+
+
+def test_llm_tokens_cleanup_when_end_filtered(make_intermediate_step: Callable[..., IntermediateStep]) -> None:
+    """
+    Verify that `_llm_tokens` buffer is cleaned up upon `LLM_END` even if the end event is filtered out.
+    """
+    config = StepAdaptorConfig(
+        mode=StepAdaptorMode.CUSTOM,
+        custom_event_types=[IntermediateStepType.LLM_START, IntermediateStepType.LLM_NEW_TOKEN],
+        stream_llm_tokens=True,
+    )
+    adaptor = StepAdaptor(config=config)
+    uuid = "llm-filtered-end-uuid"
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="Prompt",
+        UUID=uuid,
+    )
+    step_token = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="streamed chunk",
+        UUID=uuid,
+    )
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_END,
+        data_output="Final Output",
+        UUID=uuid,
+    )
+
+    adaptor.process(step_start)
+    adaptor.process(step_token)
+    assert uuid in adaptor._llm_tokens
+    assert adaptor._llm_tokens[uuid] == "streamed chunk"
+    assert adaptor._llm_token_counts[uuid] == len("streamed chunk")
+    assert uuid in adaptor._llm_inputs
+    assert adaptor._llm_inputs[uuid] == "Prompt"
+
+    result_end = adaptor.process(step_end)
+    assert result_end is None, "LLM_END should be filtered out in this custom mode"
+    assert uuid not in adaptor._llm_tokens, "_llm_tokens must be cleaned up on LLM_END even when filtered"
+    assert uuid not in adaptor._llm_token_counts, "_llm_token_counts must be cleaned up on LLM_END even when filtered"
+    assert uuid not in adaptor._llm_inputs, "_llm_inputs must be cleaned up on LLM_END even when filtered"
+
+
+@pytest.mark.parametrize("empty_output", [None, "", "   "])
+def test_llm_end_output_fallback_to_tokens(
+    make_intermediate_step: Callable[..., IntermediateStep],
+    empty_output: str | None,
+) -> None:
+    """
+    Verify that `LLM_END` falls back to accumulated streaming tokens when `step.data.output` is `None` or empty.
+    """
+    config = StepAdaptorConfig(stream_llm_tokens=True)
+    adaptor = StepAdaptor(config=config)
+    uuid = "llm-end-fallback-uuid"
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="Prompt input",
+        UUID=uuid,
+    )
+    step_token1 = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="streamed ",
+        UUID=uuid,
+    )
+    step_token2 = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="content",
+        UUID=uuid,
+    )
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_END,
+        data_output=empty_output,
+        UUID=uuid,
+    )
+
+    adaptor.process(step_start)
+    adaptor.process(step_token1)
+    adaptor.process(step_token2)
+    assert uuid in adaptor._llm_tokens
+    assert uuid in adaptor._llm_inputs
+
+    result_end = adaptor.process(step_end)
+    assert result_end is not None
+    assert "streamed content" in result_end.payload
+    assert uuid not in adaptor._llm_tokens
+    assert uuid not in adaptor._llm_token_counts
+    assert uuid not in adaptor._llm_inputs
+
+
+def test_llm_token_accumulation_in_default_mode(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
+    """
+    Verify that in default mode (stream_llm_tokens=False), tokens accumulate and emit full output on LLM_END.
+    """
+    uuid = "llm-accum-default-uuid"
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="Prompt input",
+        UUID=uuid,
+    )
+    step_token1 = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="Hello ",
+        UUID=uuid,
+    )
+    step_token2 = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="World!",
+        UUID=uuid,
+    )
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_END,
+        data_output=None,
+        UUID=uuid,
+    )
+
+    result_start = step_adaptor_default.process(step_start)
+    assert result_start is not None
+    assert uuid in step_adaptor_default._llm_inputs
+
+    result_t1 = step_adaptor_default.process(step_token1)
+    assert result_t1 is None
+
+    result_t2 = step_adaptor_default.process(step_token2)
+    assert result_t2 is None
+
+    result_end = step_adaptor_default.process(step_end)
+    assert result_end is not None
+    assert "Hello World!" in result_end.payload
+    assert uuid not in step_adaptor_default._llm_tokens
+    assert uuid not in step_adaptor_default._llm_token_counts
+    assert uuid not in step_adaptor_default._llm_inputs
+
+
+def test_llm_inputs_caching_and_eviction(make_intermediate_step: Callable[..., IntermediateStep]) -> None:
+    """
+    Verify that `_llm_inputs` caches start input during streaming and is evicted on `LLM_END`.
+    """
+    config = StepAdaptorConfig(stream_llm_tokens=True)
+    adaptor = StepAdaptor(config=config)
+    uuid = "llm-inputs-cache-uuid"
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="Cached prompt input",
+        UUID=uuid,
+    )
+    step_token = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="token",
+        UUID=uuid,
+    )
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_END,
+        data_output="Final output",
+        UUID=uuid,
+    )
+
+    res_start = adaptor.process(step_start)
+    assert res_start is not None
+    assert uuid in adaptor._llm_inputs
+    assert adaptor._llm_inputs[uuid] == "Cached prompt input"
+
+    res_token = adaptor.process(step_token)
+    assert res_token is not None
+    assert "Cached prompt input" in res_token.payload
+    assert "token" in res_token.payload
+
+    res_end = adaptor.process(step_end)
+    assert res_end is not None
+    assert "Cached prompt input" in res_end.payload
+    assert "Final output" in res_end.payload
+    assert uuid not in adaptor._llm_inputs
+    assert uuid not in adaptor._llm_tokens
+    assert uuid not in adaptor._llm_token_counts
+
+
+def test_llm_streaming_bounded_memory_many_chunks(make_intermediate_step: Callable[..., IntermediateStep]) -> None:
+    """
+    Verify that streaming many chunks bounds memory in `_llm_tokens` and formats truncation correctly.
+    """
+    max_output_len = 50
+    config = StepAdaptorConfig(stream_llm_tokens=True, max_output_length=max_output_len)
+    adaptor = StepAdaptor(config=config)
+    uuid = "llm-many-chunks-uuid"
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="Start Prompt",
+        UUID=uuid,
+    )
+    adaptor.process(step_start)
+
+    # Stream 500 chunks of 11 characters each (total 5500 characters)
+    for i in range(500):
+        chunk_step = make_intermediate_step(
+            event_type=IntermediateStepType.LLM_NEW_TOKEN,
+            data_output=f"chunk_{i:04d}_",
+            UUID=uuid,
+        )
+        res = adaptor.process(chunk_step)
+        assert res is not None
+        # Bounded buffer must never exceed max_output_len
+        assert len(adaptor._llm_tokens[uuid]) <= max_output_len
+
+    assert adaptor._llm_token_counts[uuid] == 500 * 11
+    assert len(adaptor._llm_tokens[uuid]) == max_output_len
+
+    # Check the emitted result of the last token
+    assert res is not None
+    assert f"[truncated {500 * 11 - 18} characters]" in res.payload
+
+    # End the stream and verify eviction and history retention
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_END,
+        data_output=None,
+        UUID=uuid,
+    )
+    res_end = adaptor.process(step_end)
+    assert res_end is not None
+    assert f"[truncated {500 * 11 - 18} characters]" in res_end.payload
+    assert uuid not in adaptor._llm_tokens
+    assert uuid not in adaptor._llm_token_counts
+    assert uuid not in adaptor._llm_inputs
+    # Only start and end steps are appended to history; none of the 500 tokens
+    assert adaptor._history == [step_start, step_end]
+
+
+def test_llm_new_token_not_appended_to_history(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
+    """
+    Verify that `LLM_NEW_TOKEN` events are not retained in `_history` during streaming.
+    """
+    uuid = "llm-history-filter-uuid"
+
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="Prompt input",
+        UUID=uuid,
+    )
+    step_token1 = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="token 1",
+        UUID=uuid,
+    )
+    step_token2 = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        data_output="token 2",
+        UUID=uuid,
+    )
+    step_end = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_END,
+        data_output="Final response",
+        UUID=uuid,
+    )
+
+    step_adaptor_default.process(step_start)
+    assert step_adaptor_default._history == [step_start]
+
+    step_adaptor_default.process(step_token1)
+    step_adaptor_default.process(step_token2)
+    # Tokens must not be in _history
+    assert step_adaptor_default._history == [step_start]
+    assert step_token1 not in step_adaptor_default._history
+    assert step_token2 not in step_adaptor_default._history
+
+    step_adaptor_default.process(step_end)
+    assert step_adaptor_default._history == [step_start, step_end]
+
+
+def test_llm_new_token_empty_stream_event_data_ignored(
+    step_adaptor_default: StepAdaptor,
+    make_intermediate_step: Callable[..., IntermediateStep],
+) -> None:
+    """
+    Verify that `LLM_NEW_TOKEN` events with empty object data (e.g. `StreamEventData()`) are ignored.
+    """
+    uuid = "llm-empty-data-uuid"
+    step_start = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_START,
+        data_input="Prompt input",
+        UUID=uuid,
+    )
+    step_adaptor_default.process(step_start)
+
+    step_empty = make_intermediate_step(
+        event_type=IntermediateStepType.LLM_NEW_TOKEN,
+        UUID=uuid,
+    )
+    step_empty.payload.data = StreamEventData()
+
+    step_adaptor_default.process(step_empty)
+    # Empty object must not add characters to _llm_token_counts or _llm_tokens
+    assert uuid not in step_adaptor_default._llm_token_counts
+    assert uuid not in step_adaptor_default._llm_tokens


### PR DESCRIPTION
## Description
Closes #1645 

Addresses intermediate step payload bloat and UI freezing in `nat-ui` by introducing payload size bounding and optimizing LLM token stream handling in `StepAdaptor`.

### Key Changes
- **Payload Truncation:** Added `max_input_length` and `max_output_length` to `StepAdaptorConfig` and applied safe truncation across Tool, Function, and LLM input/output steps to prevent large payloads from locking the frontend.
- **LLM Stream Optimization:** Added `stream_llm_tokens` (default: `False`) to `StepAdaptorConfig` to eliminate redundant $O(N^2)$ cumulative prompt/token re-transmissions. When `False`, intermediate `LLM_NEW_TOKEN` events are omitted while `LLM_START` and `LLM_END` remain fully preserved.
- **$O(1)$ Chunk Accumulation:** Replaced quadratic history scans in `_handle_llm` with an in-memory dictionary buffer keyed by step UUID, with automatic cleanup on `LLM_END`.
- **Unit Tests:** Added test coverage in `test_step_adaptor.py` validating truncation limits, stream toggling, and buffer lifecycle.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional LLM token streaming, disabled by default.
  * Added cumulative token buffering for chunked and final response formats.
  * Added configurable input and output length limits, defaulting to 4,000 characters.

* **Bug Fixes**
  * Filtered token events when streaming is disabled.
  * Improved streamed token cleanup and finalization.
  * Applied truncation consistently to LLM, tool, and function data.
  * Added validation to prevent negative length limits.
  * Improved truncation notices to report the actual amount removed.
  * Skipped empty structured token events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->