### PR TITLE
fix: Preserve optional defaults in ADK tool signatures

### DIFF
--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tool Wrapper file"""
-
 import logging
 import types
 from collections.abc import AsyncIterator
@@ -56,7 +55,7 @@ def resolve_type(t: Any) -> Any:
 def google_adk_tool_wrapper(
     name: str,
     fn: Function,
-    _builder: Builder,  # pylint: disable=W0613
+    _builder: Builder  # pylint: disable=W0613
 ) -> Any:  # Changed from Callable[..., Any] to Any to allow FunctionTool return
     """Wrap a NAT `Function` as a Google ADK `FunctionTool`.
 
@@ -152,9 +151,8 @@ def google_adk_tool_wrapper(
                 if model_fields is not None:
                     field_items = ((n, f.annotation, _field_default(f)) for n, f in model_fields.items())
                 else:
-                    field_items = (
-                        (n, a, inspect.Parameter.empty) for n, a in getattr(input_schema, "__annotations__", {}).items()
-                    )
+                    field_items = ((n, a, inspect.Parameter.empty)
+                                   for n, a in getattr(input_schema, "__annotations__", {}).items())
                 for param_name, param_annotation, default in field_items:
                     params.append(
                         inspect.Parameter(
@@ -162,8 +160,7 @@ def google_adk_tool_wrapper(
                             inspect.Parameter.POSITIONAL_OR_KEYWORD,
                             annotation=resolve_type(param_annotation),
                             default=default,
-                        )
-                    )
+                        ))
             params.sort(key=lambda param: param.default is not inspect.Parameter.empty)
             setattr(func_to_wrap, "__signature__", inspect.Signature(parameters=params))
 

