### PR TITLE
fix: accept omitted fields with default factories

### DIFF
--- a/packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/tool_converter.py
+++ b/packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/tool_converter.py
@@ -20,9 +20,11 @@ import logging
 import re
 from inspect import Parameter
 from inspect import Signature
+from typing import Annotated
 from typing import Any
 
 from pydantic import BaseModel
+from pydantic import Field
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
@@ -35,6 +37,22 @@ logger = logging.getLogger(__name__)
 
 # Sentinel: marks "optional; let Pydantic supply default/factory"
 _USE_PYDANTIC_DEFAULT = object()
+
+
+def _use_pydantic_default() -> Any:
+    """Defer an omitted argument's factory to the original input model."""
+    return _USE_PYDANTIC_DEFAULT
+
+
+def _build_field_annotation(field_info: FieldInfo) -> Any:
+    """Keep factory-backed arguments optional without evaluating their factories."""
+    annotation = field_info.annotation or Any
+    if field_info.default_factory is not None:
+        # FastMCP validates arguments before invoking the wrapper. Supply a marker
+        # there so the original model can apply its factory with validated data.
+        # The marker is removed by the wrapper and must not be type-validated.
+        return Annotated[annotation, Field(default_factory=_use_pydantic_default, validate_default=False)]
+    return annotation
 
 
 def _sanitize_parameter_name(name: str) -> str:
@@ -139,7 +157,7 @@ def _build_signature_from_schema(schema: Any) -> tuple[Signature, dict[str, str]
 
     params: list[Parameter] = []
     for name, field_info in schema.model_fields.items():  # type: ignore[attr-defined]
-        annotation = field_info.annotation or Any
+        annotation = _build_field_annotation(field_info)
         default = _get_field_default(field_info)
         safe_name = name_map[name]
         if default is _USE_PYDANTIC_DEFAULT:
@@ -175,7 +193,7 @@ def _build_annotations_from_schema(schema: Any) -> dict[str, Any]:
     annotations: dict[str, Any] = {}
     for name, field_info in schema.model_fields.items():  # type: ignore[attr-defined]
         safe_name = name_map[name]
-        annotations[safe_name] = field_info.annotation or Any
+        annotations[safe_name] = _build_field_annotation(field_info)
     return annotations
 
 

--- a/packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/tool_converter.py
+++ b/packages/nvidia_nat_fastmcp/src/nat/plugins/fastmcp/server/tool_converter.py
@@ -45,14 +45,15 @@ def _use_pydantic_default() -> Any:
 
 
 def _build_field_annotation(field_info: FieldInfo) -> Any:
-    """Keep factory-backed arguments optional without evaluating their factories."""
+    """Preserve field metadata and defer factories to the original input model."""
     annotation = field_info.annotation or Any
+    field_metadata: list[Any] = [field_info]
     if field_info.default_factory is not None:
         # FastMCP validates arguments before invoking the wrapper. Supply a marker
         # there so the original model can apply its factory with validated data.
         # The marker is removed by the wrapper and must not be type-validated.
-        return Annotated[annotation, Field(default_factory=_use_pydantic_default, validate_default=False)]
-    return annotation
+        field_metadata.append(Field(default_factory=_use_pydantic_default, validate_default=False))
+    return Annotated[(annotation, *field_metadata)]
 
 
 def _sanitize_parameter_name(name: str) -> str:

--- a/packages/nvidia_nat_fastmcp/tests/server/test_tool_converter.py
+++ b/packages/nvidia_nat_fastmcp/tests/server/test_tool_converter.py
@@ -184,10 +184,10 @@ async def test_registered_tool_defers_default_factory(field_name, data_aware):
     schema = create_model(
         "FactorySchema",
         **{
-            "query": (int, ...),
+            "query": (int, Field(gt=0, description="Query identifier")),
             field_name: (list[int],
                          Field(default_factory=data_factory if data_aware else factory, validate_default=True)),
-            "limit": (int, 10),
+            "limit": (int, Field(default=10, ge=1, description="Result limit")),
         })
     mock_sm = _mock_session_manager()
     mock_sm.workflow = MagicMock(input_schema=schema)
@@ -198,6 +198,12 @@ async def test_registered_tool_defers_default_factory(field_name, data_aware):
     async with Client(server) as client:
         tools = await client.list_tools()
         assert tools[0].inputSchema["required"] == ["query"]
+        properties = tools[0].inputSchema["properties"]
+        assert properties["query"]["exclusiveMinimum"] == 0
+        assert properties["query"]["description"] == "Query identifier"
+        assert properties["limit"]["minimum"] == 1
+        assert properties["limit"]["description"] == "Result limit"
+        assert properties["limit"]["default"] == 10
         assert factory_calls == []
         for _ in range(2):
             result = await client.call_tool("tool", {"query": "7"})
@@ -227,13 +233,21 @@ async def test_registered_tool_validates_factory_default(default_value, succeeds
     """The original model still validates the factory's type and constraints."""
     schema = create_model("ValidatedFactorySchema",
                           labels=(list[int],
-                                  Field(default_factory=lambda: default_value, min_length=1, validate_default=True)))
+                                  Field(default_factory=lambda: default_value,
+                                        min_length=1,
+                                        description="Selected labels",
+                                        validate_default=True)))
     mock_sm = _mock_session_manager()
     mock_sm.workflow = MagicMock(input_schema=schema)
     server = FastMCP("factory-validation-test")
     register_function_with_mcp(server, "tool", mock_sm)
 
     async with Client(server) as client:
