### PR TITLE
fix: improve content safety guard result handling

### DIFF
--- a/examples/safety_and_security/retail_agent/README.md
+++ b/examples/safety_and_security/retail_agent/README.md
@@ -288,6 +288,27 @@ middleware:
       should be flagged as incorrect.
 ```
 
+**Configuration Example (Content Safety Guard):**
+
+```yaml
+middleware:
+  content_safety_guard_tools:
+    _type: content_safety_guard
+    llm_name: guard_llm
+    target_function_or_group: retail_tools__get_product_info
+    target_location: output
+    target_field: $.reviews[*].review
+    target_field_resolution_strategy: all
+    action: redirection
+    max_content_length: 32000
+```
+
+The content safety guard allows content only when the guard model returns a recognized `Safe` verdict. It handles
+`Unsafe`, `Controversial`, malformed, and unrecognized verdicts according to the configured action. Content longer
+than `max_content_length` and guard-model failures stop protected execution instead of allowing unchecked content.
+Oversized content is not truncated because truncation could omit content that the guard must evaluate. The
+`partial_compliance` action remains a monitoring mode that logs classified violations while allowing content.
+
 **Configuration Example (Pre-Tool Verifier):**
 
 ```yaml

--- a/packages/nvidia_nat_security/src/nat/plugins/security/middleware/defense/defense_middleware_content_guard.py
+++ b/packages/nvidia_nat_security/src/nat/plugins/security/middleware/defense/defense_middleware_content_guard.py
@@ -15,8 +15,8 @@
 """
 Content Safety Guard Middleware.
 
-This middleware uses guard models to classify content as safe or harmful
-with simple Yes/No answers.
+This middleware uses guard models to classify content as safe, unsafe, or
+controversial.
 """
 
 import json