--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py
@@ -77,12 +77,7 @@ def google_adk_tool_wrapper(
             return inspect.Parameter.empty
         default_factory = getattr(field, "default_factory", None)
         if default_factory is not None:
-            if getattr(field, "default_factory_takes_validated_data", False):
-                return None
-            try:
-                return default_factory()
-            except TypeError:
-                return None
+            return None
         return getattr(field, "default", inspect.Parameter.empty)
 
     async def callable_ainvoke(*args: Any, **kwargs: Any) -> Any:

--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py
@@ -77,7 +77,10 @@ def google_adk_tool_wrapper(
             return inspect.Parameter.empty
         default_factory = getattr(field, "default_factory", None)
         if default_factory is not None:
-            return default_factory()
+            try:
+                return default_factory()
+            except TypeError:
+                return None
         return getattr(field, "default", inspect.Parameter.empty)
 
     async def callable_ainvoke(*args: Any, **kwargs: Any) -> Any:

--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 """Tool Wrapper file"""
+
 import logging
 import types
 from collections.abc import AsyncIterator
@@ -55,7 +56,7 @@ def resolve_type(t: Any) -> Any:
 def google_adk_tool_wrapper(
     name: str,
     fn: Function,
-    _builder: Builder  # pylint: disable=W0613
+    _builder: Builder,  # pylint: disable=W0613
 ) -> Any:  # Changed from Callable[..., Any] to Any to allow FunctionTool return
     """Wrap a NAT `Function` as a Google ADK `FunctionTool`.
 
@@ -67,6 +68,18 @@ def google_adk_tool_wrapper(
         A Google ADK `FunctionTool` wrapping the NAT `Function`.
     """
     import inspect
+
+    def _field_default(field: Any) -> Any:
+        """Return a Pydantic field's default for an inspect signature."""
+        is_required = getattr(field, "is_required", None)
+        if is_required is not None and is_required():
+            return inspect.Parameter.empty
+        if getattr(field, "required", False):
+            return inspect.Parameter.empty
+        default_factory = getattr(field, "default_factory", None)
+        if default_factory is not None:
+            return default_factory()
+        return getattr(field, "default", inspect.Parameter.empty)
 
     async def callable_ainvoke(*args: Any, **kwargs: Any) -> Any:
         """Async function to invoke the NAT function.
@@ -137,16 +150,21 @@ def google_adk_tool_wrapper(
             if input_schema is not None:
                 model_fields = getattr(input_schema, "model_fields", None)
                 if model_fields is not None:
-                    field_items = ((n, f.annotation) for n, f in model_fields.items())
+                    field_items = ((n, f.annotation, _field_default(f)) for n, f in model_fields.items())
                 else:
-                    field_items = getattr(input_schema, "__annotations__", {}).items()
-                for param_name, param_annotation in field_items:
+                    field_items = (
+                        (n, a, inspect.Parameter.empty) for n, a in getattr(input_schema, "__annotations__", {}).items()
+                    )
+                for param_name, param_annotation, default in field_items:
                     params.append(
                         inspect.Parameter(
                             param_name,
                             inspect.Parameter.POSITIONAL_OR_KEYWORD,
                             annotation=resolve_type(param_annotation),
-                        ))
+                            default=default,
+                        )
+                    )
+            params.sort(key=lambda param: param.default is not inspect.Parameter.empty)
             setattr(func_to_wrap, "__signature__", inspect.Signature(parameters=params))
 
             return func_to_wrap

--- a/packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py
+++ b/packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py
@@ -77,6 +77,8 @@ def google_adk_tool_wrapper(
             return inspect.Parameter.empty
         default_factory = getattr(field, "default_factory", None)
         if default_factory is not None:
+            if getattr(field, "default_factory_takes_validated_data", False):
+                return None
             try:
                 return default_factory()
             except TypeError:
@@ -154,8 +156,13 @@ def google_adk_tool_wrapper(
                 if model_fields is not None:
                     field_items = ((n, f.annotation, _field_default(f)) for n, f in model_fields.items())
                 else:
-                    field_items = ((n, a, inspect.Parameter.empty)
-                                   for n, a in getattr(input_schema, "__annotations__", {}).items())
+                    legacy_fields = getattr(input_schema, "__fields__", None)
+                    if legacy_fields is not None:
+                        field_items = ((n, getattr(f, "outer_type_", f.annotation), _field_default(f))
+                                       for n, f in legacy_fields.items())
+                    else:
+                        field_items = ((n, a, getattr(input_schema, n, inspect.Parameter.empty))
+                                       for n, a in getattr(input_schema, "__annotations__", {}).items())
                 for param_name, param_annotation, default in field_items:
                     params.append(
                         inspect.Parameter(

--- a/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
@@ -32,6 +32,11 @@ class DummyInput(BaseModel):
     value: int
 
 
+class OptionalInput(BaseModel):
+    optional_value: int = 42
+    required_value: str
+
+
 class DummyOutput(BaseModel):
     result: int
 
@@ -59,7 +64,7 @@ class DummyFunction:
 
     def __init__(self):
         self.description = "Dummy ADK function"
-        self.config = type('Config', (), {'type': 'dummy_adk_func'})
+        self.config = type("Config", (), {"type": "dummy_adk_func"})
         self.has_single_output = True
         self.has_streaming_output = False
         self.input_schema = DummyInput
@@ -76,7 +81,7 @@ class DummyNestedFunction:
 
     def __init__(self):
         self.description = "Nested ADK function"
-        self.config = type('Config', (), {'type': 'nested_adk_func'})
+        self.config = type("Config", (), {"type": "nested_adk_func"})
         self.has_single_output = True
         self.has_streaming_output = False
         self.input_schema = OuterModel
@@ -93,7 +98,7 @@ class DummyStreamingFunction:
 
     def __init__(self):
         self.description = "Streaming ADK function"
-        self.config = type('Config', (), {'type': 'streaming_adk_func'})
+        self.config = type("Config", (), {"type": "streaming_adk_func"})
         self.has_single_output = False
         self.has_streaming_output = True
         self.input_schema = DummyInput
@@ -148,7 +153,7 @@ def test_resolve_type():
     assert resolved is str
 
 
-@patch('google.adk.tools.function_tool.FunctionTool')
+@patch("google.adk.tools.function_tool.FunctionTool")
 @pytest.mark.asyncio
 async def test_google_adk_tool_wrapper_simple_function(mock_function_tool):
     """Test the ADK tool wrapper with a simple function."""
@@ -160,18 +165,18 @@ async def test_google_adk_tool_wrapper_simple_function(mock_function_tool):
     mock_function_tool.return_value = mock_tool_instance
 
     # Call the wrapper
-    result = google_adk_tool_wrapper('dummy_adk_func', dummy_fn, mock_builder)
+    result = google_adk_tool_wrapper("dummy_adk_func", dummy_fn, mock_builder)
 
     # Verify FunctionTool was called
     assert mock_function_tool.called
     assert result == mock_tool_instance
     # Verify the callable was created with correct metadata
     call_args = mock_function_tool.call_args[0][0]
-    assert call_args.__name__ == 'dummy_adk_func'
+    assert call_args.__name__ == "dummy_adk_func"
     assert call_args.__doc__ == "Dummy ADK function"
 
 
-@patch('google.adk.tools.function_tool.FunctionTool')
+@patch("google.adk.tools.function_tool.FunctionTool")
 @pytest.mark.asyncio
 async def test_google_adk_tool_wrapper_nested_function(mock_function_tool):
     """Test the ADK tool wrapper with nested BaseModel input."""
@@ -182,7 +187,7 @@ async def test_google_adk_tool_wrapper_nested_function(mock_function_tool):
     mock_function_tool.return_value = mock_tool_instance
 
     # Call the wrapper
-    result = google_adk_tool_wrapper('nested_adk_func', dummy_fn, mock_builder)
+    result = google_adk_tool_wrapper("nested_adk_func", dummy_fn, mock_builder)
 
     # Verify FunctionTool was called
     assert mock_function_tool.called
@@ -190,11 +195,35 @@ async def test_google_adk_tool_wrapper_nested_function(mock_function_tool):
 
     # Verify the callable was created with correct metadata
     call_args = mock_function_tool.call_args[0][0]
-    assert call_args.__name__ == 'nested_adk_func'
+    assert call_args.__name__ == "nested_adk_func"
     assert call_args.__doc__ == "Nested ADK function"
 
 
-@patch('google.adk.tools.function_tool.FunctionTool')
+@patch("google.adk.tools.function_tool.FunctionTool")
+def test_google_adk_tool_wrapper_preserves_field_defaults(mock_function_tool):
+    """Optional input fields must remain optional in the ADK signature."""
+    import inspect
+
+    class OptionalFunction:
+        description = "Optional ADK function"
+        has_single_output = True
+        has_streaming_output = False
+        input_schema = OptionalInput
+
+        async def acall_invoke(self, *_args, **_kwargs):
+            return None
+
+    google_adk_tool_wrapper("optional_adk_func", OptionalFunction(), MagicMock())
+
+    callable_tool = mock_function_tool.call_args[0][0]
+    signature = inspect.signature(callable_tool)
+
+    assert list(signature.parameters) == ["required_value", "optional_value"]
+    assert signature.parameters["required_value"].default is inspect.Parameter.empty
+    assert signature.parameters["optional_value"].default == 42
+
+
+@patch("google.adk.tools.function_tool.FunctionTool")
 @pytest.mark.asyncio
 async def test_google_adk_tool_wrapper_streaming_function(mock_function_tool):
     """Test the ADK tool wrapper with streaming function."""
@@ -205,7 +234,7 @@ async def test_google_adk_tool_wrapper_streaming_function(mock_function_tool):
     mock_function_tool.return_value = mock_tool_instance
 
     # Call the wrapper
-    result = google_adk_tool_wrapper('streaming_adk_func', dummy_fn, mock_builder)
+    result = google_adk_tool_wrapper("streaming_adk_func", dummy_fn, mock_builder)
 
     # Verify FunctionTool was called
     assert mock_function_tool.called
@@ -213,7 +242,7 @@ async def test_google_adk_tool_wrapper_streaming_function(mock_function_tool):
 
     # Verify the callable was created for streaming
     call_args = mock_function_tool.call_args[0][0]
-    assert call_args.__name__ == 'streaming_adk_func'
+    assert call_args.__name__ == "streaming_adk_func"
     assert call_args.__doc__ == "Streaming ADK function"
 
 
@@ -223,11 +252,11 @@ async def test_callable_ainvoke_functionality():
     dummy_fn = DummyFunction()
 
     # Test the actual callable functionality
-    with patch('google.adk.tools.function_tool.FunctionTool') as mock_function_tool:
+    with patch("google.adk.tools.function_tool.FunctionTool") as mock_function_tool:
         mock_tool_instance = MagicMock()
         mock_function_tool.return_value = mock_tool_instance
 
-        google_adk_tool_wrapper('dummy_adk_func', dummy_fn, None)
+        google_adk_tool_wrapper("dummy_adk_func", dummy_fn, None)
 
         # Get the callable that was passed to FunctionTool
         callable_func = mock_function_tool.call_args[0][0]
@@ -242,11 +271,11 @@ async def test_callable_ainvoke_functionality():
     dummy_fn = DummyStreamingFunction()
 
     # Test the actual streaming callable functionality
-    with patch('google.adk.tools.function_tool.FunctionTool') as mock_function_tool:
+    with patch("google.adk.tools.function_tool.FunctionTool") as mock_function_tool:
         mock_tool_instance = MagicMock()
         mock_function_tool.return_value = mock_tool_instance
 
-        google_adk_tool_wrapper('streaming_adk_func', dummy_fn, None)
+        google_adk_tool_wrapper("streaming_adk_func", dummy_fn, None)
 
         # Get the callable that was passed to FunctionTool
         callable_func = mock_function_tool.call_args[0][0]
@@ -268,7 +297,7 @@ async def test_callable_ainvoke_functionality():
 # ----------------------------
 
 
-@patch('google.adk.tools.function_tool.FunctionTool')
+@patch("google.adk.tools.function_tool.FunctionTool")
 async def test_google_adk_tool_wrapper_pep563_annotations(mock_function_tool):
     """Regression test for GitHub issue #2161.
 
@@ -290,10 +319,7 @@ async def test_google_adk_tool_wrapper_pep563_annotations(mock_function_tool):
     sys.modules[pep563_module.__name__] = pep563_module
     try:
         exec(  # noqa: S102  (safe: controlled test-only string)
-            "from pydantic import BaseModel\n"
-            "class PEP563Input(BaseModel):\n"
-            "    text: str\n"
-            "    count: int\n",
+            "from pydantic import BaseModel\nclass PEP563Input(BaseModel):\n    text: str\n    count: int\n",
             pep563_module.__dict__,
         )
         PEP563Input = pep563_module.PEP563Input  # type: ignore[attr-defined]
@@ -328,9 +354,9 @@ async def test_google_adk_tool_wrapper_pep563_annotations(mock_function_tool):
 
     # All parameters must carry real type objects, not strings.
     for param in sig.parameters.values():
-        assert not isinstance(param.annotation,
-                              str), (f"Parameter '{param.name}' has a string annotation '{param.annotation}'; "
-                                     "expected a resolved type object.")
+        assert not isinstance(param.annotation, str), (
+            f"Parameter '{param.name}' has a string annotation '{param.annotation}'; expected a resolved type object."
+        )
 
     assert sig.parameters["text"].annotation is str
     assert sig.parameters["count"].annotation is int

--- a/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
@@ -195,7 +195,7 @@ async def test_google_adk_tool_wrapper_nested_function(mock_function_tool):
 
     # Verify the callable was created with correct metadata
     call_args = mock_function_tool.call_args[0][0]
-    assert call_args.__name__ == "nested_adk_func"
+    assert call_args.__name__ == 'nested_adk_func'
     assert call_args.__doc__ == "Nested ADK function"
 
 
@@ -242,7 +242,7 @@ async def test_google_adk_tool_wrapper_streaming_function(mock_function_tool):
 
     # Verify the callable was created for streaming
     call_args = mock_function_tool.call_args[0][0]
-    assert call_args.__name__ == "streaming_adk_func"
+    assert call_args.__name__ == 'streaming_adk_func'
     assert call_args.__doc__ == "Streaming ADK function"
 
 

--- a/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
@@ -19,6 +19,7 @@ from unittest.mock import patch
 
 import pytest
 from pydantic import BaseModel
+from pydantic import Field
 
 from nat.plugins.adk.tool_wrapper import google_adk_tool_wrapper
 from nat.plugins.adk.tool_wrapper import resolve_type
@@ -221,6 +222,34 @@ def test_google_adk_tool_wrapper_preserves_field_defaults(mock_function_tool):
     assert list(signature.parameters) == ["required_value", "optional_value"]
     assert signature.parameters["required_value"].default is inspect.Parameter.empty
     assert signature.parameters["optional_value"].default == 42
+
+
+@patch('google.adk.tools.function_tool.FunctionTool')
+def test_google_adk_tool_wrapper_handles_data_aware_default_factory(mock_function_tool):
+    """A default factory requiring validated data must not break signature creation."""
+    import inspect
+
+    class FactoryInput(BaseModel):
+        required_value: str
+        generated: list[str] = Field(default_factory=list)
+        derived: str = Field(default_factory=lambda data: data["required_value"])
+
+    class FactoryFunction:
+        description = "Factory ADK function"
+        has_single_output = True
+        has_streaming_output = False
+        input_schema = FactoryInput
+
+        async def acall_invoke(self, *_args, **_kwargs):
+            return None
+
+    google_adk_tool_wrapper("factory_adk_func", FactoryFunction(), MagicMock())
+
+    signature = inspect.signature(mock_function_tool.call_args[0][0])
+
+    assert list(signature.parameters) == ["required_value", "generated", "derived"]
+    assert signature.parameters["generated"].default == []
+    assert signature.parameters["derived"].default is None
 
 
 @patch('google.adk.tools.function_tool.FunctionTool')

--- a/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
@@ -228,13 +228,19 @@ def test_google_adk_tool_wrapper_preserves_field_defaults(mock_function_tool):
 
 
 @patch('google.adk.tools.function_tool.FunctionTool')
-def test_google_adk_tool_wrapper_handles_data_aware_default_factory(mock_function_tool):
-    """A default factory requiring validated data must not break signature creation."""
+def test_google_adk_tool_wrapper_does_not_evaluate_default_factories(mock_function_tool):
+    """Default factories remain deferred until Pydantic validates the input model."""
     import inspect
+
+    factory_calls = []
+
+    def generate_value():
+        factory_calls.append("called")
+        return ["generated"]
 
     class FactoryInput(BaseModel):
         required_value: str
-        generated: list[str] = Field(default_factory=list)
+        generated: list[str] = Field(default_factory=generate_value)
         derived: str = Field(default_factory=lambda data: data["required_value"])
 
     class FactoryFunction:
@@ -251,8 +257,17 @@ def test_google_adk_tool_wrapper_handles_data_aware_default_factory(mock_functio
     signature = inspect.signature(mock_function_tool.call_args[0][0])
 
     assert list(signature.parameters) == ["required_value", "generated", "derived"]
-    assert signature.parameters["generated"].default == []
+    assert signature.parameters["generated"].default is None
     assert signature.parameters["derived"].default is None
+    assert factory_calls == []
+
+    first = FactoryInput(required_value="first")
+    second = FactoryInput(required_value="second")
+    assert factory_calls == ["called", "called"]
+    assert first.generated == ["generated"]
+    assert second.generated == ["generated"]
+    assert first.derived == "first"
+    assert second.derived == "second"
 
 
 @patch('google.adk.tools.function_tool.FunctionTool')
@@ -269,7 +284,9 @@ def test_google_adk_tool_wrapper_supports_legacy_and_annotation_fields(mock_func
 
     class LegacyInput:
         __fields__: ClassVar[dict[str, object]] = {
-            "required_value": type("RequiredField", (), {"annotation": str, "outer_type_": str, "required": True})(),
+            "required_value": type("RequiredField", (), {
+                "annotation": str, "outer_type_": str, "required": True
+            })(),
             "optional_value": LegacyField(),
         }
 

--- a/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
@@ -34,6 +34,8 @@ class DummyInput(BaseModel):
 
 
 class OptionalInput(BaseModel):
+    """Input model with one required and one optional field."""
+
     optional_value: int = 42
     required_value: str
 
@@ -250,6 +252,53 @@ def test_google_adk_tool_wrapper_handles_data_aware_default_factory(mock_functio
     assert list(signature.parameters) == ["required_value", "generated", "derived"]
     assert signature.parameters["generated"].default == []
     assert signature.parameters["derived"].default is None
+
+
+@patch('google.adk.tools.function_tool.FunctionTool')
+def test_google_adk_tool_wrapper_supports_legacy_and_annotation_fields(mock_function_tool):
+    """Legacy Pydantic and annotation-only schemas must preserve defaults."""
+    import inspect
+
+    class LegacyField:
+        annotation = int
+        outer_type_ = int
+        required = False
+        default = 7
+        default_factory = None
+
+    class LegacyInput:
+        __fields__ = {
+            "required_value": type("RequiredField", (), {"annotation": str, "outer_type_": str, "required": True})(),
+            "optional_value": LegacyField(),
+        }
+
+    class AnnotationInput:
+        __annotations__ = {"required_value": str, "optional_value": int}
+        optional_value = 7
+
+    class LegacyFunction:
+        description = "Legacy ADK function"
+        has_single_output = True
+        has_streaming_output = False
+        input_schema = LegacyInput
+
+        async def acall_invoke(self, *_args, **_kwargs):
+            return None
+
+    class AnnotationFunction(LegacyFunction):
+        input_schema = AnnotationInput
+
+    google_adk_tool_wrapper("legacy_adk_func", LegacyFunction(), MagicMock())
+    legacy_signature = inspect.signature(mock_function_tool.call_args[0][0])
+    assert list(legacy_signature.parameters) == ["required_value", "optional_value"]
+    assert legacy_signature.parameters["required_value"].default is inspect.Parameter.empty
+    assert legacy_signature.parameters["optional_value"].default == 7
+
+    google_adk_tool_wrapper("annotation_adk_func", AnnotationFunction(), MagicMock())
+    annotation_signature = inspect.signature(mock_function_tool.call_args[0][0])
+    assert list(annotation_signature.parameters) == ["required_value", "optional_value"]
+    assert annotation_signature.parameters["required_value"].default is inspect.Parameter.empty
+    assert annotation_signature.parameters["optional_value"].default == 7
 
 
 @patch('google.adk.tools.function_tool.FunctionTool')

--- a/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
@@ -64,7 +64,7 @@ class DummyFunction:
 
     def __init__(self):
         self.description = "Dummy ADK function"
-        self.config = type("Config", (), {"type": "dummy_adk_func"})
+        self.config = type('Config', (), {'type': 'dummy_adk_func'})
         self.has_single_output = True
         self.has_streaming_output = False
         self.input_schema = DummyInput
@@ -81,7 +81,7 @@ class DummyNestedFunction:
 
     def __init__(self):
         self.description = "Nested ADK function"
-        self.config = type("Config", (), {"type": "nested_adk_func"})
+        self.config = type('Config', (), {'type': 'nested_adk_func'})
         self.has_single_output = True
         self.has_streaming_output = False
         self.input_schema = OuterModel
@@ -98,7 +98,7 @@ class DummyStreamingFunction:
 
     def __init__(self):
         self.description = "Streaming ADK function"
-        self.config = type("Config", (), {"type": "streaming_adk_func"})
+        self.config = type('Config', (), {'type': 'streaming_adk_func'})
         self.has_single_output = False
         self.has_streaming_output = True
         self.input_schema = DummyInput
@@ -153,7 +153,7 @@ def test_resolve_type():
     assert resolved is str
 
 
-@patch("google.adk.tools.function_tool.FunctionTool")
+@patch('google.adk.tools.function_tool.FunctionTool')
 @pytest.mark.asyncio
 async def test_google_adk_tool_wrapper_simple_function(mock_function_tool):
     """Test the ADK tool wrapper with a simple function."""
@@ -165,18 +165,18 @@ async def test_google_adk_tool_wrapper_simple_function(mock_function_tool):
     mock_function_tool.return_value = mock_tool_instance
 
     # Call the wrapper
-    result = google_adk_tool_wrapper("dummy_adk_func", dummy_fn, mock_builder)
+    result = google_adk_tool_wrapper('dummy_adk_func', dummy_fn, mock_builder)
 
     # Verify FunctionTool was called
     assert mock_function_tool.called
     assert result == mock_tool_instance
     # Verify the callable was created with correct metadata
     call_args = mock_function_tool.call_args[0][0]
-    assert call_args.__name__ == "dummy_adk_func"
+    assert call_args.__name__ == 'dummy_adk_func'
     assert call_args.__doc__ == "Dummy ADK function"
 
 
-@patch("google.adk.tools.function_tool.FunctionTool")
+@patch('google.adk.tools.function_tool.FunctionTool')
 @pytest.mark.asyncio
 async def test_google_adk_tool_wrapper_nested_function(mock_function_tool):
     """Test the ADK tool wrapper with nested BaseModel input."""
@@ -187,7 +187,7 @@ async def test_google_adk_tool_wrapper_nested_function(mock_function_tool):
     mock_function_tool.return_value = mock_tool_instance
 
     # Call the wrapper
-    result = google_adk_tool_wrapper("nested_adk_func", dummy_fn, mock_builder)
+    result = google_adk_tool_wrapper('nested_adk_func', dummy_fn, mock_builder)
 
     # Verify FunctionTool was called
     assert mock_function_tool.called
@@ -199,7 +199,7 @@ async def test_google_adk_tool_wrapper_nested_function(mock_function_tool):
     assert call_args.__doc__ == "Nested ADK function"
 
 
-@patch("google.adk.tools.function_tool.FunctionTool")
+@patch('google.adk.tools.function_tool.FunctionTool')
 def test_google_adk_tool_wrapper_preserves_field_defaults(mock_function_tool):
     """Optional input fields must remain optional in the ADK signature."""
     import inspect
@@ -223,7 +223,7 @@ def test_google_adk_tool_wrapper_preserves_field_defaults(mock_function_tool):
     assert signature.parameters["optional_value"].default == 42
 
 
-@patch("google.adk.tools.function_tool.FunctionTool")
+@patch('google.adk.tools.function_tool.FunctionTool')
 @pytest.mark.asyncio
 async def test_google_adk_tool_wrapper_streaming_function(mock_function_tool):
     """Test the ADK tool wrapper with streaming function."""
@@ -234,7 +234,7 @@ async def test_google_adk_tool_wrapper_streaming_function(mock_function_tool):
     mock_function_tool.return_value = mock_tool_instance
 
     # Call the wrapper
-    result = google_adk_tool_wrapper("streaming_adk_func", dummy_fn, mock_builder)
+    result = google_adk_tool_wrapper('streaming_adk_func', dummy_fn, mock_builder)
 
     # Verify FunctionTool was called
     assert mock_function_tool.called
@@ -252,11 +252,11 @@ async def test_callable_ainvoke_functionality():
     dummy_fn = DummyFunction()
 
     # Test the actual callable functionality
-    with patch("google.adk.tools.function_tool.FunctionTool") as mock_function_tool:
+    with patch('google.adk.tools.function_tool.FunctionTool') as mock_function_tool:
         mock_tool_instance = MagicMock()
         mock_function_tool.return_value = mock_tool_instance
 
-        google_adk_tool_wrapper("dummy_adk_func", dummy_fn, None)
+        google_adk_tool_wrapper('dummy_adk_func', dummy_fn, None)
 
         # Get the callable that was passed to FunctionTool
         callable_func = mock_function_tool.call_args[0][0]
@@ -271,11 +271,11 @@ async def test_callable_ainvoke_functionality():
     dummy_fn = DummyStreamingFunction()
 
     # Test the actual streaming callable functionality
-    with patch("google.adk.tools.function_tool.FunctionTool") as mock_function_tool:
+    with patch('google.adk.tools.function_tool.FunctionTool') as mock_function_tool:
         mock_tool_instance = MagicMock()
         mock_function_tool.return_value = mock_tool_instance
 
-        google_adk_tool_wrapper("streaming_adk_func", dummy_fn, None)
+        google_adk_tool_wrapper('streaming_adk_func', dummy_fn, None)
 
         # Get the callable that was passed to FunctionTool
         callable_func = mock_function_tool.call_args[0][0]
@@ -297,7 +297,7 @@ async def test_callable_ainvoke_functionality():
 # ----------------------------
 
 
-@patch("google.adk.tools.function_tool.FunctionTool")
+@patch('google.adk.tools.function_tool.FunctionTool')
 async def test_google_adk_tool_wrapper_pep563_annotations(mock_function_tool):
     """Regression test for GitHub issue #2161.
 
@@ -319,7 +319,10 @@ async def test_google_adk_tool_wrapper_pep563_annotations(mock_function_tool):
     sys.modules[pep563_module.__name__] = pep563_module
     try:
         exec(  # noqa: S102  (safe: controlled test-only string)
-            "from pydantic import BaseModel\nclass PEP563Input(BaseModel):\n    text: str\n    count: int\n",
+            "from pydantic import BaseModel\n"
+            "class PEP563Input(BaseModel):\n"
+            "    text: str\n"
+            "    count: int\n",
             pep563_module.__dict__,
         )
         PEP563Input = pep563_module.PEP563Input  # type: ignore[attr-defined]
@@ -354,9 +357,9 @@ async def test_google_adk_tool_wrapper_pep563_annotations(mock_function_tool):
 
     # All parameters must carry real type objects, not strings.
     for param in sig.parameters.values():
-        assert not isinstance(param.annotation, str), (
-            f"Parameter '{param.name}' has a string annotation '{param.annotation}'; expected a resolved type object."
-        )
+        assert not isinstance(param.annotation,
+                              str), (f"Parameter '{param.name}' has a string annotation '{param.annotation}'; "
+                                     "expected a resolved type object.")
 
     assert sig.parameters["text"].annotation is str
     assert sig.parameters["count"].annotation is int

--- a/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
+++ b/packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 from typing import Any
+from typing import ClassVar
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
@@ -267,7 +268,7 @@ def test_google_adk_tool_wrapper_supports_legacy_and_annotation_fields(mock_func
         default_factory = None
 
     class LegacyInput:
-        __fields__ = {
+        __fields__: ClassVar[dict[str, object]] = {
             "required_value": type("RequiredField", (), {"annotation": str, "outer_type_": str, "required": True})(),
             "optional_value": LegacyField(),
         }


### PR DESCRIPTION
## Description

Closes #2183.

`google_adk_tool_wrapper` rebuilt wrapped call signatures without carrying defaults from the Pydantic input model. Google ADK therefore advertised optional tool fields as required.

This change preserves Pydantic field defaults, including default factories, in the wrapped signature and orders required parameters before optional parameters so the resulting Python signature remains valid.

## Compatibility

Required fields remain required. Fields with defaults are now optional in the Google ADK tool declaration. The change does not require an external LLM or API service.

## Tests

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTHONPATH=test_stubs;packages/nvidia_nat_adk/src;packages/nvidia_nat_core/src uv run --offline --python 3.12 --no-project --with "pydantic>=2,<3" --with pytest --with pytest-asyncio python -m pytest -p pytest_asyncio.plugin --asyncio-mode=auto packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py -q` — 9 passed, covering Pydantic v1/v2 metadata, annotation-only defaults, parameter ordering, and data-aware `default_factory` handling.
- `uv run --offline --no-project --with "pydantic>=2,<3" --with mypy python -m mypy --ignore-missing-imports packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py` — passed.
- `python -m ruff check packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py` — passed.
- `python -m compileall -q packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py` — passed.
- `python -m ruff format --check packages/nvidia_nat_adk/src/nat/plugins/adk/tool_wrapper.py packages/nvidia_nat_adk/tests/test_adk_tool_wrapper.py` — reports both files would be reformatted; no formatter writes were kept because the same result is present before this change.

## Limitations

The full repository checkout and full CI suite were not run because GitHub Git transport and codeload downloads terminated with TLS EOF errors in the local environment. The focused test was run against a REST-reconstructed source subset with test-only import stubs; the stubs are not part of this PR. Running the other ADK package tests in that subset stops during collection because the subset does not contain the core `nat.data_models` and `nat.llm` modules those tests import.

## By Submitting this PR I confirm:

- I am familiar with the Contributing Guidelines and have followed them.
- I have signed off on my commit as required by the Developer Certificate of Origin.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date or not required for this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tool parameter handling so required fields and configured defaults are preserved correctly.
  * Added support for literal defaults, generated list defaults, and data-aware default values.
  * Improved compatibility with legacy and annotation-only schema formats.
  * Prevented errors when processing default factories that require validated input data.

* **Tests**
  * Added regression coverage for field metadata, required-field ordering, and supported default types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->