+        tools = await client.list_tools()
+        input_schema = tools[0].inputSchema
+        assert "labels" not in input_schema.get("required", [])
+        assert input_schema["properties"]["labels"]["minItems"] == 1
+        assert input_schema["properties"]["labels"]["description"] == "Selected labels"
         result = await client.call_tool("tool", {}, raise_on_error=False)
     assert result.is_error is not succeeds
     assert mock_sm.run.call_count == int(succeeds)

--- a/packages/nvidia_nat_fastmcp/tests/server/test_tool_converter.py
+++ b/packages/nvidia_nat_fastmcp/tests/server/test_tool_converter.py
@@ -12,16 +12,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""Tests for FastMCP tool_converter parameter name sanitization."""
+"""Tests for FastMCP tool conversion and parameter name sanitization."""
 
 from unittest.mock import AsyncMock
 from unittest.mock import MagicMock
 
+import pytest
+from fastmcp import Client
+from fastmcp import FastMCP
+from pydantic import Field
 from pydantic import create_model
 
 from nat.plugins.fastmcp.server.tool_converter import _build_name_mapping
 from nat.plugins.fastmcp.server.tool_converter import _sanitize_parameter_name
 from nat.plugins.fastmcp.server.tool_converter import create_function_wrapper
+from nat.plugins.fastmcp.server.tool_converter import register_function_with_mcp
 from nat.runtime.session import SessionManager
 
 
@@ -160,3 +165,75 @@ class TestParameterNameSanitization:
         wrapper = create_function_wrapper("tool", _mock_session_manager(), schema)
 
         assert "from_" in wrapper.__annotations__
+
+
+@pytest.mark.parametrize("field_name", ["labels", "from"])
+@pytest.mark.parametrize("data_aware", [False, True])
+async def test_registered_tool_defers_default_factory(field_name, data_aware):
+    """Omission stays optional and factories run once per call in the original model."""
+    factory_calls = []
+
+    def factory():
+        factory_calls.append(None)
+        return []
+
+    def data_factory(data):
+        factory_calls.append(data["query"])
+        return [data["query"]]
+
+    schema = create_model(
+        "FactorySchema",
+        **{
+            "query": (int, ...),
+            field_name: (list[int],
+                         Field(default_factory=data_factory if data_aware else factory, validate_default=True)),
+            "limit": (int, 10),
+        })
+    mock_sm = _mock_session_manager()
+    mock_sm.workflow = MagicMock(input_schema=schema)
+    server = FastMCP("factory-test")
+    register_function_with_mcp(server, "tool", mock_sm)
+    safe_name = _sanitize_parameter_name(field_name)
+
+    async with Client(server) as client:
+        tools = await client.list_tools()
+        assert tools[0].inputSchema["required"] == ["query"]
+        assert factory_calls == []
+        for _ in range(2):
+            result = await client.call_tool("tool", {"query": "7"})
+            assert not result.is_error
+
+        first, second = [call.args[0] for call in mock_sm.run.call_args_list]
+        assert getattr(first, field_name) == ([7] if data_aware else [])
+        assert getattr(first, field_name) is not getattr(second, field_name)
+        assert first.limit == 10
+        assert field_name not in first.model_fields_set
+        assert factory_calls == ([7, 7] if data_aware else [None, None])
+
+        result = await client.call_tool("tool", {"query": 7, safe_name: [9]})
+        assert not result.is_error
+        assert getattr(mock_sm.run.call_args.args[0], field_name) == [9]
+        assert field_name in mock_sm.run.call_args.args[0].model_fields_set
+        assert len(factory_calls) == 2
+
+        for arguments in ({"query": 7, safe_name: None}, {safe_name: []}):
+            result = await client.call_tool("tool", arguments, raise_on_error=False)
+            assert result.is_error
+        assert mock_sm.run.call_count == 3
+
+
+@pytest.mark.parametrize("default_value, succeeds", [([1], True), ([], False), (["invalid"], False)])
+async def test_registered_tool_validates_factory_default(default_value, succeeds):
+    """The original model still validates the factory's type and constraints."""
+    schema = create_model("ValidatedFactorySchema",
+                          labels=(list[int],
+                                  Field(default_factory=lambda: default_value, min_length=1, validate_default=True)))
+    mock_sm = _mock_session_manager()
+    mock_sm.workflow = MagicMock(input_schema=schema)
+    server = FastMCP("factory-validation-test")
+    register_function_with_mcp(server, "tool", mock_sm)
+
+    async with Client(server) as client:
+        result = await client.call_tool("tool", {}, raise_on_error=False)
+    assert result.is_error is not succeeds
+    assert mock_sm.run.call_count == int(succeeds)


