### PR TITLE
fix(langchain): support Windows graph paths

### DIFF
--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
@@ -193,6 +193,17 @@ class LanggraphWrapperFunction(Function[LanggraphWrapperInput, LanggraphWrapperO
         return ChatResponseChunk.from_string(text)
 
 
+def split_graph_path(graph: str) -> tuple[str, str]:
+    """Split a graph reference into its module path and graph name."""
+    module_path, separator, name = graph.rpartition(":")
+    if not separator or not module_path or not name:
+        raise ValueError(
+            f"Graph definition path '{graph}' must contain a non-empty module path and graph name "
+            "separated by a colon (e.g., '/path/to/module.py:graph_name').")
+
+    return module_path, name
+
+
 @register_function(config_type=LanggraphWrapperConfig, framework_wrappers=[LLMFrameworkEnum.LANGCHAIN])
 async def register(config: LanggraphWrapperConfig, b: Builder):
 
@@ -227,14 +238,7 @@ async def register(config: LanggraphWrapperConfig, b: Builder):
                     f"Env '{config.env}' is not a valid type. At the moment, we only support strings and dictionaries.")
 
         # Now process the graph.
-        # Check that config.graph contains exactly one colon
-        if config.graph.count(":") != 1:
-            raise ValueError(
-                f"Graph definition path '{config.graph}' must contain exactly one colon to split module and name "
-                f"(e.g., '/path/to/module.py:graph_name'). Found {config.graph.count(':')}.")
-
-        # Split the graph path into module and name
-        module_path, name = config.graph.rsplit(":", 1)
+        module_path, name = split_graph_path(config.graph)
 
         unique_module_name = f"langgraph_workflow_{uuid.uuid4().hex[:8]}"
 

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py
@@ -197,9 +197,8 @@ def split_graph_path(graph: str) -> tuple[str, str]:
     """Split a graph reference into its module path and graph name."""
     module_path, separator, name = graph.rpartition(":")
     if not separator or not module_path or not name:
-        raise ValueError(
-            f"Graph definition path '{graph}' must contain a non-empty module path and graph name "
-            "separated by a colon (e.g., '/path/to/module.py:graph_name').")
+        raise ValueError(f"Graph definition path '{graph}' must contain a non-empty module path and graph name "
+                         "separated by a colon (e.g., '/path/to/module.py:graph_name').")
 
     return module_path, name
 

--- a/packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py
+++ b/packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py
@@ -28,6 +28,27 @@ from nat.data_models.api_server import UserMessageContentRoleType
 from nat.plugins.langchain.langgraph_workflow import LanggraphWrapperFunction
 from nat.plugins.langchain.langgraph_workflow import LanggraphWrapperInput
 from nat.plugins.langchain.langgraph_workflow import LanggraphWrapperOutput
+from nat.plugins.langchain.langgraph_workflow import split_graph_path
+
+
+@pytest.mark.parametrize(
+    ("graph", "expected"),
+    [
+        ("/path/to/module.py:graph_name", ("/path/to/module.py", "graph_name")),
+        (r"C:\\path\\to\\module.py:graph", (r"C:\\path\\to\\module.py", "graph")),
+        ("relative.py:graph", ("relative.py", "graph")),
+    ],
+)
+def test_split_graph_path(graph, expected):
+    """Graph references split at the final colon, including Windows drive paths."""
+    assert split_graph_path(graph) == expected
+
+
+@pytest.mark.parametrize("graph", ["module.py", ":graph", "module.py:", ""])
+def test_split_graph_path_rejects_missing_parts(graph):
+    """Graph references require both a module path and graph name."""
+    with pytest.raises(ValueError, match="non-empty module path"):
+        split_graph_path(graph)
 
 
 class TestConvertChatRequest:


### PR DESCRIPTION
## Summary

- allow Windows drive-letter paths in `langgraph_wrapper` graph references
- keep rejecting references with a missing module path, separator, or graph name
- extract parsing into a unit-testable helper and cover POSIX, Windows, relative, and invalid forms

## Validation

- `python -m pytest packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py -q` (26 passed)
- `ruff check packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py`
- `python -m compileall -q packages/nvidia_nat_langchain/src/nat/plugins/langchain/langgraph_workflow.py packages/nvidia_nat_langchain/tests/test_langgraph_workflow.py`
- `git diff --check`

Closes #2185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved LangGraph reference parsing to support module paths containing additional colons, including Windows-style paths.
  * Added validation to reject references with missing module paths or graph names.

* **Tests**
  * Added coverage for Unix-style, Windows-style, and relative module paths, plus invalid references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->