@@ -50,13 +50,19 @@ class ContentSafetyGuardMiddlewareConfig(DefenseMiddlewareConfig, name="content_
 
     llm_name: str = Field(description="Name of the guard model LLM (must be defined in llms section)")
 
+    max_content_length: int = Field(
+        default=32000,
+        gt=0,
+        description="Maximum number of characters sent to the guard model. Content exceeding this limit stops "
+        "protected execution instead of being truncated or sent to the model.")
+
 
 class ContentSafetyGuardMiddleware(DefenseMiddleware):
     """Safety guard middleware using guard models to classify content as safe or unsafe.
 
     This middleware analyzes content using guard models (e.g., NVIDIA Nemoguard, Qwen Guard)
-    that return "Safe" or "Unsafe" classifications. The middleware extracts safety categories
-    when unsafe content is detected.
+    that return "Safe", "Unsafe", or "Controversial" classifications. The middleware extracts
+    safety categories when unsafe content is detected.
 
     Streaming Behavior:
         For 'refusal' and 'redirection' actions, chunks are buffered and checked
@@ -144,11 +150,10 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
     def _parse_guard_response(self, response_text: str) -> GuardResponseResult:
         """Parse guard model response.
 
-        Searches for Safe or Unsafe keywords anywhere in the response (case-insensitive).
-        Works with any guard model format (JSON, structured text, or plain text).
-        Also extracts safety categories from both JSON and text formats.
-        If neither keyword is found, falls back to implicit refusal detection.
-        Prioritizes Unsafe if both keywords are present.
+        Accepts exact Safe, Unsafe, or Controversial verdicts from supported JSON,
+        Qwen Guard text, or plain-text response formats. Also extracts safety
+        categories from JSON and text formats. Treats Controversial, malformed,
+        and unrecognized responses as unsafe.
 
         Args:
             response_text: Raw response from guard model.
@@ -156,43 +161,60 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
         Returns:
             GuardResponseResult with is_safe boolean, categories list, and raw response.
         """
-        cleaned_text = re.sub(r'[*_]+', '', response_text).strip()
-        response_lower = cleaned_text.lower()
-
-        # Search for "Unsafe" or "Safe" anywhere in the response (case-insensitive)
-        # Prioritize "Unsafe" if both are present
-        if re.search(r'\bunsafe\b', response_lower):
-            is_safe = False
-        elif re.search(r'\bsafe\b', response_lower):
-            is_safe = True
-        else:
-            # Detect implicit refusals (model refuses = harmful content detected)
-            refusal_indicators = [
-                "i cannot",
-                "i can't",
-                "i won't",
-                "i will not",
-                "i'm unable",
-                "i am unable",
-                "i refuse",
-                "cannot provide",
-                "can't provide",
-                "won't provide",
-                "illegal",
-                "harmful",
-                "dangerous",
-                "inappropriate"
-            ]
-
-            if any(indicator in response_lower for indicator in refusal_indicators):
-                is_safe = False  # Model refused = harmful detected
-            else:
-                is_safe = True  # Default to safe if unclear
+        verdict = self._extract_guard_verdict(response_text)
+        is_safe = verdict == "safe"
 
         # Extract categories only if unsafe
         categories = self._extract_unsafe_categories(response_text, is_safe)
 
         return GuardResponseResult(is_safe=is_safe, categories=categories, raw_response=response_text)
+
+    @staticmethod
+    def _extract_guard_verdict(response_text: str) -> str | None:
+        """Extract an exact verdict from a supported guard response format.
+
+        Args:
+            response_text: Raw guard response.
+
+        Returns:
+            A lowercase ``safe``, ``unsafe``, or ``controversial`` verdict when recognized; otherwise ``None``.
+        """
+
+        def reject_duplicate_keys(pairs):
+            json_object = {}
+            for key, value in pairs:
+                if key in json_object:
+                    raise ValueError(f"Duplicate JSON field: {key}")
+                json_object[key] = value
+            return json_object
+
+        try:
+            json_data = json.loads(response_text.strip(), object_pairs_hook=reject_duplicate_keys)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            json_data = None
+
+        if isinstance(json_data, dict):
+            verdict_fields = ("User Safety", "Safety", "user_safety", "safety")
+            candidates = [str(json_data[field]).strip().lower() for field in verdict_fields if field in json_data]
+            valid_verdicts = {"safe", "unsafe", "controversial"}
+            if not candidates or any(candidate not in valid_verdicts for candidate in candidates):
+                return None
+            return candidates[0] if len(set(candidates)) == 1 else None
+
+        response_lines = [line.strip() for line in response_text.splitlines() if line.strip()]
+        first_line = response_lines[0].strip("*_").strip() if response_lines else ""
+        match = re.fullmatch(r'(?:Safety\s*:\s*)?(Safe|Unsafe|Controversial)', first_line, re.IGNORECASE)
+        if match is None:
+            return None
+
+        for line in response_lines[1:]:
+            cleaned_line = line.strip("*_").strip()
+            if re.fullmatch(r'(?:Safety\s*:\s*)?(Safe|Unsafe|Controversial)', cleaned_line, re.IGNORECASE):
+                return None
+            if re.match(r'Safety\s*:', cleaned_line, re.IGNORECASE):
+                return None
+
+        return match.group(1).lower()
 
     def _should_refuse(self, parsed_result: GuardResponseResult) -> bool:
         """Determine if content should be refused.
@@ -218,45 +240,40 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
 
         Returns:
             Safety classification result with should_refuse flag
+
+        Raises:
+            ValueError: If content exceeds ``max_content_length``.
+            Exception: Propagates guard loading and invocation failures so protected execution stops.
         """
-        try:
-            # Get the guard model LLM
-            llm = await self._get_llm()
+        content_str = str(content)
+        if len(content_str) > self.config.max_content_length:
+            raise ValueError(f"Content Safety Guard input length {len(content_str)} exceeds configured "
+                             f"max_content_length={self.config.max_content_length}")
 
-            content_str = str(content)
+        llm = await self._get_llm()
 
-            # Call the guard model using messages format to ensure chat template is applied
-            # Format matches: messages = [{"role": "user", "content": prompt}]
-            messages = [{"role": "user", "content": content_str}]
-            response = await llm.ainvoke(messages)
+        # Call the guard model using messages format to ensure chat template is applied
+        # Format matches: messages = [{"role": "user", "content": prompt}]
+        messages = [{"role": "user", "content": content_str}]
+        response = await llm.ainvoke(messages)
 
-            # Extract text from response
-            if hasattr(response, 'content'):
-                response_text = response.content.strip()
-            elif isinstance(response, str):
-                response_text = response.strip()
-            else:
-                response_text = str(response).strip()
-            # Parse the guard model response
+        # Extract text from response
+        if hasattr(response, 'content'):
+            response_text = response.content.strip()
+        elif isinstance(response, str):
+            response_text = response.strip()
+        else:
+            response_text = str(response).strip()
 
-            parsed = self._parse_guard_response(response_text)
-            should_refuse = self._should_refuse(parsed)
+        parsed = self._parse_guard_response(response_text)
+        should_refuse = self._should_refuse(parsed)
 
-            return ContentAnalysisResult(is_safe=parsed.is_safe,
-                                         categories=parsed.categories,
-                                         raw_response=parsed.raw_response,
-                                         should_refuse=should_refuse,
-                                         error=False,
-                                         error_message=None)
-
-        except Exception as e:
-            logger.exception("Content Safety Guard analysis failed: %s", e)
-            return ContentAnalysisResult(is_safe=True,
-                                         categories=[],
-                                         raw_response="",
-                                         should_refuse=False,
-                                         error=True,
-                                         error_message=str(e))
+        return ContentAnalysisResult(is_safe=parsed.is_safe,
+                                     categories=parsed.categories,
+                                     raw_response=parsed.raw_response,
+                                     should_refuse=should_refuse,
+                                     error=False,
+                                     error_message=None)
 
     async def _handle_threat(self,
                              content: Any,
@@ -361,8 +378,10 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
                                                                           func_ctx,
                                                                           original_input=original_input)
             return context
-        except Exception as e:
-            logger.error("Failed to apply content safety guard to function %s: %s", func_ctx.name, e, exc_info=True)
+        except Exception as error:
+            logger.error("Failed to apply content safety guard to function %s (%s); protected execution stopped",
+                         func_ctx.name,
+                         type(error).__name__)
             raise
 
     async def function_middleware_stream(self,
@@ -421,10 +440,10 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
                 for chunk in accumulated_chunks:
                     yield chunk
 
-        except Exception:
+        except Exception as error:
             logger.error(
-                "Failed to apply content safety guard to streaming function %s",
+                "Failed to apply content safety guard to streaming function %s (%s); protected execution stopped",
                 context.name,
-                exc_info=True,
+                type(error).__name__,
             )
             raise

--- a/packages/nvidia_nat_security/src/nat/plugins/security/middleware/defense/defense_middleware_content_guard.py
+++ b/packages/nvidia_nat_security/src/nat/plugins/security/middleware/defense/defense_middleware_content_guard.py
@@ -415,17 +415,23 @@ class ContentSafetyGuardMiddleware(DefenseMiddleware):
         try:
             buffer_chunks = self.config.action in ("refusal", "redirection")
             accumulated_chunks: list[Any] = []
+            serialized_chunks: list[str] = []
+            accumulated_length = 0
 
             async for chunk in call_next(value, *args[1:], **kwargs):
-                if buffer_chunks:
-                    accumulated_chunks.append(chunk)
-                else:
+                serialized_chunk = chunk if isinstance(chunk, str) else str(chunk)
+                accumulated_length += len(serialized_chunk)
+                if accumulated_length > self.config.max_content_length:
+                    raise ValueError(f"Content Safety Guard input length {accumulated_length} exceeds configured "
+                                     f"max_content_length={self.config.max_content_length}")
+
+                accumulated_chunks.append(chunk)
+                serialized_chunks.append(serialized_chunk)
+                if not buffer_chunks:
                     # partial_compliance: stream through, but still accumulate for analysis/logging
                     yield chunk
-                    accumulated_chunks.append(chunk)
 
-            # Join chunks efficiently (only convert to string if needed)
-            full_output = "".join(chunk if isinstance(chunk, str) else str(chunk) for chunk in accumulated_chunks)
+            full_output = "".join(serialized_chunks)
 
             processed_output = await self._process_content_safety_detection(full_output, context, original_input=value)
 

--- a/packages/nvidia_nat_security/tests/middleware/defense/test_defense_middleware_content_guard.py
+++ b/packages/nvidia_nat_security/tests/middleware/defense/test_defense_middleware_content_guard.py
@@ -350,6 +350,180 @@ class TestContentSafetyGuardInvoke:
             mock_logger.warning.assert_called()
             assert result == "harmful content"
 
+    async def test_qwen_guard_controversial_response(self, mock_builder, middleware_context):
+        """Test that a Qwen Guard controversial verdict is refused."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal")
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = "Safety: Controversial\nCategories: None"
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        middleware._llm = mock_llm
+
+        async def mock_next(_value):
+            return "synthetic content"
+
+        with pytest.raises(ValueError, match="Content blocked by safety policy"):
+            await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
+
+    async def test_qwen_guard_safe_response(self, mock_builder, middleware_context):
+        """Test that an exact Qwen Guard safe verdict is allowed."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal")
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = "Safety: Safe\nCategories: None"
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        middleware._llm = mock_llm
+
+        async def mock_next(_value):
+            return "synthetic content"
+
+        result = await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
+
+        assert result == "synthetic content"
+
+    async def test_json_guard_safe_response(self, mock_builder, middleware_context):
+        """Test that an exact JSON safe verdict is allowed."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal")
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = '{"user_safety": "safe", "safety_categories": []}'
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        middleware._llm = mock_llm
+
+        async def mock_next(_value):
+            return "synthetic content"
+
+        result = await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
+
+        assert result == "synthetic content"
+
+    @pytest.mark.parametrize(
+        "response_text",
+        [
+            '{"User Safety": "safe", "Safety": "unsafe"}',
+            '{"Safety": "unsafe", "Safety": "safe"}',
+            "Safety: Safe\nSafety: Unsafe",
+        ],
+        ids=["conflicting-json-fields", "duplicate-json-field", "conflicting-text-verdicts"],
+    )
+    async def test_conflicting_guard_verdicts_refuse(self, mock_builder, middleware_context, response_text):
+        """Test that duplicate or conflicting verdicts are treated as malformed."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal")
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = response_text
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        middleware._llm = mock_llm
+
+        async def mock_next(_value):
+            return "synthetic content"
+
+        with pytest.raises(ValueError, match="Content blocked by safety policy"):
+            await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
+
+    async def test_unrecognized_guard_response_refuses(self, mock_builder, middleware_context):
+        """Test that an unrecognized guard verdict is treated as unsafe."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal")
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = "Safety: Undetermined\nCategories: None"
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        middleware._llm = mock_llm
+
+        async def mock_next(_value):
+            return "synthetic content"
+
+        with pytest.raises(ValueError, match="Content blocked by safety policy"):
+            await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
+
+    @pytest.mark.parametrize(
+        "response_text",
+        ["Safety: Not Safe", "No valid verdict; safe handling unavailable"],
+        ids=["negated-safe", "safe-in-explanation"],
+    )
+    async def test_malformed_guard_response_with_safe_word_refuses(self,
+                                                                   mock_builder,
+                                                                   middleware_context,
+                                                                   response_text):
+        """Test that a Safe keyword outside an exact verdict does not allow content."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal")
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = response_text
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        middleware._llm = mock_llm
+
+        async def mock_next(_value):
+            return "synthetic content"
+
+        with pytest.raises(ValueError, match="Content blocked by safety policy"):
+            await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
+
+    @pytest.mark.parametrize(
+        "guard_error",
+        [RuntimeError("synthetic guard unavailable"), ValueError("synthetic guard context limit exceeded")],
+        ids=["provider-unavailable", "context-limit"],
+    )
+    async def test_guard_model_error_propagates(self, mock_builder, middleware_context, guard_error):
+        """Test that guard model failures stop protected execution."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal")
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(side_effect=guard_error)
+        middleware._llm = mock_llm
+
+        async def mock_next(_value):
+            return "synthetic content"
+
+        with pytest.raises(type(guard_error)) as exc_info:
+            await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
+        assert exc_info.value is guard_error
+
+    async def test_content_at_max_length_reaches_guard(self, mock_builder, middleware_context):
+        """Test that content exactly at the configured limit is analyzed."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal", max_content_length=17)
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        mock_llm = AsyncMock()
+        mock_response = MagicMock()
+        mock_response.content = "Safe"
+        mock_llm.ainvoke = AsyncMock(return_value=mock_response)
+        middleware._llm = mock_llm
+
+        async def mock_next(_value):
+            return "synthetic content"
+
+        result = await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
+
+        assert result == "synthetic content"
+        mock_llm.ainvoke.assert_awaited_once()
+
+    async def test_oversized_content_stops_before_guard(self, mock_builder, middleware_context):
+        """Test that oversized content stops execution without invoking the guard model."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal", max_content_length=16)
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        async def mock_next(_value):
+            return "synthetic content"
+
+        with pytest.raises(ValueError, match=r"input length 17 exceeds configured max_content_length=16"):
+            await middleware.function_middleware_invoke({}, call_next=mock_next, context=middleware_context)
+
+        mock_builder.get_llm.assert_not_called()
+
     async def test_plain_safe_response(self, mock_builder, middleware_context):
         """Test parsing plain "Safe" response."""
         config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="partial_compliance")
