### PR TITLE
fix(retry): respect do_auto_retry in framework adapters

### DIFF
--- a/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
+++ b/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
@@ -60,7 +60,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
                 messages.insert(0, Message(role="system", content=self.system_prompt))
             return FunctionArgumentWrapper(messages, *args, **kwargs)
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_agno/tests/test_llm_agno.py
+++ b/packages/nvidia_nat_agno/tests/test_llm_agno.py
@@ -24,8 +24,21 @@ from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.data_models.llm import APITypeEnum
 from nat.llm.nim_llm import NIMModelConfig
 from nat.llm.openai_llm import OpenAIModelConfig
+from nat.plugins.agno.llm import _patch_llm_based_on_config
 from nat.plugins.agno.llm import nim_agno
 from nat.plugins.agno.llm import openai_agno
+
+
+def test_llm_retry_can_be_disabled():
+    """Do not wrap an Agno client when automatic retries are disabled."""
+    config = OpenAIModelConfig(model_name="gpt-4", do_auto_retry=False)
+    client = MagicMock()
+
+    with patch("nat.plugins.agno.llm.patch_with_retry") as mock_patch_retry:
+        result = _patch_llm_based_on_config(client, config)
+
+    mock_patch_retry.assert_not_called()
+    assert result is client
 
 
 class TestNimAgno:

--- a/packages/nvidia_nat_autogen/src/nat/plugins/autogen/llm.py
+++ b/packages/nvidia_nat_autogen/src/nat/plugins/autogen/llm.py
@@ -96,7 +96,7 @@ def _patch_autogen_client_based_on_config(client: ModelType, llm_config: LLMBase
             return FunctionArgumentWrapper(new_messages, *args, **kwargs)
 
     # Apply retry mixin if configured
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_autogen/tests/test_llm_autogen.py
+++ b/packages/nvidia_nat_autogen/tests/test_llm_autogen.py
@@ -89,6 +89,17 @@ class TestPatchAutoGenClient:
                                                  retry_on_messages=["timeout", "connection"])
         assert result == mock_patched_client
 
+    @patch('nat.plugins.autogen.llm.patch_with_retry')
+    def test_patch_with_retry_disabled(self, mock_patch_retry):
+        """Do not patch an AutoGen client when automatic retries are disabled."""
+        mock_client = Mock()
+        retry_config = MockRetryConfig(do_auto_retry=False)
+
+        result = _patch_autogen_client_based_on_config(mock_client, retry_config)
+
+        mock_patch_retry.assert_not_called()
+        assert result is mock_client
+
     @patch('nat.plugins.autogen.llm.patch_with_thinking')
     def test_patch_with_thinking_mixin(self, mock_patch_thinking):
         """Test patching client with thinking mixin."""

--- a/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
+++ b/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
@@ -56,7 +56,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
                 messages.insert(0, {"role": "system", "content": self.system_prompt})
             return FunctionArgumentWrapper(messages, *args, **kwargs)
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_crewai/tests/test_llm_crewai.py
+++ b/packages/nvidia_nat_crewai/tests/test_llm_crewai.py
@@ -25,8 +25,22 @@ from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.data_models.llm import APITypeEnum
 from nat.llm.nim_llm import NIMModelConfig
 from nat.llm.openai_llm import OpenAIModelConfig
+from nat.plugins.crewai.llm import _patch_llm_based_on_config
 from nat.plugins.crewai.llm import nim_crewai
 from nat.plugins.crewai.llm import openai_crewai
+
+
+def test_llm_retry_can_be_disabled():
+    """Do not wrap a CrewAI client when automatic retries are disabled."""
+    config = OpenAIModelConfig(model_name="gpt-4o", do_auto_retry=False)
+    client = MagicMock()
+
+    with patch("nat.plugins.crewai.llm.patch_with_retry") as mock_patch_retry:
+        result = _patch_llm_based_on_config(client, config)
+
+    mock_patch_retry.assert_not_called()
+    assert result is client
+
 
 # ---------------------------------------------------------------------------
 # NIM → CrewAI wrapper tests

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
@@ -45,7 +45,7 @@ async def azure_openai_langchain(embedder_config: AzureOpenAIEmbedderModelConfig
             http_async_client=http_clients_dict["async_http_client"],
         )
 
