### PR TITLE
fix `haystack_deep_research_agent` example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,6 @@ examples/notebooks/examples/retail_sales_agent/deploy/volumes/
 
 # End of https://www.gitignore.io/api/vim,c++,cmake,python,synology
 /.idea
+
+# PDF file downloaded in examples/frameworks/haystack_deep_research_agent example
+examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/data/bedrock-ug.pdf

--- a/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/configs/config.yml
+++ b/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/configs/config.yml
@@ -17,14 +17,17 @@ llms:
   rag_llm:
     _type: nim
     model: nvidia/nemotron-3-super-120b-a12b
+    base_url: https://integrate.api.nvidia.com:443/v1
   agent_llm:
     _type: nim
     model: nvidia/nemotron-3-super-120b-a12b
+    base_url: https://integrate.api.nvidia.com:443/v1
 
 embedders:
   nv-embed:
     _type: nim
     model: nvidia/nemotron-3-embed-1b
+    base_url: https://integrate.api.nvidia.com:443/v1
 
 workflow:
   _type: haystack_deep_research_agent

--- a/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/configs/config.yml
+++ b/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/configs/config.yml
@@ -32,10 +32,10 @@ embedders:
 workflow:
   _type: haystack_deep_research_agent
   max_agent_steps: 20
-  search_top_k: 10
+  search_top_k: 3
   rag_top_k: 15
   opensearch_url: http://localhost:9200
   index_on_startup: true
   data_dir: examples/frameworks/haystack_deep_research_agent/data
   embedder_name: nv-embed
-  embedding_dim: 1024
+  embedding_dim: 2048

--- a/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/pipelines/indexing.py
+++ b/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/pipelines/indexing.py
@@ -32,7 +32,11 @@ def _gather_sources(base_dir: Path) -> tuple[list[Path], list[Path]]:
     return pdfs, texts
 
 
-def _build_indexing_pipeline(document_store, embedder_model: str) -> Pipeline:
+def _build_indexing_pipeline(
+    document_store,
+    embedder_model: str,
+    embedder_api_url: str | None = None,
+) -> Pipeline:
     p = Pipeline()
     p.add_component("joiner", DocumentJoiner())
     p.add_component("cleaner", DocumentCleaner())
@@ -42,10 +46,15 @@ def _build_indexing_pipeline(document_store, embedder_model: str) -> Pipeline:
         "splitter",
         DocumentSplitter(split_by="word", split_length=200, split_overlap=30),
     )