@@ -609,3 +783,42 @@ class TestContentSafetyGuardStreaming:
 
         assert chunks == ["chunk1", "chunk2"]
         assert not hasattr(middleware, '_llm') or middleware._llm is None
+
+    async def test_streaming_guard_error_propagates(self, mock_builder, middleware_context):
+        """Test that a streaming guard failure stops protected execution."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal")
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        guard_error = RuntimeError("synthetic guard unavailable")
+        mock_llm = AsyncMock()
+        mock_llm.ainvoke = AsyncMock(side_effect=guard_error)
+        middleware._llm = mock_llm
+
+        async def mock_stream(_value):
+            yield "synthetic "
+            yield "content"
+
+        with pytest.raises(RuntimeError) as exc_info:
+            async for _ in middleware.function_middleware_stream({}, call_next=mock_stream, context=middleware_context):
+                pass
+
+        assert exc_info.value is guard_error
+
+    async def test_streaming_oversized_content_releases_no_chunks(self, mock_builder, middleware_context):
+        """Test that oversized buffered content is blocked before guard invocation or chunk release."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm", action="refusal", max_content_length=16)
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        async def mock_stream(_value):
+            yield "synthetic "
+            yield "content"
+
+        chunks = []
+        with pytest.raises(ValueError, match=r"input length 17 exceeds configured max_content_length=16"):
+            async for chunk in middleware.function_middleware_stream({},
+                                                                     call_next=mock_stream,
+                                                                     context=middleware_context):
+                chunks.append(chunk)
+
+        assert chunks == []
+        mock_builder.get_llm.assert_not_called()

