### PR TITLE
fix(core): support zero-argument functions

### DIFF
--- a/packages/nvidia_nat_core/src/nat/builder/function_info.py
+++ b/packages/nvidia_nat_core/src/nat/builder/function_info.py
@@ -674,7 +674,7 @@ class FunctionInfo:
                         single_fn = _stream_to_single_output_empty
 
                     else:
-                        single_input_type = sig.parameters[list(sig.parameters.keys())[0]].annotation
+                        single_input_type = next(iter(sig.parameters.values())).annotation
 
                         async def _stream_to_single_output(message: single_input_type) -> single_output_type:
                             values = []

--- a/packages/nvidia_nat_core/src/nat/builder/function_info.py
+++ b/packages/nvidia_nat_core/src/nat/builder/function_info.py
@@ -453,7 +453,22 @@ class FunctionInfo:
 
             final_single_fn_desc = FunctionDescriptor.from_function(final_single_fn)
 
-            if (final_single_fn_desc.arg_count > 1):
+            if (final_single_fn_desc.arg_count == 0):
+                input_schema = input_schema or create_model("EmptyInputSchema")
+
+                saved_final_single_fn = final_single_fn
+
+                async def _convert_input_pydantic_empty(
+                        value: input_schema) -> final_single_fn_desc.output_type:
+                    no_args_fn = typing.cast(Callable[[], Awaitable[typing.Any]], saved_final_single_fn)
+                    return await no_args_fn()
+
+                final_single_fn = _convert_input_pydantic_empty
+
+                # Reset the descriptor
+                final_single_fn_desc = FunctionDescriptor.from_function(final_single_fn)
+
+            elif (final_single_fn_desc.arg_count > 1):
                 if (input_schema is not None):
                     logger.warning("Using provided input_schema for multi-argument function")
                 else:
@@ -495,7 +510,23 @@ class FunctionInfo:
 
             final_stream_fn_desc = FunctionDescriptor.from_function(final_stream_fn)
 
-            if (final_stream_fn_desc.arg_count > 1):
+            if (final_stream_fn_desc.arg_count == 0):
+                input_schema = input_schema or create_model("EmptyInputSchema")
+
+                saved_final_stream_fn = final_stream_fn
+
+                async def _convert_input_pydantic_empty_stream(
+                        value: input_schema) -> AsyncGenerator[final_stream_fn_desc.output_type]:
+                    no_args_fn = typing.cast(Callable[[], AsyncGenerator[typing.Any]], saved_final_stream_fn)
+                    async for m in no_args_fn():
+                        yield m
+
+                final_stream_fn = _convert_input_pydantic_empty_stream
+
+                # Reset the descriptor
+                final_stream_fn_desc = FunctionDescriptor.from_function(final_stream_fn)
+
+            elif (final_stream_fn_desc.arg_count > 1):
                 if (input_schema is not None):
                     logger.warning("Using provided input_schema for multi-argument function")
                 else:

--- a/packages/nvidia_nat_core/src/nat/builder/function_info.py
+++ b/packages/nvidia_nat_core/src/nat/builder/function_info.py
@@ -411,14 +411,27 @@ class FunctionInfo:
             if (single_fn_desc.output_type != single_to_stream_fn_desc.input_type):
                 raise ValueError("single_to_stream_fn must have the same input type as the output from single_fn")
 
-            async def _converted_stream_fn(
-                    message: single_fn_desc.input_type) -> AsyncGenerator[single_to_stream_fn_desc.output_type]:
-                value = await single_fn(message)
+            if (single_fn_desc.arg_count == 0):
 
-                async for m in single_to_stream_fn(value):
-                    yield m
+                async def _converted_stream_fn_empty() -> AsyncGenerator[single_to_stream_fn_desc.output_type]:
+                    no_args_fn = typing.cast(Callable[[], Awaitable[typing.Any]], single_fn)
+                    value = await no_args_fn()
 
-            final_stream_fn = _converted_stream_fn
+                    async for m in single_to_stream_fn(value):
+                        yield m
+
+                final_stream_fn = _converted_stream_fn_empty
+
+            else:
+
+                async def _converted_stream_fn(
+                        message: single_fn_desc.input_type) -> AsyncGenerator[single_to_stream_fn_desc.output_type]:
+                    value = await single_fn(message)
+
+                    async for m in single_to_stream_fn(value):
+                        yield m
+
+                final_stream_fn = _converted_stream_fn
 
         if (stream_to_single_fn is not None):
 
@@ -442,11 +455,21 @@ class FunctionInfo:
                 raise ValueError("stream_to_single_fn must take an async generator with "
                                  "the same input type as the output from stream_fn")
 
-            async def _converted_single_fn(message: stream_fn_desc.input_type) -> stream_to_single_fn_desc.output_type:
+            if (stream_fn_desc.arg_count == 0):
 
-                return await stream_to_single_fn(stream_fn(message))
+                async def _converted_single_fn_empty() -> stream_to_single_fn_desc.output_type:
+                    no_args_fn = typing.cast(Callable[[], AsyncGenerator[typing.Any]], stream_fn)
+                    return await stream_to_single_fn(no_args_fn())
 
