### PR TITLE
Fix truncate_string exceeding max_length for small limits

### DIFF
--- a/packages/nvidia_nat_core/src/nat/utils/string_utils.py
+++ b/packages/nvidia_nat_core/src/nat/utils/string_utils.py
@@ -38,6 +38,9 @@ def convert_to_str(value: Any) -> str:
         raise ValueError(f"Unsupported type for conversion to string: {type(value)}")
 
 
+_ELLIPSIS = "..."
+
+
 def truncate_string(text: str | None, max_length: int = 100) -> str | None:
     """
     Truncate a string to a maximum length, adding ellipsis if truncated.
@@ -47,8 +50,16 @@ def truncate_string(text: str | None, max_length: int = 100) -> str | None:
         max_length: Maximum allowed length (default: 100)
 
     Returns:
-        The truncated text with ellipsis if needed, or None if input was None
+        The truncated text with ellipsis if needed, or None if input was None. The
+        returned string never exceeds ``max_length`` characters.
     """
     if not text or len(text) <= max_length:
         return text
-    return text[:max_length - 3] + "..."
+    # When there is no room for text plus the ellipsis, return as much of the
+    # ellipsis as fits. Guarding here avoids the negative-index slice
+    # ``text[:max_length - 3]`` would produce for ``max_length < 3`` (which cut
+    # characters off the end of ``text`` and returned a string longer than
+    # ``max_length``).
+    if max_length < len(_ELLIPSIS):
+        return _ELLIPSIS[:max(max_length, 0)]
+    return text[:max_length - len(_ELLIPSIS)] + _ELLIPSIS

--- a/packages/nvidia_nat_core/tests/nat/utils/test_string_utils.py
+++ b/packages/nvidia_nat_core/tests/nat/utils/test_string_utils.py
@@ -15,9 +15,11 @@
 
 import dataclasses
 
+import pytest
 from pydantic import BaseModel
 
 from nat.utils.string_utils import convert_to_str
+from nat.utils.string_utils import truncate_string
 
 
 class _M(BaseModel):
@@ -42,3 +44,35 @@ def test_convert_to_str_object_with_str():
             return f"C({self.x})"
 
     assert convert_to_str(C(3)) == "C(3)"
+
+
+def test_truncate_string_none_returns_none():
+    assert truncate_string(None) is None
+
+
+def test_truncate_string_shorter_than_limit_unchanged():
+    assert truncate_string("hello", max_length=100) == "hello"
+
+
+def test_truncate_string_equal_to_limit_unchanged():
+    assert truncate_string("abcde", max_length=5) == "abcde"
+
+
+def test_truncate_string_truncates_with_ellipsis():
+    assert truncate_string("abcdefghij", max_length=5) == "ab..."
+
+
+@pytest.mark.parametrize("max_length", [0, 1, 2, 3, 5, 8, 99])
+def test_truncate_string_never_exceeds_max_length(max_length):
+    # Regression: for max_length < 3 the old implementation used the negative
+    # slice text[:max_length - 3], which cut characters off the end of the input
+    # and returned a string *longer* than max_length (e.g. len 12 for max 2).
+    result = truncate_string("abcdefghijklmnopqrstuvwxyz", max_length=max_length)
+    assert result is not None
+    assert len(result) <= max_length
+
+
+def test_truncate_string_small_limits_return_partial_ellipsis():
+    assert truncate_string("abcdefghij", max_length=2) == ".."
+    assert truncate_string("abcdefghij", max_length=1) == "."
+    assert truncate_string("abcdefghij", max_length=0) == ""


### PR DESCRIPTION
## Description

`nat.utils.string_utils.truncate_string` is documented to "truncate a string to a
maximum length," but for `max_length < 3` it returned a string **longer** than
`max_length`. On the truncating path it did:

```python
return text[:max_length - 3] + "..."
```

When `max_length < 3`, `max_length - 3` is negative, so `text[:max_length - 3]`
slices from the *end* of the input instead of the start, and `"..."` is then
appended — producing output longer than `max_length` and cut from the wrong end:

```python
truncate_string("abcdefghij", 2)   # was 'abcdefghi...' (12 chars for max_length=2)
```

## Fix

Guard the case where there is no room for text plus the ellipsis and return only
as much of the ellipsis as fits (`".."`, `"."`, or `""`), instead of using the
negative slice. Behavior for `max_length >= 3` is unchanged
(`truncate_string("abcdefghij", 5) == "ab..."`), and the returned string now
never exceeds `max_length`.

## Tests

Added `tests/nat/utils/test_string_utils.py` covering `None`, no-truncation,
exact-length, normal truncation, and — as a regression guard — that the result
never exceeds `max_length` for a range of limits including `0`, `1`, `2`. The
regression assertions fail on the current code and pass with this change; `yapf`
and `ruff check` are clean on both files.

## By Submitting this PR I confirm:

- I am familiar with the Contributing Guidelines.
- The commit is signed off under the Developer Certificate of Origin (`git commit -s`).
- Existing and new tests cover these changes.
- No documentation update is required; this is an internal correctness fix with no
  change to any public API or configuration surface.

Closes #2220.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text truncation to ensure results never exceed the specified maximum length.
  * Added safe handling for very small length limits while preserving expected behavior for empty and short inputs.

* **Tests**
  * Added coverage for unchanged inputs, ellipsis truncation, maximum-length enforcement, and small-limit edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->