--- a/packages/nvidia_nat_security/tests/middleware/defense/test_defense_middleware_content_guard.py
+++ b/packages/nvidia_nat_security/tests/middleware/defense/test_defense_middleware_content_guard.py
@@ -766,6 +766,31 @@ class TestContentSafetyGuardStreaming:
             assert chunks == ["harmful ", "content"]
             mock_logger.warning.assert_called()
 
+    async def test_streaming_partial_compliance_stops_at_content_limit(self, mock_builder, middleware_context):
+        """Test that partial compliance stops before releasing the first over-limit chunk."""
+        config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm",
+                                                    action="partial_compliance",
+                                                    max_content_length=5)
+        middleware = ContentSafetyGuardMiddleware(config, mock_builder)
+
+        produced_chunks = []
+
+        async def mock_stream(_value):
+            for chunk in ("1234", "5", "6", "not requested"):
+                produced_chunks.append(chunk)
+                yield chunk
+
+        released_chunks = []
+        with pytest.raises(ValueError, match=r"input length 6 exceeds configured max_content_length=5"):
+            async for chunk in middleware.function_middleware_stream({},
+                                                                     call_next=mock_stream,
+                                                                     context=middleware_context):
+                released_chunks.append(chunk)
+
+        assert produced_chunks == ["1234", "5", "6"]
+        assert released_chunks == ["1234", "5"]
+        mock_builder.get_llm.assert_not_called()
+
     async def test_streaming_skips_when_not_targeted(self, mock_builder, middleware_context):
         """Test streaming skips when function not targeted."""
         config = ContentSafetyGuardMiddlewareConfig(llm_name="test_llm",


### PR DESCRIPTION
## Description
<!-- Note: The pull request title will be included in the CHANGELOG. -->
<!-- Provide a standalone description of changes in this PR. -->

Content Safety Guard handling was inconsistent when the guard model returned unsupported or conflicting verdicts, raised an exception, or received content beyond its configured input limit.

This change:

- Accepts only an exact recognized `Safe` verdict as successful.
- Routes unsafe, controversial, conflicting, malformed, and unrecognized verdicts through the configured action.
- Propagates guard initialization and invocation errors to the workflow caller.
- Adds a configurable `max_content_length` check before invoking the guard model.
- Preserves buffered streaming behavior for refusal and redirection actions.
- Documents the updated configuration and result-handling behavior.

Validation completed:

- Repository preflight validation passed.
- Content Safety Guard tests passed: 37 tests.
- Affected package tests passed: 220 tests.
- Streaming failure regression tests passed across three consecutive runs.
- Live smoke tests confirmed successful safe responses, configured handling of other verdicts, provider-error propagation, oversized-input rejection, and successful streaming completion.

Existing dependency-owned Pydantic warnings remain unchanged; this PR does not modify those dependencies.

<!-- Reference any issues closed by this PR with "closes #1234". All PRs should have an issue they close-->
Closes [NAT-444](https://linear.app/nvidia/issue/NAT-444/psirt-content-safety-guard-fail-open-two-bypass-vectors)

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configurable maximum content length for content safety checks.
  * Added support for safe, unsafe, and controversial safety classifications.
  * Added documentation and an example for configuring content safety protection on product review outputs.

* **Bug Fixes**
  * Ambiguous, malformed, oversized, or controversial content is now handled safely.
  * Safety-check failures now surface errors instead of incorrectly allowing content through.
  * Streaming responses are blocked when content exceeds the configured limit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->