-            final_single_fn = _converted_single_fn
+                final_single_fn = _converted_single_fn_empty
+
+            else:
+
+                async def _converted_single_fn(
+                        message: stream_fn_desc.input_type) -> stream_to_single_fn_desc.output_type:
+                    return await stream_to_single_fn(stream_fn(message))
+
+                final_single_fn = _converted_single_fn
 
         # Check the input/output of the functions to make sure they are all BaseModels
         if (final_single_fn is not None):
@@ -635,18 +658,33 @@ class FunctionInfo:
                         break
 
                 if (stream_arg):
-                    single_input_type = sig.parameters[list(sig.parameters.keys())[0]].annotation
                     single_output_type = stream_arg.single_output_type
 
-                    async def _stream_to_single_output(message: single_input_type) -> single_output_type:
-                        values = []
+                    if (len(sig.parameters) == 0):
 
-                        async for m in stream_fn(message):
-                            values.append(m)
+                        async def _stream_to_single_output_empty() -> single_output_type:
+                            values = []
 
-                        return stream_arg.convert(values)
+                            no_args_stream_fn = typing.cast(Callable[[], AsyncGenerator[typing.Any]], stream_fn)
+                            async for m in no_args_stream_fn():
+                                values.append(m)
 
-                    single_fn = _stream_to_single_output
+                            return stream_arg.convert(values)
+
+                        single_fn = _stream_to_single_output_empty
+
+                    else:
+                        single_input_type = sig.parameters[list(sig.parameters.keys())[0]].annotation
+
+                        async def _stream_to_single_output(message: single_input_type) -> single_output_type:
+                            values = []
+
+                            async for m in stream_fn(message):
+                                values.append(m)
+
+                            return stream_arg.convert(values)
+
+                        single_fn = _stream_to_single_output
 
         elif (inspect.iscoroutinefunction(fn)):
             single_fn = fn

--- a/packages/nvidia_nat_core/src/nat/builder/function_info.py
+++ b/packages/nvidia_nat_core/src/nat/builder/function_info.py
@@ -481,8 +481,7 @@ class FunctionInfo:
 
                 saved_final_single_fn = final_single_fn
 
-                async def _convert_input_pydantic_empty(
-                        value: input_schema) -> final_single_fn_desc.output_type:
+                async def _convert_input_pydantic_empty(value: input_schema) -> final_single_fn_desc.output_type:
                     no_args_fn = typing.cast(Callable[[], Awaitable[typing.Any]], saved_final_single_fn)
                     return await no_args_fn()
 

--- a/packages/nvidia_nat_core/tests/nat/builder/test_function_info.py
+++ b/packages/nvidia_nat_core/tests/nat/builder/test_function_info.py
@@ -17,6 +17,7 @@ import inspect
 import typing
 from collections.abc import AsyncGenerator
 from collections.abc import Callable
+from collections.abc import Sequence
 from types import NoneType
 
 import pytest
@@ -68,11 +69,20 @@ async def fn_no_args_to_str_stream() -> AsyncGenerator[str]:
     yield "no args stream"
 
 
-def collect_strings(values: list[str]) -> str:
+def collect_strings(values: Sequence[str]) -> str:
+    """Combine streamed strings into one result.
+
+    Args:
+        values: The streamed string values.
+
+    Returns:
+        The concatenated string.
+    """
     return "".join(values)
 
 
 async def fn_no_args_streaming() -> typing.Annotated[AsyncGenerator[str], Streaming(convert=collect_strings)]:
+    """Yield values from a zero-argument streaming function."""
     yield "streaming"
 
 

--- a/packages/nvidia_nat_core/tests/nat/builder/test_function_info.py
+++ b/packages/nvidia_nat_core/tests/nat/builder/test_function_info.py
@@ -59,6 +59,14 @@ async def fn_int_to_str(param: int) -> str:
     return str(param)
 
 
+async def fn_no_args_to_str() -> str:
+    return "no args"
+
+
+async def fn_no_args_to_str_stream() -> AsyncGenerator[str]:
+    yield "no args stream"
+
+
 async def fn_int_annotated_to_str(param: typing.Annotated[int, ...]) -> str:
     return str(param)
 
@@ -831,6 +839,17 @@ async def test_create_and_from_fn_description():
 
     assert info_from_fn.description == "Test Description"
     assert info_create.description == "Test Description"
+
+
+async def test_create_and_from_fn_no_args():
+    single_info = FunctionInfo.from_fn(fn_no_args_to_str)
+    assert single_info.input_schema.model_fields == {}
+    assert await single_info.single_fn(single_info.input_schema()) == "no args"
+
+    stream_info = FunctionInfo.from_fn(fn_no_args_to_str_stream)
+    assert stream_info.input_schema.model_fields == {}
+    values = [value async for value in stream_info.stream_fn(stream_info.input_schema())]
+    assert values == ["no args stream"]
 
 
 async def test_create_and_from_fn_input_schema():