-        if isinstance(embedder_config, RetryMixin):
+        if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
             client = patch_with_retry(client,
                                       retries=embedder_config.num_retries,
                                       retry_codes=embedder_config.retry_on_status_codes,
@@ -63,7 +63,7 @@ async def nim_langchain(embedder_config: NIMEmbedderModelConfig, builder: Builde
     client = NVIDIAEmbeddings(
         **embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True, exclude_unset=True))
 
-    if isinstance(embedder_config, RetryMixin):
+    if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=embedder_config.num_retries,
                                   retry_codes=embedder_config.retry_on_status_codes,
@@ -87,7 +87,7 @@ async def openai_langchain(embedder_config: OpenAIEmbedderModelConfig, builder: 
             http_async_client=http_clients_dict["async_http_client"],
         )
 
-        if isinstance(embedder_config, RetryMixin):
+        if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
             client = patch_with_retry(client,
                                       retries=embedder_config.num_retries,
                                       retry_codes=embedder_config.retry_on_status_codes,
@@ -128,7 +128,7 @@ async def huggingface_langchain(embedder_config: HuggingFaceEmbedderConfig, _bui
             encode_kwargs=encode_kwargs,
         )
 
-    if isinstance(embedder_config, RetryMixin):
+    if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=embedder_config.num_retries,
                                   retry_codes=embedder_config.retry_on_status_codes,

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -129,7 +129,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: "LLMBaseConfig") -
     if model_field is not None:
         client = client.configurable_fields(**{model_field: ConfigurableField(id="model_name")})
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_langchain/tests/test_embedder_langchain.py
+++ b/packages/nvidia_nat_langchain/tests/test_embedder_langchain.py
@@ -158,8 +158,8 @@ class TestNIMEmbedderLangChain:
 class TestHuggingFaceEmbedderLangChain:
     """Tests for the huggingface_langchain embedder wrapper."""
 
-    @pytest.fixture
-    def huggingface_embedder_config(self):
+    @pytest.fixture(name="huggingface_embedder_config")
+    def huggingface_embedder_config_fixture(self):
         return HuggingFaceEmbedderConfig(model_name="sentence-transformers/all-MiniLM-L6-v2")
 
     @patch("langchain_huggingface.HuggingFaceEmbeddings")

--- a/packages/nvidia_nat_langchain/tests/test_embedder_langchain.py
+++ b/packages/nvidia_nat_langchain/tests/test_embedder_langchain.py
@@ -18,9 +18,11 @@ from unittest.mock import patch
 import pytest
 
 from nat.embedder.azure_openai_embedder import AzureOpenAIEmbedderModelConfig
+from nat.embedder.huggingface_embedder import HuggingFaceEmbedderConfig
 from nat.embedder.nim_embedder import NIMEmbedderModelConfig
 from nat.embedder.openai_embedder import OpenAIEmbedderModelConfig
 from nat.plugins.langchain.embedder import azure_openai_langchain
+from nat.plugins.langchain.embedder import huggingface_langchain
 from nat.plugins.langchain.embedder import nim_langchain
 from nat.plugins.langchain.embedder import openai_langchain
 
@@ -52,6 +54,17 @@ class TestOpenAIEmbedderLangChain:
             assert mock_httpx_async_client.call_args.kwargs["verify"] is verify_ssl
             mock_httpx_sync_client.assert_called_once()
             assert mock_httpx_sync_client.call_args.kwargs["verify"] is verify_ssl
+
+    @patch("langchain_openai.OpenAIEmbeddings")
+    async def test_auto_retry_can_be_disabled(self, mock_embeddings, openai_embedder_config, mock_builder):
+        """Do not wrap an OpenAI embedder when automatic retries are disabled."""
+        openai_embedder_config.do_auto_retry = False
+
+        with patch("nat.plugins.langchain.embedder.patch_with_retry") as mock_patch_retry:
+            async with openai_langchain(openai_embedder_config, mock_builder):
+                pass
+
+        mock_patch_retry.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +101,22 @@ class TestAzureOpenAIEmbedderLangChain:
             mock_httpx_sync_client.assert_called_once()
             assert mock_httpx_sync_client.call_args.kwargs["verify"] is verify_ssl
 
+    @patch("langchain_openai.AzureOpenAIEmbeddings")
+    async def test_auto_retry_can_be_disabled(self,
+                                              mock_embeddings,
+                                              azure_embedder_config,
+                                              mock_builder,
+                                              mock_httpx_async_client,
+                                              mock_httpx_sync_client):
+        """Do not wrap an Azure OpenAI embedder when automatic retries are disabled."""
+        azure_embedder_config.do_auto_retry = False
+
+        with patch("nat.plugins.langchain.embedder.patch_with_retry") as mock_patch_retry:
+            async with azure_openai_langchain(azure_embedder_config, mock_builder):
+                pass
+
+        mock_patch_retry.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # NIM embedder → LangChain
@@ -113,3 +142,33 @@ class TestNIMEmbedderLangChain:
         async with nim_langchain(nim_embedder_config, mock_builder):
             mock_embeddings.assert_called_once()
             assert mock_embeddings.call_args.kwargs["verify_ssl"] is verify_ssl
+
+    @patch("langchain_nvidia_ai_endpoints.NVIDIAEmbeddings")
+    async def test_auto_retry_can_be_disabled(self, mock_embeddings, nim_embedder_config, mock_builder):
+        """Do not wrap a NIM embedder when automatic retries are disabled."""
+        nim_embedder_config.do_auto_retry = False
+
+        with patch("nat.plugins.langchain.embedder.patch_with_retry") as mock_patch_retry:
+            async with nim_langchain(nim_embedder_config, mock_builder):
+                pass
+
+        mock_patch_retry.assert_not_called()
+
+
+class TestHuggingFaceEmbedderLangChain:
+    """Tests for the huggingface_langchain embedder wrapper."""
+
+    @pytest.fixture
+    def huggingface_embedder_config(self):
+        return HuggingFaceEmbedderConfig(model_name="sentence-transformers/all-MiniLM-L6-v2")
+
+    @patch("langchain_huggingface.HuggingFaceEmbeddings")
+    async def test_auto_retry_can_be_disabled(self, mock_embeddings, huggingface_embedder_config, mock_builder):
+        """Do not wrap a HuggingFace embedder when automatic retries are disabled."""
+        huggingface_embedder_config.do_auto_retry = False
+
+        with patch("nat.plugins.langchain.embedder.patch_with_retry") as mock_patch_retry:
+            async with huggingface_langchain(huggingface_embedder_config, mock_builder):
+                pass
+
+        mock_patch_retry.assert_not_called()

--- a/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
+++ b/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
@@ -30,6 +30,7 @@ from nat.llm.litellm_llm import LiteLlmModelConfig
 from nat.llm.nim_llm import NIMModelConfig
 from nat.llm.oci_llm import OCIModelConfig
 from nat.llm.openai_llm import OpenAIModelConfig
+from nat.plugins.langchain.llm import _patch_llm_based_on_config
 from nat.plugins.langchain.llm import aws_bedrock_langchain
 from nat.plugins.langchain.llm import azure_openai_langchain
 from nat.plugins.langchain.llm import dynamo_langchain
@@ -37,6 +38,19 @@ from nat.plugins.langchain.llm import litellm_langchain
 from nat.plugins.langchain.llm import nim_langchain
 from nat.plugins.langchain.llm import oci_langchain
 from nat.plugins.langchain.llm import openai_langchain
+
+
+def test_llm_retry_can_be_disabled():
+    """Do not wrap a LangChain client when automatic retries are disabled."""
+    config = OpenAIModelConfig(model_name="gpt-4o-mini", do_auto_retry=False)
+    client = MagicMock()
+
+    with patch("nat.plugins.langchain.llm.patch_with_retry") as mock_patch_retry:
+        result = _patch_llm_based_on_config(client, config)
+
+    mock_patch_retry.assert_not_called()
+    assert result is client
+
 
 # ---------------------------------------------------------------------------
 # NIM → LangChain wrapper tests

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
@@ -39,7 +39,7 @@ async def azure_openai_llama_index(embedder_config: AzureOpenAIEmbedderModelConf
             **http_clients_dict,
         )
 
-        if isinstance(embedder_config, RetryMixin):
+        if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
             client = patch_with_retry(client,
                                       retries=embedder_config.num_retries,
                                       retry_codes=embedder_config.retry_on_status_codes,
@@ -65,7 +65,7 @@ async def nim_llama_index(embedder_config: NIMEmbedderModelConfig, _builder: Bui
         model=embedder_config.model_name,
     )
 
-    if isinstance(embedder_config, RetryMixin):
+    if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=embedder_config.num_retries,
                                   retry_codes=embedder_config.retry_on_status_codes,
@@ -88,7 +88,7 @@ async def openai_llama_index(embedder_config: OpenAIEmbedderModelConfig, _builde
             **http_clients_dict,
         )
 
-        if isinstance(embedder_config, RetryMixin):
+        if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
             client = patch_with_retry(client,
                                       retries=embedder_config.num_retries,
                                       retry_codes=embedder_config.retry_on_status_codes,

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
@@ -60,7 +60,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
                 messages.insert(0, ChatMessage(role="system", content=self.system_prompt))
             return FunctionArgumentWrapper(messages, *args, **kwargs)
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_llama_index/tests/test_embedder_llama_index.py
+++ b/packages/nvidia_nat_llama_index/tests/test_embedder_llama_index.py
@@ -55,6 +55,17 @@ class TestOpenAIEmbedderLlamaIndex:
             mock_httpx_sync_client.assert_called_once()
             assert mock_httpx_sync_client.call_args.kwargs["verify"] is verify_ssl
 
+    @patch("llama_index.embeddings.openai.OpenAIEmbedding")
+    async def test_auto_retry_can_be_disabled(self, mock_embedding, openai_embedder_config, mock_builder):
+        """Do not wrap an OpenAI embedder when automatic retries are disabled."""
+        openai_embedder_config.do_auto_retry = False
+
+        with patch("nat.plugins.llama_index.embedder.patch_with_retry") as mock_patch_retry:
+            async with openai_llama_index(openai_embedder_config, mock_builder):
+                pass
+
+        mock_patch_retry.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Azure OpenAI embedder → Llama-Index
@@ -90,6 +101,22 @@ class TestAzureOpenAIEmbedderLlamaIndex:
             mock_httpx_sync_client.assert_called_once()
             assert mock_httpx_sync_client.call_args.kwargs["verify"] is verify_ssl
 
+    @patch("llama_index.embeddings.azure_openai.AzureOpenAIEmbedding")
+    async def test_auto_retry_can_be_disabled(self,
+                                              mock_embedding,
+                                              azure_embedder_config,
+                                              mock_builder,
+                                              mock_httpx_async_client,
+                                              mock_httpx_sync_client):
+        """Do not wrap an Azure OpenAI embedder when automatic retries are disabled."""
+        azure_embedder_config.do_auto_retry = False
+
+        with patch("nat.plugins.llama_index.embedder.patch_with_retry") as mock_patch_retry:
+            async with azure_openai_llama_index(azure_embedder_config, mock_builder):
+                pass
+
+        mock_patch_retry.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # NIM embedder → Llama-Index
@@ -117,3 +144,14 @@ class TestNIMEmbedderLlamaIndex:
         with pytest.raises(ValueError, match="verify_ssl is currently not supported for NVIDIAEmbedding"):
             async with nim_llama_index(nim_embedder_config, mock_builder):
                 pass
+
+    @patch("llama_index.embeddings.nvidia.NVIDIAEmbedding")
+    async def test_auto_retry_can_be_disabled(self, mock_embedding, nim_embedder_config, mock_builder):
+        """Do not wrap a NIM embedder when automatic retries are disabled."""
+        nim_embedder_config.do_auto_retry = False
+
+        with patch("nat.plugins.llama_index.embedder.patch_with_retry") as mock_patch_retry:
+            async with nim_llama_index(nim_embedder_config, mock_builder):
+                pass
+
+        mock_patch_retry.assert_not_called()

--- a/packages/nvidia_nat_llama_index/tests/test_llm_llama_index.py
+++ b/packages/nvidia_nat_llama_index/tests/test_llm_llama_index.py
@@ -25,9 +25,23 @@ from nat.data_models.llm import APITypeEnum
 from nat.llm.aws_bedrock_llm import AWSBedrockModelConfig
 from nat.llm.nim_llm import NIMModelConfig
 from nat.llm.openai_llm import OpenAIModelConfig
+from nat.plugins.llama_index.llm import _patch_llm_based_on_config
 from nat.plugins.llama_index.llm import aws_bedrock_llama_index
 from nat.plugins.llama_index.llm import nim_llama_index
 from nat.plugins.llama_index.llm import openai_llama_index
+
+
+def test_llm_retry_can_be_disabled():
+    """Do not wrap a LlamaIndex client when automatic retries are disabled."""
+    config = OpenAIModelConfig(model_name="gpt-4o", do_auto_retry=False)
+    client = MagicMock()
+
+    with patch("nat.plugins.llama_index.llm.patch_with_retry") as mock_patch_retry:
+        result = _patch_llm_based_on_config(client, config)
+
+    mock_patch_retry.assert_not_called()
+    assert result is client
+
 
 # ---------------------------------------------------------------------------
 # NIM → Llama-Index wrapper tests

--- a/packages/nvidia_nat_mem0ai/src/nat/plugins/mem0ai/memory.py
+++ b/packages/nvidia_nat_mem0ai/src/nat/plugins/mem0ai/memory.py
@@ -48,7 +48,7 @@ async def mem0_memory_client(config: Mem0MemoryClientConfig, builder: Builder):
 
     memory_editor = Mem0Editor(mem0_client=mem0_client)
 
-    if isinstance(config, RetryMixin):
+    if isinstance(config, RetryMixin) and config.do_auto_retry:
         memory_editor = patch_with_retry(memory_editor,
                                          retries=config.num_retries,
                                          retry_codes=config.retry_on_status_codes,

--- a/packages/nvidia_nat_mem0ai/tests/test_mem0_editor.py
+++ b/packages/nvidia_nat_mem0ai/tests/test_mem0_editor.py
@@ -14,11 +14,15 @@
 # limitations under the License.
 
 from unittest.mock import AsyncMock
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 
 from nat.memory.models import MemoryItem
 from nat.plugins.mem0ai.mem0_editor import Mem0Editor
+from nat.plugins.mem0ai.memory import Mem0MemoryClientConfig
+from nat.plugins.mem0ai.memory import mem0_memory_client
 
 
 @pytest.fixture(name="mock_mem0_client")
@@ -127,3 +131,16 @@ async def test_remove_items_missing_arguments(mem0_editor: Mem0Editor):
     result = await mem0_editor.remove_items()
 
     assert result is None
+
+
+async def test_mem0_memory_client_respects_disabled_retry():
+    """Do not wrap a Mem0 editor when automatic retries are disabled."""
+    config = Mem0MemoryClientConfig(do_auto_retry=False)
+
+    with patch.dict("os.environ", {"MEM0_API_KEY": "test-key"}):
+        with patch("mem0.AsyncMemoryClient", return_value=Mock()):
+            with patch("nat.plugins.mem0ai.memory.patch_with_retry") as mock_patch_retry:
+                async with mem0_memory_client(config, Mock()) as editor:
+                    assert editor is not None
+
+    mock_patch_retry.assert_not_called()

--- a/packages/nvidia_nat_memmachine/src/nat/plugins/memmachine/memory.py
+++ b/packages/nvidia_nat_memmachine/src/nat/plugins/memmachine/memory.py
@@ -89,10 +89,10 @@ async def memmachine_memory_client(
 
     memory_editor = MemMachineEditor(memmachine_instance=memmachine_instance)
 
-    # Apply retry wrapper (config always inherits from RetryMixin)
-    memory_editor = patch_with_retry(memory_editor,
-                                     retries=config.num_retries,
-                                     retry_codes=config.retry_on_status_codes,
-                                     retry_on_messages=config.retry_on_errors)
+    if isinstance(config, RetryMixin) and config.do_auto_retry:
+        memory_editor = patch_with_retry(memory_editor,
+                                         retries=config.num_retries,
+                                         retry_codes=config.retry_on_status_codes,
+                                         retry_on_messages=config.retry_on_errors)
 
     yield memory_editor

--- a/packages/nvidia_nat_memmachine/src/nat/plugins/memmachine/memory.py
+++ b/packages/nvidia_nat_memmachine/src/nat/plugins/memmachine/memory.py
@@ -60,8 +60,9 @@ async def memmachine_memory_client(
     # This follows the documented SDK pattern for local instances:
     # client = MemMachineClient(base_url="http://localhost:8095")
     # Note: api_key is not needed for local/self-hosted MemMachine instances
+    sdk_max_retries = config.max_retries if config.do_auto_retry else 0
     try:
-        client = MemMachineClient(base_url=config.base_url, timeout=config.timeout, max_retries=config.max_retries)
+        client = MemMachineClient(base_url=config.base_url, timeout=config.timeout, max_retries=sdk_max_retries)
     except Exception as e:
         raise RuntimeError(f"Failed to initialize MemMachineClient with base_url '{config.base_url}'. "
                            f"Error: {e}. "

--- a/packages/nvidia_nat_memmachine/tests/test_memory.py
+++ b/packages/nvidia_nat_memmachine/tests/test_memory.py
@@ -155,3 +155,17 @@ async def test_memmachine_memory_client_with_retry_mixin(config: MemMachineMemor
                 assert call_kwargs["retries"] == 5
                 assert call_kwargs["retry_codes"] == [500, 502, 503]
                 assert call_kwargs["retry_on_messages"] == ["ConnectionError"]
+
+
+async def test_memmachine_memory_client_respects_disabled_retry(config_minimal: MemMachineMemoryClientConfig,
+                                                                mock_builder: Mock,
+                                                                mock_memmachine_client: Mock):
+    """Do not wrap a MemMachine editor when automatic retries are disabled."""
+    config_minimal.do_auto_retry = False
+
+    with patch("memmachine_client.MemMachineClient", return_value=mock_memmachine_client):
+        with patch("nat.plugins.memmachine.memory.patch_with_retry") as mock_patch:
+            async with memmachine_memory_client(config_minimal, mock_builder) as editor:
+                assert editor is not None
+
+    mock_patch.assert_not_called()

--- a/packages/nvidia_nat_memmachine/tests/test_memory.py
+++ b/packages/nvidia_nat_memmachine/tests/test_memory.py
@@ -143,7 +143,7 @@ async def test_memmachine_memory_client_with_retry_mixin(config: MemMachineMemor
     config.retry_on_status_codes = [500, 502, 503]
     config.retry_on_errors = ["ConnectionError"]
 
-    with patch("memmachine_client.MemMachineClient", return_value=mock_memmachine_client):
+    with patch("memmachine_client.MemMachineClient", return_value=mock_memmachine_client) as mock_client_constructor:
         with patch("nat.plugins.memmachine.memory.patch_with_retry") as mock_patch:
             mock_patch.return_value = Mock()
             # @register_memory wraps the function with asynccontextmanager, so use async with
@@ -155,6 +155,7 @@ async def test_memmachine_memory_client_with_retry_mixin(config: MemMachineMemor
                 assert call_kwargs["retries"] == 5
                 assert call_kwargs["retry_codes"] == [500, 502, 503]
                 assert call_kwargs["retry_on_messages"] == ["ConnectionError"]
+        assert mock_client_constructor.call_args.kwargs["max_retries"] == 3
 
 
 async def test_memmachine_memory_client_respects_disabled_retry(config_minimal: MemMachineMemoryClientConfig,
@@ -163,9 +164,10 @@ async def test_memmachine_memory_client_respects_disabled_retry(config_minimal: 
     """Do not wrap a MemMachine editor when automatic retries are disabled."""
     config_minimal.do_auto_retry = False
 
-    with patch("memmachine_client.MemMachineClient", return_value=mock_memmachine_client):
+    with patch("memmachine_client.MemMachineClient", return_value=mock_memmachine_client) as mock_client_constructor:
         with patch("nat.plugins.memmachine.memory.patch_with_retry") as mock_patch:
             async with memmachine_memory_client(config_minimal, mock_builder) as editor:
                 assert editor is not None
 
     mock_patch.assert_not_called()
+    assert mock_client_constructor.call_args.kwargs["max_retries"] == 0

--- a/packages/nvidia_nat_semantic_kernel/src/nat/plugins/semantic_kernel/llm.py
+++ b/packages/nvidia_nat_semantic_kernel/src/nat/plugins/semantic_kernel/llm.py
@@ -68,7 +68,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
                 )
                 return FunctionArgumentWrapper(new_messages, *args, **kwargs)
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_semantic_kernel/tests/test_llm_sk.py
+++ b/packages/nvidia_nat_semantic_kernel/tests/test_llm_sk.py
@@ -24,8 +24,22 @@ from nat.builder.framework_enum import LLMFrameworkEnum
 from nat.data_models.llm import APITypeEnum
 from nat.llm.azure_openai_llm import AzureOpenAIModelConfig
 from nat.llm.openai_llm import OpenAIModelConfig
+from nat.plugins.semantic_kernel.llm import _patch_llm_based_on_config
 from nat.plugins.semantic_kernel.llm import azure_openai_semantic_kernel
 from nat.plugins.semantic_kernel.llm import openai_semantic_kernel
+
+
+def test_llm_retry_can_be_disabled():
+    """Do not wrap a Semantic Kernel client when automatic retries are disabled."""
+    config = OpenAIModelConfig(model_name="gpt-4o", do_auto_retry=False)
+    client = MagicMock()
+
+    with patch("nat.plugins.semantic_kernel.llm.patch_with_retry") as mock_patch_retry:
+        result = _patch_llm_based_on_config(client, config)
+
+    mock_patch_retry.assert_not_called()
+    assert result is client
+
 
 # ---------------------------------------------------------------------------
 # OpenAI → Semantic-Kernel wrapper tests

--- a/packages/nvidia_nat_strands/src/nat/plugins/strands/llm.py
+++ b/packages/nvidia_nat_strands/src/nat/plugins/strands/llm.py
@@ -117,7 +117,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
 
             return FunctionArgumentWrapper(messages, *new_args, **new_kwargs)
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_strands/tests/test_strands_llm.py
+++ b/packages/nvidia_nat_strands/tests/test_strands_llm.py
@@ -394,6 +394,16 @@ class TestPatchLLMBasedOnConfig:
         assert result == mock_client
 
     @patch("nat.plugins.strands.llm.patch_with_retry")
+    def test_patch_llm_with_retry_disabled(self, mock_patch_retry, mock_client):
+        """Do not wrap a Strands client when automatic retries are disabled."""
+        config = OpenAIModelConfig(model_name="gpt-4", do_auto_retry=False)
+
+        result = _patch_llm_based_on_config(mock_client, config)
+
+        mock_patch_retry.assert_not_called()
+        assert result is mock_client
+
+    @patch("nat.plugins.strands.llm.patch_with_retry")
     def test_patch_llm_with_retry_mixin(self, mock_patch_retry, mock_client):
         """Test patching with retry mixin."""
         from nat.data_models.retry_mixin import RetryMixin

--- a/packages/nvidia_nat_zep_cloud/src/nat/plugins/zep_cloud/memory.py
+++ b/packages/nvidia_nat_zep_cloud/src/nat/plugins/zep_cloud/memory.py
@@ -45,7 +45,7 @@ async def zep_memory_client(config: ZepMemoryClientConfig, builder: Builder):
                           follow_redirects=config.follow_redirects)
     memory_editor = ZepEditor(zep_client)
 
-    if isinstance(config, RetryMixin):
+    if isinstance(config, RetryMixin) and config.do_auto_retry:
         memory_editor = patch_with_retry(memory_editor,
                                          retries=config.num_retries,
                                          retry_codes=config.retry_on_status_codes,

--- a/packages/nvidia_nat_zep_cloud/tests/test_zep_editor.py
+++ b/packages/nvidia_nat_zep_cloud/tests/test_zep_editor.py
@@ -17,6 +17,8 @@ from unittest.mock import AsyncMock
 from unittest.mock import Mock
 from unittest.mock import patch
 
+from nat.plugins.zep_cloud.memory import ZepMemoryClientConfig
+from nat.plugins.zep_cloud.memory import zep_memory_client
 from nat.plugins.zep_cloud.zep_editor import ZepEditor
 
 
@@ -79,3 +81,16 @@ async def test_search_falls_back_to_thread_context_without_graph_results():
     zep_client.thread.get_user_context.assert_awaited_once_with(thread_id="conversation-123", mode="summary")
     assert len(results) == 1
     assert results[0].memory == "Formatted Zep context"
+
+
+async def test_zep_memory_client_respects_disabled_retry():
+    """Do not wrap a Zep editor when automatic retries are disabled."""
+    config = ZepMemoryClientConfig(do_auto_retry=False)
+
+    with patch.dict("os.environ", {"ZEP_API_KEY": "test-key"}):
+        with patch("zep_cloud.client.AsyncZep", return_value=Mock()):
+            with patch("nat.plugins.zep_cloud.memory.patch_with_retry") as mock_patch_retry:
+                async with zep_memory_client(config, Mock()) as editor:
+                    assert editor is not None
+
+    mock_patch_retry.assert_not_called()


### PR DESCRIPTION
## Description

Runtime framework adapters wrapped LLM, embedder, and memory clients whenever their configuration inherited `RetryMixin`. Because provider configurations inherit that mixin, `do_auto_retry: false` was ignored and `patch_with_retry` was still installed.

This change gates every affected runtime adapter call site on `do_auto_retry` while preserving the default retry behavior, and adds regression coverage for the LLM, embedder, and memory paths.

Closes #2212

## Verification

- Focused adapter tests: `192 passed`
- Changed-file YAPF and Ruff pre-commit hooks pass.
- The existing `RetryMixin.do_auto_retry` documentation already describes the opt-out, so no documentation change is needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic retries are now applied only when explicitly enabled across supported LLM, embedding, and memory integrations.
  * Integrations remain unchanged when automatic retries are disabled, preventing unexpected retry behavior.

* **Tests**
  * Added coverage confirming disabled automatic retries are respected across all affected integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->