### PR TITLE
fix: respect do_auto_retry in LLM, embedder, and memory framework adapters

### DIFF
--- a/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
+++ b/packages/nvidia_nat_agno/src/nat/plugins/agno/llm.py
@@ -60,7 +60,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
                 messages.insert(0, Message(role="system", content=self.system_prompt))
             return FunctionArgumentWrapper(messages, *args, **kwargs)
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_autogen/src/nat/plugins/autogen/llm.py
+++ b/packages/nvidia_nat_autogen/src/nat/plugins/autogen/llm.py
@@ -96,7 +96,7 @@ def _patch_autogen_client_based_on_config(client: ModelType, llm_config: LLMBase
             return FunctionArgumentWrapper(new_messages, *args, **kwargs)
 
     # Apply retry mixin if configured
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_autogen/tests/test_llm_autogen.py
+++ b/packages/nvidia_nat_autogen/tests/test_llm_autogen.py
@@ -89,6 +89,17 @@ class TestPatchAutoGenClient:
                                                  retry_on_messages=["timeout", "connection"])
         assert result == mock_patched_client
 
+    @patch('nat.plugins.autogen.llm.patch_with_retry')
+    def test_patch_with_retry_mixin_disabled(self, mock_patch_retry):
+        """Test client is not patched when do_auto_retry is False."""
+        mock_client = Mock()
+        retry_config = MockRetryConfig(do_auto_retry=False)
+
+        result = _patch_autogen_client_based_on_config(mock_client, retry_config)
+
+        mock_patch_retry.assert_not_called()
+        assert result == mock_client
+
     @patch('nat.plugins.autogen.llm.patch_with_thinking')
     def test_patch_with_thinking_mixin(self, mock_patch_thinking):
         """Test patching client with thinking mixin."""

--- a/packages/nvidia_nat_autogen/tests/test_llm_autogen.py
+++ b/packages/nvidia_nat_autogen/tests/test_llm_autogen.py
@@ -90,7 +90,7 @@ class TestPatchAutoGenClient:
         assert result == mock_patched_client
 
     @patch('nat.plugins.autogen.llm.patch_with_retry')
-    def test_patch_with_retry_mixin_disabled(self, mock_patch_retry):
+    def test_patch_with_retry_mixin_disabled(self, mock_patch_retry: Mock):
         """Test client is not patched when do_auto_retry is False."""
         mock_client = Mock()
         retry_config = MockRetryConfig(do_auto_retry=False)

--- a/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
+++ b/packages/nvidia_nat_crewai/src/nat/plugins/crewai/llm.py
@@ -56,7 +56,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
                 messages.insert(0, {"role": "system", "content": self.system_prompt})
             return FunctionArgumentWrapper(messages, *args, **kwargs)
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/embedder.py
@@ -45,7 +45,7 @@ async def azure_openai_langchain(embedder_config: AzureOpenAIEmbedderModelConfig
             http_async_client=http_clients_dict["async_http_client"],
         )
 