--- a/packages/nvidia_nat_core/tests/nat/builder/test_function_info.py
+++ b/packages/nvidia_nat_core/tests/nat/builder/test_function_info.py
@@ -879,8 +879,7 @@ async def test_create_no_args_conversions():
     async def convert_to_stream(value: str) -> AsyncGenerator[int]:
         yield len(value)
 
-    single_to_stream_info = FunctionInfo.create(single_fn=fn_no_args_to_str,
-                                                single_to_stream_fn=convert_to_stream)
+    single_to_stream_info = FunctionInfo.create(single_fn=fn_no_args_to_str, single_to_stream_fn=convert_to_stream)
     assert await single_to_stream_info.single_fn(single_to_stream_info.input_schema()) == "no args"
     values = [value async for value in single_to_stream_info.stream_fn(single_to_stream_info.input_schema())]
     assert values == [len("no args")]

--- a/packages/nvidia_nat_core/tests/nat/builder/test_function_info.py
+++ b/packages/nvidia_nat_core/tests/nat/builder/test_function_info.py
@@ -25,6 +25,7 @@ from pydantic import Field
 
 from nat.builder.function_info import FunctionDescriptor
 from nat.builder.function_info import FunctionInfo
+from nat.data_models.streaming import Streaming
 
 
 def _compare_dicts_partial(test_dict: dict, valid_dict: dict):
@@ -65,6 +66,14 @@ async def fn_no_args_to_str() -> str:
 
 async def fn_no_args_to_str_stream() -> AsyncGenerator[str]:
     yield "no args stream"
+
+
+def collect_strings(values: list[str]) -> str:
+    return "".join(values)
+
+
+async def fn_no_args_streaming() -> typing.Annotated[AsyncGenerator[str], Streaming(convert=collect_strings)]:
+    yield "streaming"
 
 
 async def fn_int_annotated_to_str(param: typing.Annotated[int, ...]) -> str:
@@ -850,6 +859,28 @@ async def test_create_and_from_fn_no_args():
     assert stream_info.input_schema.model_fields == {}
     values = [value async for value in stream_info.stream_fn(stream_info.input_schema())]
     assert values == ["no args stream"]
+
+    streaming_info = FunctionInfo.from_fn(fn_no_args_streaming)
+    assert await streaming_info.single_fn(streaming_info.input_schema()) == "streaming"
+
+
+async def test_create_no_args_conversions():
+
+    async def convert_to_stream(value: str) -> AsyncGenerator[int]:
+        yield len(value)
+
+    single_to_stream_info = FunctionInfo.create(single_fn=fn_no_args_to_str,
+                                                single_to_stream_fn=convert_to_stream)
+    assert await single_to_stream_info.single_fn(single_to_stream_info.input_schema()) == "no args"
+    values = [value async for value in single_to_stream_info.stream_fn(single_to_stream_info.input_schema())]
+    assert values == [len("no args")]
+
+    async def convert_to_single(values: AsyncGenerator[str]) -> int:
+        return len("".join([value async for value in values]))
+
+    stream_to_single_info = FunctionInfo.create(stream_fn=fn_no_args_to_str_stream,
+                                                stream_to_single_fn=convert_to_single)
+    assert await stream_to_single_info.single_fn(stream_to_single_info.input_schema()) == len("no args stream")
 
 
 async def test_create_and_from_fn_input_schema():


### PR DESCRIPTION
## Summary

`FunctionInfo.from_fn` rejected valid zero-argument coroutine and async-generator functions because the function descriptor recognized the zero-argument case but `FunctionInfo.create` only adapted functions with multiple arguments.

This change adapts zero-argument functions to the existing single-input pipeline with an empty Pydantic input model. The original callable is invoked without arguments, while framework consumers continue to receive one validated input object. Both single and streaming function paths are covered, including explicit conversion helpers and `Streaming` metadata; existing one- and multi-argument behavior is unchanged.

## Validation

- `PYTHONPATH=packages/nvidia_nat_core/src python -m pytest packages/nvidia_nat_core/tests/nat/builder/test_function_info.py -q --no-cov` — 128 passed
- `ruff check packages/nvidia_nat_core/src/nat/builder/function_info.py packages/nvidia_nat_core/tests/nat/builder/test_function_info.py` — passed
- `python -m compileall -q packages/nvidia_nat_core/src/nat/builder/function_info.py packages/nvidia_nat_core/tests/nat/builder/test_function_info.py` — passed
- `git diff --check` — passed

The full core-package test collection was attempted locally but is limited by missing optional dependencies and Windows-only incompatibilities; the focused builder suite runs successfully.

Closes #2184.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved support for zero-argument functions that produce single results or streams.
  - Fixed conversions between single-result and streaming outputs for functions without input parameters.
  - Preserved streamed values when converting results, including annotated streaming functions.
  - Added empty input schemas for zero-argument functions, ensuring these functions execute without requiring input messages.
  - Improved handling of streaming functions that convert multiple emitted values into a single result.

- **Tests**
  - Added coverage for zero-argument streaming functions and single/stream result conversions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->