-    p.add_component(
-        "embedder",
-        NvidiaDocumentEmbedder(model=embedder_model, truncate="END"),
-    )
+    if embedder_api_url:
+        document_embedder = NvidiaDocumentEmbedder(
+            model=embedder_model,
+            api_url=embedder_api_url,
+            truncate="END",
+        )
+    else:
+        document_embedder = NvidiaDocumentEmbedder(model=embedder_model, truncate="END")
+    p.add_component("embedder", document_embedder)
     p.add_component(
         "writer",
         DocumentWriter(document_store=document_store, policy=DuplicatePolicy.SKIP),
@@ -59,6 +68,7 @@ def run_startup_indexing(
     logger,
     *,
     embedder_model: str,
+    embedder_api_url: str | None = None,
 ) -> None:
     try:
         if not embedder_model:
@@ -92,7 +102,11 @@ def run_startup_indexing(
                 len(text_sources),
             )
 
-            indexing_pipeline = _build_indexing_pipeline(document_store, embedder_model)
+            indexing_pipeline = _build_indexing_pipeline(
+                document_store,
+                embedder_model,
+                embedder_api_url,
+            )
 
             pipeline_data = {}
             if len(pdf_sources) > 0:

--- a/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/pipelines/rag.py
+++ b/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/pipelines/rag.py
@@ -29,6 +29,7 @@ def create_rag_tool(
     top_k: int = 15,
     generator: NvidiaChatGenerator | None = None,
     embedder_model: str,
+    embedder_api_url: str | None = None,
 ) -> tuple[ComponentTool, Pipeline]:
     """
     Build a RAG tool composed of OpenSearch retriever and NvidiaChatGenerator.
@@ -38,6 +39,7 @@ def create_rag_tool(
         top_k: Number of documents to retrieve for RAG.
         generator: Pre-configured NvidiaChatGenerator created from builder LLM config.
         embedder_model: The name of the embedding model to use for query encoding.
+        embedder_api_url: Optional API URL for the embedding model.
 
     Returns:
         (ComponentTool, Pipeline): The tool and underlying pipeline.
@@ -49,7 +51,10 @@ def create_rag_tool(
         raise ValueError("An embedder model name must be provided for the RAG tool.")
 
     retriever = OpenSearchEmbeddingRetriever(document_store=document_store, top_k=top_k)
-    query_embedder = NvidiaTextEmbedder(model=embedder_model)
+    if embedder_api_url:
+        query_embedder = NvidiaTextEmbedder(model=embedder_model, api_url=embedder_api_url)
+    else:
+        query_embedder = NvidiaTextEmbedder(model=embedder_model)
     if generator is None:
         raise ValueError("NvidiaChatGenerator instance must be provided via builder-configured LLM.")
 

--- a/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/register.py
+++ b/examples/frameworks/haystack_deep_research_agent/src/nat_haystack_deep_research_agent/register.py
@@ -75,6 +75,7 @@ async def haystack_deep_research_agent_workflow(config: HaystackDeepResearchWork
 
     embedder_config = builder.get_embedder_config(config.embedder_name)
     embedder_model = getattr(embedder_config, "model", None) or getattr(embedder_config, "model_name", None)
+    embedder_api_url = getattr(embedder_config, "base_url", None)
     if not embedder_model:
         raise ValueError("Embedder configuration must define a model name.")
 
@@ -93,9 +94,12 @@ async def haystack_deep_research_agent_workflow(config: HaystackDeepResearchWork
             data_dir=config.data_dir,
             logger=logger,
             embedder_model=str(embedder_model),
+            embedder_api_url=embedder_api_url,
         )
 
     def _nim_to_haystack_generator(cfg: NIMModelConfig) -> NvidiaChatGenerator:
+        if cfg.base_url:
+            return NvidiaChatGenerator(model=cfg.model_name, api_base_url=cfg.base_url)
         return NvidiaChatGenerator(model=cfg.model_name)
 
     # Instantiate LLMs via builder configs (expecting NIM)
@@ -113,6 +117,7 @@ async def haystack_deep_research_agent_workflow(config: HaystackDeepResearchWork
         top_k=config.rag_top_k,
         generator=rag_generator,
         embedder_model=str(embedder_model),
+        embedder_api_url=embedder_api_url,
     )
 
     # Create the agent

--- a/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
+++ b/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
@@ -78,6 +78,8 @@ def test_config_yaml_loads_and_has_keys() -> None:
     ]:
         assert key in text, f"Missing key: {key}"
 
+    assert text.count("base_url: https://integrate.api.nvidia.com:443/v1") == 3
+
 
 def test_indexing_chunks_stay_within_embedder_token_limit() -> None:
     """Regression test for NAT-309.
@@ -115,3 +117,44 @@ def test_indexing_chunks_stay_within_embedder_token_limit() -> None:
     assert len(chunks) > 1, "expected the long document to be split into multiple chunks"
     for chunk in chunks:
         assert len(chunk.content.split()) <= split_length
+
+
+def test_indexing_pipeline_uses_configured_embedder_api_url() -> None:
+    from haystack.document_stores.in_memory import InMemoryDocumentStore
+
+    from nat_haystack_deep_research_agent.pipelines.indexing import _build_indexing_pipeline
+
+    embedder_api_url = "https://integrate.api.nvidia.com:443/v1"
+    pipeline = _build_indexing_pipeline(
+        InMemoryDocumentStore(),
+        embedder_model="nvidia/nemotron-3-embed-1b",
+        embedder_api_url=embedder_api_url,
+    )
+
+    components = pipeline.to_dict()["components"]
+    assert components["embedder"]["init_parameters"]["api_url"] == embedder_api_url
+
+
+def test_rag_pipeline_uses_configured_api_urls() -> None:
+    from haystack_integrations.components.generators.nvidia import NvidiaChatGenerator
+    from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore
+
+    from nat_haystack_deep_research_agent.pipelines.rag import create_rag_tool
+
+    api_url = "https://integrate.api.nvidia.com:443/v1"
+    document_store = OpenSearchDocumentStore(hosts=["http://localhost:9200"], embedding_dim=1024)
+    generator = NvidiaChatGenerator(
+        model="nvidia/nemotron-3-super-120b-a12b",
+        api_base_url=api_url,
+    )
+
+    _, pipeline = create_rag_tool(
+        document_store,
+        generator=generator,
+        embedder_model="nvidia/nemotron-3-embed-1b",
+        embedder_api_url=api_url,
+    )
+
+    components = pipeline.to_dict()["components"]
+    assert components["query_embedder"]["init_parameters"]["api_url"] == api_url
+    assert components["llm"]["init_parameters"]["api_base_url"] == api_url

--- a/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
+++ b/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
@@ -134,6 +134,7 @@ def test_indexing_pipeline_uses_configured_embedder_api_url() -> None:
     components = pipeline.to_dict()["components"]
     assert components["embedder"]["init_parameters"]["api_url"] == embedder_api_url
 
+
 @pytest.mark.integration
 @pytest.mark.usefixtures("nvidia_api_key")
 def test_rag_pipeline_uses_configured_api_urls() -> None:

--- a/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
+++ b/examples/frameworks/haystack_deep_research_agent/tests/test_haystack_deep_research_agent.py
@@ -134,7 +134,8 @@ def test_indexing_pipeline_uses_configured_embedder_api_url() -> None:
     components = pipeline.to_dict()["components"]
     assert components["embedder"]["init_parameters"]["api_url"] == embedder_api_url
 
-
+@pytest.mark.integration
+@pytest.mark.usefixtures("nvidia_api_key")
 def test_rag_pipeline_uses_configured_api_urls() -> None:
     from haystack_integrations.components.generators.nvidia import NvidiaChatGenerator
     from haystack_integrations.document_stores.opensearch import OpenSearchDocumentStore


### PR DESCRIPTION
## Description
* Bypass Haystack's pre-defined model-check which doesn't include the newer models. By defining the `base_url` with the port number it causes a url mis-match causing Haystack to treat it as a custom model bypassing the model check.
* Update embedding configs to match the new embedding model.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for configuring NVIDIA API base URLs for language models and embedding services.
  - Updated deep research indexing and retrieval settings, including search result limits and embedding dimensions.

- **Tests**
  - Added coverage verifying configured API URLs are used for indexing and retrieval.
  - Added validation for required NVIDIA API endpoint settings.

- **Chores**
  - Excluded a downloaded research PDF from version control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->