### PR TITLE
fix(core): allow FunctionInfo.from_fn to accept zero-argument functions

### DIFF
--- a/packages/nvidia_nat_core/src/nat/builder/function_info.py
+++ b/packages/nvidia_nat_core/src/nat/builder/function_info.py
@@ -453,7 +453,23 @@ class FunctionInfo:
 
             final_single_fn_desc = FunctionDescriptor.from_function(final_single_fn)
 
-            if (final_single_fn_desc.arg_count > 1):
+            if (final_single_fn_desc.arg_count == 0):
+                # Zero-argument function: wrap in a single-parameter shim with an empty model
+                if (input_schema is None):
+                    input_schema = create_model(f"{final_single_fn.__name__}Input")
+
+                saved_final_single_fn = final_single_fn
+
+                async def _convert_input_pydantic(value: input_schema) -> final_single_fn_desc.output_type:
+                    # Ignore the empty model, call the original function with no arguments
+                    return await saved_final_single_fn()
+
+                final_single_fn = _convert_input_pydantic
+
+                # Reset the descriptor
+                final_single_fn_desc = FunctionDescriptor.from_function(final_single_fn)
+
+            elif (final_single_fn_desc.arg_count > 1):
                 if (input_schema is not None):
                     logger.warning("Using provided input_schema for multi-argument function")
                 else:

--- a/packages/nvidia_nat_core/tests/nat/builder/test_function_info_future_annotations.py
+++ b/packages/nvidia_nat_core/tests/nat/builder/test_function_info_future_annotations.py
@@ -101,3 +101,26 @@ async def test_from_fn_multi_argument_resolves_future_annotations():
     assert info.single_fn is not None
     value = info.input_schema(first="a: ", second=EchoInput(text="b"))
     assert await info.single_fn(value) == "a: b"
+
+
+async def test_from_fn_zero_argument():
+    """Regression test for zero-argument functions (issue #2184)."""
+
+    async def get_status() -> str:
+        return "ok"
+
+    info = FunctionInfo.from_fn(get_status, description="get status")
+
+    # The function should be wrapped with an empty input model
+    assert info.input_schema is not None
+    assert len(info.input_schema.model_fields) == 0
+
+    assert info.single_fn is not None
+    # Call with an empty model instance
+    value = info.input_schema()
+    assert await info.single_fn(value) == "ok"
+
+    # The auto-synthesized streaming wrapper should also work
+    assert info.stream_fn is not None
+    chunks = [chunk async for chunk in info.stream_fn(info.input_schema())]
+    assert chunks == ["ok"]


### PR DESCRIPTION
## Problem

`FunctionInfo.from_fn` rejects functions with no parameters. A zero-argument function is recognised when the descriptor is built, but never wrapped, so it reaches `_validate_single_fn` which requires exactly one parameter and raises `ValueError`.

Functions with 0 or 1 parameters pass through unchanged, while functions with >1 parameters are wrapped in a Pydantic model shim. The zero-argument case is an oversight.

No-input tools are common - fetch the current policy, get the current time, list everything, health check.

Fixes #2184

## Solution

Add an `arg_count == 0` branch in `FunctionInfo.create` that wraps the zero-argument function in a single-parameter shim taking an empty Pydantic model, mirroring the existing `arg_count > 1` handling. This allows the rest of the pipeline to continue seeing exactly one input parameter.

## Changes

- `packages/nvidia_nat_core/src/nat/builder/function_info.py`: Add zero-argument function wrapping
- `packages/nvidia_nat_core/tests/nat/builder/test_function_info_future_annotations.py`: Add regression test

## Testing

All 319 existing builder tests pass. New test `test_from_fn_zero_argument` verifies:
- Zero-argument function is wrapped with an empty input model
- The wrapped function can be called with an empty model instance
- The auto-synthesized streaming wrapper also works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling for single functions that require no arguments.
  * Zero-argument asynchronous functions now support input validation and streaming correctly.

* **Tests**
  * Added regression coverage for invoking and streaming zero-argument asynchronous functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->