-        if isinstance(embedder_config, RetryMixin):
+        if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
             client = patch_with_retry(client,
                                       retries=embedder_config.num_retries,
                                       retry_codes=embedder_config.retry_on_status_codes,
@@ -63,7 +63,7 @@ async def nim_langchain(embedder_config: NIMEmbedderModelConfig, builder: Builde
     client = NVIDIAEmbeddings(
         **embedder_config.model_dump(exclude={"type"}, by_alias=True, exclude_none=True, exclude_unset=True))
 
-    if isinstance(embedder_config, RetryMixin):
+    if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=embedder_config.num_retries,
                                   retry_codes=embedder_config.retry_on_status_codes,
@@ -87,7 +87,7 @@ async def openai_langchain(embedder_config: OpenAIEmbedderModelConfig, builder: 
             http_async_client=http_clients_dict["async_http_client"],
         )
 
-        if isinstance(embedder_config, RetryMixin):
+        if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
             client = patch_with_retry(client,
                                       retries=embedder_config.num_retries,
                                       retry_codes=embedder_config.retry_on_status_codes,
@@ -128,7 +128,7 @@ async def huggingface_langchain(embedder_config: HuggingFaceEmbedderConfig, _bui
             encode_kwargs=encode_kwargs,
         )
 
-    if isinstance(embedder_config, RetryMixin):
+    if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=embedder_config.num_retries,
                                   retry_codes=embedder_config.retry_on_status_codes,

--- a/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
+++ b/packages/nvidia_nat_langchain/src/nat/plugins/langchain/llm.py
@@ -129,7 +129,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: "LLMBaseConfig") -
     if model_field is not None:
         client = client.configurable_fields(**{model_field: ConfigurableField(id="model_name")})
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
+++ b/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
@@ -151,7 +151,11 @@ class TestOpenAILangChain:
 
     @patch("nat.plugins.langchain.llm.patch_with_retry")
     @patch("langchain_openai.ChatOpenAI")
-    async def test_auto_retry_enabled_by_default(self, mock_chat, mock_patch_retry, oa_cfg, mock_builder):
+    async def test_auto_retry_enabled_by_default(self,
+                                                 mock_chat: MagicMock,
+                                                 mock_patch_retry: MagicMock,
+                                                 oa_cfg: OpenAIModelConfig,
+                                                 mock_builder: MagicMock):
         """When do_auto_retry is True (default), patch_with_retry is called."""
         mock_patch_retry.return_value = mock_chat.return_value
         async with openai_langchain(oa_cfg, mock_builder):
@@ -160,7 +164,11 @@ class TestOpenAILangChain:
 
     @patch("nat.plugins.langchain.llm.patch_with_retry")
     @patch("langchain_openai.ChatOpenAI")
-    async def test_auto_retry_disabled(self, mock_chat, mock_patch_retry, oa_cfg, mock_builder):
+    async def test_auto_retry_disabled(self,
+                                       mock_chat: MagicMock,
+                                       mock_patch_retry: MagicMock,
+                                       oa_cfg: OpenAIModelConfig,
+                                       mock_builder: MagicMock):
         """When do_auto_retry is False, patch_with_retry is not called."""
         oa_cfg.do_auto_retry = False
         async with openai_langchain(oa_cfg, mock_builder):

--- a/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
+++ b/packages/nvidia_nat_langchain/tests/test_llm_langchain.py
@@ -149,6 +149,24 @@ class TestOpenAILangChain:
         mock_httpx_async_client.assert_called_once()
         assert mock_httpx_async_client.call_args.kwargs["verify"] is verify_ssl
 
+    @patch("nat.plugins.langchain.llm.patch_with_retry")
+    @patch("langchain_openai.ChatOpenAI")
+    async def test_auto_retry_enabled_by_default(self, mock_chat, mock_patch_retry, oa_cfg, mock_builder):
+        """When do_auto_retry is True (default), patch_with_retry is called."""
+        mock_patch_retry.return_value = mock_chat.return_value
+        async with openai_langchain(oa_cfg, mock_builder):
+            pass
+        mock_patch_retry.assert_called_once()
+
+    @patch("nat.plugins.langchain.llm.patch_with_retry")
+    @patch("langchain_openai.ChatOpenAI")
+    async def test_auto_retry_disabled(self, mock_chat, mock_patch_retry, oa_cfg, mock_builder):
+        """When do_auto_retry is False, patch_with_retry is not called."""
+        oa_cfg.do_auto_retry = False
+        async with openai_langchain(oa_cfg, mock_builder):
+            pass
+        mock_patch_retry.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Azure OpenAI → LangChain wrapper tests

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/embedder.py
@@ -39,7 +39,7 @@ async def azure_openai_llama_index(embedder_config: AzureOpenAIEmbedderModelConf
             **http_clients_dict,
         )
 
-        if isinstance(embedder_config, RetryMixin):
+        if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
             client = patch_with_retry(client,
                                       retries=embedder_config.num_retries,
                                       retry_codes=embedder_config.retry_on_status_codes,
@@ -65,7 +65,7 @@ async def nim_llama_index(embedder_config: NIMEmbedderModelConfig, _builder: Bui
         model=embedder_config.model_name,
     )
 
-    if isinstance(embedder_config, RetryMixin):
+    if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=embedder_config.num_retries,
                                   retry_codes=embedder_config.retry_on_status_codes,
@@ -88,7 +88,7 @@ async def openai_llama_index(embedder_config: OpenAIEmbedderModelConfig, _builde
             **http_clients_dict,
         )
 
-        if isinstance(embedder_config, RetryMixin):
+        if isinstance(embedder_config, RetryMixin) and embedder_config.do_auto_retry:
             client = patch_with_retry(client,
                                       retries=embedder_config.num_retries,
                                       retry_codes=embedder_config.retry_on_status_codes,

--- a/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
+++ b/packages/nvidia_nat_llama_index/src/nat/plugins/llama_index/llm.py
@@ -60,7 +60,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
                 messages.insert(0, ChatMessage(role="system", content=self.system_prompt))
             return FunctionArgumentWrapper(messages, *args, **kwargs)
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_llama_index/tests/test_llm_llama_index.py
+++ b/packages/nvidia_nat_llama_index/tests/test_llm_llama_index.py
@@ -135,6 +135,24 @@ class TestOpenAILlamaIndex:
             mock_httpx_sync_client.assert_called_once()
             assert mock_httpx_sync_client.call_args.kwargs["verify"] is verify_ssl
 
+    @patch("nat.plugins.llama_index.llm.patch_with_retry")
+    @patch("llama_index.llms.openai.OpenAI")
+    async def test_auto_retry_enabled_by_default(self, mock_openai, mock_patch_retry, oa_cfg_chat, mock_builder):
+        """When do_auto_retry is True (default), patch_with_retry is called."""
+        mock_patch_retry.return_value = mock_openai.return_value
+        async with openai_llama_index(oa_cfg_chat, mock_builder):
+            pass
+        mock_patch_retry.assert_called_once()
+
+    @patch("nat.plugins.llama_index.llm.patch_with_retry")
+    @patch("llama_index.llms.openai.OpenAI")
+    async def test_auto_retry_disabled(self, mock_openai, mock_patch_retry, oa_cfg_chat, mock_builder):
+        """When do_auto_retry is False, patch_with_retry is not called."""
+        oa_cfg_chat.do_auto_retry = False
+        async with openai_llama_index(oa_cfg_chat, mock_builder):
+            pass
+        mock_patch_retry.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # AWS Bedrock → Llama-Index wrapper tests

--- a/packages/nvidia_nat_llama_index/tests/test_llm_llama_index.py
+++ b/packages/nvidia_nat_llama_index/tests/test_llm_llama_index.py
@@ -137,7 +137,11 @@ class TestOpenAILlamaIndex:
 
     @patch("nat.plugins.llama_index.llm.patch_with_retry")
     @patch("llama_index.llms.openai.OpenAI")
-    async def test_auto_retry_enabled_by_default(self, mock_openai, mock_patch_retry, oa_cfg_chat, mock_builder):
+    async def test_auto_retry_enabled_by_default(self,
+                                                 mock_openai: MagicMock,
+                                                 mock_patch_retry: MagicMock,
+                                                 oa_cfg_chat: OpenAIModelConfig,
+                                                 mock_builder: MagicMock):
         """When do_auto_retry is True (default), patch_with_retry is called."""
         mock_patch_retry.return_value = mock_openai.return_value
         async with openai_llama_index(oa_cfg_chat, mock_builder):
@@ -146,7 +150,11 @@ class TestOpenAILlamaIndex:
 
     @patch("nat.plugins.llama_index.llm.patch_with_retry")
     @patch("llama_index.llms.openai.OpenAI")
-    async def test_auto_retry_disabled(self, mock_openai, mock_patch_retry, oa_cfg_chat, mock_builder):
+    async def test_auto_retry_disabled(self,
+                                       mock_openai: MagicMock,
+                                       mock_patch_retry: MagicMock,
+                                       oa_cfg_chat: OpenAIModelConfig,
+                                       mock_builder: MagicMock):
         """When do_auto_retry is False, patch_with_retry is not called."""
         oa_cfg_chat.do_auto_retry = False
         async with openai_llama_index(oa_cfg_chat, mock_builder):

--- a/packages/nvidia_nat_mem0ai/src/nat/plugins/mem0ai/memory.py
+++ b/packages/nvidia_nat_mem0ai/src/nat/plugins/mem0ai/memory.py
@@ -48,7 +48,7 @@ async def mem0_memory_client(config: Mem0MemoryClientConfig, builder: Builder):
 
     memory_editor = Mem0Editor(mem0_client=mem0_client)
 
-    if isinstance(config, RetryMixin):
+    if isinstance(config, RetryMixin) and config.do_auto_retry:
         memory_editor = patch_with_retry(memory_editor,
                                          retries=config.num_retries,
                                          retry_codes=config.retry_on_status_codes,

--- a/packages/nvidia_nat_memmachine/src/nat/plugins/memmachine/memory.py
+++ b/packages/nvidia_nat_memmachine/src/nat/plugins/memmachine/memory.py
@@ -89,10 +89,10 @@ async def memmachine_memory_client(
 
     memory_editor = MemMachineEditor(memmachine_instance=memmachine_instance)
 
-    # Apply retry wrapper (config always inherits from RetryMixin)
-    memory_editor = patch_with_retry(memory_editor,
-                                     retries=config.num_retries,
-                                     retry_codes=config.retry_on_status_codes,
-                                     retry_on_messages=config.retry_on_errors)
+    if isinstance(config, RetryMixin) and config.do_auto_retry:
+        memory_editor = patch_with_retry(memory_editor,
+                                         retries=config.num_retries,
+                                         retry_codes=config.retry_on_status_codes,
+                                         retry_on_messages=config.retry_on_errors)
 
     yield memory_editor

--- a/packages/nvidia_nat_semantic_kernel/src/nat/plugins/semantic_kernel/llm.py
+++ b/packages/nvidia_nat_semantic_kernel/src/nat/plugins/semantic_kernel/llm.py
@@ -68,7 +68,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
                 )
                 return FunctionArgumentWrapper(new_messages, *args, **kwargs)
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_strands/src/nat/plugins/strands/llm.py
+++ b/packages/nvidia_nat_strands/src/nat/plugins/strands/llm.py
@@ -117,7 +117,7 @@ def _patch_llm_based_on_config(client: ModelType, llm_config: LLMBaseConfig) -> 
 
             return FunctionArgumentWrapper(messages, *new_args, **new_kwargs)
 
-    if isinstance(llm_config, RetryMixin):
+    if isinstance(llm_config, RetryMixin) and llm_config.do_auto_retry:
         client = patch_with_retry(client,
                                   retries=llm_config.num_retries,
                                   retry_codes=llm_config.retry_on_status_codes,

--- a/packages/nvidia_nat_strands/tests/test_strands_llm.py
+++ b/packages/nvidia_nat_strands/tests/test_strands_llm.py
@@ -419,6 +419,21 @@ class TestPatchLLMBasedOnConfig:
                                                  retry_on_messages=["timeout"])
         assert result == mock_patched_client
 
+    @patch("nat.plugins.strands.llm.patch_with_retry")
+    def test_patch_llm_with_retry_mixin_disabled(self, mock_patch_retry, mock_client):
+        """Test client is not patched when do_auto_retry is False."""
+        from nat.data_models.retry_mixin import RetryMixin
+
+        class TestConfigWithRetry(OpenAIModelConfig, RetryMixin):
+            pass
+
+        config = TestConfigWithRetry(model_name="gpt-4", do_auto_retry=False)
+
+        result = _patch_llm_based_on_config(mock_client, config)
+
+        mock_patch_retry.assert_not_called()
+        assert result == mock_client
+
     @patch("nat.plugins.strands.llm.patch_with_thinking")
     def test_patch_llm_with_thinking_mixin(self, mock_patch_thinking, mock_client):
         """Test patching with thinking mixin."""

--- a/packages/nvidia_nat_strands/tests/test_strands_llm.py
+++ b/packages/nvidia_nat_strands/tests/test_strands_llm.py
@@ -420,7 +420,7 @@ class TestPatchLLMBasedOnConfig:
         assert result == mock_patched_client
 
     @patch("nat.plugins.strands.llm.patch_with_retry")
-    def test_patch_llm_with_retry_mixin_disabled(self, mock_patch_retry, mock_client):
+    def test_patch_llm_with_retry_mixin_disabled(self, mock_patch_retry: MagicMock, mock_client: MagicMock):
         """Test client is not patched when do_auto_retry is False."""
         from nat.data_models.retry_mixin import RetryMixin
 

--- a/packages/nvidia_nat_zep_cloud/src/nat/plugins/zep_cloud/memory.py
+++ b/packages/nvidia_nat_zep_cloud/src/nat/plugins/zep_cloud/memory.py
@@ -45,7 +45,7 @@ async def zep_memory_client(config: ZepMemoryClientConfig, builder: Builder):
                           follow_redirects=config.follow_redirects)
     memory_editor = ZepEditor(zep_client)
 
-    if isinstance(config, RetryMixin):
+    if isinstance(config, RetryMixin) and config.do_auto_retry:
         memory_editor = patch_with_retry(memory_editor,
                                          retries=config.num_retries,
                                          retry_codes=config.retry_on_status_codes,


### PR DESCRIPTION
## Description
`RetryMixin` provides `do_auto_retry: bool = Field(default=True, description="Whether to automatically retry method calls that fail with a retryable error.", exclude=True)` and `num_retries: int = Field(default=5, gt=0, ...)`.

Because `num_retries` requires `gt=0`, setting `do_auto_retry: false` in workflow configs is the documented mechanism to disable retries.

While evaluator modules (`langsmith_judge.py`, `trajectory_evaluator.py`, `ragas/register.py`) properly check `if config.do_auto_retry:`, runtime framework adapters across LLM, embedder, and memory plugins previously checked only `if isinstance(config, RetryMixin):` (or called `patch_with_retry` unconditionally in `nvidia_nat_memmachine`). Because all provider configs inherit from `RetryMixin`, `do_auto_retry: false` was silently ignored, causing 5 retry attempts with exponential backoff on retryable HTTP errors (429, 500, 503).

This PR ensures all LLM, embedder, and memory client adapters respect `do_auto_retry`.

> **Note**: This PR is submitted by the issue author, who identified the issue and prepared the fix and test coverage as noted in #2212.

Closes #2212

### Changes Made
- **`nvidia_nat_langchain`**:
  - `llm.py`: Added check `and llm_config.do_auto_retry`.
  - `embedder.py`: Added check `and embedder_config.do_auto_retry` across all 4 embedders (`azure_openai`, `nim`, `openai`, `huggingface`).
  - `test_llm_langchain.py`: Added tests verifying `patch_with_retry` is called by default and bypassed when `do_auto_retry=False`.
- **`nvidia_nat_llama_index`**:
  - `llm.py`: Added check `and llm_config.do_auto_retry`.
  - `embedder.py`: Added check `and embedder_config.do_auto_retry` across all 3 embedders (`azure_openai`, `nim`, `openai`).
  - `test_llm_llama_index.py`: Added tests verifying `patch_with_retry` is called by default and bypassed when `do_auto_retry=False`.
- **`nvidia_nat_agno`**:
  - `llm.py`: Added check `and llm_config.do_auto_retry`.
- **`nvidia_nat_autogen`**:
  - `llm.py`: Added check `and llm_config.do_auto_retry`.
  - `test_llm_autogen.py`: Added test `test_patch_with_retry_mixin_disabled`.
- **`nvidia_nat_crewai`**:
  - `llm.py`: Added check `and llm_config.do_auto_retry`.
- **`nvidia_nat_semantic_kernel`**:
  - `llm.py`: Added check `and llm_config.do_auto_retry`.
- **`nvidia_nat_strands`**:
  - `llm.py`: Added check `and llm_config.do_auto_retry`.
  - `test_strands_llm.py`: Added test `test_patch_llm_with_retry_mixin_disabled`.
- **`nvidia_nat_mem0ai`**:
  - `memory.py`: Added check `and config.do_auto_retry`.
- **`nvidia_nat_memmachine`**:
  - `memory.py`: Wrapped `patch_with_retry` in `if isinstance(config, RetryMixin) and config.do_auto_retry:`.
- **`nvidia_nat_zep_cloud`**:
  - `memory.py`: Added check `and config.do_auto_retry`.

## By Submitting this PR I confirm:
- I am familiar with the [Contributing Guidelines](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/resources/contributing/index.md).
- We require that all contributors "sign-off" on their commits. This certifies that the contribution is your original work, or you have rights to submit it under the same license, or a compatible license.
  - Any contribution which contains commits that are not Signed-Off will not be accepted.
- When the PR is ready for review, new or existing tests cover these changes.
- When the PR is ready for review, the documentation is up to date with these changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Automatic retries are now applied only when explicitly enabled.
  * Configurations with retry support but automatic retries disabled retain their original behavior across supported LLM, embedder, and memory integrations.

* **Tests**
  * Added coverage confirming retries remain enabled by default and are skipped when explicitly disabled across multiple integrations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->