### PR DESCRIPTION
 ## Reference Issues/PRs

  Addresses the FastMCP `default_factory` omission bug reported in #2138.
  Related to #2134.

  ## What does this implement/fix? Explain your changes.

  The standalone FastMCP adapter in NVIDIA NeMo Agent Toolkit incorrectly marks Pydantic
  fields with default_factory as required.

  For example, labels: list[str] = Field(default_factory=list) allows omission in the
  original input model. However, the adapter discards factory metadata when constructing
  the tool signature. FastMCP consequently rejects calls without labels with Missing
  required keyword only argument, before the workflow can run.

  ### Fix

 I preserved optional factory-backed arguments through an annotated internal marker factory:

  - FastMCP accepts omission and supplies the marker.
  - The existing wrapper removes the marker before validating the original input model.
  - The original model evaluates the actual factory with access to validated preceding
    fields.

  This follows the deferred-default approach used by the SDK adapter I saw in #2134. Factories
  are evaluated at invocation time, avoiding registration-time side effects and shared
  mutable defaults. Concrete defaults and non-factory annotations remain unchanged. No
  dependency changes.

  ## Testing

  I added parameterized tests in test_tool_converter.py using a real in-process FastMCP
  client. Coverage includes advertised schemas, omitted arguments, data-aware factories,
  fresh mutable defaults, sanitized names, explicit values, required arguments, null
  rejection, and factory-output validation.


  ## Checklist
  - [x] New/changed code is tested.
  - [x] Documentation reviewed; no configuration or public API changes require updates.
  - [x] Commit is signed off (DCO).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved generated tool schemas to preserve Pydantic field constraints, descriptions, defaults, and optionality.
  * Ensured default factories are evaluated per call, including factories that depend on validated data.
  * Improved handling of sanitized field names and explicit field overrides.
  * Added validation for invalid inputs and factory-generated values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->